### PR TITLE
feat(151): PWA citizen workflow inbox — Things to do (sub-project A)

### DIFF
--- a/docs/superpowers/specs/2026-06-13-pwa-citizen-workflow-inbox-design.md
+++ b/docs/superpowers/specs/2026-06-13-pwa-citizen-workflow-inbox-design.md
@@ -1,0 +1,241 @@
+# PWA Citizen Workflow Inbox — Design (Sub-project A)
+
+**Date:** 2026-06-13
+**Status:** Design — awaiting user review before speckit specify
+**Decision owner:** Stuart Fraser
+**Parent programme:** PWA workflow participation (closing the "credentials only → perform Sorcha workflows" gap)
+
+---
+
+## 1. Context & the parent programme
+
+Today the Citizen Wallet PWA (`Sorcha.Wallet.Pwa`) is, in practice, credential-first: it
+holds, syncs, presents and verifies credentials, and it can submit **one** workflow action if
+the citizen arrives at `Pages/ApplicationInstance.razor` with a known `instanceId` (Feature
+125/137). The schema-driven form renderer (`SorchaFormRenderer` + the `Controls/` library +
+`FormPayloadBuilder`) is already shared via `Sorcha.UI.Components.User` and works identically in
+the web app and the PWA. What's missing is everything **around** that single form: a citizen has
+no way to *discover* work waiting on them, and no surface for performing flows generally.
+
+The goal is to let a citizen (and, later, a user in their organisational role) **perform Sorcha
+workflows** on their phone — gathering and entering data, including photos — not just manage
+credentials. This is larger than one feature, so it is decomposed into four independently
+shippable sub-projects, each with its own spec → plan → tasks → implement cycle:
+
+| # | Sub-project | Tier | Delivers | Depends on |
+|---|-------------|------|----------|------------|
+| **A** | **Citizen workflow inbox (online)** | consumer | "Actions waiting on me" list + open/fill/submit via the existing renderer; live count badge | — |
+| **B** | Service catalogue | consumer | New catalogue API + browse-and-start-new (`Applications.razor`) | A |
+| **C** | Offline / field capture | consumer | Encrypted local drafts (IndexedDB), camera/media capture, queued deferred submit, conflict handling | A |
+| **D** | Dual-tier PWA + org-role work | + platform | PWA holds a platform session (sign-in by role); surfaces org-role actions; reopens the F136 boundary for mobile | A + C |
+
+**Agreed sequence:** A → C → D, with B sloting in any time after A. This proves the
+discovery→fill→submit loop on the lowest-risk tier (A), de-risks the offline/media plumbing while
+still on consumer tier (C), and tackles the risky dual-tier auth change last (D), reusing a proven
+UI and offline layer. The headline use case — an org field-worker capturing evidence offline — is
+the **combination of C + D** on top of A.
+
+This document specifies **sub-project A only**.
+
+### Relationship to the companion-first decision
+
+The companion-first roadmap (`docs/superpowers/specs/2026-06-06-citizen-wallet-companion-roadmap.md`)
+scopes the PWA to sign-in / pairing / hold / sync / present / verify, with wallet creation, signup
+and recovery explicitly web-only. A is a **deliberate, consistent extension** of "present": a
+citizen acting as the **data subject of their own workflows** (apply for a thing, respond to an
+action whose turn is theirs) is the natural companion to holding and presenting credentials. A
+stays strictly **consumer-tier**. The platform-tier expansion (org-role work) is isolated in D,
+where the F136 audience boundary is addressed on its own terms.
+
+---
+
+## 2. Scope of A
+
+**In scope**
+- A PWA **inbox page** ("Things to do") listing the citizen's pending actions — actions a live
+  instance is currently waiting on **where the citizen is the designated actor** (it is their
+  turn). Source: `GET /api/actions/pending`.
+- **Lifecycle grouping**: *Needs you* (real list from `/api/actions/pending`) and *In review*
+  (the existing single Feature-124 pending-application notice, rendered as a lightweight banner).
+- Tapping a row routes into the **existing** `ApplicationInstance` form-fill/submit flow — no
+  change to the renderer, payload builder, or `/execute` submit path.
+- A nav entry with a **count badge** fed by `GET /api/actions/pending/count`, refreshed on the
+  existing citizen SignalR signal.
+- Graceful online degradation (last-known list retained on a refresh failure).
+
+**Explicitly out of scope (deferred to the named sub-project)**
+- Browse-and-start-new / service catalogue + its new API → **B**.
+- Local draft save/resume, offline list/working, camera/media capture, queued deferred submit,
+  conflict handling → **C**. *(There is no draft model anywhere today; A does not introduce one.)*
+- A complete "all my instances and their state" tracker (including instances where it is someone
+  else's turn beyond the single Feature-124 notice) → **B/C** (would need a new consumer-tier
+  read endpoint; see §7).
+- Org-role / platform-tier actions, dual-tier sign-in → **D**.
+- Action rejection / dispute UX, async-encryption progress → later (parity items not required to
+  prove the loop; revisit per sub-project).
+
+**No backend changes** are required for A. The endpoints it depends on already serve consumer-tier
+citizen tokens.
+
+---
+
+## 3. Backend surface A builds on (verified)
+
+| Surface | Route | Auth | Consumer-ready? |
+|---------|-------|------|-----------------|
+| List pending actions | `GET /api/actions/pending?page&pageSize` | plain `RequireAuthorization()` | ✅ resolves wallet via `platform_user_id` |
+| Pending count | `GET /api/actions/pending/count` | plain `RequireAuthorization()` | ✅ |
+| Load instance + blueprint | `GET /api/instances/{id}`, `GET /api/blueprints/{id}` | existing | ✅ (used by `ApplicationInstance` today) |
+| Submit action | `POST /api/instances/{id}/actions/{actionId}/execute` | `RequireAuthorization()` + wallet-ownership | ✅ |
+| Pending-application notice (label) | `GET /api/v1/wallet/pending-applications` | `RequireConsumerAudience` | ✅ |
+
+**"Pending" semantics (verified in code).** `GetPendingActionsByWalletAsync`
+(`EfCoreInstanceStore.cs:265`) iterates `instance.CurrentActionIds` — the actions an *Active*
+instance is currently waiting on — and filters them with `IsActionForWallet`
+(`EfCoreInstanceStore.cs:658`), which keeps an action only when its blueprint **`Sender`** (the
+participant *designated to perform that action*) binds to the citizen's wallet, or is still
+open/unbound. It explicitly excludes actions whose sender is bound to a *different* wallet (the
+F142 "citizen wrongly sees the analyst's action" fix). So `/api/actions/pending` means precisely
+**"current actions whose turn is mine"** — not "actions I previously sent." This is the correct
+inbox semantic and requires no change.
+
+> **Do NOT add `RequireConsumerAudience` to `/api/actions/pending`.** The web `MyActions` page
+> calls the same endpoint on the **platform** tier. It is a legitimately cross-tier "any-human"
+> endpoint and, per F136, correctly stays plain `RequireAuthorization()`. Tightening it would break
+> the web app.
+
+Identity resolution prefers `platform_user_id` then falls back to `sub`/`wallet_address`
+(`ActionEndpoints.cs:166`, aligned with Feature 136 / #878), so a consumer token with no wallet
+binding still resolves the citizen's wallet(s) and their pending actions.
+
+---
+
+## 4. Architecture & components
+
+A is intentionally small: **one typed client, one page, one nav badge** — the form machinery is
+already shared and unchanged.
+
+- **`IMyActionsClient`** (new, `Sorcha.Wallet.Pwa/Services/Actions/`)
+  - `Task<PendingActionsPage> GetPendingAsync(int page = 1, int pageSize = 20, CancellationToken)`
+  - `Task<PendingActionsCount> GetCountAsync(CancellationToken)`
+  - Thin wrapper over `GET /api/actions/pending` and `/api/actions/pending/count`; deserialises to
+    the existing `PendingActionSummary` shape (InstanceId, ActionId, title, Deadline, Urgency).
+  - Consumer-tier bearer token attached by the PWA's existing auth message handler.
+  - Registered in PWA DI alongside the other application clients.
+- **`Actions.razor`** (new page, route `actions`)
+  - The inbox. Built from shared `Sorcha.UI.Components.User` primitives (no MudBlazor `ISnackbar`;
+    feedback via `IInlineFeedback` per Critical Pattern #12).
+  - Renders the *Needs you* list (rows: title, deadline, urgency chip) and the *In review* banner
+    (existing `IPendingApplicationClient`).
+  - Decision pending in plan: repurpose the current empty-stub `Applications.razor` vs. add a new
+    page and leave `Applications.razor` for B's catalogue. Naming/routing resolved in tasks.
+- **Nav + badge**
+  - A "Things to do" entry in PWA navigation with a count from `GetCountAsync`, refreshed on the
+    citizen SignalR signal and on page focus.
+- **Reuse, no fork**
+  - `ApplicationInstance.razor` + `IApplicationActionClient` remain the single open-action surface.
+    The inbox only *navigates* to `applications/{instanceId}` (base-relative — PWA path-prefix rule).
+
+### Unit boundaries
+- `IMyActionsClient` — *what:* fetch the citizen's pending actions + count. *Depends on:* the PWA
+  `HttpClient` + auth handler. *Testable* with a stub `HttpMessageHandler`.
+- `Actions.razor` — *what:* present the list + banner, route to the action. *Depends on:*
+  `IMyActionsClient`, `IPendingApplicationClient`, `NavigationManager`. *Testable* with bUnit and a
+  stubbed client.
+
+---
+
+## 5. Data flow
+
+1. **Inbox load** — `Actions.razor` → `IMyActionsClient.GetPendingAsync(page)` →
+   `GET /api/actions/pending` → render `PendingActionSummary` rows, sorted urgent → normal then by
+   deadline ascending. Empty → friendly empty-state. Below the list, the Feature-124 notice renders
+   as an "In review" banner via `IPendingApplicationClient`.
+2. **Open** — tap row → `NavigateTo($"applications/{instanceId}")` → existing `ApplicationInstance`
+   loads + renders the action with `SorchaFormRenderer`.
+3. **Submit** — unchanged: `IApplicationActionClient.SubmitAsync` → `/execute`. On success it
+   already posts the pending-application notice; A additionally returns the user to the inbox and
+   refreshes list + count.
+4. **Live refresh** — subscribe to the existing citizen hub signal (the same channel that drives
+   silent credential sync); on signal, re-fetch count + list. A short poll runs **only while the
+   page is open** as a fallback. (Background/push notification is out of scope — see C/P2 of the
+   companion roadmap.)
+
+---
+
+## 6. Error handling & states
+
+- **Refresh failure / transient network error on the list** — non-blocking inline message
+  ("Couldn't refresh — showing last known"); retain the last-rendered list; never a blank error
+  page. (True offline list caching is C; A degrades gracefully but does not persist.)
+- **Empty** — "Nothing needs you right now" empty-state, with a catalogue CTA stub (becomes live
+  in B).
+- **Stale item** — if an action was already completed elsewhere, opening it lands on
+  `ApplicationInstance`, which already handles "no current action"; surface that via
+  `IInlineFeedback`, not a snackbar.
+- **Auth/token expiry** — handled by the existing PWA sign-in/session refresh; no special handling
+  in A.
+
+---
+
+## 7. Open questions / decisions deferred
+
+- **Complete "my instances" tracker** — A's *In review* group is the single Feature-124 notice
+  only. A full "all my instances + lifecycle state (Needs you / In review / Done)" tracker needs a
+  new consumer-tier read endpoint (e.g. `GET /api/.../my-instances` listing instances where I'm a
+  participant with their `InstanceState`). **Decision (2026-06-13): defer** to B/C; A ships with no
+  new backend.
+- **Page identity** — repurpose `Applications.razor` vs. new `Actions.razor`. Resolve in tasks;
+  must not collide with B's catalogue plans for `Applications.razor`.
+- **`urgentCount`** — `/api/actions/pending/count` returns `urgentCount` but it is always 0 today.
+  A renders total count; urgent styling rides on each row's `Urgency`. Surfacing a real urgent
+  count is a later backend refinement.
+
+---
+
+## 8. Testing strategy
+
+- **PWA component tests** (bUnit, `JSRuntimeMode.Loose`, per the `sorcha-ui` / `playwright` skills):
+  - Inbox renders rows from a stubbed `IMyActionsClient`.
+  - Empty-state renders when no pending actions.
+  - Urgent-before-normal ordering, then deadline ascending.
+  - Nav badge shows the count from `GetCountAsync`.
+  - **Row tap navigates to `applications/{instanceId}` (base-relative)** — guards the PWA
+    path-prefix regression class (the 12 broken-nav buttons of PR #698).
+- **Client test** — `IMyActionsClient` maps `/api/actions/pending` JSON to `PendingActionSummary`
+  via a stub `HttpMessageHandler`; count mapping likewise.
+- **No new backend tests** — A makes no backend change; existing `/api/actions/pending` coverage
+  stands.
+- **E2E (deferred, not blocking A)** — full inbox→open→submit against n1 once a seeded citizen with
+  a pending action exists.
+
+---
+
+## 9. File references (read-only grounding)
+
+- Pending actions endpoint + count — `src/Services/Sorcha.Blueprint.Service/Endpoints/ActionEndpoints.cs:16` (routes), `:166` (`ResolveUserWalletAddressesAsync`, prefers `platform_user_id`).
+- "My turn" semantics — `src/Services/Sorcha.Blueprint.Service/Storage/EfCoreInstanceStore.cs:265` (`GetPendingActionsByWalletAsync`), `:658` (`IsActionForWallet`).
+- Pending-action model — `src/Services/Sorcha.Blueprint.Service/Models/PendingActionSummary.cs:13`.
+- Instance lifecycle states — `src/Services/Sorcha.Blueprint.Service/Models/Instance.cs:150` (`InstanceState`).
+- Pending-application notice (label) — `src/Services/Sorcha.Wallet.Service/Endpoints/PendingApplicationEndpoints.cs:19`; PWA client `src/Apps/Sorcha.Wallet.Pwa/Services/IPendingApplicationClient.cs`.
+- Existing open-action surface (reused unchanged) — `src/Apps/Sorcha.Wallet.Pwa/Pages/ApplicationInstance.razor`; `src/Apps/Sorcha.Wallet.Pwa/Services/Applications/IApplicationActionClient.cs:83` (`LoadFormAsync`), `:137` (`SubmitAsync`).
+- Shared form renderer (reused unchanged) — `src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Forms/SorchaFormRenderer.razor`; `.../Services/User/Forms/FormPayloadBuilder.cs`.
+- Stub catalogue page (B) — `src/Apps/Sorcha.Wallet.Pwa/Pages/Applications.razor`.
+- Companion-first decision — `docs/superpowers/specs/2026-06-06-citizen-wallet-companion-roadmap.md`.
+
+---
+
+## 10. Definition of done (A)
+
+A citizen signed into the PWA on a consumer-tier session can:
+1. Open a "Things to do" inbox and see a real list of the actions currently waiting on them
+   (their turn), with title, deadline and urgency.
+2. See a nav count badge that updates live when a new action arrives (SignalR) and after they act.
+3. Tap an action, fill it via the existing renderer (including the field controls already shared),
+   and submit it through the existing `/execute` path.
+4. Return to the inbox and see it refresh; see an "In review" banner while an application awaits.
+5. Experience graceful degradation on a transient refresh failure (no blank error, last-known list
+   retained).
+
+All with **no backend change**, strictly **consumer-tier**, reusing the shared renderer and the
+existing `ApplicationInstance` submit flow.

--- a/specs/151-citizen-workflow-inbox/checklists/requirements.md
+++ b/specs/151-citizen-workflow-inbox/checklists/requirements.md
@@ -1,0 +1,38 @@
+# Specification Quality Checklist: PWA Citizen Workflow Inbox
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-06-13
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Spec deliberately abstracts the verified backend surface (the pending-actions list/count and the
+  existing fill-and-submit flow) into capability language; concrete endpoints, components, and tiers
+  live in the source design doc and will be re-introduced in `plan.md`.
+- Scope constraints (SCOPE-001…004) bound this to sub-project A; B/C/D are explicitly excluded.
+- All items pass on first validation; no [NEEDS CLARIFICATION] markers. Ready for `/speckit.plan`.

--- a/specs/151-citizen-workflow-inbox/contracts/consumed-endpoints.md
+++ b/specs/151-citizen-workflow-inbox/contracts/consumed-endpoints.md
@@ -1,0 +1,69 @@
+# Consumed Endpoint Contracts (read-only): PWA Citizen Workflow Inbox
+
+**Feature**: 151-citizen-workflow-inbox | **Date**: 2026-06-13
+
+A defines **no new endpoints**. It consumes the following **existing** endpoints unchanged. This
+file documents the contract A relies on so any drift is caught. (No OpenAPI is added; these already
+appear in the services' OpenAPI.)
+
+## 1. List pending actions
+
+```
+GET /api/actions/pending?page={int}&pageSize={int}
+Service: Blueprint Service  (ActionEndpoints.cs:27)
+Auth:    Bearer (consumer-tier token works); plain RequireAuthorization() — DO NOT tighten
+Tier:    cross-tier ("any-human"); citizen wallet resolved via platform_user_id
+```
+
+**Response (200)** — paginated list of `PendingActionSummary`. Fields A consumes:
+`InstanceId`, `ActionId`, `ActionTitle`, `BlueprintTitle`, `InstanceReference`, `Summary`,
+`Urgency` (`"normal" | "warning" | "urgent"`), `Deadline` (nullable), `ReceivedAt`,
+`NavigationPath` (nullable). Other fields are ignored by the inbox.
+
+**Semantics A depends on**: returns only actions where the citizen is the **designated sender/actor**
+(their turn) and excludes actions bound to a different participant
+(`EfCoreInstanceStore.IsActionForWallet`). This is the correctness guarantee behind SC-002.
+
+**Contract test A owns**: `MyActionsClientTests` deserialises a representative JSON body (stub
+`HttpMessageHandler`) into `PendingActionItem[]` with correct field + `Urgency` mapping and
+unknown-urgency → `Normal`.
+
+## 2. Pending count
+
+```
+GET /api/actions/pending/count
+Service: Blueprint Service  (ActionEndpoints.cs:116)
+Auth:    Bearer (consumer-tier works); plain RequireAuthorization()
+```
+
+**Response (200)**: `{ "count": int, "urgentCount": int }`. A renders `count` (FR-006);
+`urgentCount` is always 0 today and is not relied upon.
+
+## 3. Open / fill / submit (reused unchanged via IApplicationActionClient)
+
+```
+GET  /api/instances/{id}                          (load instance)
+GET  /api/blueprints/{id}                          (load blueprint/action schema)
+POST /api/instances/{id}/actions/{actionId}/execute (submit)
+```
+
+A does **not** call these directly — it navigates to `Pages/ApplicationInstance.razor`, which uses
+`IApplicationActionClient` as today. Listed here only to record the downstream contract the inbox
+hands off to. No change.
+
+## 4. In-review notice (reused unchanged)
+
+```
+GET /api/v1/wallet/pending-applications
+Service: Wallet Service  (PendingApplicationEndpoints.cs:24)
+Auth:    RequireConsumerAudience  (consumer-tier)
+```
+
+**Response (200)**: the existing pending-application notice (a human-readable label). A renders it
+as the "In review" banner via the existing `IPendingApplicationClient` (FR-009). No change.
+
+---
+
+**Drift guard**: if any of the field names/semantics above change server-side, A's
+`MyActionsClientTests` (contract test) and the inbox ordering test should fail — flag and re-align
+rather than silently mapping around it.

--- a/specs/151-citizen-workflow-inbox/data-model.md
+++ b/specs/151-citizen-workflow-inbox/data-model.md
@@ -1,0 +1,66 @@
+# Phase 1 Data Model: PWA Citizen Workflow Inbox
+
+**Feature**: 151-citizen-workflow-inbox | **Date**: 2026-06-13
+
+A introduces **no persistent storage** and **no new server-side model**. The only new types are
+client-side DTOs/view-models in the PWA that map the existing server responses. Source server
+shape: `Sorcha.Blueprint.Service/Models/PendingActionSummary.cs`.
+
+## Client DTO — `PendingActionItem`
+
+Maps the subset of the server `PendingActionSummary` the inbox needs. Lives in
+`Sorcha.Wallet.Pwa/Services/Actions/Models/`.
+
+| Field | Type | Source field | Notes |
+|-------|------|--------------|-------|
+| `InstanceId` | `string` (Guid) | `InstanceId` | Used to navigate to `applications/{InstanceId}` |
+| `ActionId` | `int` | `ActionId` | The action within the instance |
+| `Title` | `string` | `ActionTitle` (fallback `BlueprintTitle`) | Display title (FR-002) |
+| `WorkflowTitle` | `string` | `BlueprintTitle` | Which application/workflow it belongs to |
+| `Reference` | `string?` | `InstanceReference` | Human-readable instance reference, if present |
+| `Summary` | `string?` | `Summary` | Optional one-line context |
+| `Urgency` | `enum { Normal, Warning, Urgent }` | `Urgency` (string) | Drives ordering + chip (FR-002) |
+| `Deadline` | `DateTimeOffset?` | `Deadline` | Optional due date (FR-002) |
+| `ReceivedAt` | `DateTimeOffset` | `ReceivedAt` | Tiebreak / secondary sort |
+| `NavigationPath` | `string?` | `NavigationPath` | If server supplies an explicit path, prefer it (still made base-relative) |
+
+**Validation / mapping rules**:
+- `Urgency` parses case-insensitively; unknown → `Normal` (never throw on an unexpected value).
+- `Title` falls back to `BlueprintTitle`, then to `"Action {ActionId}"` so a row is never blank.
+- Fields not needed by the inbox (`SenderAddress`, `TransactionId`, `PrepopulatedPayload`,
+  `DataSchema`, etc.) are ignored by the inbox client — the open-action flow
+  (`IApplicationActionClient`) fetches what the form needs itself.
+
+## Client DTO — `PendingActionsCount`
+
+| Field | Type | Source | Notes |
+|-------|------|--------|-------|
+| `Count` | `int` | `/api/actions/pending/count` → `count` | Total outstanding (FR-006) |
+| `UrgentCount` | `int` | `…count` → `urgentCount` | Always 0 today; carried but not relied upon |
+
+## Client view-model — inbox page state
+
+Held by `Actions.razor` (transient, not persisted):
+
+- `IReadOnlyList<PendingActionItem> Items` — current list, **ordered**: Urgent → Warning → Normal,
+  then `Deadline` ascending (nulls last), then `ReceivedAt` ascending.
+- `bool IsLoading` / `bool HasLoadedOnce` — drives spinner vs. content vs. empty.
+- `string? LastError` — non-blocking refresh-failure notice (FR-010); list retained.
+- `PendingApplicationNotice? InReviewNotice` — existing Feature-124 notice for the banner (FR-009),
+  via `IPendingApplicationClient` (reused, not redefined here).
+
+## Ordering rule (single source of truth)
+
+`Compare(a, b)`:
+1. `Urgency` rank desc (Urgent=2, Warning=1, Normal=0)
+2. `Deadline` asc, `null` last
+3. `ReceivedAt` asc
+
+This rule is implemented once (a comparer) and covered by a unit test (SC: "most pressing first").
+
+## State transitions
+
+There are no server state transitions owned by A. The inbox reflects server truth:
+- An action **appears** when the instance is Active and the action's sender binds to the citizen.
+- An action **disappears** after the citizen submits it (next list refresh) or once it is no longer
+  the citizen's turn — observed via refresh / SignalR, not modelled locally (FR-005, SC-006).

--- a/specs/151-citizen-workflow-inbox/plan.md
+++ b/specs/151-citizen-workflow-inbox/plan.md
@@ -1,0 +1,127 @@
+# Implementation Plan: PWA Citizen Workflow Inbox
+
+**Branch**: `151-citizen-workflow-inbox` | **Date**: 2026-06-13 | **Spec**: [spec.md](./spec.md)
+
+**Input**: Feature specification from `/specs/151-citizen-workflow-inbox/spec.md`
+
+**Source design**: `docs/superpowers/specs/2026-06-13-pwa-citizen-workflow-inbox-design.md`
+
+## Summary
+
+Add a consumer-tier "Things to do" inbox to the Citizen Wallet PWA. The inbox lists the workflow
+actions currently awaiting the signed-in citizen (their turn) by consuming the **existing**
+`GET /api/actions/pending` and `GET /api/actions/pending/count` endpoints — which already resolve a
+citizen's wallet(s) from a consumer-tier token via `platform_user_id`. Tapping an action routes
+into the **existing** `ApplicationInstance` fill-and-submit flow (unchanged). The existing
+Feature-124 pending-application notice is surfaced as a lightweight "In review" banner, and a nav
+count badge reflects outstanding work, refreshing live on the existing citizen SignalR signal.
+
+**Technical approach**: one new typed client (`IMyActionsClient`) over the two existing endpoints,
+one new inbox page in `Sorcha.Wallet.Pwa`, and a nav count badge — reusing the shared
+`SorchaFormRenderer` and `ApplicationInstance` flow with **no backend change** and strictly
+**consumer-tier**.
+
+## Technical Context
+
+**Language/Version**: C# 14 / .NET 10 (Blazor WebAssembly PWA)
+
+**Primary Dependencies**: `Sorcha.Wallet.Pwa` (host); shared `Sorcha.UI.Components.User`
+(`SorchaFormRenderer`, form controls, feedback primitives); MudBlazor (Material components);
+existing PWA HTTP client + consumer-tier auth message handler; existing
+`CitizenWalletHubConnection` (SignalR) for live refresh.
+
+**Storage**: N/A — no persistence in A. (Local drafts / encrypted IndexedDB are sub-project C.)
+
+**Testing**: bUnit component tests (`JSRuntimeMode.Loose`) + stub `HttpMessageHandler` client tests,
+per the `sorcha-ui` / `playwright` / `xunit` skills. No new backend tests (no backend change).
+
+**Target Platform**: Blazor WASM PWA mounted at `/wallet/` behind the API Gateway (consumer tier).
+
+**Project Type**: Mobile-style web (PWA) front-end feature against existing backend services.
+
+**Performance Goals**: Inbox renders the citizen's outstanding actions promptly on open; live count
+reflects a newly-arrived action within ~10s while the app is open (SC-004); single-form action
+completable in under 2 minutes excluding user data entry (SC-003).
+
+**Constraints**: No backend changes (SCOPE-001); strictly consumer-tier (FR-012); reuse the shared
+renderer and existing submit path; base-relative navigation only (PWA path-prefix rule); no
+`ISnackbar` (Critical Pattern #12 — use `IInlineFeedback`).
+
+**Scale/Scope**: One client + one page + one nav badge in `Sorcha.Wallet.Pwa`. ~3 production units,
+~2 test classes. No new endpoints, no new persistence.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Applies? | Status |
+|-----------|----------|--------|
+| I. Microservices-First | No service boundaries touched | ✅ PASS — front-end only, consumes existing APIs; no upward/new coupling |
+| II. Security First | Consumer-tier surface | ✅ PASS — no secrets; consumer-tier token via existing handler; reuses existing authz on existing endpoints; no new external boundary (no new input validation surface) |
+| III. API Documentation | No new APIs | ✅ N/A — no new endpoints; existing OpenAPI unaffected |
+| IV. Testing (>85% new code) | Yes | ✅ PLANNED — bUnit + client tests for all new units; TDD per task ordering |
+| V. Code Quality | Yes | ✅ PLANNED — nullable enabled, async I/O, DI, no warnings; follows existing PWA patterns |
+| VI. Blueprint Standards | No blueprints | ✅ N/A |
+| VII. Domain-Driven Design | Yes | ✅ PASS — uses ubiquitous terms (Action, Participant, Instance); "inbox/Things to do" is UI labelling over Actions |
+| VIII. Observability | Front-end | ✅ PASS — structured logging via existing PWA logger; no string-interpolated logs; no new service health surface |
+
+**Result**: PASS. No violations; Complexity Tracking not required.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/151-citizen-workflow-inbox/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output (client view models + consumed shapes)
+├── quickstart.md        # Phase 1 output (build/run/test)
+├── contracts/           # Phase 1 output (consumed endpoint contracts — read-only)
+│   └── consumed-endpoints.md
+├── checklists/
+│   └── requirements.md  # Spec quality checklist (from /speckit.specify)
+└── tasks.md             # Phase 2 output (/speckit.tasks — NOT created here)
+```
+
+### Source Code (repository root)
+
+```text
+src/Apps/Sorcha.Wallet.Pwa/
+├── Services/
+│   └── Actions/                         # NEW
+│       ├── IMyActionsClient.cs          # NEW — typed client over the two existing endpoints
+│       ├── HttpMyActionsClient.cs       # NEW — implementation
+│       └── Models/                      # NEW — client DTOs (PendingActionItem, PendingActionsCount)
+├── Pages/
+│   └── Actions.razor                    # NEW — the "Things to do" inbox page (route: actions)
+├── Components/
+│   └── Layout/ (or Shared nav)          # MODIFY — add "Things to do" nav entry + count badge
+├── Pages/ApplicationInstance.razor      # UNCHANGED — reused as the open-action target
+└── Program.cs                           # MODIFY — register IMyActionsClient in DI
+
+src/Apps/Sorcha.UI/Sorcha.UI.Components.User/
+└── Components/Forms/ (SorchaFormRenderer, controls)   # UNCHANGED — reused
+
+tests/
+└── (PWA component-test project, per existing convention)
+    ├── Actions/MyActionsClientTests.cs              # NEW — JSON mapping via stub handler
+    └── Pages/ActionsInboxTests.cs                   # NEW — bUnit: list/empty/order/badge/nav
+```
+
+**Structure Decision**: Front-end feature contained within `Sorcha.Wallet.Pwa`, reusing the shared
+`Sorcha.UI.Components.User` library and the existing `ApplicationInstance` submit flow. The exact
+nav-host file and the `Actions.razor`-vs-repurpose-`Applications.razor` decision are resolved in
+research.md / tasks (see Open Decisions). No backend project is touched.
+
+## Open Decisions (resolved in research.md)
+
+- **Page identity**: new `Actions.razor` vs. repurposing the empty-stub `Applications.razor`.
+  Decision in research.md (must not collide with sub-project B's catalogue plans for
+  `Applications.razor`).
+- **Test project location**: which existing PWA test project hosts the new tests.
+- **Nav host**: which layout/nav component carries the "Things to do" entry + badge.
+
+## Complexity Tracking
+
+> No Constitution Check violations. Section intentionally empty.

--- a/specs/151-citizen-workflow-inbox/quickstart.md
+++ b/specs/151-citizen-workflow-inbox/quickstart.md
@@ -1,0 +1,61 @@
+# Quickstart: PWA Citizen Workflow Inbox
+
+**Feature**: 151-citizen-workflow-inbox | **Date**: 2026-06-13
+
+## What this feature adds
+
+A "Things to do" inbox in the Citizen Wallet PWA: a consumer-tier list of the workflow actions
+currently waiting on the citizen, a live nav count badge, and an "In review" banner — tapping an
+action opens the existing fill-and-submit form.
+
+## Where the code lives
+
+```
+src/Apps/Sorcha.Wallet.Pwa/
+├── Services/Actions/IMyActionsClient.cs        (new)
+├── Services/Actions/HttpMyActionsClient.cs     (new)
+├── Services/Actions/Models/PendingActionItem.cs, PendingActionsCount.cs (new)
+├── Pages/Actions.razor                          (new — route: actions)
+├── MainLayout.razor                             (modify — FloatingTabBar 5th tab + badge)
+└── Program.cs                                   (modify — register IMyActionsClient)
+
+shared (unchanged, reused):
+src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Wallet/FloatingTabBar.razor  (add tab)
+src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Forms/SorchaFormRenderer.razor
+src/Apps/Sorcha.Wallet.Pwa/Pages/ApplicationInstance.razor
+```
+
+## Build & test
+
+```bash
+# Build the PWA + shared component lib
+dotnet build src/Apps/Sorcha.Wallet.Pwa/Sorcha.Wallet.Pwa.csproj
+
+# Run the PWA test project (component + client tests)
+dotnet test tests/Sorcha.Wallet.Pwa.Tests/Sorcha.Wallet.Pwa.Tests.csproj
+```
+
+## Manual verification (against Docker / n1)
+
+1. `docker-compose up -d`; sign into the PWA (`/wallet`) as a citizen who has at least one
+   outstanding action (their turn) — e.g. a citizen mid-application in a seeded blueprint.
+2. Confirm the **FloatingTabBar** shows a "To do" destination with a **count badge** matching the
+   number of outstanding actions.
+3. Open the inbox; confirm each outstanding action lists with a title (and due date / urgency chip
+   where present), ordered most-pressing first.
+4. Tap an action → confirm it opens the existing `ApplicationInstance` form; fill + submit.
+5. Return to the inbox → confirm the completed action is gone and the badge decremented.
+6. With another participant's action in a shared instance, confirm it does **not** appear.
+7. Kill connectivity, reopen the inbox → confirm last-known list is retained with a non-blocking
+   "couldn't refresh" notice (no blank/error screen).
+8. While the inbox is open, cause a new action to arrive → confirm the list/badge update without a
+   manual refresh.
+
+## Guardrails (from research)
+
+- **Base-relative navigation only** (`NavigateTo("applications/{id}")`, `NavigateTo("actions")`) —
+  never origin-absolute, under the `/wallet/` prefix.
+- **No `ISnackbar`** — use `IInlineFeedback` for refresh-failure / stale-action messages.
+- **No backend changes** — consume existing endpoints only; do not add a consumer guard to
+  `/api/actions/pending` (the web shares it).
+- **Consumer-tier only** — the feature must not require any org role.

--- a/specs/151-citizen-workflow-inbox/research.md
+++ b/specs/151-citizen-workflow-inbox/research.md
@@ -1,0 +1,94 @@
+# Phase 0 Research: PWA Citizen Workflow Inbox
+
+**Feature**: 151-citizen-workflow-inbox | **Date**: 2026-06-13
+
+The source design (`docs/superpowers/specs/2026-06-13-pwa-citizen-workflow-inbox-design.md`) and a
+read-only codebase investigation resolved the substantive unknowns before planning. This file
+records the decisions; there are **no open NEEDS CLARIFICATION** items.
+
+## Decision 1 — Backend surface to consume
+
+**Decision**: Consume the existing `GET /api/actions/pending?page&pageSize` and
+`GET /api/actions/pending/count` (Blueprint Service). No new or modified backend.
+
+**Rationale**: Both endpoints already resolve a citizen's wallet(s) from a consumer-tier token via
+`platform_user_id` (`ActionEndpoints.cs:166`, aligned with F136/#878) and return only actions the
+citizen is the designated actor of (`EfCoreInstanceStore.cs:265` + `:658` `IsActionForWallet`) —
+i.e. "my turn". This is exactly the inbox semantic (FR-001, FR-003, SC-002).
+
+**Alternatives considered**:
+- *Add a consumer-tier guard to `/api/actions/pending`* — **rejected**: the web `MyActions` page
+  calls the same endpoint on the platform tier; it is a legitimately cross-tier "any-human"
+  endpoint and per F136 correctly stays plain `RequireAuthorization()`. Tightening it would break
+  the web app.
+- *New consumer-only `my-instances` endpoint for a full tracker* — deferred to B/C (SCOPE; the full
+  "all my workflows + state" tracker is not in A).
+
+## Decision 2 — Open-action flow
+
+**Decision**: Reuse `Pages/ApplicationInstance.razor` + `IApplicationActionClient` unchanged. The
+inbox navigates to `applications/{instanceId}` (base-relative).
+
+**Rationale**: The fill/submit loop (load instance + blueprint → `SorchaFormRenderer` →
+`POST /…/execute`) already works (F125/F137). A only adds discovery around it (FR-004, FR-005).
+Base-relative navigation is mandatory under the `/wallet/` path prefix (guards the PR #698
+broken-nav regression class).
+
+## Decision 3 — "In review" indication
+
+**Decision**: Render the existing Feature-124 pending-application notice
+(`IPendingApplicationClient` → `GET /api/v1/wallet/pending-applications`, consumer-tier) as a
+lightweight banner below the "needs you" list.
+
+**Rationale**: Reuses an existing, consumer-tier signal (FR-009). A complete instance-state tracker
+is deferred (B/C). The notice is already posted on successful submit by `IApplicationActionClient`.
+
+## Decision 4 — Navigation placement (was: nav host open decision)
+
+**Decision**: Surface the inbox as a **new primary destination** reachable from the shared
+`FloatingTabBar` (`Sorcha.UI.Components.User/Components/Wallet/FloatingTabBar.razor`) with a **count
+badge**, route `actions`, plus a complementary entry point on Home.
+
+**Rationale**: The PWA's primary navigation is the `FloatingTabBar` (currently Home / Cards /
+Activity / Settings). A "Things to do" destination there is the discoverable home for the inbox and
+the natural carrier for the live count badge (FR-006, FR-007).
+
+**Risk / constraint (verified)**: `FloatingTabBar` lives in the shared `Sorcha.UI.Components.User`
+library but is consumed by **exactly one** host — the PWA `MainLayout.razor` (verified:
+`grep FloatingTabBar src --include=*.razor` returns only the PWA). A 5th tab is therefore safe with
+no web-host impact, and no parameterisation is required. A five-item bottom bar is at the upper
+bound of mobile IA guidance, so the exact visual treatment (5th tab vs. badge-on-Home + tab) is a
+candidate for `/speckit.ui-phase` / the `frontend-design` skill, but it does not block planning.
+
+## Decision 5 — Page identity
+
+**Decision**: New `Pages/Actions.razor` (route `actions`). Do **not** repurpose `Applications.razor`.
+
+**Rationale**: `Applications.razor` (route `/applications`) is the empty stub reserved for
+sub-project B's catalogue ("start something new"). Keeping the inbox separate avoids a collision
+with B and keeps the two discovery surfaces (do-existing vs. start-new) cleanly bounded.
+
+## Decision 6 — Live refresh
+
+**Decision**: Subscribe to the existing `CitizenWalletHubConnection` signal (the same channel that
+drives silent credential sync) to re-fetch list + count; a short poll runs only while the page is
+open as a fallback.
+
+**Rationale**: Reuses the existing real-time plumbing (FR-007, SC-004). Background/closed-app push
+is explicitly out of scope (companion roadmap P2 / sub-project C).
+
+## Decision 7 — Test placement
+
+**Decision**: New tests live in `tests/Sorcha.Wallet.Pwa.Tests` (the existing PWA test project):
+`Actions/MyActionsClientTests.cs` (JSON mapping via stub `HttpMessageHandler`) and
+`Pages/ActionsInboxTests.cs` (bUnit, `JSRuntimeMode.Loose`).
+
+**Rationale**: Matches existing PWA test conventions (`sorcha-ui` skill). No backend test project is
+touched (no backend change).
+
+## Decision 8 — Feedback surface
+
+**Decision**: Use `IInlineFeedback` for refresh-failure / stale-action messages; never `ISnackbar`.
+
+**Rationale**: Critical Pattern #12 — the PWA has retired the snackbar surface; a CI gate enforces
+it. Inline feedback renders via the existing `InlineFeedbackHost`.

--- a/specs/151-citizen-workflow-inbox/spec.md
+++ b/specs/151-citizen-workflow-inbox/spec.md
@@ -1,0 +1,197 @@
+# Feature Specification: PWA Citizen Workflow Inbox
+
+**Feature Branch**: `151-citizen-workflow-inbox`
+
+**Created**: 2026-06-13
+
+**Status**: Draft
+
+**Input**: User description: "PWA citizen workflow inbox (sub-project A): consumer-tier Things-to-do inbox in the Citizen Wallet PWA listing the actions currently waiting on the citizen, an In-review banner from the existing pending-application notice, and a live nav count badge. Tapping an action routes into the existing fill-and-submit flow. No backend changes; consumer-tier only; reuse the shared form renderer."
+
+**Source design**: `docs/superpowers/specs/2026-06-13-pwa-citizen-workflow-inbox-design.md` (sub-project A of the PWA workflow-participation programme A/B/C/D).
+
+## User Scenarios & Testing *(mandatory)*
+
+A citizen uses the wallet on their phone today to hold and present credentials. When a workflow
+needs something from them — for example, completing or progressing an application they are part of
+— there is currently no way for them to discover that on the phone; they must already hold a direct
+link. This feature gives the citizen a place to see and act on the things waiting for them.
+
+### User Story 1 - Discover and complete an action waiting on me (Priority: P1)
+
+A citizen opens the wallet, sees a "Things to do" area listing the actions that are currently
+waiting on **them** (it is their turn), taps one, fills in the form (including any data or details
+requested), submits it, and returns to find the item cleared from the list.
+
+**Why this priority**: This is the whole point of the feature and the minimum viable slice. Without
+discovery, the citizen cannot participate in a workflow on the phone at all. With just this story,
+a citizen can find their outstanding work and complete it end-to-end — a complete, demonstrable
+value loop on its own.
+
+**Independent Test**: With a citizen who has at least one outstanding action, open the inbox, see
+the action listed with a meaningful title, open it, complete and submit the form, and confirm the
+action no longer appears. Fully testable without the count badge or the in-review banner.
+
+**Acceptance Scenarios**:
+
+1. **Given** a signed-in citizen with one or more actions currently awaiting their input, **When**
+   they open the "Things to do" inbox, **Then** they see each such action listed with a meaningful
+   title and, where present, a due date and an urgency indicator.
+2. **Given** the inbox is showing an action, **When** the citizen taps it, **Then** they are taken
+   into the existing form for that action and can fill and submit it.
+3. **Given** the citizen has just submitted an action, **When** they return to the inbox, **Then**
+   that action is no longer listed and the list reflects their current outstanding work.
+4. **Given** a citizen has no actions awaiting their input, **When** they open the inbox, **Then**
+   they see a clear, friendly "nothing needs you right now" state rather than an empty or broken
+   screen.
+5. **Given** a workflow action belongs to a different participant in an instance the citizen is also
+   part of, **When** the citizen opens the inbox, **Then** that other participant's action is **not**
+   shown as if it were the citizen's.
+
+---
+
+### User Story 2 - Know at a glance how many things need me (Priority: P2)
+
+A citizen can see, from the wallet's navigation, a count of how many actions are currently waiting
+on them, and that count updates on its own while the app is open when a new action arrives or after
+they complete one.
+
+**Why this priority**: Strongly improves the "do I need to act?" awareness that makes the inbox
+useful day-to-day, but the inbox is fully usable without it. Builds directly on Story 1.
+
+**Independent Test**: With a citizen who has a known number of outstanding actions, confirm the
+navigation shows that number; trigger a new action while the app is open and confirm the number
+increases without a manual refresh; complete an action and confirm it decreases.
+
+**Acceptance Scenarios**:
+
+1. **Given** a citizen with N actions awaiting their input, **When** they look at the wallet
+   navigation, **Then** they see the count N (and no badge when N is zero).
+2. **Given** the app is open, **When** a new action becomes the citizen's to do, **Then** the count
+   updates on its own within a few seconds without the citizen refreshing.
+3. **Given** the citizen completes an action, **When** the submission succeeds, **Then** the count
+   decreases to reflect the remaining work.
+
+---
+
+### User Story 3 - See what I've submitted and is in review (Priority: P3)
+
+A citizen who has submitted an application can see a lightweight indication that it has been
+received and is in review / awaiting another party, so they understand that there is nothing more
+for them to do right now.
+
+**Why this priority**: Reduces "did it go through / what now?" anxiety, but is informational only
+and reuses an existing signal. Lowest priority of the three.
+
+**Independent Test**: With a citizen who has submitted an application that is awaiting another
+party, open the inbox and confirm an "in review" indication is shown distinctly from the actions
+that still need them.
+
+**Acceptance Scenarios**:
+
+1. **Given** a citizen has submitted an application that is now awaiting another party, **When**
+   they open the inbox, **Then** they see an "in review" indication that is visually distinct from
+   the "needs you" actions.
+2. **Given** there is nothing in review, **When** the citizen opens the inbox, **Then** no "in
+   review" indication is shown.
+
+---
+
+### Edge Cases
+
+- **Refresh failure / no connectivity**: When the list cannot be refreshed (transient network
+  failure), the citizen sees a non-blocking notice and the last-known list is retained — never a
+  blank or broken screen. (Persistent offline working is a later sub-project.)
+- **Stale action**: If an action was already completed elsewhere (e.g. on another device) and the
+  citizen opens it, the system explains there is nothing to do for that item rather than presenting
+  a broken or empty form.
+- **Action arrives while viewing**: A new action becoming the citizen's to do while the inbox is
+  open is reflected without requiring the citizen to manually reload.
+- **Large number of outstanding actions**: The list remains usable when the citizen has many
+  outstanding actions (ordered so the most pressing surface first).
+- **Mistaken identity of work**: Only actions where the citizen is the designated actor appear;
+  actions assigned to other participants of a shared workflow never appear in the citizen's inbox.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The wallet MUST provide a "Things to do" inbox that lists the workflow actions
+  currently awaiting the signed-in citizen's input (i.e. actions where it is the citizen's turn to
+  act).
+- **FR-002**: Each listed action MUST display a meaningful title and, where available, a due date
+  and an urgency indicator; the list MUST be ordered so the most pressing actions surface first.
+- **FR-003**: The inbox MUST exclude actions that belong to other participants of a workflow the
+  citizen merely shares, showing only the citizen's own outstanding actions.
+- **FR-004**: Tapping a listed action MUST take the citizen into the existing action form, where
+  they can enter the requested data and submit, using the wallet's existing fill-and-submit
+  capability unchanged.
+- **FR-005**: After a successful submission, the citizen MUST be returned to the inbox and the inbox
+  MUST reflect their updated outstanding work (the completed action no longer listed).
+- **FR-006**: The wallet navigation MUST show a count of the citizen's outstanding actions, with no
+  badge shown when the count is zero.
+- **FR-007**: While the wallet is open, the count and list MUST update on their own (without a
+  manual refresh) when a new action becomes the citizen's to do or when the citizen completes one.
+- **FR-008**: The inbox MUST present a clear, friendly empty state when the citizen has no
+  outstanding actions.
+- **FR-009**: The inbox MUST show a distinct, lightweight "in review" indication when the citizen
+  has a submitted application awaiting another party, reusing the existing post-submission signal.
+- **FR-010**: On a transient failure to refresh the list, the wallet MUST retain the last-known list
+  and surface a non-blocking notice, never a blank or error screen.
+- **FR-011**: When the citizen opens an action that is no longer outstanding (already completed
+  elsewhere), the wallet MUST explain there is nothing to do rather than present a broken form.
+- **FR-012**: The feature MUST be available to a citizen acting in their personal (consumer)
+  capacity and MUST NOT require the citizen to hold any organisational role or permission.
+
+### Scope Constraints (carried from the design)
+
+- **SCOPE-001**: This feature MUST NOT require changes to back-end services; it builds entirely on
+  capabilities that already serve a citizen acting in their personal capacity.
+- **SCOPE-002**: Browsing and starting a brand-new application from a catalogue is out of scope
+  (sub-project B).
+- **SCOPE-003**: Saving an unfinished action to resume later, working offline, and capturing
+  photos/media are out of scope (sub-project C).
+- **SCOPE-004**: Performing actions in an organisational role is out of scope (sub-project D).
+
+### Key Entities
+
+- **Outstanding action ("thing to do")**: A workflow action currently awaiting the citizen's input.
+  Key attributes a citizen cares about: which application/workflow it belongs to, a human-readable
+  title, an optional due date, and an urgency indicator.
+- **Outstanding-action count**: The number of outstanding actions for the citizen, surfaced in
+  navigation.
+- **In-review indication**: A lightweight signal that the citizen has submitted something now
+  awaiting another party (informational; reuses the existing post-submission notice).
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A citizen with outstanding actions can, starting from opening the wallet, find and
+  open the right action **without needing a direct link or knowing any identifier** — i.e. discovery
+  is self-service.
+- **SC-002**: 100% of the actions shown in a citizen's inbox are ones where it is the citizen's turn
+  to act; **zero** actions belonging to other participants appear (correctness of "my turn").
+- **SC-003**: A citizen can go from opening the inbox to a submitted action in **under 2 minutes**
+  for a typical single-form action (excluding the time they spend entering their own data).
+- **SC-004**: When a new action becomes the citizen's to do while the wallet is open, the navigation
+  count reflects it **within 10 seconds** without a manual refresh.
+- **SC-005**: On a transient refresh failure, **no** citizen sees a blank or error screen; the
+  last-known list is retained in 100% of such cases.
+- **SC-006**: After a successful submission, the completed action disappears from the inbox on the
+  citizen's return **every time** (no stale entries).
+
+## Assumptions
+
+- The capability to list "actions currently awaiting me" and to count them already exists and serves
+  a citizen acting in their personal (consumer) capacity; this feature consumes it without change.
+- The capability to open, fill, and submit a single action already exists in the wallet and is
+  reused unchanged; this feature only adds discovery and navigation around it.
+- The "in review" indication reuses the existing post-submission notice (a single, lightweight
+  signal). A complete "all my workflows and their states" tracker is a later sub-project.
+- Live updates while the wallet is open ride on the wallet's existing real-time signal; background
+  notifications when the wallet is closed are out of scope here.
+- "Most pressing first" ordering uses the urgency indicator and due date already associated with an
+  action; a separately computed urgent count is not required for this feature.
+- A citizen is signed in to the wallet in their personal capacity; session handling and sign-in are
+  existing behaviour and out of scope.

--- a/specs/151-citizen-workflow-inbox/tasks.md
+++ b/specs/151-citizen-workflow-inbox/tasks.md
@@ -1,0 +1,183 @@
+# Tasks: PWA Citizen Workflow Inbox
+
+**Input**: Design documents from `/specs/151-citizen-workflow-inbox/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/consumed-endpoints.md, quickstart.md
+
+**Tests**: INCLUDED (TDD). Constitution §IV (>85% new-code coverage, TDD encouraged) and design §8
+request tests; test tasks are written before their implementation and must fail first.
+
+**Organization**: Tasks grouped by user story (US1 P1 = MVP, US2 P2, US3 P3). No backend changes.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependency on an incomplete task)
+- **[Story]**: US1 / US2 / US3 (user-story phases only)
+- All paths are repo-relative.
+
+## Conventions (from research.md — apply to every UI task)
+
+- **Base-relative navigation only** under the `/wallet/` prefix: `NavigateTo("actions")`,
+  `NavigateTo($"applications/{instanceId}")` — never origin-absolute.
+- **No `ISnackbar`** (Critical Pattern #12): use `IInlineFeedback` for refresh-failure / stale messages.
+- **No backend changes**; consume existing endpoints only. Do NOT add a consumer guard to
+  `/api/actions/pending` (the web shares it).
+- bUnit tests use `JSRuntimeMode.Loose`; client tests use a stub `HttpMessageHandler`.
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Client DTOs the rest of the feature maps onto.
+
+- [ ] T001 [P] Create `src/Apps/Sorcha.Wallet.Pwa/Services/Actions/Models/PendingActionItem.cs` with the `Urgency` enum (`Normal`/`Warning`/`Urgent`) and the fields per `data-model.md` (InstanceId, ActionId, Title, WorkflowTitle, Reference, Summary, Urgency, Deadline, ReceivedAt, NavigationPath).
+- [ ] T002 [P] Create `src/Apps/Sorcha.Wallet.Pwa/Services/Actions/Models/PendingActionsCount.cs` (`Count`, `UrgentCount`) per `data-model.md`.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: The shared typed client over the two existing endpoints. **Blocks US1 and US2.**
+
+**⚠️ CRITICAL**: No user-story work begins until this phase is complete.
+
+- [ ] T003 Create `src/Apps/Sorcha.Wallet.Pwa/Services/Actions/IMyActionsClient.cs` — interface with `Task<IReadOnlyList<PendingActionItem>> GetPendingAsync(int page, int pageSize, CancellationToken)` and `Task<PendingActionsCount> GetCountAsync(CancellationToken)`.
+- [ ] T004 [P] (TDD) Write **failing** `tests/Sorcha.Wallet.Pwa.Tests/Actions/MyActionsClientTests.cs` using a stub `HttpMessageHandler`: maps a representative `/api/actions/pending` JSON body to `PendingActionItem[]` (Urgency parse incl. unknown→`Normal`; `Title` fallback to `BlueprintTitle` then `"Action {id}"`); maps `/api/actions/pending/count` JSON to `PendingActionsCount`. Per `contracts/consumed-endpoints.md`.
+- [ ] T005 Implement `src/Apps/Sorcha.Wallet.Pwa/Services/Actions/HttpMyActionsClient.cs` — `GET /api/actions/pending?page&pageSize` and `GET /api/actions/pending/count`, mapping to the DTOs; tolerant of unknown urgency / missing fields. Make T004 pass.
+- [ ] T006 Register `IMyActionsClient` → `HttpMyActionsClient` in `src/Apps/Sorcha.Wallet.Pwa/Program.cs` DI, on the existing PWA `HttpClient` with the consumer-tier bearer handler (`BearerTokenHandler`).
+
+**Checkpoint**: A consumer-tier citizen's pending actions + count are fetchable in code (covered by T004).
+
+---
+
+## Phase 3: User Story 1 — Discover and complete an action waiting on me (Priority: P1) 🎯 MVP
+
+**Goal**: A citizen opens a "Things to do" inbox, sees the actions awaiting them (their turn), taps
+one, fills + submits it via the existing flow, and returns to find it cleared.
+
+**Independent Test**: With a citizen who has ≥1 outstanding action, open the inbox, see it listed,
+open + submit it, confirm it is gone. Testable without the count badge (US2) or in-review banner (US3).
+
+### Tests for User Story 1 ⚠️ (write first, ensure they FAIL)
+
+- [ ] T007 [P] [US1] Write **failing** `tests/Sorcha.Wallet.Pwa.Tests/Actions/PendingActionOrderingTests.cs`: comparer orders Urgent→Warning→Normal, then `Deadline` ascending (nulls last), then `ReceivedAt` ascending.
+- [ ] T008 [P] [US1] Write **failing** `tests/Sorcha.Wallet.Pwa.Tests/Pages/ActionsInboxTests.cs` (bUnit, stub `IMyActionsClient`): renders a row per item with title (+ deadline/urgency chip where present); shows empty-state when none; **row tap calls `NavigateTo` with base-relative `applications/{InstanceId}`**; on a client throw, retains last-known rows and shows a non-blocking inline notice (no blank/error).
+
+### Implementation for User Story 1
+
+- [ ] T009 [US1] Create `src/Apps/Sorcha.Wallet.Pwa/Services/Actions/PendingActionOrdering.cs` (the comparer from `data-model.md`). Make T007 pass.
+- [ ] T010 [US1] Create `src/Apps/Sorcha.Wallet.Pwa/Pages/Actions.razor` (`@page "actions"`): inject `IMyActionsClient` + `NavigationManager`; load + order via the comparer; render rows (title, optional deadline, urgency chip) using shared `Sorcha.UI.Components.User` primitives; friendly empty-state (FR-008); refresh-failure → retain last-known list + `IInlineFeedback` (FR-010); row tap → `NavigateTo($"applications/{InstanceId}")`. Make T008 pass.
+- [ ] T011 [US1] Add the "To do" destination to `src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Wallet/FloatingTabBar.razor` (route `actions`, icon, `data-testid="footer-nav-todo"`; **no badge yet** — badge is US2) and wire its active-route in `src/Apps/Sorcha.Wallet.Pwa/MainLayout.razor` (`_activeRoute`). Adjust `FloatingTabBar.razor.css` for a 5-item layout. (Verified PWA-only consumer — see research Decision 4.)
+- [ ] T012 [US1] Confirm the stale-action path: opening an action that is no longer outstanding lands on the existing `ApplicationInstance` "no current action" handling; surface it via `IInlineFeedback` rather than a broken form (FR-011). Add/extend a bUnit assertion in `ActionsInboxTests` or an `ApplicationInstance` test as appropriate.
+
+**Checkpoint**: US1 fully functional and independently testable — the MVP. A citizen can find,
+open, complete, and clear an action; reachable via the new tab.
+
+---
+
+## Phase 4: User Story 2 — Know at a glance how many things need me (Priority: P2)
+
+**Goal**: A live count badge on the "To do" tab that updates on its own while the app is open.
+
+**Independent Test**: With N outstanding actions, the tab shows N; a new action arriving while open
+increments it without manual refresh; completing one decrements it.
+
+### Tests for User Story 2 ⚠️ (write first, ensure they FAIL)
+
+- [ ] T013 [P] [US2] Write **failing** `tests/Sorcha.Wallet.Pwa.Tests/Pages/ActionsBadgeTests.cs` (bUnit): the "To do" tab shows the count from a stubbed `IMyActionsClient.GetCountAsync`; shows **no** badge when count is 0; a simulated hub signal triggers a re-fetch that updates the badge.
+
+### Implementation for User Story 2
+
+- [ ] T014 [US2] Add a `Badge` (count) parameter to the "To do" tab in `FloatingTabBar.razor` (render only when > 0) + badge styling in `FloatingTabBar.razor.css`.
+- [ ] T015 [US2] In `MainLayout.razor`, fetch the count via `IMyActionsClient.GetCountAsync` and pass it to `FloatingTabBar`; subscribe to the existing `CitizenWalletHubConnection` signal to re-fetch count (and refresh the inbox list if mounted) within ~10s (SC-004); refresh after a successful submit so the badge decrements (FR-007). Make T013 pass.
+- [ ] T016 [US2] Ensure the inbox page (`Actions.razor`) also re-loads its list on the same hub signal while mounted (live list refresh, FR-007), reusing the MainLayout subscription or a scoped page subscription.
+
+**Checkpoint**: US1 + US2 both work independently; the badge reflects live outstanding work.
+
+---
+
+## Phase 5: User Story 3 — See what I've submitted and is in review (Priority: P3)
+
+**Goal**: A distinct, lightweight "In review" indication for submitted-and-awaiting-others.
+
+**Independent Test**: With a submitted application awaiting another party, the inbox shows an
+"in review" indication distinct from the "needs you" rows; hidden when there is nothing in review.
+
+### Tests for User Story 3 ⚠️ (write first, ensure they FAIL)
+
+- [ ] T017 [P] [US3] Write **failing** bUnit test in `tests/Sorcha.Wallet.Pwa.Tests/Pages/ActionsInReviewBannerTests.cs`: the banner renders (visually distinct from the action rows) when the stubbed `IPendingApplicationClient` returns a notice; hidden when it returns none.
+
+### Implementation for User Story 3
+
+- [ ] T018 [US3] In `Actions.razor`, inject the existing `IPendingApplicationClient`, fetch the Feature-124 notice, and render it as a distinct "In review" banner below the "needs you" list (FR-009). Make T017 pass.
+
+**Checkpoint**: All three stories independently functional.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+- [ ] T019 [P] Run `scripts/check-no-snackbar.ps1` and confirm no new `ISnackbar`/`Snackbar.Add(` references were introduced by this feature.
+- [ ] T020 [P] Update `src/Apps/Sorcha.Wallet.Pwa` README / `Sorcha.UI.Components.User` README if the FloatingTabBar destination set is documented there; note the new "To do" inbox.
+- [ ] T021 [P] Confirm new-code coverage ≥85% for the added client + page logic (constitution §IV); add focused unit tests if any branch (urgency mapping, ordering edge cases, refresh-failure retention) is uncovered.
+- [ ] T022 Run `quickstart.md` manual verification against Docker/n1 (steps 1–8), including the "other participant's action does not appear" check (SC-002) and the offline-retain check (FR-010). Record results.
+- [ ] T023 Build `Sorcha.Wallet.Pwa` + run `tests/Sorcha.Wallet.Pwa.Tests` green with no new warnings (constitution §V).
+
+---
+
+## Dependencies & Execution Order
+
+### Phase dependencies
+
+- **Setup (Phase 1)**: no dependencies.
+- **Foundational (Phase 2)**: depends on Setup; **blocks US1 and US2** (both consume `IMyActionsClient`). US3 does not depend on it (uses the existing `IPendingApplicationClient`).
+- **US1 (Phase 3)**: depends on Foundational.
+- **US2 (Phase 4)**: depends on Foundational **and** on US1's `FloatingTabBar` "To do" tab existing (the badge attaches to that tab; T014 builds on T011).
+- **US3 (Phase 5)**: depends only on US1's `Actions.razor` existing (T018 adds the banner to it); independent of Foundational.
+- **Polish (Phase 6)**: after the desired stories are complete.
+
+### Within each story
+
+- Tests written first and FAIL before implementation (T004 before T005; T007/T008 before T009/T010; T013 before T014/T015; T017 before T018).
+- DTOs → client → page → nav.
+
+### Parallel opportunities
+
+- T001, T002 (Setup DTOs) in parallel.
+- T004 (client test) authored in parallel with T003 (interface).
+- T007 + T008 (US1 tests) in parallel.
+- Polish T019–T021 in parallel.
+
+---
+
+## Parallel Example: User Story 1
+
+```text
+# Author US1 tests together (they must fail first):
+Task: "PendingActionOrderingTests.cs — comparer ordering" (T007)
+Task: "ActionsInboxTests.cs — list/empty/nav/refresh-failure" (T008)
+```
+
+---
+
+## Implementation Strategy
+
+### MVP first (US1 only)
+
+1. Phase 1 Setup → 2. Phase 2 Foundational → 3. Phase 3 US1 → **STOP & VALIDATE** (citizen can
+   find, open, complete, clear an action) → demo. This alone closes the "no discovery on the phone"
+   gap and proves the discovery→fill→submit loop.
+
+### Incremental delivery
+
+- + US2 (live count badge) → demo.
+- + US3 (in-review banner) → demo.
+- Each story is additive and independently testable; none breaks a prior one.
+
+---
+
+## Notes
+
+- No backend project is touched; the only shared-library change is the PWA-only `FloatingTabBar`.
+- This is sub-project **A**. B (catalogue), C (offline/drafts/camera), D (dual-tier/org-role) are
+  separate spec→plan→tasks→implement cycles and explicitly out of scope here.
+- Commit after each task or logical group; stop at any checkpoint to validate a story independently.

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Wallet/FloatingTabBar.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Wallet/FloatingTabBar.razor
@@ -20,7 +20,13 @@
                 aria-current="@(active ? "page" : null)"
                 data-testid="@tab.TestId"
                 @onclick="@(() => HandleNavigateAsync(tab.Route))">
-            <MudIcon Icon="@tab.Icon" Size="Size.Medium" />
+            <span class="tab-pill__icon">
+                <MudIcon Icon="@tab.Icon" Size="Size.Medium" />
+                @if (tab.Route == "actions" && TodoCount > 0)
+                {
+                    <span class="tab-pill__badge" data-testid="footer-nav-todo-badge">@TodoCount</span>
+                }
+            </span>
             @if (active)
             {
                 <span class="tab-pill__label">@tab.Label</span>
@@ -38,6 +44,12 @@
 
     /// <summary>Fired with the base-relative route when a tab is tapped (host performs NavigateTo).</summary>
     [Parameter] public EventCallback<string> OnNavigate { get; set; }
+
+    /// <summary>
+    /// Feature 151 — count of outstanding workflow actions, shown as a badge on the "To do" tab.
+    /// No badge is rendered when this is 0. The host supplies and live-refreshes the value.
+    /// </summary>
+    [Parameter] public int TodoCount { get; set; }
 
     private string RootClass => "floating-tab-bar" + (Dark ? " floating-tab-bar--dark" : "");
 

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Wallet/FloatingTabBar.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Wallet/FloatingTabBar.razor
@@ -52,6 +52,8 @@
     private static readonly Tab[] Tabs =
     [
         new("", "Home", Icons.Material.Filled.Home, "footer-nav-home"),
+        // Feature 151 — "Things to do" workflow inbox destination (route "actions").
+        new("actions", "To do", Icons.Material.Filled.Checklist, "footer-nav-todo"),
         new("cards", "Cards", Icons.Material.Filled.CreditCard, "footer-nav-cards"),
         new("activity", "Activity", Icons.Material.Filled.History, "footer-nav-activity"),
         new("settings", "Settings", Icons.Material.Filled.Settings, "footer-nav-settings"),

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Wallet/FloatingTabBar.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Wallet/FloatingTabBar.razor
@@ -3,10 +3,11 @@
     Copyright (c) 2026 Sorcha Contributors
 
     Feature 141 — floating pill navigation bar for the wallet shell. Replaces
-    the flush bottom MudAppBar rail. Four fixed destinations; the active tab
-    shows a gradient pill + label, the rest are icon-only. The host owns
-    navigation (base-relative) via OnNavigate. Design:
-    docs/mockups/design_handoff_wallet_home/ (TabBar variant="bold").
+    the flush bottom MudAppBar rail. Fixed destinations (Home / To do / Cards /
+    Activity / Settings); the active tab shows a gradient pill + label, the rest
+    are icon-only. The "To do" tab (Feature 151) carries an outstanding-action
+    count badge via TodoCount. The host owns navigation (base-relative) via
+    OnNavigate. Design: docs/mockups/design_handoff_wallet_home/ (TabBar variant="bold").
 *@
 @namespace Sorcha.UI.Core.Components.Wallet
 

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Wallet/FloatingTabBar.razor.css
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Wallet/FloatingTabBar.razor.css
@@ -55,6 +55,28 @@
     white-space: nowrap;
 }
 
+/* Feature 151 — count badge on the "To do" tab. */
+.tab-pill__icon {
+    position: relative;
+    display: inline-flex;
+}
+
+.tab-pill__badge {
+    position: absolute;
+    top: -6px;
+    right: -8px;
+    min-width: 16px;
+    height: 16px;
+    padding: 0 4px;
+    border-radius: 8px;
+    background: var(--mud-palette-error, #e5484d);
+    color: #fff;
+    font-size: 10px;
+    font-weight: 700;
+    line-height: 16px;
+    text-align: center;
+}
+
 @media (prefers-reduced-motion: reduce) {
     .tab-pill {
         transition: none;

--- a/src/Apps/Sorcha.Wallet.Pwa/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Extensions/ServiceCollectionExtensions.cs
@@ -192,6 +192,15 @@ public static class ServiceCollectionExtensions
             .AddHttpMessageHandler<BearerTokenHandler>()
             .AddHttpMessageHandler<ServerClockHandler>();
 
+        // Feature 151 — citizen workflow inbox ("Things to do"). Reads the Blueprint Service's
+        // existing GET /api/actions/pending (list) and /api/actions/pending/count (badge), which
+        // resolve the citizen's wallet(s) from the consumer-tier JWT. Same auth chain; no backend change.
+        services.AddHttpClient<Sorcha.Wallet.Pwa.Services.Actions.IMyActionsClient,
+                               Sorcha.Wallet.Pwa.Services.Actions.HttpMyActionsClient>(c =>
+            c.BaseAddress = new Uri(gatewayBaseAddress))
+            .AddHttpMessageHandler<BearerTokenHandler>()
+            .AddHttpMessageHandler<ServerClockHandler>();
+
         // Feature 128 — shared has-any-device probe. Drives the wallet PWA
         // pairing-takeover trigger (sub-PR A3) and the Sorcha Web nag-banner
         // trigger (sub-PR B). Registered Singleton so the cached value +

--- a/src/Apps/Sorcha.Wallet.Pwa/MainLayout.razor
+++ b/src/Apps/Sorcha.Wallet.Pwa/MainLayout.razor
@@ -34,6 +34,8 @@
 @inject IThemeService ThemeService
 @inject WalletAuthenticationStateProvider AuthState
 @inject ISessionExpiryNotifier SessionExpiry
+@inject Sorcha.Wallet.Pwa.Services.Actions.IMyActionsClient MyActions
+@inject CitizenWalletHubConnection CitizenHub
 
 @* Feature 141 — dark mode now follows IThemeService (previously the provider
    was unbound, so the wallet never rendered dark). *@
@@ -143,7 +145,7 @@
    unauthenticated screens. Same AuthorizeView gate the PairingTakeover uses. *@
 <AuthorizeView>
     <Authorized>
-        <FloatingTabBar ActiveRoute="@_activeRoute" Dark="@_isDark" OnNavigate="HandleTabNavigate" />
+        <FloatingTabBar ActiveRoute="@_activeRoute" Dark="@_isDark" OnNavigate="HandleTabNavigate" TodoCount="@_todoCount" />
     </Authorized>
 </AuthorizeView>
 </CascadingValue>
@@ -175,6 +177,16 @@
     private bool _isDark;
     private bool _isHome = true;
     private string _activeRoute = "";
+
+    // Feature 151 — outstanding-action count for the "To do" tab badge.
+    private int _todoCount;
+
+    /// <summary>
+    /// Feature 151 — raised when the citizen's outstanding work may have changed (count refreshed
+    /// or a live signal fired). The mounted inbox page subscribes (via cascading) to re-load its
+    /// list. Avoids the inbox injecting the concrete hub directly (keeps it unit-testable).
+    /// </summary>
+    public event Action? OutstandingWorkChanged;
 
     // Build version for the bottom-right badge. Stamped at build time by the unified
     // versioning standard (root Directory.Build.props): 2.<run>.<attempt> on CI images,
@@ -214,6 +226,8 @@
         // suppression, and resolve dark mode from the user's theme preference.
         UpdateRoute();
         Nav.LocationChanged += HandleLocationChanged;
+        // Feature 151 — refresh the To-do badge when a credential/work signal arrives.
+        CitizenHub.OnCredentialAvailable += HandleWorkSignal;
         SessionExpiry.SessionExpired += HandleSessionExpired;
         ThemeService.OnThemeChanged += HandleThemeChanged;
         await ThemeService.InitializeAsync();
@@ -225,7 +239,37 @@
         UpdateActiveLabel();
         await EvaluateTourEligibilityAsync();
         await InitialiseInboxAsync();
+        await RefreshTodoCountAsync();
     }
+
+    /// <summary>
+    /// Feature 151 — re-fetch the outstanding-action count for the To-do badge. Swallows transient
+    /// failures (the badge keeps its last-known value rather than dropping to 0 on a blip).
+    /// </summary>
+    private async Task RefreshTodoCountAsync()
+    {
+        try
+        {
+            var count = await MyActions.GetCountAsync();
+            if (count.Count != _todoCount)
+            {
+                _todoCount = count.Count;
+                StateHasChanged();
+            }
+        }
+        catch
+        {
+            // Keep the last-known count; a later refresh corrects it.
+        }
+    }
+
+    // Feature 151 — a credential/work signal arrived: refresh the badge and let the mounted inbox
+    // re-load its list.
+    private void HandleWorkSignal(string _) => InvokeAsync(async () =>
+    {
+        await RefreshTodoCountAsync();
+        OutstandingWorkChanged?.Invoke();
+    });
 
     /// <summary>Feature 141 — base-relative route → Home flag + active tab.</summary>
     private void UpdateRoute()
@@ -242,6 +286,8 @@
     {
         UpdateRoute();
         StateHasChanged();
+        // Feature 151 — navigating (e.g. returning from a submitted action) refreshes the To-do badge.
+        _ = InvokeAsync(RefreshTodoCountAsync);
     }
 
     private void HandleThemeChanged()
@@ -410,6 +456,7 @@
     {
         UserContext.OnContextChanged -= HandleContextChanged;
         Nav.LocationChanged -= HandleLocationChanged;
+        CitizenHub.OnCredentialAvailable -= HandleWorkSignal;
         SessionExpiry.SessionExpired -= HandleSessionExpired;
         ThemeService.OnThemeChanged -= HandleThemeChanged;
         if (_inboxHubStarted)

--- a/src/Apps/Sorcha.Wallet.Pwa/Pages/Actions.razor
+++ b/src/Apps/Sorcha.Wallet.Pwa/Pages/Actions.razor
@@ -1,0 +1,123 @@
+@*
+    SPDX-License-Identifier: MIT
+    Copyright (c) 2026 Sorcha Contributors
+
+    Feature 151 (US1) — the "Things to do" inbox. Lists the workflow actions currently awaiting the
+    signed-in citizen (their turn), from GET /api/actions/pending (consumer-tier). Tapping a row
+    opens the existing ApplicationInstance fill/submit flow (base-relative). The "In review" banner
+    (US3) and live count badge (US2) are layered on in later slices. No backend change.
+*@
+@page "/actions"
+@layout MainLayout
+@using Microsoft.AspNetCore.Authorization
+@using Sorcha.Wallet.Pwa.Services.Actions
+@using Sorcha.Wallet.Pwa.Services.Actions.Models
+@attribute [Authorize]
+@inject IMyActionsClient MyActions
+@inject NavigationManager Nav
+
+<PageTitle>Things to do · Sorcha Wallet</PageTitle>
+
+<MudContainer MaxWidth="MaxWidth.Small" Class="pt-4">
+    <div class="actions-header">
+        <MudText Typo="Typo.h5">Things to do</MudText>
+    </div>
+
+    @if (_refreshError)
+    {
+        <MudAlert Severity="Severity.Warning" Dense="true" Class="mb-2" data-testid="actions-refresh-error">
+            Couldn't refresh just now — showing what we last loaded.
+        </MudAlert>
+    }
+
+    @if (_items is null)
+    {
+        @if (!_refreshError)
+        {
+            <div class="actions-list" data-testid="actions-loading">
+                @for (var i = 0; i < 3; i++)
+                {
+                    <div class="action-row-skeleton" aria-hidden="true"></div>
+                }
+            </div>
+        }
+    }
+    else if (_items.Count == 0)
+    {
+        <div class="actions-empty" data-testid="actions-empty">
+            <MudIcon Icon="@Icons.Material.Filled.TaskAlt" Size="Size.Large" />
+            <MudText Typo="Typo.subtitle1" Class="mt-2">Nothing needs you right now</MudText>
+            <MudText Typo="Typo.body2" Class="mud-text-secondary">
+                When an application needs your input, it'll show up here.
+            </MudText>
+        </div>
+    }
+    else
+    {
+        <div class="actions-list" data-testid="actions-list">
+            @foreach (var item in _items)
+            {
+                <button type="button" class="action-row" data-testid="@($"actions-item-{item.InstanceId}")"
+                        @onclick="@(() => Open(item))">
+                    <div class="action-row__main">
+                        <MudText Typo="Typo.subtitle1" Class="action-row__title">@item.Title</MudText>
+                        <MudText Typo="Typo.body2" Class="mud-text-secondary">@item.WorkflowTitle</MudText>
+                        @if (!string.IsNullOrWhiteSpace(item.Summary))
+                        {
+                            <MudText Typo="Typo.body2" Class="mud-text-secondary action-row__summary">@item.Summary</MudText>
+                        }
+                    </div>
+                    <div class="action-row__meta">
+                        @if (item.Urgency != ActionUrgency.Normal)
+                        {
+                            <MudChip T="string" Size="Size.Small" Color="@UrgencyColor(item.Urgency)" Variant="Variant.Filled">
+                                @item.Urgency.ToString()
+                            </MudChip>
+                        }
+                        @if (item.Deadline is { } due)
+                        {
+                            <MudText Typo="Typo.caption" Class="mud-text-secondary">Due @due.ToLocalTime().ToString("d MMM")</MudText>
+                        }
+                    </div>
+                </button>
+            }
+        </div>
+    }
+</MudContainer>
+
+@code {
+    private IReadOnlyList<PendingActionItem>? _items;
+    private bool _refreshError;
+
+    protected override Task OnInitializedAsync() => RefreshAsync();
+
+    /// <summary>
+    /// Loads (or re-loads) the citizen's outstanding actions. On a transient failure the last-known
+    /// list is retained and a non-blocking notice is shown (FR-010); a successful load clears it.
+    /// Public so the host can re-invoke it on a live signal (US2).
+    /// </summary>
+    public async Task RefreshAsync()
+    {
+        try
+        {
+            var items = await MyActions.GetPendingAsync();
+            _items = PendingActionOrdering.Order(items);
+            _refreshError = false;
+        }
+        catch (Exception)
+        {
+            // Retain _items (last-known); surface a non-blocking notice. Never a blank/error screen.
+            _refreshError = true;
+        }
+        StateHasChanged();
+    }
+
+    private void Open(PendingActionItem item) => Nav.NavigateTo($"applications/{item.InstanceId}");
+
+    private static Color UrgencyColor(ActionUrgency u) => u switch
+    {
+        ActionUrgency.Urgent => Color.Error,
+        ActionUrgency.Warning => Color.Warning,
+        _ => Color.Default,
+    };
+}

--- a/src/Apps/Sorcha.Wallet.Pwa/Pages/Actions.razor
+++ b/src/Apps/Sorcha.Wallet.Pwa/Pages/Actions.razor
@@ -10,11 +10,13 @@
 @page "/actions"
 @layout MainLayout
 @using Microsoft.AspNetCore.Authorization
+@using Sorcha.Wallet.Pwa.Services
 @using Sorcha.Wallet.Pwa.Services.Actions
 @using Sorcha.Wallet.Pwa.Services.Actions.Models
 @attribute [Authorize]
 @implements IDisposable
 @inject IMyActionsClient MyActions
+@inject IPendingApplicationClient PendingApplications
 @inject NavigationManager Nav
 
 <PageTitle>Things to do · Sorcha Wallet</PageTitle>
@@ -84,11 +86,23 @@
             }
         </div>
     }
+
+    @if (_inReview is not null)
+    {
+        <MudAlert Severity="Severity.Info" Dense="true" Class="mt-3 actions-in-review"
+                  Icon="@Icons.Material.Filled.HourglassEmpty" data-testid="actions-in-review">
+            <span class="actions-in-review__label"><strong>In review:</strong> @_inReview.Label</span>
+            <MudText Typo="Typo.body2" Class="mud-text-secondary">
+                Submitted — waiting on the next step. Nothing more for you to do right now.
+            </MudText>
+        </MudAlert>
+    }
 </MudContainer>
 
 @code {
     private IReadOnlyList<PendingActionItem>? _items;
     private bool _refreshError;
+    private PendingApplicationView? _inReview;
 
     /// <summary>
     /// Feature 151 — the wallet shell (cascaded by MainLayout). When present, the inbox subscribes
@@ -135,6 +149,18 @@
             // Retain _items (last-known); surface a non-blocking notice. Never a blank/error screen.
             _refreshError = true;
         }
+
+        // US3 — the "In review" banner reuses the Feature-124 notice. Its failure is independent of
+        // the list and must never break the inbox; on error we simply omit the banner.
+        try
+        {
+            _inReview = await PendingApplications.GetAsync();
+        }
+        catch (Exception)
+        {
+            _inReview = null;
+        }
+
         StateHasChanged();
     }
 

--- a/src/Apps/Sorcha.Wallet.Pwa/Pages/Actions.razor
+++ b/src/Apps/Sorcha.Wallet.Pwa/Pages/Actions.razor
@@ -13,6 +13,7 @@
 @using Sorcha.Wallet.Pwa.Services.Actions
 @using Sorcha.Wallet.Pwa.Services.Actions.Models
 @attribute [Authorize]
+@implements IDisposable
 @inject IMyActionsClient MyActions
 @inject NavigationManager Nav
 
@@ -89,7 +90,32 @@
     private IReadOnlyList<PendingActionItem>? _items;
     private bool _refreshError;
 
-    protected override Task OnInitializedAsync() => RefreshAsync();
+    /// <summary>
+    /// Feature 151 — the wallet shell (cascaded by MainLayout). When present, the inbox subscribes
+    /// to its outstanding-work signal so the list re-loads live while mounted. Null under test
+    /// (no shell), so the page degrades to load-on-open.
+    /// </summary>
+    [CascadingParameter] public MainLayout? Shell { get; set; }
+
+    protected override async Task OnInitializedAsync()
+    {
+        if (Shell is not null)
+        {
+            Shell.OutstandingWorkChanged += OnWorkChanged;
+        }
+        await RefreshAsync();
+    }
+
+    private void OnWorkChanged() => _ = InvokeAsync(RefreshAsync);
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        if (Shell is not null)
+        {
+            Shell.OutstandingWorkChanged -= OnWorkChanged;
+        }
+    }
 
     /// <summary>
     /// Loads (or re-loads) the citizen's outstanding actions. On a transient failure the last-known

--- a/src/Apps/Sorcha.Wallet.Pwa/Services/Actions/HttpMyActionsClient.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Services/Actions/HttpMyActionsClient.cs
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Sorcha.Wallet.Pwa.Services.Actions.Models;
+
+namespace Sorcha.Wallet.Pwa.Services.Actions;
+
+/// <summary>
+/// Default <see cref="IMyActionsClient"/> — reads the Blueprint Service's existing
+/// <c>GET /api/actions/pending</c> and <c>GET /api/actions/pending/count</c> through the
+/// gateway-routed, bearer-authed PWA <see cref="HttpClient"/>. No backend change: these endpoints
+/// already resolve the citizen's wallet(s) from the consumer-tier token. Transient failures return
+/// empty so the inbox can retain its last-known list and surface a non-blocking notice.
+/// </summary>
+public sealed class HttpMyActionsClient : IMyActionsClient
+{
+    private readonly HttpClient _http;
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+    };
+
+    /// <summary>Initialises a new instance.</summary>
+    public HttpMyActionsClient(HttpClient http) => _http = http ?? throw new ArgumentNullException(nameof(http));
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<PendingActionItem>> GetPendingAsync(
+        int page = 1, int pageSize = 20, CancellationToken ct = default)
+    {
+        try
+        {
+            var result = await _http.GetFromJsonAsync<PendingPage>(
+                $"api/actions/pending?page={page}&pageSize={pageSize}", JsonOptions, ct).ConfigureAwait(false);
+
+            var items = result?.Items;
+            if (items is null || items.Count == 0)
+            {
+                return Array.Empty<PendingActionItem>();
+            }
+
+            var mapped = new List<PendingActionItem>(items.Count);
+            foreach (var dto in items)
+            {
+                mapped.Add(Map(dto));
+            }
+            return mapped;
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch
+        {
+            // Transient failure — the inbox retains its last-known list and shows a notice.
+            return Array.Empty<PendingActionItem>();
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<PendingActionsCount> GetCountAsync(CancellationToken ct = default)
+    {
+        try
+        {
+            var dto = await _http.GetFromJsonAsync<CountDto>(
+                "api/actions/pending/count", JsonOptions, ct).ConfigureAwait(false);
+            return dto is null ? PendingActionsCount.Empty : new PendingActionsCount(dto.Count, dto.UrgentCount);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch
+        {
+            return PendingActionsCount.Empty;
+        }
+    }
+
+    private static PendingActionItem Map(PendingActionDto dto)
+    {
+        var title = !string.IsNullOrWhiteSpace(dto.ActionTitle)
+            ? dto.ActionTitle!
+            : !string.IsNullOrWhiteSpace(dto.BlueprintTitle)
+                ? dto.BlueprintTitle!
+                : $"Action {dto.ActionId}";
+
+        return new PendingActionItem(
+            InstanceId: dto.InstanceId ?? string.Empty,
+            ActionId: dto.ActionId,
+            Title: title,
+            WorkflowTitle: dto.BlueprintTitle ?? string.Empty,
+            Reference: string.IsNullOrWhiteSpace(dto.InstanceReference) ? null : dto.InstanceReference,
+            Summary: string.IsNullOrWhiteSpace(dto.Summary) ? null : dto.Summary,
+            Urgency: PendingActionItem.ParseUrgency(dto.Urgency),
+            Deadline: dto.Deadline,
+            ReceivedAt: dto.ReceivedAt,
+            NavigationPath: string.IsNullOrWhiteSpace(dto.NavigationPath) ? null : dto.NavigationPath);
+    }
+
+    private sealed class PendingPage
+    {
+        [JsonPropertyName("items")] public List<PendingActionDto>? Items { get; set; }
+        [JsonPropertyName("totalCount")] public int TotalCount { get; set; }
+    }
+
+    private sealed class PendingActionDto
+    {
+        public string? InstanceId { get; set; }
+        public int ActionId { get; set; }
+        public string? ActionTitle { get; set; }
+        public string? BlueprintTitle { get; set; }
+        public string? InstanceReference { get; set; }
+        public string? Summary { get; set; }
+        public string? Urgency { get; set; }
+        public DateTimeOffset? Deadline { get; set; }
+        public DateTimeOffset ReceivedAt { get; set; }
+        public string? NavigationPath { get; set; }
+    }
+
+    private sealed class CountDto
+    {
+        public int Count { get; set; }
+        public int UrgentCount { get; set; }
+    }
+}

--- a/src/Apps/Sorcha.Wallet.Pwa/Services/Actions/HttpMyActionsClient.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Services/Actions/HttpMyActionsClient.cs
@@ -29,55 +29,38 @@ public sealed class HttpMyActionsClient : IMyActionsClient
     public HttpMyActionsClient(HttpClient http) => _http = http ?? throw new ArgumentNullException(nameof(http));
 
     /// <inheritdoc />
+    /// <remarks>
+    /// Transient failures (network / non-success / malformed body) are NOT swallowed — they
+    /// propagate so the inbox can retain its last-known list and surface a non-blocking notice
+    /// (FR-010), distinct from a genuinely empty inbox.
+    /// </remarks>
     public async Task<IReadOnlyList<PendingActionItem>> GetPendingAsync(
         int page = 1, int pageSize = 20, CancellationToken ct = default)
     {
-        try
-        {
-            var result = await _http.GetFromJsonAsync<PendingPage>(
-                $"api/actions/pending?page={page}&pageSize={pageSize}", JsonOptions, ct).ConfigureAwait(false);
+        var result = await _http.GetFromJsonAsync<PendingPage>(
+            $"api/actions/pending?page={page}&pageSize={pageSize}", JsonOptions, ct).ConfigureAwait(false);
 
-            var items = result?.Items;
-            if (items is null || items.Count == 0)
-            {
-                return Array.Empty<PendingActionItem>();
-            }
-
-            var mapped = new List<PendingActionItem>(items.Count);
-            foreach (var dto in items)
-            {
-                mapped.Add(Map(dto));
-            }
-            return mapped;
-        }
-        catch (OperationCanceledException)
+        var items = result?.Items;
+        if (items is null || items.Count == 0)
         {
-            throw;
-        }
-        catch
-        {
-            // Transient failure — the inbox retains its last-known list and shows a notice.
             return Array.Empty<PendingActionItem>();
         }
+
+        var mapped = new List<PendingActionItem>(items.Count);
+        foreach (var dto in items)
+        {
+            mapped.Add(Map(dto));
+        }
+        return mapped;
     }
 
     /// <inheritdoc />
+    /// <remarks>Transient failures propagate; the badge owner retains its last-known count.</remarks>
     public async Task<PendingActionsCount> GetCountAsync(CancellationToken ct = default)
     {
-        try
-        {
-            var dto = await _http.GetFromJsonAsync<CountDto>(
-                "api/actions/pending/count", JsonOptions, ct).ConfigureAwait(false);
-            return dto is null ? PendingActionsCount.Empty : new PendingActionsCount(dto.Count, dto.UrgentCount);
-        }
-        catch (OperationCanceledException)
-        {
-            throw;
-        }
-        catch
-        {
-            return PendingActionsCount.Empty;
-        }
+        var dto = await _http.GetFromJsonAsync<CountDto>(
+            "api/actions/pending/count", JsonOptions, ct).ConfigureAwait(false);
+        return dto is null ? PendingActionsCount.Empty : new PendingActionsCount(dto.Count, dto.UrgentCount);
     }
 
     private static PendingActionItem Map(PendingActionDto dto)

--- a/src/Apps/Sorcha.Wallet.Pwa/Services/Actions/IMyActionsClient.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Services/Actions/IMyActionsClient.cs
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using Sorcha.Wallet.Pwa.Services.Actions.Models;
+
+namespace Sorcha.Wallet.Pwa.Services.Actions;
+
+/// <summary>
+/// Feature 151 (citizen workflow inbox) — PWA-side client for the citizen's "actions waiting on me"
+/// surface. Reads the Blueprint Service's <c>GET /api/actions/pending</c> (list) and
+/// <c>GET /api/actions/pending/count</c> (badge) endpoints, which already resolve the citizen's
+/// wallet(s) from a consumer-tier token via <c>platform_user_id</c> and return only actions where
+/// the citizen is the designated actor (their turn). The shared <see cref="HttpClient"/> carries
+/// the bearer token chain; callers pass no token.
+/// </summary>
+public interface IMyActionsClient
+{
+    /// <summary>
+    /// Returns the actions currently awaiting the citizen's input ("their turn"), most-pressing
+    /// ordering is applied by the caller. Returns an empty list on a transient failure (the caller
+    /// retains its last-known list and surfaces a non-blocking notice).
+    /// </summary>
+    Task<IReadOnlyList<PendingActionItem>> GetPendingAsync(
+        int page = 1, int pageSize = 20, CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns the count of outstanding actions for the navigation badge. Returns
+    /// <see cref="PendingActionsCount.Empty"/> on a transient failure.
+    /// </summary>
+    Task<PendingActionsCount> GetCountAsync(CancellationToken ct = default);
+}

--- a/src/Apps/Sorcha.Wallet.Pwa/Services/Actions/IMyActionsClient.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Services/Actions/IMyActionsClient.cs
@@ -16,16 +16,18 @@ namespace Sorcha.Wallet.Pwa.Services.Actions;
 public interface IMyActionsClient
 {
     /// <summary>
-    /// Returns the actions currently awaiting the citizen's input ("their turn"), most-pressing
-    /// ordering is applied by the caller. Returns an empty list on a transient failure (the caller
-    /// retains its last-known list and surfaces a non-blocking notice).
+    /// Returns the actions currently awaiting the citizen's input ("their turn"); most-pressing
+    /// ordering is applied by the caller. An empty list means "nothing waiting on you". A transient
+    /// failure (network / non-success / malformed body) <b>throws</b> so the caller can retain its
+    /// last-known list and surface a non-blocking notice (FR-010) — failure is never conflated with
+    /// an empty inbox.
     /// </summary>
     Task<IReadOnlyList<PendingActionItem>> GetPendingAsync(
         int page = 1, int pageSize = 20, CancellationToken ct = default);
 
     /// <summary>
-    /// Returns the count of outstanding actions for the navigation badge. Returns
-    /// <see cref="PendingActionsCount.Empty"/> on a transient failure.
+    /// Returns the count of outstanding actions for the navigation badge. A transient failure
+    /// throws; the badge owner retains its last-known count.
     /// </summary>
     Task<PendingActionsCount> GetCountAsync(CancellationToken ct = default);
 }

--- a/src/Apps/Sorcha.Wallet.Pwa/Services/Actions/Models/PendingActionItem.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Services/Actions/Models/PendingActionItem.cs
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+namespace Sorcha.Wallet.Pwa.Services.Actions.Models;
+
+/// <summary>
+/// Feature 151 (citizen workflow inbox) — urgency of an outstanding action, used for ordering and
+/// the row chip. Parsed case-insensitively from the server <c>urgency</c> string; an unrecognised
+/// value maps to <see cref="Normal"/> (never throws).
+/// </summary>
+public enum ActionUrgency
+{
+    /// <summary>Default — no special urgency.</summary>
+    Normal = 0,
+
+    /// <summary>Approaching a deadline / elevated attention.</summary>
+    Warning = 1,
+
+    /// <summary>Time-critical.</summary>
+    Urgent = 2,
+}
+
+/// <summary>
+/// Feature 151 — the citizen-facing view of a workflow action currently awaiting their input (an
+/// action where the citizen is the designated actor — "their turn"). Maps the subset of the
+/// Blueprint Service's <c>PendingActionSummary</c> the "Things to do" inbox needs; fields the inbox
+/// does not use (sender address, transaction id, prepopulated payload, data schema) are ignored —
+/// the open-action flow fetches what the form needs itself.
+/// </summary>
+/// <param name="InstanceId">The workflow instance id; the inbox navigates to <c>applications/{InstanceId}</c>.</param>
+/// <param name="ActionId">The action within the instance.</param>
+/// <param name="Title">Display title (server action title, falling back to blueprint title, then "Action {id}").</param>
+/// <param name="WorkflowTitle">Which application/workflow this belongs to.</param>
+/// <param name="Reference">Human-readable instance reference, if present.</param>
+/// <param name="Summary">Optional one-line context.</param>
+/// <param name="Urgency">Drives ordering and the row chip.</param>
+/// <param name="Deadline">Optional due date.</param>
+/// <param name="ReceivedAt">When the action became outstanding (secondary sort / tiebreak).</param>
+/// <param name="NavigationPath">An explicit server-supplied path, if any (still made base-relative by the caller).</param>
+public sealed record PendingActionItem(
+    string InstanceId,
+    int ActionId,
+    string Title,
+    string WorkflowTitle,
+    string? Reference,
+    string? Summary,
+    ActionUrgency Urgency,
+    DateTimeOffset? Deadline,
+    DateTimeOffset ReceivedAt,
+    string? NavigationPath)
+{
+    /// <summary>
+    /// Parses a server urgency string (<c>"normal"</c> / <c>"warning"</c> / <c>"urgent"</c>)
+    /// case-insensitively. Any unrecognised or empty value maps to <see cref="ActionUrgency.Normal"/>.
+    /// </summary>
+    public static ActionUrgency ParseUrgency(string? value) => value?.Trim().ToLowerInvariant() switch
+    {
+        "urgent" => ActionUrgency.Urgent,
+        "warning" => ActionUrgency.Warning,
+        _ => ActionUrgency.Normal,
+    };
+}

--- a/src/Apps/Sorcha.Wallet.Pwa/Services/Actions/Models/PendingActionsCount.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Services/Actions/Models/PendingActionsCount.cs
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+namespace Sorcha.Wallet.Pwa.Services.Actions.Models;
+
+/// <summary>
+/// Feature 151 — the count of the citizen's outstanding actions, for the navigation badge.
+/// <see cref="UrgentCount"/> mirrors the server field but is always 0 today (urgency-aware
+/// counting is a future server iteration) and is not relied upon by the badge.
+/// </summary>
+/// <param name="Count">Total outstanding actions awaiting the citizen.</param>
+/// <param name="UrgentCount">Outstanding actions flagged urgent (currently always 0).</param>
+public sealed record PendingActionsCount(int Count, int UrgentCount)
+{
+    /// <summary>An empty count (nothing outstanding).</summary>
+    public static readonly PendingActionsCount Empty = new(0, 0);
+}

--- a/src/Apps/Sorcha.Wallet.Pwa/Services/Actions/PendingActionOrdering.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Services/Actions/PendingActionOrdering.cs
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using Sorcha.Wallet.Pwa.Services.Actions.Models;
+
+namespace Sorcha.Wallet.Pwa.Services.Actions;
+
+/// <summary>
+/// Feature 151 — the single source of truth for "most pressing first" inbox ordering:
+/// Urgent → Warning → Normal, then earliest <see cref="PendingActionItem.Deadline"/> first
+/// (items with no deadline last), then earliest <see cref="PendingActionItem.ReceivedAt"/>.
+/// </summary>
+public static class PendingActionOrdering
+{
+    /// <summary>Returns a new ordered list; the input is not mutated.</summary>
+    public static IReadOnlyList<PendingActionItem> Order(IEnumerable<PendingActionItem> items) =>
+        items
+            .OrderByDescending(i => (int)i.Urgency)
+            .ThenBy(i => i.Deadline ?? DateTimeOffset.MaxValue)
+            .ThenBy(i => i.ReceivedAt)
+            .ToList();
+}

--- a/tests/Sorcha.UI.Core.Tests/Components/Wallet/WalletChromeComponentTests.cs
+++ b/tests/Sorcha.UI.Core.Tests/Components/Wallet/WalletChromeComponentTests.cs
@@ -153,12 +153,13 @@ public sealed class WalletChromeComponentTests : BunitContext
     // ── FloatingTabBar ──────────────────────────────────────────────────────
 
     [Fact]
-    public void FloatingTabBar_RendersFourTabs_WithStableTestIds()
+    public void FloatingTabBar_RendersFiveTabs_WithStableTestIds()
     {
         var cut = Render<FloatingTabBar>(ps => ps.Add(p => p.ActiveRoute, ""));
 
-        cut.FindAll(".tab-pill").Count.Should().Be(4);
-        foreach (var id in new[] { "footer-nav-home", "footer-nav-cards", "footer-nav-activity", "footer-nav-settings" })
+        // Feature 151 added the "To do" workflow-inbox destination (footer-nav-todo).
+        cut.FindAll(".tab-pill").Count.Should().Be(5);
+        foreach (var id in new[] { "footer-nav-home", "footer-nav-todo", "footer-nav-cards", "footer-nav-activity", "footer-nav-settings" })
         {
             cut.FindAll($"[data-testid='{id}']").Should().ContainSingle($"tab {id} must exist for navigation tests");
         }

--- a/tests/Sorcha.Wallet.Pwa.Tests/Actions/MyActionsClientTests.cs
+++ b/tests/Sorcha.Wallet.Pwa.Tests/Actions/MyActionsClientTests.cs
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Sorcha.Wallet.Pwa.Services.Actions;
+using Sorcha.Wallet.Pwa.Services.Actions.Models;
+using Xunit;
+
+namespace Sorcha.Wallet.Pwa.Tests.Actions;
+
+/// <summary>
+/// Feature 151 — contract test for <see cref="HttpMyActionsClient"/>: maps the existing
+/// <c>/api/actions/pending</c> and <c>/api/actions/pending/count</c> JSON shapes onto the inbox
+/// DTOs, with tolerant urgency parsing and title fallback. Guards drift against
+/// <c>contracts/consumed-endpoints.md</c>.
+/// </summary>
+public sealed class MyActionsClientTests
+{
+    [Fact]
+    public async Task GetPendingAsync_MapsItems_WithTitleAndUrgencyAndDeadline()
+    {
+        const string json = """
+        {
+          "items": [
+            {
+              "instanceId": "11111111-1111-1111-1111-111111111111",
+              "actionId": 2,
+              "actionTitle": "Upload proof of address",
+              "blueprintTitle": "Blue Badge Application",
+              "instanceReference": "BB-RIV-14-A7K3",
+              "summary": "We need a recent utility bill.",
+              "urgency": "urgent",
+              "deadline": "2026-07-01T00:00:00+00:00",
+              "receivedAt": "2026-06-13T09:00:00+00:00"
+            }
+          ],
+          "totalCount": 1, "page": 1, "pageSize": 20
+        }
+        """;
+        var client = Create((req, _) =>
+        {
+            req.RequestUri!.AbsolutePath.Should().Be("/api/actions/pending");
+            return Ok(json);
+        });
+
+        var items = await client.GetPendingAsync();
+
+        items.Should().ContainSingle();
+        var item = items[0];
+        item.InstanceId.Should().Be("11111111-1111-1111-1111-111111111111");
+        item.ActionId.Should().Be(2);
+        item.Title.Should().Be("Upload proof of address");
+        item.WorkflowTitle.Should().Be("Blue Badge Application");
+        item.Reference.Should().Be("BB-RIV-14-A7K3");
+        item.Urgency.Should().Be(ActionUrgency.Urgent);
+        item.Deadline.Should().Be(new DateTimeOffset(2026, 7, 1, 0, 0, 0, TimeSpan.Zero));
+    }
+
+    [Fact]
+    public async Task GetPendingAsync_UnknownUrgency_MapsToNormal()
+    {
+        var client = Create((_, _) => Ok(ItemWith(urgency: "bananas")));
+
+        var items = await client.GetPendingAsync();
+
+        items[0].Urgency.Should().Be(ActionUrgency.Normal);
+    }
+
+    [Fact]
+    public async Task GetPendingAsync_NoActionTitle_FallsBackToBlueprintTitle()
+    {
+        var client = Create((_, _) => Ok(ItemWith(urgency: "normal", actionTitle: "")));
+
+        var items = await client.GetPendingAsync();
+
+        items[0].Title.Should().Be("Blue Badge Application");
+    }
+
+    [Fact]
+    public async Task GetPendingAsync_NoTitlesAtAll_FallsBackToActionId()
+    {
+        const string json = """
+        { "items": [ { "instanceId": "i", "actionId": 7, "receivedAt": "2026-06-13T09:00:00+00:00" } ],
+          "totalCount": 1, "page": 1, "pageSize": 20 }
+        """;
+        var client = Create((_, _) => Ok(json));
+
+        var items = await client.GetPendingAsync();
+
+        items[0].Title.Should().Be("Action 7");
+    }
+
+    [Fact]
+    public async Task GetPendingAsync_TransientFailure_ReturnsEmpty()
+    {
+        var client = Create((_, _) => throw new HttpRequestException("offline"));
+
+        var items = await client.GetPendingAsync();
+
+        items.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetCountAsync_MapsCount()
+    {
+        var client = Create((req, _) =>
+        {
+            req.RequestUri!.AbsolutePath.Should().Be("/api/actions/pending/count");
+            return Ok("""{ "count": 4, "urgentCount": 0 }""");
+        });
+
+        var count = await client.GetCountAsync();
+
+        count.Count.Should().Be(4);
+    }
+
+    [Fact]
+    public async Task GetCountAsync_TransientFailure_ReturnsEmpty()
+    {
+        var client = Create((_, _) => new HttpResponseMessage(HttpStatusCode.InternalServerError));
+
+        var count = await client.GetCountAsync();
+
+        count.Count.Should().Be(0);
+    }
+
+    private static string ItemWith(string urgency, string actionTitle = "Some action") => $$"""
+    {
+      "items": [
+        {
+          "instanceId": "11111111-1111-1111-1111-111111111111",
+          "actionId": 1,
+          "actionTitle": "{{actionTitle}}",
+          "blueprintTitle": "Blue Badge Application",
+          "urgency": "{{urgency}}",
+          "receivedAt": "2026-06-13T09:00:00+00:00"
+        }
+      ],
+      "totalCount": 1, "page": 1, "pageSize": 20
+    }
+    """;
+
+    private static HttpMyActionsClient Create(
+        Func<HttpRequestMessage, CancellationToken, HttpResponseMessage> respond)
+    {
+        var http = new HttpClient(new StubHandler(respond)) { BaseAddress = new Uri("https://test.example.com") };
+        return new HttpMyActionsClient(http);
+    }
+
+    private static HttpResponseMessage Ok(string json) =>
+        new(HttpStatusCode.OK) { Content = new StringContent(json, Encoding.UTF8, "application/json") };
+
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, CancellationToken, HttpResponseMessage> _respond;
+        public StubHandler(Func<HttpRequestMessage, CancellationToken, HttpResponseMessage> respond) => _respond = respond;
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct) =>
+            Task.FromResult(_respond(request, ct));
+    }
+}

--- a/tests/Sorcha.Wallet.Pwa.Tests/Actions/MyActionsClientTests.cs
+++ b/tests/Sorcha.Wallet.Pwa.Tests/Actions/MyActionsClientTests.cs
@@ -98,13 +98,12 @@ public sealed class MyActionsClientTests
     }
 
     [Fact]
-    public async Task GetPendingAsync_TransientFailure_ReturnsEmpty()
+    public async Task GetPendingAsync_TransientFailure_Throws()
     {
         var client = Create((_, _) => throw new HttpRequestException("offline"));
 
-        var items = await client.GetPendingAsync();
-
-        items.Should().BeEmpty();
+        await client.Invoking(c => c.GetPendingAsync())
+            .Should().ThrowAsync<HttpRequestException>();
     }
 
     [Fact]
@@ -122,13 +121,12 @@ public sealed class MyActionsClientTests
     }
 
     [Fact]
-    public async Task GetCountAsync_TransientFailure_ReturnsEmpty()
+    public async Task GetCountAsync_TransientFailure_Throws()
     {
         var client = Create((_, _) => new HttpResponseMessage(HttpStatusCode.InternalServerError));
 
-        var count = await client.GetCountAsync();
-
-        count.Count.Should().Be(0);
+        await client.Invoking(c => c.GetCountAsync())
+            .Should().ThrowAsync<HttpRequestException>();
     }
 
     private static string ItemWith(string urgency, string actionTitle = "Some action") => $$"""

--- a/tests/Sorcha.Wallet.Pwa.Tests/Actions/PendingActionOrderingTests.cs
+++ b/tests/Sorcha.Wallet.Pwa.Tests/Actions/PendingActionOrderingTests.cs
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using Sorcha.Wallet.Pwa.Services.Actions;
+using Sorcha.Wallet.Pwa.Services.Actions.Models;
+using Xunit;
+
+namespace Sorcha.Wallet.Pwa.Tests.Actions;
+
+/// <summary>
+/// Feature 151 — ordering rule for the inbox: Urgent → Warning → Normal, then earliest
+/// <c>Deadline</c> first (nulls last), then earliest <c>ReceivedAt</c>. Single source of truth for
+/// "most pressing first" (SC: ordering).
+/// </summary>
+public sealed class PendingActionOrderingTests
+{
+    private static PendingActionItem Item(
+        string id, ActionUrgency urgency, DateTimeOffset? deadline, DateTimeOffset receivedAt) =>
+        new(id, 1, $"t-{id}", "wf", null, null, urgency, deadline, receivedAt, null);
+
+    private static readonly DateTimeOffset T0 = new(2026, 6, 13, 9, 0, 0, TimeSpan.Zero);
+
+    [Fact]
+    public void Order_SortsByUrgencyDescending_First()
+    {
+        var items = new[]
+        {
+            Item("normal", ActionUrgency.Normal, null, T0),
+            Item("urgent", ActionUrgency.Urgent, null, T0),
+            Item("warning", ActionUrgency.Warning, null, T0),
+        };
+
+        var ordered = PendingActionOrdering.Order(items).Select(i => i.InstanceId).ToList();
+
+        ordered.Should().Equal("urgent", "warning", "normal");
+    }
+
+    [Fact]
+    public void Order_WithinSameUrgency_SortsByDeadlineAscending_NullsLast()
+    {
+        var items = new[]
+        {
+            Item("no-deadline", ActionUrgency.Normal, null, T0),
+            Item("later", ActionUrgency.Normal, T0.AddDays(5), T0),
+            Item("sooner", ActionUrgency.Normal, T0.AddDays(1), T0),
+        };
+
+        var ordered = PendingActionOrdering.Order(items).Select(i => i.InstanceId).ToList();
+
+        ordered.Should().Equal("sooner", "later", "no-deadline");
+    }
+
+    [Fact]
+    public void Order_FinalTiebreak_IsReceivedAtAscending()
+    {
+        var items = new[]
+        {
+            Item("newer", ActionUrgency.Normal, null, T0.AddHours(2)),
+            Item("older", ActionUrgency.Normal, null, T0),
+        };
+
+        var ordered = PendingActionOrdering.Order(items).Select(i => i.InstanceId).ToList();
+
+        ordered.Should().Equal("older", "newer");
+    }
+
+    [Fact]
+    public void Order_DoesNotMutateInput_AndHandlesEmpty()
+    {
+        PendingActionOrdering.Order(Array.Empty<PendingActionItem>()).Should().BeEmpty();
+    }
+}

--- a/tests/Sorcha.Wallet.Pwa.Tests/Pages/ActionsBadgeTests.cs
+++ b/tests/Sorcha.Wallet.Pwa.Tests/Pages/ActionsBadgeTests.cs
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using Bunit;
+using FluentAssertions;
+using Sorcha.UI.Testing;
+using Xunit;
+using FloatingTabBar = Sorcha.UI.Core.Components.Wallet.FloatingTabBar;
+
+namespace Sorcha.Wallet.Pwa.Tests.Pages;
+
+/// <summary>
+/// Feature 151 US2 — the "To do" tab count badge: shows the outstanding-action count when > 0,
+/// hides when 0, and updates reactively when the count parameter changes (e.g. after a live signal
+/// re-fetch in the host).
+/// </summary>
+public sealed class ActionsBadgeTests : ComponentTestFixture
+{
+    [Fact]
+    public void TodoCount_Positive_RendersBadgeWithCount()
+    {
+        var cut = Render<FloatingTabBar>(ps => ps.Add(p => p.TodoCount, 3));
+
+        var badge = cut.Find("[data-testid=footer-nav-todo-badge]");
+        badge.TextContent.Trim().Should().Be("3");
+    }
+
+    [Fact]
+    public void TodoCount_Zero_RendersNoBadge()
+    {
+        var cut = Render<FloatingTabBar>(ps => ps.Add(p => p.TodoCount, 0));
+
+        cut.FindAll("[data-testid=footer-nav-todo-badge]").Should().BeEmpty();
+    }
+
+    [Fact]
+    public void TodoCount_Change_UpdatesBadgeReactively()
+    {
+        var cut = Render<FloatingTabBar>(ps => ps.Add(p => p.TodoCount, 2));
+        cut.Find("[data-testid=footer-nav-todo-badge]").TextContent.Trim().Should().Be("2");
+
+        cut.Render(ps => ps.Add(p => p.TodoCount, 5));
+        cut.Find("[data-testid=footer-nav-todo-badge]").TextContent.Trim().Should().Be("5");
+
+        cut.Render(ps => ps.Add(p => p.TodoCount, 0));
+        cut.FindAll("[data-testid=footer-nav-todo-badge]").Should().BeEmpty();
+    }
+}

--- a/tests/Sorcha.Wallet.Pwa.Tests/Pages/ActionsInReviewBannerTests.cs
+++ b/tests/Sorcha.Wallet.Pwa.Tests/Pages/ActionsInReviewBannerTests.cs
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System;
+using System.Threading;
+using Bunit;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Sorcha.UI.Testing;
+using Sorcha.Wallet.Pwa.Services;
+using Sorcha.Wallet.Pwa.Services.Actions;
+using Sorcha.Wallet.Pwa.Services.Actions.Models;
+using Xunit;
+using ActionsPage = Sorcha.Wallet.Pwa.Pages.Actions;
+
+namespace Sorcha.Wallet.Pwa.Tests.Pages;
+
+/// <summary>
+/// Feature 151 US3 — the "In review" banner reuses the existing Feature-124 pending-application
+/// notice: shown (distinct from the "needs you" rows) when a notice exists, hidden when absent.
+/// </summary>
+public sealed class ActionsInReviewBannerTests : ComponentTestFixture
+{
+    private readonly Mock<IMyActionsClient> _client = new();
+    private readonly Mock<IPendingApplicationClient> _pending = new();
+
+    public ActionsInReviewBannerTests()
+    {
+        Services.AddSingleton(_client.Object);
+        Services.AddSingleton(_pending.Object);
+        _client.Setup(c => c.GetPendingAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<PendingActionItem>());
+    }
+
+    [Fact]
+    public void NoticePresent_ShowsInReviewBanner()
+    {
+        _pending.Setup(p => p.GetAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PendingApplicationView("Blue Badge Application", DateTimeOffset.UtcNow));
+
+        var cut = Render<ActionsPage>();
+
+        var banner = cut.Find("[data-testid=actions-in-review]");
+        banner.TextContent.Should().Contain("Blue Badge Application");
+    }
+
+    [Fact]
+    public void NoNotice_HidesInReviewBanner()
+    {
+        _pending.Setup(p => p.GetAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync((PendingApplicationView?)null);
+
+        var cut = Render<ActionsPage>();
+
+        cut.FindAll("[data-testid=actions-in-review]").Should().BeEmpty();
+    }
+}

--- a/tests/Sorcha.Wallet.Pwa.Tests/Pages/ActionsInboxTests.cs
+++ b/tests/Sorcha.Wallet.Pwa.Tests/Pages/ActionsInboxTests.cs
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Bunit;
+using FluentAssertions;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Sorcha.UI.Testing;
+using Sorcha.Wallet.Pwa.Services;
+using Sorcha.Wallet.Pwa.Services.Actions;
+using Sorcha.Wallet.Pwa.Services.Actions.Models;
+using Xunit;
+using ActionsPage = Sorcha.Wallet.Pwa.Pages.Actions;
+
+namespace Sorcha.Wallet.Pwa.Tests.Pages;
+
+/// <summary>
+/// Feature 151 US1 — bUnit tests for the "Things to do" inbox page: renders the citizen's
+/// outstanding actions, empty state, base-relative navigation on row tap, and graceful
+/// degradation on a refresh failure (last-known list retained, non-blocking notice).
+/// </summary>
+public sealed class ActionsInboxTests : ComponentTestFixture
+{
+    private readonly Mock<IMyActionsClient> _client = new();
+    private readonly Mock<IPendingApplicationClient> _pending = new();
+
+    public ActionsInboxTests()
+    {
+        Services.AddSingleton(_client.Object);
+        Services.AddSingleton(_pending.Object);
+        _pending.Setup(p => p.GetAsync(It.IsAny<CancellationToken>())).ReturnsAsync((PendingApplicationView?)null);
+    }
+
+    private static PendingActionItem Item(string id, string title) =>
+        new(id, 1, title, "Blue Badge Application", null, null, ActionUrgency.Normal, null, DateTimeOffset.UtcNow, null);
+
+    [Fact]
+    public void RendersRow_PerOutstandingAction()
+    {
+        _client.Setup(c => c.GetPendingAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<PendingActionItem> { Item("a1", "Upload proof"), Item("a2", "Confirm details") });
+
+        var cut = Render<ActionsPage>();
+
+        cut.FindAll("[data-testid=actions-list]").Should().ContainSingle();
+        cut.FindAll("[data-testid^=actions-item-]").Should().HaveCount(2);
+        cut.FindAll("[data-testid=actions-empty]").Should().BeEmpty();
+    }
+
+    [Fact]
+    public void NoActions_ShowsEmptyState()
+    {
+        _client.Setup(c => c.GetPendingAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<PendingActionItem>());
+
+        var cut = Render<ActionsPage>();
+
+        cut.FindAll("[data-testid=actions-empty]").Should().ContainSingle();
+        cut.FindAll("[data-testid=actions-list]").Should().BeEmpty();
+    }
+
+    [Fact]
+    public void RowTap_NavigatesBaseRelativeToApplicationInstance()
+    {
+        _client.Setup(c => c.GetPendingAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<PendingActionItem> { Item("11111111-1111-1111-1111-111111111111", "Upload proof") });
+        var nav = Services.GetRequiredService<NavigationManager>();
+
+        var cut = Render<ActionsPage>();
+        cut.Find("[data-testid^=actions-item-]").Click();
+
+        nav.Uri.Should().EndWith("applications/11111111-1111-1111-1111-111111111111");
+    }
+
+    [Fact]
+    public void InitialLoadFailure_ShowsNotice_NotBlankError()
+    {
+        _client.Setup(c => c.GetPendingAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException("offline"));
+
+        var cut = Render<ActionsPage>();
+
+        cut.FindAll("[data-testid=actions-refresh-error]").Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task RefreshFailureAfterLoad_RetainsLastKnownList_AndShowsNotice()
+    {
+        _client.SetupSequence(c => c.GetPendingAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<PendingActionItem> { Item("a1", "Upload proof") })
+            .ThrowsAsync(new HttpRequestException("offline"));
+
+        var cut = Render<ActionsPage>();
+        cut.FindAll("[data-testid^=actions-item-]").Should().ContainSingle();
+
+        await cut.InvokeAsync(() => cut.Instance.RefreshAsync());
+
+        cut.FindAll("[data-testid^=actions-item-]").Should().ContainSingle("the last-known list is retained on refresh failure");
+        cut.FindAll("[data-testid=actions-refresh-error]").Should().ContainSingle();
+    }
+}


### PR DESCRIPTION
## Summary

Sub-project **A** of the PWA workflow-participation programme: a consumer-tier **"Things to do" inbox** in the Citizen Wallet PWA so a citizen can *discover* the workflow actions waiting on them — not just hold/present credentials. Closes the "no discovery on the phone" gap; the form-fill/submit half already existed (`ApplicationInstance`).

**No backend changes.** Strictly **consumer-tier**. Reuses the shared `SorchaFormRenderer` and the existing `/execute` submit flow.

Design + spec: `docs/superpowers/specs/2026-06-13-pwa-citizen-workflow-inbox-design.md`, `specs/151-citizen-workflow-inbox/` (spec/plan/research/data-model/contracts/tasks).

## What's included (by user story)

- **US1 (MVP)** — `Pages/Actions.razor` (`/actions`): lists outstanding actions (their turn) from the existing `GET /api/actions/pending`, ordered most-pressing-first; empty state; row tap → base-relative `applications/{instanceId}` (existing fill/submit flow); refresh failure retains the last-known list + a non-blocking notice (never a blank/error screen). New `IMyActionsClient`/`HttpMyActionsClient` + `PendingActionOrdering`. New "To do" destination on `FloatingTabBar`.
- **US2** — live count **badge** on the "To do" tab; `MainLayout` fetches the count and refreshes on navigation + the `CitizenWalletHub` credential signal (last-known retained on a blip).
- **US3** — distinct **"In review" banner** reusing the existing Feature-124 pending-application notice.

## Key decisions

- `GET /api/actions/pending` already serves consumer-tier citizen tokens and means **"my turn"** (sender = the participant designated to act). **Deliberately not** tightened with a consumer guard — the web `MyActions` shares that cross-tier endpoint.
- `FloatingTabBar` is **PWA-only** (verified), so the 5th tab + badge param don't affect web hosts.
- No draft model is introduced (offline/drafts/camera are sub-project C).

## Tests

`Sorcha.Wallet.Pwa.Tests`: **227 passed / 0 failed** (+21 new — client mapping, ordering, inbox list/empty/nav/refresh-retain, badge, banner). PWA builds **0 warnings / 0 errors**. No-snackbar gate passes.

## Not done in this PR

- **Live walkthrough (T022)** against Docker/n1 with a seeded citizen mid-application — deferred to a pre-merge live check; not run in this session.
- A fully-idle push for a *newly-assigned* action needs a backend "new pending action" thin-signal that doesn't exist today (no backend change here) — navigation + credential signal + manual refresh cover the loop.

## Scope

Sub-project A only. B (catalogue), C (offline/drafts/camera), D (dual-tier/org-role) are separate spec→plan→tasks→implement cycles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)