### PR TITLE
feat(152): PWA offline / field capture — drafts, queue, conflict, photos (sub-project C)

### DIFF
--- a/docs/superpowers/specs/2026-06-13-pwa-offline-field-capture-design.md
+++ b/docs/superpowers/specs/2026-06-13-pwa-offline-field-capture-design.md
@@ -1,0 +1,191 @@
+# PWA Offline / Field Capture — Design (Sub-project C)
+
+**Date:** 2026-06-13
+**Status:** Design — awaiting user review before speckit specify
+**Decision owner:** Stuart Fraser
+**Parent programme:** PWA workflow participation (A/B/C/D). Depends on **A** (citizen workflow inbox).
+
+---
+
+## 1. Context
+
+Sub-project A gave the Citizen Wallet PWA a "Things to do" inbox: a citizen can discover the
+actions waiting on them, open one, fill it via the shared `SorchaFormRenderer`, and submit — **but
+only online, in one sitting, and only the action they opened (its schema is fetched on open), with
+no way to attach photos end-to-end.** C makes workflow participation **field-first**: a citizen (or
+a user in the field) can open any of their pending actions **with no connectivity**, fill it,
+**capture photos/media**, save an **encrypted local draft**, and have the PWA **submit it when back
+online** — with safe conflict handling if the world moved on.
+
+This matches the headline use case behind the whole programme: a field worker gathering data and
+photos for a workflow on their phone, offline, syncing later.
+
+### Decisions taken in brainstorming (2026-06-13)
+
+1. **Unified C** — offline drafts **and** photo/media capture **and** the attachment-submission
+   wiring ship together (not split).
+2. **Conflict handling = detect, hold, and ask** — a deferred submit that is no longer valid is
+   never silently dropped; the draft is kept, marked "needs attention", and the citizen is told
+   what changed with discard vs. re-open-fresh choices.
+3. **Offline boundary = pre-cache all my pending actions** — when online, the PWA proactively
+   caches every inbox action's form context so any pending action can be opened offline.
+
+### Grounding (verified, read-only)
+
+- **Reusable:** XChaCha20-Poly1305 + IndexedDB device-bound encryption (`IndexedDbCredentialCache`
+  + `indexeddb-bridge.js`/`xchacha-bridge.js`); capture controls `FileRenderer` (40 MB ceiling) and
+  `PortraitCaptureControl` (camera → file-picker fallback today, into in-memory `FormContext`);
+  `ISyncService` as a foreground drain trigger; server-side **idempotency/replay protection** keyed
+  by `(instanceId, actionId, senderWallet, lastTransactionId)` → safe retry.
+- **Attachment submission already exists** (not greenfield): the Blueprint Service consumes inline
+  `Files` (base64) → `BuildFileTransactionsAsync` → stores file content → returns file-transaction
+  hashes referenced from the action (`Program.cs:1560`), plus the consumer-tier `/api/file-chunks`
+  staging pipeline (XChaCha20, 10 × 4 MB) for large files. **It is just not on the PWA's `/execute`
+  path yet** — C's attachment work is *wiring an existing mechanism to the PWA submit path*.
+- **Must build (PWA):** `IDraftStore` + `drafts` store; `ISubmitQueue` + `submitQueue` store (outbox);
+  pre-cache of pending-action contexts; offline/connectivity status UI; conflict surface. The dev
+  service worker is a no-op and there is **no** Background Sync API today — C drains on foreground
+  signals (online event / app open / `ISyncService`), not closed-app push (that stays out of scope,
+  companion-roadmap P2).
+
+---
+
+## 2. Scope
+
+**In scope (consumer-tier, Citizen Wallet PWA):**
+- Encrypted local **drafts** of an action's form data (autosave + resume).
+- **Pre-caching** every pending action's form context so it can be opened offline.
+- **Queued/deferred submit** (outbox) that flushes on reconnect, with per-item status.
+- **Conflict handling** (detect/hold/ask) for stale deferred submits.
+- **Photo/media capture** persisted in the encrypted draft, and **attachment submission** wired to
+  the existing inline-`Files`/file-chunk mechanism on the PWA submit path.
+- Connectivity + offline/queued/sync **status UI**.
+
+**Out of scope:**
+- Closed-app background push / Background Sync API (companion roadmap P2).
+- Catalogue / start-new (sub-project B).
+- Org-role / platform-tier work (sub-project D).
+- Server-side draft storage (drafts are device-local only).
+
+---
+
+## 3. Architecture & components
+
+All new PWA code unless noted. Reuses A's `IMyActionsClient`, `Actions.razor`,
+`ApplicationInstance`, and the shared `SorchaFormRenderer`.
+
+- **`IDraftStore`** (new) + `drafts` IndexedDB store — encrypted (XChaCha20-Poly1305, device key,
+  reusing the credential-cache pattern). Key: `instanceId:actionId`. Holds serialized form data +
+  captured media (as encrypted blobs) + metadata (saved-at, status). Mirrors `ICredentialCache`.
+- **`IActionContextCache`** (new) + reuse/extend a store — caches each pending action's form
+  context (blueprint action schema + layout + register/sender context) so the action renders
+  offline. Refreshed from the inbox when online (hooks `ISyncService` / inbox load).
+- **`ISubmitQueue`** (new) + `submitQueue` IndexedDB store (outbox) — enqueues a completed
+  submission (payload + attachment refs); a drainer flushes on connectivity signals; per-item state
+  `Queued → Submitting → Submitted | NeedsAttention`. Idempotency key reused so a retry can't
+  double-submit.
+- **Attachment submission** — on submit, captured media is sent via the existing inline-`Files`
+  mechanism (small) or staged through `/api/file-chunks` (large), brought to the PWA `/execute`
+  path. The exact wiring (extend the execute path to honor `Files` vs. submit through the
+  Files-aware endpoint) is a plan/tasks decision; both reuse `BuildFileTransactionsAsync`.
+- **Connectivity + status UI** — an `IConnectivity` signal (online/offline) and inbox/draft badges
+  ("Saved offline", "Queued", "Needs attention"). `Actions.razor` (A) shows draft/queue state per
+  row; `ApplicationInstance` (A) loads from / saves to the draft store.
+- **Conflict handling** — the submit drainer inspects the server response; a stale/idempotent-reject
+  marks the queue item + draft `NeedsAttention` and records *why* (already submitted / step moved on
+  / instance closed). The UI offers **discard** or **re-open fresh** (re-fetch current action).
+
+### Unit boundaries
+- `IDraftStore` — persist/list/load/delete encrypted drafts. Testable via the IndexedDB JS-interop
+  seam (mock the bridge).
+- `ISubmitQueue` — enqueue/list/drain with injected clock + submit delegate. Testable with a stub
+  submit function and an in-memory store.
+- `IActionContextCache` — cache/get/refresh action contexts. Testable with a stub `IMyActionsClient`
+  + action loader.
+- Conflict classifier — pure function: server outcome → `{ Submitted | Stale(reason) | Retry }`.
+
+---
+
+## 4. User stories (priority order)
+
+- **US1 (P1) — Resume & submit an offline draft.** Open a cached action offline, fill it, autosave
+  an encrypted draft, resume it later, and submit when back online. *MVP of the offline loop.*
+- **US2 (P1, foundational) — Pre-cache pending actions for offline open.** When online, cache every
+  inbox action's form context so any pending action opens offline. (Foundational for US1's "open
+  offline".)
+- **US3 (P2) — Queued/deferred submit.** Submissions made offline are queued and auto-flushed on
+  reconnect with visible per-item status.
+- **US4 (P2) — Conflict handling.** A stale deferred submit is detected, held, and explained
+  (discard / re-open-fresh) — no silent loss.
+- **US5 (P3) — Photo/media capture + attachment submission.** Capture photos offline, persist them
+  in the encrypted draft, and submit them via the existing Files/file-chunk mechanism on the PWA
+  path. (The one backend-touching slice — isolated last.)
+
+**Sequence:** US2 + US1 → US3 → US4 → US5.
+
+---
+
+## 5. Data & lifecycle
+
+- **Draft**: `{ instanceId, actionId, formData, media[], savedAt, status }`, encrypted at rest.
+  Status: `Editing → ReadyToSubmit → Queued → Submitted | NeedsAttention`.
+- **Cached action context**: `{ instanceId, actionId, blueprintActionSchema, layout, registerId,
+  senderWallet, cachedAt }`. Refreshed when online; staleness feeds conflict handling.
+- **Queue item**: `{ id, instanceId, actionId, payload, attachmentRefs, idempotencyKey, state,
+  attempts, lastError }`.
+- **Device-bound encryption**: same key source as the credential cache. **Consequence:** drafts are
+  lost if the device is lost/unpaired — acceptable and consistent with the credential cache (no
+  server copy of in-progress drafts).
+
+---
+
+## 6. Error handling & edge cases
+
+- **Offline open of an un-cached action** — if pre-cache hasn't run for an action, show a clear
+  "available when you're back online" state rather than a broken form.
+- **Draft store / encryption failure** — fail safe: never lose the in-memory form silently; surface
+  a notice; don't crash the form.
+- **Queue drain partial failure** — per-item; one item's failure doesn't block others; transient
+  errors retry with backoff, stale → `NeedsAttention`.
+- **Media too large** — respect the existing 40 MB ceiling / chunk limits; warn at capture, not at
+  submit.
+- **Duplicate submit** — server idempotency makes a double-flush safe (same key → same tx).
+
+---
+
+## 7. Testing strategy
+
+- **`IDraftStore`** — save/load/round-trip (encrypted), list, delete; via the IndexedDB bridge seam.
+- **`ISubmitQueue`** — enqueue, drain success, drain transient-retry, drain stale→NeedsAttention,
+  ordering, idempotency-key reuse; stub submit delegate.
+- **Conflict classifier** — table-driven: server outcomes → Submitted / Stale(reason) / Retry.
+- **`IActionContextCache`** — cache + offline-get + refresh.
+- **bUnit** — `ApplicationInstance` loads from / saves to draft; offline open of cached vs un-cached
+  action; draft/queue/needs-attention badges on `Actions.razor`; connectivity-driven status.
+- **US5** — capture → draft persistence → attachment-ref submission path; the backend wiring gets a
+  Blueprint Service test if `/execute` is extended to honor `Files`.
+
+---
+
+## 8. Risks
+
+- **Attachment wiring is the only backend-touching part** — isolate in US5 so US1-US4 stay
+  pure-PWA. The mechanism exists (`BuildFileTransactionsAsync` / file-chunks); the work is routing
+  the PWA submit through it.
+- **Pre-cache freshness** — a cached schema can drift from the server; conflict handling (US4) is
+  the backstop, and the cache refreshes whenever online.
+- **No Background Sync** — drains are foreground-only; a citizen must open the app to flush the
+  queue. Closed-app push is explicitly out of scope (P2).
+- **Device-bound drafts** — lost on device loss; acceptable, matches the credential cache; messaged
+  honestly.
+
+---
+
+## 9. Definition of done (C)
+
+A citizen can, **with no connectivity**: open any of their pending actions, fill it, capture
+photos, and save it; reopen and resume it; and when back online have it **submit automatically**
+with visible status — and if it can no longer be applied, be **told why and offered discard or
+re-open-fresh**, never losing their captured work silently. All consumer-tier; offline drafts +
+queue + pre-cache are pure-PWA; only the attachment-submission slice (US5) touches the backend, by
+reusing the existing Files/file-chunk mechanism.

--- a/specs/152-offline-field-capture/checklists/requirements.md
+++ b/specs/152-offline-field-capture/checklists/requirements.md
@@ -1,0 +1,40 @@
+# Specification Quality Checklist: PWA Offline / Field Capture
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-06-13
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Spec abstracts the verified plumbing (encrypted IndexedDB store, the existing Files/file-chunk
+  attachment mechanism, server idempotency) into capability language; concrete reuse + the one
+  backend-touching slice (US5 attachment wiring) live in the design doc and will surface in plan.md.
+- Scope constraints bound this to sub-project C; closed-app push, server-side drafts, catalogue (B),
+  and org-role (D) are explicitly excluded.
+- Depends on sub-project A (inbox / open / submit), which is reused.
+- All items pass on first validation; no clarifications. Ready for `/speckit.plan`.

--- a/specs/152-offline-field-capture/contracts/consumed-and-touched-endpoints.md
+++ b/specs/152-offline-field-capture/contracts/consumed-and-touched-endpoints.md
@@ -1,0 +1,52 @@
+# Endpoint Contracts: PWA Offline / Field Capture
+
+**Feature**: 152-offline-field-capture | **Date**: 2026-06-13
+
+C is mostly device-local. It **consumes** existing endpoints unchanged and **touches one** endpoint
+(US5) to honor attachments. No new endpoints.
+
+## Consumed unchanged
+
+| Use | Route | Notes |
+|-----|-------|-------|
+| Pre-cache action context (US2) | `GET /api/instances/{id}`, `GET /api/blueprints/{id}` | Same calls A's `IApplicationActionClient.LoadFormAsync` makes; cached locally for offline open |
+| Pending list/count (badges) | `GET /api/actions/pending`, `/pending/count` | From A; drives which actions to pre-cache |
+| In-review notice | `GET /api/v1/wallet/pending-applications` | From A |
+
+## Touched (US5 only)
+
+```
+POST /{instanceId}/actions/{actionId}/execute    (Blueprint Service, Program.cs:2315)
+```
+
+- **Today**: accepts `ActionSubmissionRequest` (which includes `Files`) but processes only
+  `PayloadData`; `Files` is ignored.
+- **Change (US5)**: honor `request.Files` by reusing the **existing** logic the legacy `/api/actions`
+  endpoint runs (`Program.cs:1560`): `BuildFileTransactionsAsync` → `StoreFileContentAsync` → file-
+  transaction hashes referenced from the action transaction. No request/response **shape** change —
+  the `Files` field already exists; it just becomes effective on this path.
+- **Auth**: unchanged (`RequireAuthorization()`, consumer-tier capable).
+- **Docs**: update the endpoint's OpenAPI summary/description + XML docs to note attachment support;
+  add a Blueprint Service test covering submit-with-Files on the execute path.
+
+## Conflict signals (US4) — read from existing responses
+
+The execute response + server idempotency already surface the signals C classifies:
+- success / idempotent replay → `Submitted`
+- action no longer current / instance not active / already executed → `Stale(reason)`
+- network / 5xx → `Retry`
+
+No new conflict endpoint; C interprets existing outcomes.
+
+## Large-file path (refinement, not MVP)
+
+```
+POST /api/file-chunks    (Blueprint Service — consumer-tier, XChaCha20, 10 × 4 MB)
+```
+Staging for media exceeding the inline `Files` payload limit; referenced from the action payload.
+Used only if a capture exceeds the inline ceiling.
+
+---
+
+**Drift guard**: if the execute request/response or idempotency semantics change, C's conflict
+classifier tests + the US5 attachment test should fail — re-align rather than mapping around it.

--- a/specs/152-offline-field-capture/data-model.md
+++ b/specs/152-offline-field-capture/data-model.md
@@ -1,0 +1,72 @@
+# Phase 1 Data Model: PWA Offline / Field Capture
+
+**Feature**: 152-offline-field-capture | **Date**: 2026-06-13
+
+All new state is **device-local, encrypted at rest** (XChaCha20-Poly1305, device key). No new
+server-side model. Three new IndexedDB stores; the action payload + attachment shapes reuse the
+existing `ActionSubmissionRequest` / `FileAttachment` server contract.
+
+## Store: `drafts` (key: `instanceId:actionId`)
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `InstanceId` | string (Guid) | The action's instance |
+| `ActionId` | int | The action |
+| `FormData` | dictionary | Flat JSON-Pointer-keyed form values (as `SorchaFormRenderer` emits) |
+| `Media` | list of `DraftMedia` | Captured photos/files (see below) |
+| `Status` | enum | `Editing → ReadyToSubmit → Queued → Submitted | NeedsAttention` |
+| `SavedAt` | DateTimeOffset | Last autosave |
+| `ConflictReason` | string? | Set when `NeedsAttention` (already-submitted / step-moved-on / closed) |
+
+`DraftMedia`: `{ FileName, ContentType, Bytes (encrypted blob), CapturedAt }` — respects the existing
+40 MB ceiling.
+
+## Store: `submitQueue` (key: autoincrement `id`)
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `Id` | long | Queue order |
+| `InstanceId` / `ActionId` | string / int | Target action |
+| `Payload` | dictionary | Nested submission payload (as the execute body expects) |
+| `Attachments` | list of `FileAttachment` | base64 inline (or chunk refs for large files) |
+| `IdempotencyKey` | string | Reused server key so a re-flush can't duplicate |
+| `State` | enum | `Queued → Submitting → Submitted | NeedsAttention` |
+| `Attempts` | int | For backoff |
+| `LastError` | string? | Last transient error / conflict reason |
+
+## Store: `actionContext` (key: `instanceId:actionId`)
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `InstanceId` / `ActionId` | string / int | Identity |
+| `ActionSchema` | json | Blueprint action (schema + layout) for offline render |
+| `RegisterId` / `SenderWallet` | string | Submission context (as `ApplicationFormContext` carries) |
+| `CachedAt` | DateTimeOffset | Freshness; refreshed when online |
+
+## Conflict classification (pure)
+
+`SubmitConflictClassifier.Classify(serverOutcome) -> ConflictResult`:
+- `Submitted` — success (incl. idempotent same-key replay).
+- `Stale(reason)` — no longer applicable: `AlreadySubmitted` / `StepMovedOn` / `InstanceClosed`.
+- `Retry` — transient (network / 5xx).
+
+Drives queue-item + draft state transitions; unit-tested table-driven.
+
+## State transitions (client-owned)
+
+```
+Draft:   Editing --(complete)--> ReadyToSubmit --(enqueue)--> Queued
+Queue:   Queued --(flush)--> Submitting --(Submitted)--> Submitted (draft cleared)
+                                         --(Stale)-----> NeedsAttention (draft kept + reason)
+                                         --(Retry)-----> Queued (backoff)
+NeedsAttention --(citizen: discard)--> removed
+              --(citizen: re-open fresh)--> Editing against current action context
+```
+
+## Reused server contract (no new model)
+
+- `ActionSubmissionRequest { PayloadData, Files: List<FileAttachment>? }` and
+  `FileAttachment { FileName, ContentType, ContentBase64 }` — already defined; US5 makes `/execute`
+  honor `Files` (reusing `BuildFileTransactionsAsync`).
+- Server idempotency keyed by `(instanceId, actionId, senderWallet, lastTransactionId)` — reused for
+  safe retry / duplicate prevention.

--- a/specs/152-offline-field-capture/plan.md
+++ b/specs/152-offline-field-capture/plan.md
@@ -1,0 +1,120 @@
+# Implementation Plan: PWA Offline / Field Capture
+
+**Branch**: `152-offline-field-capture` | **Date**: 2026-06-13 | **Spec**: [spec.md](./spec.md)
+
+**Input**: Feature specification from `/specs/152-offline-field-capture/spec.md`
+
+**Source design**: `docs/superpowers/specs/2026-06-13-pwa-offline-field-capture-design.md`
+
+**Depends on**: sub-project A (`151-citizen-workflow-inbox`) — reuses `IMyActionsClient`,
+`Actions.razor`, `ApplicationInstance`, and the shared `SorchaFormRenderer`.
+
+## Summary
+
+Make Citizen Wallet PWA workflow participation field-first: a consumer-tier citizen can open any of
+their pending actions **offline**, fill them, **capture photos**, save an **encrypted local draft**
+(autosave/resume), and have the PWA **submit automatically on reconnect** with a **detect/hold/ask**
+conflict path. Reuses the proven XChaCha20-Poly1305/IndexedDB device-bound encryption, the capture
+controls (`FileRenderer`/`PortraitCaptureControl`), `ISyncService` as a drain trigger, and the
+existing platform attachment mechanism (inline `Files` → `BuildFileTransactionsAsync` / `/api/file-
+chunks`). New PWA infrastructure: a draft store, an action-context pre-cache, a submit-queue outbox,
+a conflict classifier, and offline/queued status UI. The only backend-touching slice is US5 (routing
+the citizen submit path through the existing attachment mechanism).
+
+## Technical Context
+
+**Language/Version**: C# 14 / .NET 10 (Blazor WebAssembly PWA); JS interop for IndexedDB + AEAD.
+
+**Primary Dependencies**: `Sorcha.Wallet.Pwa`; shared `Sorcha.UI.Components.User` (form renderer,
+capture controls); existing `indexeddb-bridge.js` + `xchacha-bridge.js` (XChaCha20-Poly1305,
+device-bound key); `ISyncService` (drain trigger); A's `IMyActionsClient` / `ApplicationInstance`;
+the Blueprint Service attachment mechanism (`Files` / `BuildFileTransactionsAsync` / `/api/file-
+chunks`) for US5.
+
+**Storage**: Device-local **IndexedDB** — new `drafts` and `submitQueue` stores + an
+action-context cache store, all encrypted at rest (XChaCha20-Poly1305, device key). No server-side
+draft storage.
+
+**Testing**: xUnit + bUnit (`JSRuntimeMode.Loose`) in `tests/Sorcha.Wallet.Pwa.Tests`; mock the
+IndexedDB JS-interop seam and the submit delegate. US5 attachment wiring, if it extends the execute
+path, gets a Blueprint Service test in `tests/Sorcha.Blueprint.Service.Tests`.
+
+**Target Platform**: Blazor WASM PWA at `/wallet/` (consumer tier).
+
+**Project Type**: PWA front-end + one backend-touching slice (US5 attachment submission).
+
+**Performance Goals**: Open a prepared action and autosave a draft with no perceptible lag offline;
+queue flush completes promptly on reconnect; capture/persist a photo without blocking the form.
+
+**Constraints**: Consumer-tier only; drafts encrypted at rest (constitution §II); device-bound (lost
+on device loss — messaged honestly); base-relative navigation under `/wallet/`; no `ISnackbar`
+(Pattern #12); foreground-only drain (no Background Sync API); reuse the existing attachment
+mechanism rather than inventing one.
+
+**Scale/Scope**: ~3 new PWA services (`IDraftStore`, `ISubmitQueue`, `IActionContextCache`) + a
+conflict classifier + a connectivity signal + status UI + draft/queue integration into A's pages;
+one IndexedDB schema bump; one backend-touching slice (US5).
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Applies? | Status |
+|-----------|----------|--------|
+| I. Microservices-First | US5 may touch Blueprint Service | ✅ PASS — reuses existing attachment seam; no new service or upward dependency |
+| II. Security First | **Yes — at-rest encryption** | ✅ PASS — drafts/media/queue encrypted with XChaCha20-Poly1305 device key (reuses credential-cache pattern); consumer-tier; no secrets committed; idempotency prevents double-submit |
+| III. API Documentation | US5 only if execute path changes | ✅ — if `/execute` is extended to honor `Files`, update its OpenAPI summary/description + XML docs; otherwise N/A |
+| IV. Testing (>85% new code) | Yes | ✅ PLANNED — store/queue/classifier/cache unit-tested; bUnit for page integration; TDD ordering |
+| V. Code Quality | Yes | ✅ PLANNED — nullable, async I/O, DI, no warnings; follow existing PWA service patterns |
+| VI. Blueprint Standards | No | ✅ N/A |
+| VII. Domain-Driven Design | Yes | ✅ PASS — Action/Participant/Instance terms; "draft/queue/prepared action" are client concepts over them |
+| VIII. Observability | Front-end + US5 | ✅ PASS — structured logging (no string interpolation); US5 backend changes keep existing telemetry |
+
+**Result**: PASS. No violations; Complexity Tracking not required.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/152-offline-field-capture/
+├── plan.md, research.md, data-model.md, quickstart.md
+├── contracts/consumed-and-touched-endpoints.md
+├── checklists/requirements.md
+└── tasks.md   # /speckit.tasks output
+```
+
+### Source Code (repository root)
+
+```text
+src/Apps/Sorcha.Wallet.Pwa/
+├── Services/Drafts/                 # NEW — IDraftStore + Indexed-DB-backed impl + models
+├── Services/Drafts/ISubmitQueue.cs  # NEW — outbox queue + drainer
+├── Services/Drafts/IActionContextCache.cs  # NEW — pre-cache of pending action contexts
+├── Services/Drafts/SubmitConflictClassifier.cs  # NEW — pure server-outcome → conflict mapping
+├── Services/IConnectivity.cs        # NEW — online/offline signal (navigator.onLine + events)
+├── Pages/Actions.razor              # MODIFY (A) — draft/queue/needs-attention badges per row
+├── Pages/ApplicationInstance.razor  # MODIFY (A) — load-from/save-to draft; offline open; capture persist
+├── wwwroot/js/indexeddb-bridge.js   # MODIFY — add drafts / submitQueue / actionContext stores (schema bump)
+├── Services/ISyncService.cs         # MODIFY — drain the submit queue on sync/reconnect
+└── Program.cs / Extensions/ServiceCollectionExtensions.cs  # MODIFY — DI registrations
+
+src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/
+├── Forms/Controls/FileRenderer.razor, Capture/PortraitCaptureControl.razor  # REUSE (capture)
+└── Forms/SorchaFormRenderer.razor   # REUSE (unchanged)
+
+src/Services/Sorcha.Blueprint.Service/   # US5 ONLY — route the citizen submit path through the
+                                          # existing Files/BuildFileTransactionsAsync mechanism
+tests/
+├── Sorcha.Wallet.Pwa.Tests/Drafts/ … bUnit + service tests
+└── Sorcha.Blueprint.Service.Tests/ …   # US5 attachment-on-execute test (if execute path extended)
+```
+
+**Structure Decision**: PWA-contained for US1-US4 (drafts, pre-cache, queue, conflict), reusing A's
+pages and the shared capture controls. US5 is the single backend-touching slice, reusing the existing
+attachment mechanism. The exact attachment-wiring choice (extend `/execute` to honor `Files` vs.
+submit through the Files-aware endpoint) is resolved in research.md.
+
+## Complexity Tracking
+
+> No Constitution Check violations. Section intentionally empty.

--- a/specs/152-offline-field-capture/quickstart.md
+++ b/specs/152-offline-field-capture/quickstart.md
@@ -1,0 +1,54 @@
+# Quickstart: PWA Offline / Field Capture
+
+**Feature**: 152-offline-field-capture | **Date**: 2026-06-13
+
+## What this adds
+
+Field-first workflow capture in the Citizen Wallet PWA: open pending actions offline, fill them,
+capture photos, save encrypted local drafts, and auto-submit on reconnect — with detect/hold/ask
+conflict handling. Builds on sub-project A.
+
+## Where the code lives
+
+```
+src/Apps/Sorcha.Wallet.Pwa/
+├── Services/Drafts/IDraftStore.cs, IndexedDbDraftStore.cs, Models/        (new — US1)
+├── Services/Drafts/IActionContextCache.cs, …                              (new — US2)
+├── Services/Drafts/ISubmitQueue.cs, …                                     (new — US3)
+├── Services/Drafts/SubmitConflictClassifier.cs                           (new — US4)
+├── Services/IConnectivity.cs                                             (new — US1/US3)
+├── Pages/ApplicationInstance.razor, Pages/Actions.razor                  (modify — A pages)
+├── Services/ISyncService.cs                                              (modify — drain queue)
+├── wwwroot/js/indexeddb-bridge.js                                        (modify — new stores)
+└── Extensions/ServiceCollectionExtensions.cs                            (modify — DI)
+
+src/Services/Sorcha.Blueprint.Service/  (US5 only — honor Files on /execute, reusing BuildFileTransactionsAsync)
+```
+
+## Build & test
+
+```bash
+dotnet build src/Apps/Sorcha.Wallet.Pwa/Sorcha.Wallet.Pwa.csproj
+dotnet test  tests/Sorcha.Wallet.Pwa.Tests/Sorcha.Wallet.Pwa.Tests.csproj
+# US5 backend slice:
+dotnet test  tests/Sorcha.Blueprint.Service.Tests/Sorcha.Blueprint.Service.Tests.csproj
+```
+
+## Manual verification (Docker / n1)
+
+1. Sign into the PWA as a citizen with pending actions; while online, let the app prepare (US2).
+2. Go offline (devtools). Open a pending action **not opened before** → form renders (US2).
+3. Fill it, capture a photo (US5), navigate away, reopen → data + photo restored (US1, SC-001/006).
+4. Complete it offline → shows "Queued" (US3).
+5. Restore connectivity → it submits automatically → "Submitted"; the photo is attached (US3, US5).
+6. For conflict (US4): queue a submit, advance the action server-side, reconnect → item is held
+   "Needs attention" with a reason; choose discard or re-open-fresh; captured data retained until chosen.
+7. Open an **un-prepared** action offline → clear "available online" state, not a broken form.
+
+## Guardrails
+
+- Drafts/media/queue **encrypted at rest** (device key); device-bound (lost on device loss — say so).
+- **Base-relative** navigation; **no `ISnackbar`** (use `IInlineFeedback`/inline state).
+- Foreground-only drain (no Background Sync); idempotency prevents duplicate submits.
+- US5 reuses the existing `Files`/`BuildFileTransactionsAsync` mechanism — do not invent a new
+  attachment endpoint.

--- a/specs/152-offline-field-capture/research.md
+++ b/specs/152-offline-field-capture/research.md
@@ -1,0 +1,93 @@
+# Phase 0 Research: PWA Offline / Field Capture
+
+**Feature**: 152-offline-field-capture | **Date**: 2026-06-13
+
+Brainstorming + a read-only codebase investigation resolved the substantive unknowns. No open
+NEEDS CLARIFICATION items.
+
+## Decision 1 — Local encryption & storage
+
+**Decision**: Reuse the existing device-bound XChaCha20-Poly1305 + IndexedDB mechanism
+(`IndexedDbCredentialCache` + `indexeddb-bridge.js` + `xchacha-bridge.js`). Add new IndexedDB stores
+`drafts`, `submitQueue`, `actionContext` via a schema bump in `indexeddb-bridge.js`. Drafts, queued
+payloads, and captured media are encrypted at rest with the device content key.
+
+**Rationale**: Proven, consumer-tier, satisfies constitution §II (at-rest encryption). No new crypto.
+
+**Consequence**: Drafts are device-bound — lost on device loss/unpair (no server copy). Acceptable
+and consistent with the credential cache; messaged honestly (SCOPE-002).
+
+## Decision 2 — Attachment submission path (the one backend-touching slice, US5)
+
+**Decision**: Extend the PWA's existing submit path — `POST /{instanceId}/actions/{actionId}/execute`
+(`Program.cs:2315`) — to honor `ActionSubmissionRequest.Files` by reusing the **same** proven logic
+the legacy `/api/actions` endpoint already runs (`Program.cs:1560`): `BuildFileTransactionsAsync` →
+`StoreFileContentAsync` → file-transaction hashes referenced from the action transaction. Typical
+photos go inline (base64 `Files`); the existing `/api/file-chunks` staging pipeline remains the
+large-file path if a capture exceeds the inline payload limit.
+
+**Rationale**: The mechanism exists and is consumer-tier; the only gap is that `/execute` accepts the
+`Files` field but doesn't process it (it delegates to `ActionExecutionService`, which ignores Files).
+Wiring the proven logic into the execute path keeps the PWA on its current submit route (no PWA
+submit-route change) and avoids inventing anything. Inline Files suits typical photos
+(`FileRenderer` ceiling 40 MB); chunking is a refinement, not MVP.
+
+**Alternatives considered**:
+- *Submit through the legacy `/api/actions` endpoint* — rejected: diverges the PWA from the F137
+  `/execute` path A already uses; two submit routes to maintain.
+- *File-chunks for everything* — rejected for MVP: more moving parts than typical photo sizes need.
+
+## Decision 3 — Pre-cache pending actions for offline open (US2)
+
+**Decision**: Add `IActionContextCache` + an `actionContext` store. When online (on inbox load /
+`ISyncService` sync), fetch and cache each pending action's form context (blueprint action schema +
+layout + register/sender context — the same shape `ApplicationInstance` loads today via
+`IApplicationActionClient.LoadFormAsync`). `ApplicationInstance` reads from the cache when offline;
+the cache refreshes whenever online.
+
+**Rationale**: Reuses A's load shape; "open any pending action offline" needs the schema local.
+Staleness is backstopped by conflict handling (Decision 5).
+
+## Decision 4 — Submit queue / drain trigger (US3)
+
+**Decision**: `ISubmitQueue` + `submitQueue` store (outbox). A completed offline submission enqueues
+`{payload, attachmentRefs, idempotencyKey, state, attempts}`. Drain on foreground connectivity
+signals — `IConnectivity` online event, app open, and `ISyncService` sync — **not** Background Sync
+(none exists; companion-roadmap P2). Reuse the server idempotency key so a re-flush can't duplicate.
+
+**Rationale**: Foreground drain is all the platform supports today; idempotency makes retries safe.
+
+## Decision 5 — Conflict handling: detect / hold / ask (US4)
+
+**Decision**: A pure `SubmitConflictClassifier` maps a server submit outcome to
+`{ Submitted | Stale(reason) | Retry }`. `Stale` (already submitted / step moved on / instance
+closed — detected from the execute response / idempotent-reject) marks the queue item + draft
+`NeedsAttention` and records the reason; the UI offers **discard** or **re-open-fresh** (re-fetch the
+current action). Captured data is retained until the citizen chooses. Transient → `Retry` with
+backoff.
+
+**Rationale**: The brainstorm decision (no silent loss). A pure classifier is unit-testable.
+
+## Decision 6 — Connectivity signal (US1/US3)
+
+**Decision**: `IConnectivity` over `navigator.onLine` + `online`/`offline` events via JS interop
+(small bridge). Drives offline UI and queue drain. Treat as a hint (a flush attempt is the real
+test).
+
+## Decision 7 — Capture reuse (US5)
+
+**Decision**: Reuse `FileRenderer` / `PortraitCaptureControl` (already capture into in-memory form
+state, camera→file-picker fallback). Add persistence: captured media is written into the encrypted
+draft (not just in-memory), and restored on reopen. No new capture UI.
+
+## Decision 8 — Test placement & feedback surface
+
+**Decision**: Tests in `tests/Sorcha.Wallet.Pwa.Tests` (service + bUnit); US5 backend wiring gets a
+`tests/Sorcha.Blueprint.Service.Tests` test if `/execute` is extended. Feedback via `IInlineFeedback`
+/ inline page state — never `ISnackbar` (Pattern #12). Navigation base-relative under `/wallet/`.
+
+## Decision 9 — Dependency on A
+
+**Decision**: Built on sub-project A (`IMyActionsClient`, `Actions.razor`, `ApplicationInstance`).
+The 152 branch is stacked on A and will be rebased onto master (`--onto`) once A merges, so C's PR
+shows only C's diff.

--- a/specs/152-offline-field-capture/spec.md
+++ b/specs/152-offline-field-capture/spec.md
@@ -1,0 +1,236 @@
+# Feature Specification: PWA Offline / Field Capture
+
+**Feature Branch**: `152-offline-field-capture`
+
+**Created**: 2026-06-13
+
+**Status**: Draft
+
+**Input**: User description: "PWA offline / field capture (sub-project C): offline-capable, field-first workflow capture in the Citizen Wallet PWA — encrypted local drafts with autosave/resume, pre-cache of pending actions for offline open, queued/deferred submit that flushes on reconnect, detect/hold/ask conflict handling, and photo/media capture submitted via the existing Files/file-chunk mechanism. Consumer-tier; depends on sub-project A."
+
+**Source design**: `docs/superpowers/specs/2026-06-13-pwa-offline-field-capture-design.md` (sub-project C of the PWA workflow-participation programme; depends on A).
+
+## User Scenarios & Testing *(mandatory)*
+
+Sub-project A lets a citizen discover and complete the actions waiting on them — but only online, in
+one sitting, and with no way to attach photos. This feature makes participation **field-first**: a
+person can open their pending workflow actions with no connectivity, fill them in, capture photos,
+save the work locally, and have it submit automatically when back online — without ever silently
+losing what they captured.
+
+### User Story 1 - Resume and submit an offline draft (Priority: P1)
+
+A citizen opens an action with no connectivity, fills in part of the form, and closes the app. Later
+they reopen the app, find their work exactly as they left it, finish it, and — once back online — it
+submits.
+
+**Why this priority**: This is the core offline loop and the minimum viable proof that work survives
+across sessions and connectivity gaps. Without it there is no "field-first".
+
+**Independent Test**: With no connectivity, open a cached action, enter some data, close and reopen
+the app, confirm the data is restored, complete it, restore connectivity, and confirm it submits.
+
+**Acceptance Scenarios**:
+
+1. **Given** a citizen filling an action with no connectivity, **When** they navigate away or close
+   the app, **Then** their entered data is saved locally and is not lost.
+2. **Given** a saved offline draft, **When** the citizen reopens that action, **Then** the form is
+   restored to exactly what they had entered.
+3. **Given** a completed draft and restored connectivity, **When** the citizen submits (or the app
+   flushes), **Then** the action is submitted and the draft is cleared.
+4. **Given** locally saved drafts, **When** the citizen views their work, **Then** each item shows a
+   clear state (e.g. "Saved offline", "Ready to submit").
+
+---
+
+### User Story 2 - Open any pending action offline (Priority: P1)
+
+A citizen, while they still have signal, lets the app prepare; later, with no connectivity, they can
+open **any** of the actions waiting on them — not just ones they opened earlier — fill them, and
+save them.
+
+**Why this priority**: True field work means a citizen can walk into a no-signal area and still start
+any outstanding action. It is the foundation that makes US1's "open offline" possible for actions
+not previously opened.
+
+**Independent Test**: With connectivity, let the app prepare; go offline; open a pending action that
+was never opened before; confirm the form renders and can be filled and saved.
+
+**Acceptance Scenarios**:
+
+1. **Given** connectivity, **When** the citizen has pending actions, **Then** the app prepares each
+   one so it can be opened later without connectivity.
+2. **Given** no connectivity, **When** the citizen opens a prepared pending action, **Then** its form
+   renders fully and can be filled and saved.
+3. **Given** no connectivity, **When** the citizen opens an action that was **not** prepared, **Then**
+   they see a clear "available when you're back online" state rather than a broken form.
+4. **Given** the prepared set is stale, **When** connectivity returns, **Then** the prepared actions
+   refresh from the current server state.
+
+---
+
+### User Story 3 - Queued submit that flushes on reconnect (Priority: P2)
+
+A citizen completes one or more actions offline; the app holds them and submits them automatically
+when connectivity returns, showing progress.
+
+**Why this priority**: Turns "saved locally" into "actually submitted" without the citizen
+babysitting it. Builds on US1.
+
+**Independent Test**: Complete an action offline, confirm it shows as queued, restore connectivity,
+and confirm it transitions to submitted without manual action.
+
+**Acceptance Scenarios**:
+
+1. **Given** an action completed with no connectivity, **When** the citizen finishes it, **Then** it
+   is queued for submission and shown as "Queued".
+2. **Given** queued submissions, **When** connectivity returns (or the app is reopened), **Then** the
+   app submits them automatically and updates each to "Submitted".
+3. **Given** multiple queued submissions, **When** one fails transiently, **Then** the others still
+   proceed and the failed one retries.
+4. **Given** a queued submission already accepted by the server, **When** it is retried, **Then** it
+   is not duplicated.
+
+---
+
+### User Story 4 - Conflict handling: detect, hold, ask (Priority: P2)
+
+A citizen submits an action that, by the time it reaches the server, is no longer valid (the workflow
+moved on, it was already submitted from another device, or the instance closed). The app does not
+silently drop it — it keeps the work, explains what changed, and asks what to do.
+
+**Why this priority**: The safety guarantee that makes offline trustworthy. Without it, field work
+can be silently lost.
+
+**Independent Test**: Queue a submission, change the underlying action state server-side, restore
+connectivity, and confirm the citizen is shown what changed with discard vs. re-open-fresh choices —
+and their captured data is retained until they choose.
+
+**Acceptance Scenarios**:
+
+1. **Given** a queued submission that is no longer applicable, **When** the app tries to submit it,
+   **Then** it is held (not discarded) and marked "Needs attention".
+2. **Given** a held submission, **When** the citizen views it, **Then** they are told why it could
+   not be applied (already submitted / step moved on / closed).
+3. **Given** a held submission, **When** the citizen decides, **Then** they can discard it or re-open
+   it against the current action state, and their captured data is retained until they choose.
+
+---
+
+### User Story 5 - Capture and submit photos/media offline (Priority: P3)
+
+A citizen captures one or more photos as part of an action while offline; the photos are saved with
+the draft and submitted along with the action when back online.
+
+**Why this priority**: Completes the field-evidence headline, but is the only part that touches the
+submission/attachment plumbing, so it is sequenced last.
+
+**Independent Test**: With no connectivity, capture a photo on an action, save and reopen the draft,
+confirm the photo persists, restore connectivity, submit, and confirm the photo is attached to the
+submitted action.
+
+**Acceptance Scenarios**:
+
+1. **Given** no connectivity, **When** the citizen captures a photo on an action, **Then** the photo
+   is saved with the draft and visible on reopen.
+2. **Given** a draft with captured photos and restored connectivity, **When** it is submitted,
+   **Then** the photos are submitted as attachments of the action.
+3. **Given** a photo exceeds the allowed size, **When** the citizen captures it, **Then** they are
+   warned at capture time, not at submission.
+
+---
+
+### Edge Cases
+
+- **Offline open of an un-prepared action** — clear "available online" state, never a broken form.
+- **Local-storage / encryption failure** — fail safe: surface a notice, never silently lose the
+  in-memory form or crash.
+- **Partial queue flush** — one item failing does not block the rest; transient errors retry, stale
+  items move to "Needs attention".
+- **Device loss** — locally saved drafts are device-bound and not recoverable elsewhere (consistent
+  with how held credentials work); this is communicated honestly, not implied as backed up.
+- **Duplicate submission** on retry — must not create a duplicate.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: A citizen MUST be able to fill an action with no connectivity and have their entered
+  data saved locally so it is not lost when they navigate away or close the app.
+- **FR-002**: A citizen MUST be able to reopen a saved draft and find the form restored to exactly
+  what they entered.
+- **FR-003**: Locally saved work MUST be encrypted at rest on the device.
+- **FR-004**: When connectivity is available, the app MUST prepare every pending action so it can be
+  opened and filled later without connectivity, and MUST refresh that prepared set when connectivity
+  returns.
+- **FR-005**: With no connectivity, opening a prepared pending action MUST render its form fully;
+  opening an un-prepared action MUST show a clear "available when you're back online" state.
+- **FR-006**: Completed actions submitted with no connectivity MUST be queued and submitted
+  automatically when connectivity returns, without the citizen having to retry manually.
+- **FR-007**: Each draft and queued submission MUST show a clear state (e.g. saved / ready / queued /
+  submitted / needs attention).
+- **FR-008**: A retry of an already-accepted submission MUST NOT create a duplicate.
+- **FR-009**: A queued submission that is no longer applicable when it reaches the server MUST be
+  held (not silently discarded), marked "needs attention", and accompanied by an explanation of what
+  changed.
+- **FR-010**: For a held submission, the citizen MUST be able to discard it or re-open it against the
+  current action state, with their captured data retained until they choose.
+- **FR-011**: A citizen MUST be able to capture photos/media on an action with no connectivity; the
+  media MUST be saved with the draft and visible on reopen.
+- **FR-012**: Captured media MUST be submitted as attachments of the action when the submission is
+  sent.
+- **FR-013**: Media that exceeds the allowed size MUST be rejected/warned at capture time, not at
+  submission.
+- **FR-014**: Partial failure of a queue flush MUST NOT block other queued items; transient failures
+  retry, non-recoverable conflicts move to "needs attention".
+- **FR-015**: The feature MUST be available to a citizen in their personal (consumer) capacity and
+  MUST NOT require any organisational role.
+
+### Scope Constraints (carried from the design)
+
+- **SCOPE-001**: Closed-app background submission / push (submitting while the app is not open) is
+  out of scope; queue flush happens on foreground signals (app open / reconnect).
+- **SCOPE-002**: Drafts are device-local only; there is no server-side copy of in-progress work.
+- **SCOPE-003**: Browsing/starting a brand-new application from a catalogue is out of scope
+  (sub-project B); org-role/platform-tier work is out of scope (sub-project D).
+- **SCOPE-004**: Attachment submission reuses the platform's existing file mechanism; this feature
+  brings it to the citizen submit path rather than inventing a new one.
+
+### Key Entities
+
+- **Draft** — a citizen's in-progress action: which action it belongs to, the entered form data, any
+  captured media, when it was saved, and its state.
+- **Prepared action** — a locally cached copy of a pending action's form definition that lets it be
+  opened offline; has a freshness/cached-at marker.
+- **Queued submission** — a completed action awaiting send: its payload, attachment references, a
+  state (queued / submitting / submitted / needs attention), and a reason when held.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A citizen can complete an entire action — open, fill, capture a photo, save — with **no
+  connectivity at any point**, and lose **none** of it across an app close/reopen.
+- **SC-002**: With no connectivity, a citizen can open **any** of their pending actions that were
+  prepared while online (not only ones opened earlier).
+- **SC-003**: When connectivity returns, queued submissions are sent **without the citizen taking any
+  manual action**, and each reaches a terminal state (submitted or needs-attention).
+- **SC-004**: **Zero** captured work is silently lost: every queued submission that cannot be applied
+  ends in a "needs attention" state with an explanation, never a silent drop.
+- **SC-005**: A retried submission **never** results in a duplicate on the server.
+- **SC-006**: A captured photo saved offline is present after an app close/reopen in **100%** of
+  cases and is attached to the action when finally submitted.
+
+## Assumptions
+
+- The capabilities to list, open, and submit an action exist (delivered by sub-project A) and are
+  reused; this feature adds offline persistence, pre-caching, queuing, conflict handling, and media.
+- Local encryption reuses the device-bound mechanism already used for held credentials; consequently
+  drafts are not recoverable if the device is lost — communicated honestly.
+- Attachment submission reuses the platform's existing file/attachment mechanism; the work is routing
+  the citizen submit path through it.
+- Queue flushing is driven by foreground connectivity signals (app open / reconnect); closed-app push
+  is out of scope.
+- Server-side idempotency/replay protection exists and makes a retried submission safe from
+  duplication.
+- A citizen is signed in to the wallet in their personal capacity.

--- a/specs/152-offline-field-capture/tasks.md
+++ b/specs/152-offline-field-capture/tasks.md
@@ -1,0 +1,141 @@
+# Tasks: PWA Offline / Field Capture
+
+**Input**: Design docs from `/specs/152-offline-field-capture/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/, quickstart.md
+**Tests**: INCLUDED (TDD) — constitution §IV + design §7. Tests written before implementation.
+**Organization**: by user story. **Depends on sub-project A** (reuses `IMyActionsClient`,
+`Actions.razor`, `ApplicationInstance`, `SorchaFormRenderer`).
+
+## Conventions (every task)
+
+- Drafts/media/queue **encrypted at rest** (XChaCha20-Poly1305 device key; reuse the credential-cache pattern).
+- **Base-relative** nav under `/wallet/`; **no `ISnackbar`** (use `IInlineFeedback`/inline state).
+- bUnit `JSRuntimeMode.Loose`; mock the IndexedDB JS-interop seam + the submit delegate.
+- Foreground-only queue drain (no Background Sync). Reuse server idempotency for safe retry.
+
+---
+
+## Phase 1: Setup
+
+- [ ] T001 [P] Create draft/queue/context models in `src/Apps/Sorcha.Wallet.Pwa/Services/Drafts/Models/` (`ActionDraft`, `DraftMedia`, `QueuedSubmission`, `CachedActionContext`, status enums) per data-model.md.
+- [ ] T002 Add IndexedDB stores `drafts`, `submitQueue`, `actionContext` to `src/Apps/Sorcha.Wallet.Pwa/wwwroot/js/indexeddb-bridge.js` (schema version bump; mirror existing store creation).
+
+---
+
+## Phase 2: Foundational (blocking)
+
+- [ ] T003 [P] (TDD) Failing tests for an encrypted IndexedDB store helper in `tests/Sorcha.Wallet.Pwa.Tests/Drafts/` (round-trip put/get/list/delete through a mocked bridge; values encrypted before put).
+- [ ] T004 Implement a reusable encrypted-store seam (extract/reuse the `IndexedDbCredentialCache` XChaCha20 pattern) used by the draft/queue/context stores. Make T003 pass.
+- [ ] T005 [P] (TDD) Failing tests for `IConnectivity` (online/offline state from a mocked JS bridge; change event raised).
+- [ ] T006 Implement `src/Apps/Sorcha.Wallet.Pwa/Services/IConnectivity.cs` over `navigator.onLine` + online/offline events. Make T005 pass.
+- [ ] T007 Register the new stores + `IConnectivity` in `Extensions/ServiceCollectionExtensions.cs` DI.
+
+**Checkpoint**: encrypted device-local storage + connectivity signal available.
+
+---
+
+## Phase 3: US2 — Pre-cache pending actions for offline open (Priority: P1, foundational for US1)
+
+**Goal**: When online, cache every pending action's form context so any can be opened offline.
+**Independent Test**: online, let it cache; go offline; open a never-opened pending action → renders.
+
+- [ ] T008 [P] [US2] (TDD) Failing tests for `IActionContextCache` in `tests/.../Drafts/ActionContextCacheTests.cs`: caches contexts for the pending list (stub `IMyActionsClient` + loader), offline-get returns a cached context, refresh overwrites, un-cached id returns null.
+- [ ] T009 [US2] Implement `IActionContextCache` + `IndexedDbActionContextCache` (`Services/Drafts/`): cache the `LoadFormAsync`-shaped context per `instanceId:actionId`. Make T008 pass.
+- [ ] T010 [US2] Hook caching into the online path — refresh from the inbox load / `ISyncService` sync (`Services/ISyncService.cs` or inbox load in `Actions.razor`), iterating the pending list.
+- [ ] T011 [US2] `ApplicationInstance.razor`: when offline (or load fails), read the action context from `IActionContextCache`; if absent, render a clear "available when you're back online" state (not the generic error). bUnit test: offline open of cached vs un-cached action.
+
+**Checkpoint**: any prepared pending action opens offline.
+
+---
+
+## Phase 4: US1 — Resume & submit an offline draft (Priority: P1) 🎯 MVP
+
+**Goal**: Open offline, fill, autosave an encrypted draft, resume, submit when online.
+**Independent Test**: offline fill → close/reopen → restored → online → submits → draft cleared.
+
+- [ ] T012 [P] [US1] (TDD) Failing tests `tests/.../Drafts/DraftStoreTests.cs`: save/load round-trip (encrypted), list, delete, status transitions.
+- [ ] T013 [US1] Implement `IDraftStore` + `IndexedDbDraftStore` (`Services/Drafts/`) keyed `instanceId:actionId`. Make T012 pass.
+- [ ] T014 [P] [US1] (TDD) Failing bUnit tests for `ApplicationInstance` draft behaviour: prefills the form from an existing draft; autosaves form changes to the draft store; clears the draft on successful submit.
+- [ ] T015 [US1] `ApplicationInstance.razor`: load draft on open (prefill `SorchaFormRenderer`), autosave on change (debounced), clear on submit success. Make T014 pass.
+- [ ] T016 [US1] `Actions.razor`: show a per-row draft state badge ("Saved offline" / "Ready to submit") sourced from `IDraftStore`. bUnit test.
+
+**Checkpoint**: MVP — offline work survives close/reopen and submits when online.
+
+---
+
+## Phase 5: US3 — Queued submit that flushes on reconnect (Priority: P2)
+
+**Goal**: Offline submissions queue and auto-send on reconnect with visible status.
+**Independent Test**: complete offline → "Queued" → reconnect → "Submitted" (no manual action).
+
+- [ ] T017 [P] [US3] (TDD) Failing tests `tests/.../Drafts/SubmitQueueTests.cs`: enqueue; drain success → Submitted; drain transient → Retry (stays queued, attempts++); ordering; idempotency-key reused so a re-flush doesn't double-submit (stub submit delegate).
+- [ ] T018 [US3] Implement `ISubmitQueue` + `IndexedDbSubmitQueue` (`Services/Drafts/`) with a `DrainAsync(submitDelegate)`. Make T017 pass.
+- [ ] T019 [US3] On offline submit, enqueue instead of direct send; on `IConnectivity` online + app open + `ISyncService` sync, drain. Wire in `ApplicationInstance` (enqueue) + `ISyncService`/MainLayout (drain trigger).
+- [ ] T020 [US3] `Actions.razor`: per-row "Queued" / "Submitting" / "Submitted" badge from `ISubmitQueue`. bUnit test.
+
+**Checkpoint**: US1 + US3 — offline completions submit themselves on reconnect.
+
+---
+
+## Phase 6: US4 — Conflict handling: detect, hold, ask (Priority: P2)
+
+**Goal**: A stale deferred submit is held + explained, never silently dropped.
+**Independent Test**: queue → advance action server-side → reconnect → "Needs attention" + reason; discard / re-open-fresh; data retained until chosen.
+
+- [ ] T021 [P] [US4] (TDD) Failing tests `tests/.../Drafts/SubmitConflictClassifierTests.cs`: table-driven server-outcome → `Submitted | Stale(AlreadySubmitted|StepMovedOn|InstanceClosed) | Retry`.
+- [ ] T022 [US4] Implement pure `SubmitConflictClassifier` (`Services/Drafts/`). Make T021 pass.
+- [ ] T023 [US4] `ISubmitQueue` drain uses the classifier: `Stale` → mark queue item + draft `NeedsAttention` + reason (retain captured data); `Retry` → backoff. Extend SubmitQueueTests for the stale path.
+- [ ] T024 [US4] UI: `Actions.razor` "Needs attention" badge + a detail surface explaining the reason with **discard** / **re-open-fresh** (re-fetch current action context). bUnit test: held item shows reason + both choices; discard removes; re-open-fresh routes to the action against fresh context.
+
+**Checkpoint**: no silent loss — every undeliverable submit ends in an explained held state.
+
+---
+
+## Phase 7: US5 — Capture & submit photos/media offline (Priority: P3, backend-touching)
+
+**Goal**: Capture photos offline, persist in the draft, submit as attachments.
+**Independent Test**: offline capture → reopen (persisted) → submit → attached to the action.
+
+- [ ] T025 [P] [US5] (TDD) Failing tests: captured media persists in the draft (`DraftStoreTests` extension — media survives round-trip, encrypted); over-ceiling media rejected at capture.
+- [ ] T026 [US5] Persist `FileRenderer`/`PortraitCaptureControl` captures into the encrypted draft (`Media`), restore on reopen; warn at capture if over the 40 MB ceiling. Wire in `ApplicationInstance`.
+- [ ] T027 [P] [US5] (TDD) Failing Blueprint Service test `tests/Sorcha.Blueprint.Service.Tests/…`: `POST /{id}/actions/{actionId}/execute` with `Files` populated creates file transactions (reusing `BuildFileTransactionsAsync`) and references them from the action.
+- [ ] T028 [US5] Wire `request.Files` handling into the `/execute` path (`Program.cs:2315` / `ActionExecutionService`) reusing the legacy endpoint's `BuildFileTransactionsAsync` → `StoreFileContentAsync` → file-hash logic. Make T027 pass. Update the endpoint OpenAPI summary/description + XML docs.
+- [ ] T029 [US5] PWA submit/queue includes draft media as `Files` (base64) in the execute body; large-file → `/api/file-chunks` path is a documented refinement (not required for typical photos). End-to-end bUnit/integration assertion that a captured photo reaches the submit body.
+
+**Checkpoint**: full field loop — offline capture through attached submission.
+
+---
+
+## Phase 8: Polish
+
+- [ ] T030 [P] Run `scripts/check-no-snackbar.ps1`; confirm no new `ISnackbar`.
+- [ ] T031 [P] New-code coverage ≥85% (constitution §IV) for stores/queue/classifier/cache/connectivity; add tests for any uncovered branch.
+- [ ] T032 [P] Docs: note offline/field-capture + the `/execute` attachment support (service README / API docs / `sorcha-architecture` skill as appropriate).
+- [ ] T033 Run `quickstart.md` manual verification (offline open, capture, resume, auto-submit, conflict, attachment) against Docker/n1; record results.
+- [ ] T034 Clean build (`Sorcha.Wallet.Pwa` + `Sorcha.Blueprint.Service`) 0 warnings; `Sorcha.Wallet.Pwa.Tests` + `Sorcha.Blueprint.Service.Tests` green.
+
+---
+
+## Dependencies & order
+
+- Setup (P1) → Foundational (P2) blocks all stories.
+- **US2 (P3 phase)** is foundational for US1's offline open → do first among stories.
+- **US1 (MVP)** depends on US2 + Foundational.
+- **US3** depends on US1 (drafts) + Foundational (connectivity).
+- **US4** depends on US3 (queue drain).
+- **US5** depends on US1 (draft persistence) + is the only backend-touching slice → last.
+- Polish after the desired stories.
+
+### Within each story
+- Tests first and FAIL before implementation; stores before services before UI before backend wiring.
+
+### Parallel
+- T001/T003/T005 setup+foundational tests; US-test authoring [P]; polish T030–T032.
+
+---
+
+## Implementation strategy
+
+**MVP** = Setup + Foundational + US2 + US1 → a citizen can open a prepared action offline, fill it,
+resume across sessions, and submit on reconnect. Then US3 (auto-flush) → US4 (conflict safety) →
+US5 (photos + attachment). Each story independently testable; US5 isolates the backend change.

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Forms/SorchaFormRenderer.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Forms/SorchaFormRenderer.razor
@@ -292,6 +292,19 @@
 @code {
     [Parameter] public Sorcha.Blueprint.Models.Action? Action { get; set; }
     [Parameter] public JsonDocument? PreviousData { get; set; }
+
+    /// <summary>
+    /// Feature 152 — editable values to seed the form with on (re)open, keyed by JSON Pointer scope
+    /// (e.g. a saved offline draft). Unlike <see cref="PreviousData"/> (read-only prior-action data),
+    /// these populate the editable controls so a citizen can resume an in-progress draft.
+    /// </summary>
+    [Parameter] public IReadOnlyDictionary<string, object?>? InitialFormData { get; set; }
+
+    /// <summary>
+    /// Feature 152 — raised when the user edits form data, carrying the current values. Lets a host
+    /// (e.g. the offline draft autosave) persist in-progress work without waiting for submit.
+    /// </summary>
+    [Parameter] public EventCallback<IReadOnlyDictionary<string, object?>> OnFormDataChanged { get; set; }
     [Parameter] public string ParticipantAddress { get; set; } = string.Empty;
     [Parameter] public string SigningWalletAddress { get; set; } = string.Empty;
     [Parameter] public EventCallback<FormSubmission> OnSubmit { get; set; }
@@ -488,6 +501,15 @@
         if (actionChanged && PreviousData is not null)
         {
             ParsePreviousData();
+        }
+
+        // Feature 152 — seed editable values from a saved draft on (re)open, before controls render.
+        if (actionChanged && InitialFormData is { Count: > 0 })
+        {
+            foreach (var kv in InitialFormData)
+            {
+                _formContext.FormData[kv.Key] = kv.Value;
+            }
         }
 
         if (actionChanged)
@@ -751,6 +773,12 @@
             _personaFillsByPath.Remove(pointer);
         }
         RefreshPersonaFillsList();
+
+        // Feature 152 — surface the edit to a host autosave (offline drafts).
+        if (OnFormDataChanged.HasDelegate)
+        {
+            _ = OnFormDataChanged.InvokeAsync(_formContext.FormData);
+        }
 
         // StateHasChanged is safe here — OnDataChanged is raised by user
         // interactions on the sync context.

--- a/src/Apps/Sorcha.Wallet.Pwa/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Extensions/ServiceCollectionExtensions.cs
@@ -41,6 +41,10 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IPresentationEngine, PresentationEngine>();
         services.AddSingleton<IDeviceKeyService, WebCryptoDeviceKeyService>();
         services.AddSingleton<ICredentialCache, IndexedDbCredentialCache>();
+        // Feature 152 (offline / field capture) — encrypted device-local store seam + connectivity.
+        services.AddSingleton<Sorcha.Wallet.Pwa.Services.Drafts.IEncryptedObjectStore,
+                              Sorcha.Wallet.Pwa.Services.Drafts.IndexedDbEncryptedObjectStore>();
+        services.AddSingleton<IConnectivity, BrowserConnectivity>();
         services.AddSingleton<IDelegationStore, IndexedDbDelegationStore>();
         services.AddSingleton<IStatusListService, IndexedDbStatusListService>();
         services.AddSingleton<ISyncCursorStore, IndexedDbSyncCursorStore>();

--- a/src/Apps/Sorcha.Wallet.Pwa/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Extensions/ServiceCollectionExtensions.cs
@@ -49,6 +49,10 @@ public static class ServiceCollectionExtensions
                               Sorcha.Wallet.Pwa.Services.Drafts.ActionContextCache>();
         services.AddSingleton<Sorcha.Wallet.Pwa.Services.Drafts.IDraftStore,
                               Sorcha.Wallet.Pwa.Services.Drafts.DraftStore>();
+        services.AddSingleton<Sorcha.Wallet.Pwa.Services.Drafts.ISubmitQueue,
+                              Sorcha.Wallet.Pwa.Services.Drafts.SubmitQueue>();
+        services.AddSingleton<Sorcha.Wallet.Pwa.Services.Drafts.ISubmitQueueDrainer,
+                              Sorcha.Wallet.Pwa.Services.Drafts.SubmitQueueDrainer>();
         services.AddSingleton<IDelegationStore, IndexedDbDelegationStore>();
         services.AddSingleton<IStatusListService, IndexedDbStatusListService>();
         services.AddSingleton<ISyncCursorStore, IndexedDbSyncCursorStore>();

--- a/src/Apps/Sorcha.Wallet.Pwa/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Extensions/ServiceCollectionExtensions.cs
@@ -213,6 +213,13 @@ public static class ServiceCollectionExtensions
             .AddHttpMessageHandler<BearerTokenHandler>()
             .AddHttpMessageHandler<ServerClockHandler>();
 
+        // Feature 152 (US5) — file-chunk uploader for captured media (consumer-tier /api/file-chunks).
+        services.AddHttpClient<Sorcha.Wallet.Pwa.Services.Drafts.IFileChunkUploader,
+                               Sorcha.Wallet.Pwa.Services.Drafts.FileChunkUploader>(c =>
+            c.BaseAddress = new Uri(gatewayBaseAddress))
+            .AddHttpMessageHandler<BearerTokenHandler>()
+            .AddHttpMessageHandler<ServerClockHandler>();
+
         // Feature 128 — shared has-any-device probe. Drives the wallet PWA
         // pairing-takeover trigger (sub-PR A3) and the Sorcha Web nag-banner
         // trigger (sub-PR B). Registered Singleton so the cached value +

--- a/src/Apps/Sorcha.Wallet.Pwa/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Extensions/ServiceCollectionExtensions.cs
@@ -45,6 +45,8 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<Sorcha.Wallet.Pwa.Services.Drafts.IEncryptedObjectStore,
                               Sorcha.Wallet.Pwa.Services.Drafts.IndexedDbEncryptedObjectStore>();
         services.AddSingleton<IConnectivity, BrowserConnectivity>();
+        services.AddSingleton<Sorcha.Wallet.Pwa.Services.Drafts.IActionContextCache,
+                              Sorcha.Wallet.Pwa.Services.Drafts.ActionContextCache>();
         services.AddSingleton<IDelegationStore, IndexedDbDelegationStore>();
         services.AddSingleton<IStatusListService, IndexedDbStatusListService>();
         services.AddSingleton<ISyncCursorStore, IndexedDbSyncCursorStore>();

--- a/src/Apps/Sorcha.Wallet.Pwa/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Extensions/ServiceCollectionExtensions.cs
@@ -47,6 +47,8 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IConnectivity, BrowserConnectivity>();
         services.AddSingleton<Sorcha.Wallet.Pwa.Services.Drafts.IActionContextCache,
                               Sorcha.Wallet.Pwa.Services.Drafts.ActionContextCache>();
+        services.AddSingleton<Sorcha.Wallet.Pwa.Services.Drafts.IDraftStore,
+                              Sorcha.Wallet.Pwa.Services.Drafts.DraftStore>();
         services.AddSingleton<IDelegationStore, IndexedDbDelegationStore>();
         services.AddSingleton<IStatusListService, IndexedDbStatusListService>();
         services.AddSingleton<ISyncCursorStore, IndexedDbSyncCursorStore>();

--- a/src/Apps/Sorcha.Wallet.Pwa/MainLayout.razor
+++ b/src/Apps/Sorcha.Wallet.Pwa/MainLayout.razor
@@ -36,6 +36,8 @@
 @inject ISessionExpiryNotifier SessionExpiry
 @inject Sorcha.Wallet.Pwa.Services.Actions.IMyActionsClient MyActions
 @inject CitizenWalletHubConnection CitizenHub
+@inject IConnectivity Connectivity
+@inject Sorcha.Wallet.Pwa.Services.Drafts.ISubmitQueueDrainer SubmitQueueDrainer
 
 @* Feature 141 — dark mode now follows IThemeService (previously the provider
    was unbound, so the wallet never rendered dark). *@
@@ -240,6 +242,33 @@
         await EvaluateTourEligibilityAsync();
         await InitialiseInboxAsync();
         await RefreshTodoCountAsync();
+
+        // Feature 152 (US3) — watch connectivity; flush the offline submit queue now and on reconnect.
+        Connectivity.Changed += HandleConnectivityChanged;
+        await Connectivity.InitializeAsync();
+        _ = DrainSubmitQueueAsync();
+    }
+
+    private void HandleConnectivityChanged(bool isOnline)
+    {
+        if (isOnline)
+        {
+            _ = InvokeAsync(DrainSubmitQueueAsync);
+        }
+    }
+
+    private async Task DrainSubmitQueueAsync()
+    {
+        try
+        {
+            await SubmitQueueDrainer.DrainAsync();
+            await RefreshTodoCountAsync();
+            OutstandingWorkChanged?.Invoke();
+        }
+        catch (Exception)
+        {
+            // Best-effort — a later reconnect/open retries.
+        }
     }
 
     /// <summary>
@@ -457,6 +486,7 @@
         UserContext.OnContextChanged -= HandleContextChanged;
         Nav.LocationChanged -= HandleLocationChanged;
         CitizenHub.OnCredentialAvailable -= HandleWorkSignal;
+        Connectivity.Changed -= HandleConnectivityChanged;
         SessionExpiry.SessionExpired -= HandleSessionExpired;
         ThemeService.OnThemeChanged -= HandleThemeChanged;
         if (_inboxHubStarted)

--- a/src/Apps/Sorcha.Wallet.Pwa/Pages/Actions.razor
+++ b/src/Apps/Sorcha.Wallet.Pwa/Pages/Actions.razor
@@ -18,6 +18,7 @@
 @inject IMyActionsClient MyActions
 @inject IPendingApplicationClient PendingApplications
 @inject Sorcha.Wallet.Pwa.Services.Drafts.IActionContextCache ActionContextCache
+@inject Sorcha.Wallet.Pwa.Services.Drafts.IDraftStore DraftStore
 @inject NavigationManager Nav
 
 <PageTitle>Things to do · Sorcha Wallet</PageTitle>
@@ -72,6 +73,11 @@
                         }
                     </div>
                     <div class="action-row__meta">
+                        @if (_draftKeys.Contains(ActionDraftKey(item)))
+                        {
+                            <MudChip T="string" Size="Size.Small" Color="Color.Info" Variant="Variant.Outlined"
+                                     data-testid="@($"actions-draft-{item.InstanceId}")">Saved offline</MudChip>
+                        }
                         @if (item.Urgency != ActionUrgency.Normal)
                         {
                             <MudChip T="string" Size="Size.Small" Color="@UrgencyColor(item.Urgency)" Variant="Variant.Filled">
@@ -104,6 +110,10 @@
     private IReadOnlyList<PendingActionItem>? _items;
     private bool _refreshError;
     private PendingApplicationView? _inReview;
+    private HashSet<string> _draftKeys = new();
+
+    private static string ActionDraftKey(PendingActionItem item) =>
+        Sorcha.Wallet.Pwa.Services.Drafts.Models.ActionDraft.MakeKey(item.InstanceId, item.ActionId);
 
     /// <summary>
     /// Feature 151 — the wallet shell (cascaded by MainLayout). When present, the inbox subscribes
@@ -164,6 +174,17 @@
         catch (Exception)
         {
             _inReview = null;
+        }
+
+        // US1 — mark rows that have a saved offline draft.
+        try
+        {
+            var drafts = await DraftStore.ListAsync();
+            _draftKeys = drafts.Select(d => d.Key).ToHashSet();
+        }
+        catch (Exception)
+        {
+            // Non-fatal — just omit draft badges.
         }
 
         StateHasChanged();

--- a/src/Apps/Sorcha.Wallet.Pwa/Pages/Actions.razor
+++ b/src/Apps/Sorcha.Wallet.Pwa/Pages/Actions.razor
@@ -17,6 +17,7 @@
 @implements IDisposable
 @inject IMyActionsClient MyActions
 @inject IPendingApplicationClient PendingApplications
+@inject Sorcha.Wallet.Pwa.Services.Drafts.IActionContextCache ActionContextCache
 @inject NavigationManager Nav
 
 <PageTitle>Things to do · Sorcha Wallet</PageTitle>
@@ -143,6 +144,10 @@
             var items = await MyActions.GetPendingAsync();
             _items = PendingActionOrdering.Order(items);
             _refreshError = false;
+
+            // Feature 152 (US2) — while online, pre-cache each pending action's form context so the
+            // citizen can open any of them offline. Best-effort, fire-and-forget; never blocks the list.
+            _ = ActionContextCache.RefreshFromPendingAsync();
         }
         catch (Exception)
         {

--- a/src/Apps/Sorcha.Wallet.Pwa/Pages/Actions.razor
+++ b/src/Apps/Sorcha.Wallet.Pwa/Pages/Actions.razor
@@ -13,12 +13,14 @@
 @using Sorcha.Wallet.Pwa.Services
 @using Sorcha.Wallet.Pwa.Services.Actions
 @using Sorcha.Wallet.Pwa.Services.Actions.Models
+@using Sorcha.Wallet.Pwa.Services.Drafts.Models
 @attribute [Authorize]
 @implements IDisposable
 @inject IMyActionsClient MyActions
 @inject IPendingApplicationClient PendingApplications
 @inject Sorcha.Wallet.Pwa.Services.Drafts.IActionContextCache ActionContextCache
 @inject Sorcha.Wallet.Pwa.Services.Drafts.IDraftStore DraftStore
+@inject Sorcha.Wallet.Pwa.Services.Drafts.ISubmitQueue SubmitQueue
 @inject NavigationManager Nav
 
 <PageTitle>Things to do · Sorcha Wallet</PageTitle>
@@ -94,6 +96,43 @@
         </div>
     }
 
+    @if (_queue.Count > 0)
+    {
+        <div class="actions-queue mt-3" data-testid="actions-queue">
+            @foreach (var q in _queue)
+            {
+                <MudPaper Class="pa-3 mb-2 d-flex flex-column gap-1" Elevation="0"
+                          data-testid="@($"actions-queue-{q.QueuedKey}")">
+                    @if (q.State == QueuedSubmissionState.NeedsAttention)
+                    {
+                        <div class="d-flex align-center gap-2">
+                            <MudIcon Icon="@Icons.Material.Filled.ErrorOutline" Color="Color.Warning" Size="Size.Small" />
+                            <MudText Typo="Typo.subtitle2">Needs attention</MudText>
+                        </div>
+                        <MudText Typo="Typo.body2" Class="mud-text-secondary" data-testid="@($"actions-queue-reason-{q.QueuedKey}")">
+                            @ReasonText(q.ConflictReason)
+                        </MudText>
+                        <div class="d-flex gap-2 mt-1">
+                            <MudButton Size="Size.Small" Variant="Variant.Text" Color="Color.Default"
+                                       data-testid="@($"actions-queue-discard-{q.QueuedKey}")"
+                                       OnClick="@(() => DiscardAsync(q))">Discard</MudButton>
+                            <MudButton Size="Size.Small" Variant="Variant.Filled" Color="Color.Primary"
+                                       data-testid="@($"actions-queue-reopen-{q.QueuedKey}")"
+                                       OnClick="@(() => ReopenFreshAsync(q))">Re-open</MudButton>
+                        </div>
+                    }
+                    else
+                    {
+                        <div class="d-flex align-center gap-2">
+                            <MudIcon Icon="@Icons.Material.Filled.Schedule" Color="Color.Info" Size="Size.Small" />
+                            <MudText Typo="Typo.body2">@(q.State == QueuedSubmissionState.Submitting ? "Submitting…" : "Queued — will submit when online")</MudText>
+                        </div>
+                    }
+                </MudPaper>
+            }
+        </div>
+    }
+
     @if (_inReview is not null)
     {
         <MudAlert Severity="Severity.Info" Dense="true" Class="mt-3 actions-in-review"
@@ -111,9 +150,31 @@
     private bool _refreshError;
     private PendingApplicationView? _inReview;
     private HashSet<string> _draftKeys = new();
+    private IReadOnlyList<QueuedSubmission> _queue = Array.Empty<QueuedSubmission>();
 
     private static string ActionDraftKey(PendingActionItem item) =>
         Sorcha.Wallet.Pwa.Services.Drafts.Models.ActionDraft.MakeKey(item.InstanceId, item.ActionId);
+
+    private static string ReasonText(ConflictReason reason) => reason switch
+    {
+        ConflictReason.AlreadySubmitted => "This was already submitted, so it doesn't need sending again.",
+        ConflictReason.StepMovedOn => "This step has moved on since you filled it in — it can't be submitted as-is.",
+        ConflictReason.InstanceClosed => "This application has closed, so it can no longer be submitted.",
+        _ => "This couldn't be submitted.",
+    };
+
+    private async Task DiscardAsync(QueuedSubmission q)
+    {
+        await SubmitQueue.RemoveAsync(q.QueuedKey);
+        await RefreshAsync();
+    }
+
+    private async Task ReopenFreshAsync(QueuedSubmission q)
+    {
+        // Drop the stale queued item and re-open the action against current (fresh) state.
+        await SubmitQueue.RemoveAsync(q.QueuedKey);
+        Nav.NavigateTo($"applications/{q.InstanceId}");
+    }
 
     /// <summary>
     /// Feature 151 — the wallet shell (cascaded by MainLayout). When present, the inbox subscribes
@@ -185,6 +246,16 @@
         catch (Exception)
         {
             // Non-fatal — just omit draft badges.
+        }
+
+        // US3/US4 — surface queued / submitting / needs-attention items.
+        try
+        {
+            _queue = await SubmitQueue.ListAsync();
+        }
+        catch (Exception)
+        {
+            _queue = Array.Empty<QueuedSubmission>();
         }
 
         StateHasChanged();

--- a/src/Apps/Sorcha.Wallet.Pwa/Pages/ApplicationInstance.razor
+++ b/src/Apps/Sorcha.Wallet.Pwa/Pages/ApplicationInstance.razor
@@ -19,8 +19,10 @@
 @using Sorcha.UI.Core.Models.Forms
 @using Sorcha.Wallet.Pwa.Services
 @using Sorcha.Wallet.Pwa.Services.Applications
+@using Sorcha.Wallet.Pwa.Services.Drafts
 @inject IApplicationActionClient ActionClient
 @inject IPendingApplicationClient PendingApplications
+@inject IActionContextCache ActionContextCache
 @inject NavigationManager Nav
 @inject ILogger<ApplicationInstance> Logger
 
@@ -67,6 +69,13 @@
             </MudPaper>
             break;
 
+        case State.Offline:
+            <MudAlert Severity="Severity.Info" data-testid="application-instance-offline">
+                This application isn't available offline yet. Open it once while you're connected and
+                it'll be ready to fill in the field next time.
+            </MudAlert>
+            break;
+
         default:
             <MudAlert Severity="Severity.Error" data-testid="application-instance-error">
                 We couldn't load this application. It may not be ready yet — try again shortly.
@@ -79,7 +88,7 @@
     /// <summary>The blueprint instance the form binds to.</summary>
     [Parameter] public Guid InstanceId { get; set; }
 
-    private enum State { Loading, Ready, Submitted, Error }
+    private enum State { Loading, Ready, Submitted, Error, Offline }
 
     private State _state = State.Loading;
     private ApplicationFormContext? _ctx;
@@ -89,8 +98,59 @@
 
     protected override async Task OnInitializedAsync()
     {
-        _ctx = await ActionClient.LoadFormAsync(InstanceId);
-        _state = _ctx is null ? State.Error : State.Ready;
+        // Online: resolve the live form context. On failure (offline / unreachable), fall back to
+        // the locally pre-cached context (Feature 152 US2) so the action still opens in the field.
+        try
+        {
+            _ctx = await ActionClient.LoadFormAsync(InstanceId);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogDebug(ex, "Live form load failed for {InstanceId}; trying offline cache.", InstanceId);
+            _ctx = null;
+        }
+
+        if (_ctx is null)
+        {
+            _ctx = await TryLoadCachedContextAsync();
+            if (_ctx is null)
+            {
+                // No live context and nothing prepared offline — distinct from a hard error.
+                _state = State.Offline;
+                return;
+            }
+        }
+
+        _state = State.Ready;
+    }
+
+    private async Task<ApplicationFormContext?> TryLoadCachedContextAsync()
+    {
+        try
+        {
+            var cached = await ActionContextCache.GetForInstanceAsync(InstanceId.ToString());
+            if (cached is null)
+            {
+                return null;
+            }
+
+            var action = System.Text.Json.JsonSerializer.Deserialize<Sorcha.Blueprint.Models.Action>(
+                cached.ActionJson,
+                new System.Text.Json.JsonSerializerOptions(System.Text.Json.JsonSerializerDefaults.Web));
+            if (action is null)
+            {
+                return null;
+            }
+
+            return new ApplicationFormContext(
+                InstanceId, action, cached.BlueprintId, cached.RegisterId, cached.SenderWallet,
+                cached.ActionId, string.IsNullOrWhiteSpace(cached.Title) ? "Application" : cached.Title);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogDebug(ex, "Offline cached context load failed for {InstanceId}.", InstanceId);
+            return null;
+        }
     }
 
     private async Task HandleSubmitAsync(FormSubmission submission)

--- a/src/Apps/Sorcha.Wallet.Pwa/Pages/ApplicationInstance.razor
+++ b/src/Apps/Sorcha.Wallet.Pwa/Pages/ApplicationInstance.razor
@@ -27,6 +27,7 @@
 @inject IActionContextCache ActionContextCache
 @inject IDraftStore DraftStore
 @inject ISubmitQueue SubmitQueue
+@inject IFileChunkUploader FileUploader
 @inject IConnectivity Connectivity
 @inject NavigationManager Nav
 @inject ILogger<ApplicationInstance> Logger
@@ -264,6 +265,8 @@
         {
             // Feature 152 (US3) — no connectivity: queue the submission to flush on reconnect,
             // rather than failing. The draft is cleared (its data now lives in the queue).
+            var media = ToDraftMedia(submission.FileAttachments);
+
             if (!Connectivity.IsOnline)
             {
                 await SubmitQueue.EnqueueAsync(new QueuedSubmission
@@ -274,6 +277,7 @@
                     RegisterId = _ctx.RegisterId,
                     SenderWallet = _ctx.SenderWallet,
                     Payload = new Dictionary<string, object?>(submission.Data),
+                    Attachments = media,
                     IdempotencyKey = Guid.NewGuid().ToString("N"),
                 });
                 _autosaveCts?.Cancel();
@@ -284,7 +288,20 @@
                 return;
             }
 
-            var result = await ActionClient.SubmitAsync(_ctx, submission.Data);
+            // US5 — online: upload captured media via the chunk pipeline and reference it in the payload.
+            var payload = new Dictionary<string, object?>(submission.Data);
+            if (media.Count > 0)
+            {
+                var uploaded = await FileUploader.AttachAllAsync(media, payload, _ctx.SenderWallet, _ctx.RegisterId);
+                if (!uploaded)
+                {
+                    _severity = Severity.Error;
+                    _status = "Couldn't upload your photo(s). Check your connection and try again.";
+                    return;
+                }
+            }
+
+            var result = await ActionClient.SubmitAsync(_ctx, payload);
             switch (result.Status)
             {
                 case ApplicationSubmissionStatus.Success:
@@ -319,4 +336,14 @@
     }
 
     private void GoHome() => Nav.NavigateTo("");
+
+    private static List<DraftMedia> ToDraftMedia(IReadOnlyList<Sorcha.UI.Core.Models.Forms.FileAttachmentInfo> attachments)
+    {
+        var list = new List<DraftMedia>(attachments.Count);
+        foreach (var a in attachments)
+        {
+            list.Add(new DraftMedia(a.FileName, a.ContentType, Convert.ToBase64String(a.Content), DateTimeOffset.UtcNow, a.Scope));
+        }
+        return list;
+    }
 }

--- a/src/Apps/Sorcha.Wallet.Pwa/Pages/ApplicationInstance.razor
+++ b/src/Apps/Sorcha.Wallet.Pwa/Pages/ApplicationInstance.razor
@@ -15,14 +15,17 @@
 @layout MainLayout
 @using Microsoft.AspNetCore.Authorization
 @attribute [Authorize]
+@implements IAsyncDisposable
 @using Sorcha.UI.Core.Components.Forms
 @using Sorcha.UI.Core.Models.Forms
 @using Sorcha.Wallet.Pwa.Services
 @using Sorcha.Wallet.Pwa.Services.Applications
 @using Sorcha.Wallet.Pwa.Services.Drafts
+@using Sorcha.Wallet.Pwa.Services.Drafts.Models
 @inject IApplicationActionClient ActionClient
 @inject IPendingApplicationClient PendingApplications
 @inject IActionContextCache ActionContextCache
+@inject IDraftStore DraftStore
 @inject NavigationManager Nav
 @inject ILogger<ApplicationInstance> Logger
 
@@ -46,7 +49,16 @@
                                     ParticipantAddress="_ctx.SenderWallet"
                                     SigningWalletAddress="_ctx.SenderWallet"
                                     IsSenderAction="true"
+                                    InitialFormData="_initialFormData"
+                                    OnFormDataChanged="HandleFormDataChangedAsync"
                                     OnSubmit="HandleSubmitAsync" />
+                @if (_draftSavedAt is { } saved)
+                {
+                    <MudText Typo="Typo.caption" Class="mud-text-secondary mt-2 d-block"
+                             data-testid="application-instance-draft-saved">
+                        Saved offline @saved.ToLocalTime().ToString("HH:mm")
+                    </MudText>
+                }
             </div>
             @if (!string.IsNullOrEmpty(_status))
             {
@@ -96,6 +108,13 @@
     private Severity _severity = Severity.Info;
     private bool _busy;
 
+    // Feature 152 (US1) — offline draft: seed editable values from a saved draft, autosave edits.
+    private IReadOnlyDictionary<string, object?>? _initialFormData;
+    private IReadOnlyDictionary<string, object?> _currentFormData = new Dictionary<string, object?>();
+    private DateTimeOffset? _draftSavedAt;
+    private CancellationTokenSource? _autosaveCts;
+    private static readonly TimeSpan AutosaveDebounce = TimeSpan.FromMilliseconds(800);
+
     protected override async Task OnInitializedAsync()
     {
         // Online: resolve the live form context. On failure (offline / unreachable), fall back to
@@ -121,7 +140,75 @@
             }
         }
 
+        // Feature 152 — seed the form from any saved offline draft for this action.
+        try
+        {
+            var draft = await DraftStore.GetAsync(InstanceId.ToString(), _ctx.ActionId);
+            if (draft is { FormData.Count: > 0 })
+            {
+                _initialFormData = draft.FormData;
+                _currentFormData = draft.FormData;
+                _draftSavedAt = draft.SavedAt;
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.LogDebug(ex, "Loading draft for {InstanceId} failed; starting fresh.", InstanceId);
+        }
+
         _state = State.Ready;
+    }
+
+    private async Task HandleFormDataChangedAsync(IReadOnlyDictionary<string, object?> data)
+    {
+        _currentFormData = data;
+        if (_ctx is null) return;
+
+        // Debounce: coalesce rapid edits into one save ~800ms after the last keystroke.
+        _autosaveCts?.Cancel();
+        _autosaveCts?.Dispose();
+        _autosaveCts = new CancellationTokenSource();
+        var token = _autosaveCts.Token;
+        try
+        {
+            await Task.Delay(AutosaveDebounce, token);
+            await SaveDraftAsync();
+            await InvokeAsync(StateHasChanged);
+        }
+        catch (TaskCanceledException) { /* superseded by a newer edit */ }
+    }
+
+    private async Task SaveDraftAsync()
+    {
+        if (_ctx is null) return;
+        try
+        {
+            await DraftStore.SaveAsync(new ActionDraft
+            {
+                InstanceId = InstanceId.ToString(),
+                ActionId = _ctx.ActionId,
+                FormData = new Dictionary<string, object?>(_currentFormData),
+                Status = DraftStatus.Editing,
+            });
+            _draftSavedAt = DateTimeOffset.Now;
+        }
+        catch (Exception ex)
+        {
+            Logger.LogWarning(ex, "Autosave of draft {InstanceId} failed.", InstanceId);
+        }
+    }
+
+    /// <inheritdoc />
+    public async ValueTask DisposeAsync()
+    {
+        // Flush any pending edit so navigating away never loses work (FR-001).
+        _autosaveCts?.Cancel();
+        _autosaveCts?.Dispose();
+        _autosaveCts = null;
+        if (_state == State.Ready && _currentFormData.Count > 0)
+        {
+            await SaveDraftAsync();
+        }
     }
 
     private async Task<ApplicationFormContext?> TryLoadCachedContextAsync()
@@ -164,6 +251,10 @@
             switch (result.Status)
             {
                 case ApplicationSubmissionStatus.Success:
+                    // Feature 152 — submitted: the draft is no longer needed.
+                    _autosaveCts?.Cancel();
+                    try { await DraftStore.DeleteAsync(InstanceId.ToString(), _ctx.ActionId); }
+                    catch (Exception ex) { Logger.LogWarning(ex, "Clearing draft after submit failed."); }
                     try
                     {
                         await PendingApplications.SetAsync(_ctx.Title);

--- a/src/Apps/Sorcha.Wallet.Pwa/Pages/ApplicationInstance.razor
+++ b/src/Apps/Sorcha.Wallet.Pwa/Pages/ApplicationInstance.razor
@@ -26,6 +26,8 @@
 @inject IPendingApplicationClient PendingApplications
 @inject IActionContextCache ActionContextCache
 @inject IDraftStore DraftStore
+@inject ISubmitQueue SubmitQueue
+@inject IConnectivity Connectivity
 @inject NavigationManager Nav
 @inject ILogger<ApplicationInstance> Logger
 
@@ -69,12 +71,24 @@
         case State.Submitted:
             <MudPaper Class="pa-6 d-flex flex-column align-center gap-3" Elevation="1"
                       data-testid="application-instance-submitted">
-                <MudIcon Icon="@Icons.Material.Filled.CheckCircle" Color="Color.Success" Size="Size.Large" />
-                <MudText Typo="Typo.h6">Application submitted</MudText>
-                <MudText Typo="Typo.body2" Align="Align.Center" Class="mud-text-secondary">
-                    You'll see the in-progress state on Home. Watch your wallet — your credential will
-                    arrive here once it's approved.
-                </MudText>
+                @if (_queuedOffline)
+                {
+                    <MudIcon Icon="@Icons.Material.Filled.CloudOff" Color="Color.Info" Size="Size.Large" />
+                    <MudText Typo="Typo.h6">Saved — will submit when online</MudText>
+                    <MudText Typo="Typo.body2" Align="Align.Center" Class="mud-text-secondary">
+                        You're offline. We've saved this and will submit it automatically the next time
+                        you're connected.
+                    </MudText>
+                }
+                else
+                {
+                    <MudIcon Icon="@Icons.Material.Filled.CheckCircle" Color="Color.Success" Size="Size.Large" />
+                    <MudText Typo="Typo.h6">Application submitted</MudText>
+                    <MudText Typo="Typo.body2" Align="Align.Center" Class="mud-text-secondary">
+                        You'll see the in-progress state on Home. Watch your wallet — your credential will
+                        arrive here once it's approved.
+                    </MudText>
+                }
                 <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="GoHome">
                     Back to wallet
                 </MudButton>
@@ -114,6 +128,7 @@
     private DateTimeOffset? _draftSavedAt;
     private CancellationTokenSource? _autosaveCts;
     private static readonly TimeSpan AutosaveDebounce = TimeSpan.FromMilliseconds(800);
+    private bool _queuedOffline;
 
     protected override async Task OnInitializedAsync()
     {
@@ -247,6 +262,28 @@
         _status = null;
         try
         {
+            // Feature 152 (US3) — no connectivity: queue the submission to flush on reconnect,
+            // rather than failing. The draft is cleared (its data now lives in the queue).
+            if (!Connectivity.IsOnline)
+            {
+                await SubmitQueue.EnqueueAsync(new QueuedSubmission
+                {
+                    InstanceId = InstanceId.ToString(),
+                    ActionId = _ctx.ActionId,
+                    BlueprintId = _ctx.BlueprintId,
+                    RegisterId = _ctx.RegisterId,
+                    SenderWallet = _ctx.SenderWallet,
+                    Payload = new Dictionary<string, object?>(submission.Data),
+                    IdempotencyKey = Guid.NewGuid().ToString("N"),
+                });
+                _autosaveCts?.Cancel();
+                try { await DraftStore.DeleteAsync(InstanceId.ToString(), _ctx.ActionId); }
+                catch (Exception ex) { Logger.LogWarning(ex, "Clearing draft after queueing failed."); }
+                _queuedOffline = true;
+                _state = State.Submitted;
+                return;
+            }
+
             var result = await ActionClient.SubmitAsync(_ctx, submission.Data);
             switch (result.Status)
             {

--- a/src/Apps/Sorcha.Wallet.Pwa/Services/Drafts/IActionContextCache.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Services/Drafts/IActionContextCache.cs
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using Microsoft.Extensions.Logging;
+using Sorcha.Wallet.Pwa.Services.Actions;
+using Sorcha.Wallet.Pwa.Services.Actions.Models;
+using Sorcha.Wallet.Pwa.Services.Applications;
+using Sorcha.Wallet.Pwa.Services.Drafts.Models;
+
+namespace Sorcha.Wallet.Pwa.Services.Drafts;
+
+/// <summary>
+/// Feature 152 (US2) — caches each pending action's form context locally (encrypted) so the citizen
+/// can open ANY of their pending actions offline, not just ones opened earlier. Refreshed from the
+/// inbox while online; read by <c>ApplicationInstance</c> when offline / the live load fails.
+/// </summary>
+public interface IActionContextCache
+{
+    /// <summary>Returns the cached context for an action, or <c>null</c> if not prepared.</summary>
+    Task<CachedActionContext?> GetAsync(string instanceId, int actionId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns the cached context for an instance's current action (offline open keys by instance id
+    /// only — the action id is resolved server-side when online). Returns the most-recently-cached
+    /// match, or <c>null</c> if the instance was not prepared.
+    /// </summary>
+    Task<CachedActionContext?> GetForInstanceAsync(string instanceId, CancellationToken ct = default);
+
+    /// <summary>Caches/overwrites a single action context.</summary>
+    Task PutAsync(CachedActionContext context, CancellationToken ct = default);
+
+    /// <summary>
+    /// Refreshes the cache from the citizen's current pending actions: loads each action's context
+    /// (while online) and stores it. Best-effort — a single load failure does not abort the rest.
+    /// Returns the number of contexts cached.
+    /// </summary>
+    Task<int> RefreshFromPendingAsync(CancellationToken ct = default);
+}
+
+/// <summary>Default <see cref="IActionContextCache"/> over the encrypted <c>actionContext</c> store.</summary>
+public sealed class ActionContextCache : IActionContextCache
+{
+    private const string StoreName = "actionContext";
+
+    private readonly IEncryptedObjectStore _store;
+    private readonly IMyActionsClient _actions;
+    private readonly IApplicationActionClient _actionClient;
+    private readonly TimeProvider _clock;
+    private readonly ILogger<ActionContextCache> _logger;
+
+    /// <summary>Initialises a new instance.</summary>
+    public ActionContextCache(
+        IEncryptedObjectStore store,
+        IMyActionsClient actions,
+        IApplicationActionClient actionClient,
+        TimeProvider clock,
+        ILogger<ActionContextCache> logger)
+    {
+        _store = store ?? throw new ArgumentNullException(nameof(store));
+        _actions = actions ?? throw new ArgumentNullException(nameof(actions));
+        _actionClient = actionClient ?? throw new ArgumentNullException(nameof(actionClient));
+        _clock = clock ?? throw new ArgumentNullException(nameof(clock));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    public Task<CachedActionContext?> GetAsync(string instanceId, int actionId, CancellationToken ct = default) =>
+        _store.GetAsync<CachedActionContext>(StoreName, ActionDraft.MakeKey(instanceId, actionId), ct);
+
+    /// <inheritdoc />
+    public async Task<CachedActionContext?> GetForInstanceAsync(string instanceId, CancellationToken ct = default)
+    {
+        var all = await _store.ListAsync<CachedActionContext>(StoreName, ct).ConfigureAwait(false);
+        CachedActionContext? best = null;
+        foreach (var ctx in all)
+        {
+            if (string.Equals(ctx.InstanceId, instanceId, StringComparison.OrdinalIgnoreCase)
+                && (best is null || ctx.CachedAt > best.CachedAt))
+            {
+                best = ctx;
+            }
+        }
+        return best;
+    }
+
+    /// <inheritdoc />
+    public Task PutAsync(CachedActionContext context, CancellationToken ct = default) =>
+        _store.PutAsync(StoreName, context.Key, context, ct);
+
+    /// <inheritdoc />
+    public async Task<int> RefreshFromPendingAsync(CancellationToken ct = default)
+    {
+        IReadOnlyList<PendingActionItem> pending;
+        try
+        {
+            pending = await _actions.GetPendingAsync(ct: ct).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Pre-cache skipped — pending actions unavailable (likely offline).");
+            return 0;
+        }
+
+        var cached = 0;
+        foreach (var item in pending)
+        {
+            ct.ThrowIfCancellationRequested();
+            if (!Guid.TryParse(item.InstanceId, out var instanceGuid))
+            {
+                continue;
+            }
+
+            try
+            {
+                var formCtx = await _actionClient.LoadFormAsync(instanceGuid, ct).ConfigureAwait(false);
+                if (formCtx is null)
+                {
+                    continue;
+                }
+
+                var context = new CachedActionContext
+                {
+                    InstanceId = item.InstanceId,
+                    ActionId = formCtx.ActionId,
+                    BlueprintId = formCtx.BlueprintId,
+                    ActionJson = System.Text.Json.JsonSerializer.Serialize(
+                        formCtx.Action, new System.Text.Json.JsonSerializerOptions(System.Text.Json.JsonSerializerDefaults.Web)),
+                    RegisterId = formCtx.RegisterId,
+                    SenderWallet = formCtx.SenderWallet,
+                    Title = formCtx.Title,
+                    CachedAt = _clock.GetUtcNow(),
+                };
+                await PutAsync(context, ct).ConfigureAwait(false);
+                cached++;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "Pre-cache of action {InstanceId} failed; continuing.", item.InstanceId);
+            }
+        }
+        return cached;
+    }
+}

--- a/src/Apps/Sorcha.Wallet.Pwa/Services/Drafts/IDraftStore.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Services/Drafts/IDraftStore.cs
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using Sorcha.Wallet.Pwa.Services.Drafts.Models;
+
+namespace Sorcha.Wallet.Pwa.Services.Drafts;
+
+/// <summary>
+/// Feature 152 (US1) — device-local, encrypted store of in-progress action drafts (form data +
+/// captured media), keyed by <c>instanceId:actionId</c>. Lets a citizen fill an action offline,
+/// close the app, and resume exactly where they left off.
+/// </summary>
+public interface IDraftStore
+{
+    /// <summary>Returns the draft for an action, or <c>null</c> if none saved.</summary>
+    Task<ActionDraft?> GetAsync(string instanceId, int actionId, CancellationToken ct = default);
+
+    /// <summary>Saves (upserts) a draft, stamping <see cref="ActionDraft.SavedAt"/>.</summary>
+    Task SaveAsync(ActionDraft draft, CancellationToken ct = default);
+
+    /// <summary>Deletes a draft (e.g. after a successful submit). Idempotent.</summary>
+    Task DeleteAsync(string instanceId, int actionId, CancellationToken ct = default);
+
+    /// <summary>Lists all saved drafts (for inbox badges).</summary>
+    Task<IReadOnlyList<ActionDraft>> ListAsync(CancellationToken ct = default);
+}
+
+/// <summary>Default <see cref="IDraftStore"/> over the encrypted <c>drafts</c> store.</summary>
+public sealed class DraftStore : IDraftStore
+{
+    private const string StoreName = "drafts";
+
+    private readonly IEncryptedObjectStore _store;
+    private readonly TimeProvider _clock;
+
+    /// <summary>Initialises a new instance.</summary>
+    public DraftStore(IEncryptedObjectStore store, TimeProvider clock)
+    {
+        _store = store ?? throw new ArgumentNullException(nameof(store));
+        _clock = clock ?? throw new ArgumentNullException(nameof(clock));
+    }
+
+    /// <inheritdoc />
+    public Task<ActionDraft?> GetAsync(string instanceId, int actionId, CancellationToken ct = default) =>
+        _store.GetAsync<ActionDraft>(StoreName, ActionDraft.MakeKey(instanceId, actionId), ct);
+
+    /// <inheritdoc />
+    public Task SaveAsync(ActionDraft draft, CancellationToken ct = default)
+    {
+        var stamped = draft with { SavedAt = _clock.GetUtcNow() };
+        return _store.PutAsync(StoreName, stamped.Key, stamped, ct);
+    }
+
+    /// <inheritdoc />
+    public Task DeleteAsync(string instanceId, int actionId, CancellationToken ct = default) =>
+        _store.DeleteAsync(StoreName, ActionDraft.MakeKey(instanceId, actionId), ct);
+
+    /// <inheritdoc />
+    public Task<IReadOnlyList<ActionDraft>> ListAsync(CancellationToken ct = default) =>
+        _store.ListAsync<ActionDraft>(StoreName, ct);
+}

--- a/src/Apps/Sorcha.Wallet.Pwa/Services/Drafts/IEncryptedObjectStore.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Services/Drafts/IEncryptedObjectStore.cs
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.JSInterop;
+
+namespace Sorcha.Wallet.Pwa.Services.Drafts;
+
+/// <summary>
+/// Feature 152 — a thin device-local, encrypted object store over the IndexedDB bridge's generic
+/// encrypted ops (<c>SorchaIndexedDb.putEnc/getEnc/listEnc/delEnc</c>). Each value is serialised to
+/// JSON and sealed with the same XChaCha20-Poly1305 device content key the credential cache uses.
+/// Keys are strings; values carry their own logical key. Used by the draft store, submit queue, and
+/// action-context cache.
+/// </summary>
+public interface IEncryptedObjectStore
+{
+    /// <summary>Encrypt + upsert <paramref name="value"/> under <paramref name="key"/>.</summary>
+    Task PutAsync<T>(string storeName, string key, T value, CancellationToken ct = default);
+
+    /// <summary>Get + decrypt the value under <paramref name="key"/>, or <c>null</c> if absent/undecryptable.</summary>
+    Task<T?> GetAsync<T>(string storeName, string key, CancellationToken ct = default) where T : class;
+
+    /// <summary>List + decrypt every value in the store (undecryptable rows are evicted, not thrown).</summary>
+    Task<IReadOnlyList<T>> ListAsync<T>(string storeName, CancellationToken ct = default) where T : class;
+
+    /// <summary>Delete the value under <paramref name="key"/>. Idempotent.</summary>
+    Task DeleteAsync(string storeName, string key, CancellationToken ct = default);
+}
+
+/// <summary>Default <see cref="IEncryptedObjectStore"/> backed by <c>indexeddb-bridge.js</c>.</summary>
+public sealed class IndexedDbEncryptedObjectStore : IEncryptedObjectStore
+{
+    private readonly IJSRuntime _js;
+    private static readonly JsonSerializerOptions JsonOpts = new(JsonSerializerDefaults.Web);
+
+    /// <summary>Initialises a new instance.</summary>
+    public IndexedDbEncryptedObjectStore(IJSRuntime js) => _js = js ?? throw new ArgumentNullException(nameof(js));
+
+    /// <inheritdoc />
+    public Task PutAsync<T>(string storeName, string key, T value, CancellationToken ct = default)
+    {
+        var json = JsonSerializer.Serialize(value, JsonOpts);
+        return _js.InvokeVoidAsync("SorchaIndexedDb.putEnc", ct, storeName, key, json).AsTask();
+    }
+
+    /// <inheritdoc />
+    public async Task<T?> GetAsync<T>(string storeName, string key, CancellationToken ct = default) where T : class
+    {
+        var json = await _js.InvokeAsync<string?>("SorchaIndexedDb.getEnc", ct, storeName, key).ConfigureAwait(false);
+        return json is null ? null : JsonSerializer.Deserialize<T>(json, JsonOpts);
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<T>> ListAsync<T>(string storeName, CancellationToken ct = default) where T : class
+    {
+        var rows = await _js.InvokeAsync<EncRow[]>("SorchaIndexedDb.listEnc", ct, storeName).ConfigureAwait(false);
+        var list = new List<T>(rows.Length);
+        foreach (var row in rows)
+        {
+            var value = JsonSerializer.Deserialize<T>(row.Json, JsonOpts);
+            if (value is not null) list.Add(value);
+        }
+        return list;
+    }
+
+    /// <inheritdoc />
+    public Task DeleteAsync(string storeName, string key, CancellationToken ct = default) =>
+        _js.InvokeVoidAsync("SorchaIndexedDb.delEnc", ct, storeName, key).AsTask();
+
+    private sealed record EncRow(
+        [property: JsonPropertyName("id")] string Id,
+        [property: JsonPropertyName("json")] string Json);
+}

--- a/src/Apps/Sorcha.Wallet.Pwa/Services/Drafts/IFileChunkUploader.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Services/Drafts/IFileChunkUploader.cs
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Net.Http.Json;
+using System.Security.Cryptography;
+using System.Text.Json;
+
+namespace Sorcha.Wallet.Pwa.Services.Drafts;
+
+/// <summary>
+/// Feature 152 (US5) — uploads a captured file to the Blueprint Service via the consumer-tier
+/// <c>/api/file-chunks</c> staging pipeline (4 MB chunks, server-side XChaCha20) and returns the
+/// file-reference object to embed as a form-field value. The execute endpoint resolves the staged
+/// chunks into a file transaction (Feature 085), so no inline bytes travel in the action payload.
+/// Mirrors the agent's <c>FileUploadHandler</c> contract.
+/// </summary>
+public interface IFileChunkUploader
+{
+    /// <summary>
+    /// Chunks + uploads <paramref name="content"/> and returns the file reference
+    /// (<c>fileName, contentType, size, hash, salt, chunkTransactionIds, uploadSessionId,
+    /// masterKeyId</c>) for the payload field, or <c>null</c> on failure.
+    /// </summary>
+    Task<Dictionary<string, object?>?> UploadAsync(
+        byte[] content, string fileName, string contentType,
+        string senderWallet, string registerId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Uploads every item in <paramref name="media"/> and sets each one's reference into
+    /// <paramref name="payload"/> at its <see cref="Sorcha.Wallet.Pwa.Services.Drafts.Models.DraftMedia.Scope"/>.
+    /// Returns <c>false</c> if any upload fails (so the caller can retry the whole submission).
+    /// </summary>
+    Task<bool> AttachAllAsync(
+        IReadOnlyList<Sorcha.Wallet.Pwa.Services.Drafts.Models.DraftMedia> media,
+        IDictionary<string, object?> payload,
+        string senderWallet, string registerId, CancellationToken ct = default);
+}
+
+/// <summary>Default <see cref="IFileChunkUploader"/> over the PWA's bearer-authed HttpClient.</summary>
+public sealed class FileChunkUploader : IFileChunkUploader
+{
+    private const int ChunkSize = 4 * 1024 * 1024; // 4 MB — matches the server chunk ceiling
+
+    private readonly HttpClient _http;
+
+    /// <summary>Initialises a new instance.</summary>
+    public FileChunkUploader(HttpClient http) => _http = http ?? throw new ArgumentNullException(nameof(http));
+
+    /// <inheritdoc />
+    public async Task<Dictionary<string, object?>?> UploadAsync(
+        byte[] content, string fileName, string contentType,
+        string senderWallet, string registerId, CancellationToken ct = default)
+    {
+        var hash = $"sha256:{Convert.ToHexStringLower(SHA256.HashData(content))}";
+        var totalChunks = Math.Max(1, (int)Math.Ceiling((double)content.Length / ChunkSize));
+
+        var chunkTxIds = new List<string>();
+        string? uploadSessionId = null;
+        string? salt = null;
+
+        for (var i = 0; i < totalChunks; i++)
+        {
+            var offset = i * ChunkSize;
+            var length = Math.Min(ChunkSize, content.Length - offset);
+            var chunk = new byte[length];
+            Array.Copy(content, offset, chunk, 0, length);
+
+            var body = new Dictionary<string, object?>
+            {
+                ["senderWallet"] = senderWallet,
+                ["registerAddress"] = registerId,
+                ["chunkIndex"] = i,
+                ["totalChunks"] = totalChunks,
+                ["fileHash"] = hash,
+                ["contentType"] = contentType,
+                ["contentBase64"] = Convert.ToBase64String(chunk),
+            };
+            if (uploadSessionId is not null) body["uploadSessionId"] = uploadSessionId;
+
+            using var resp = await _http.PostAsJsonAsync("api/file-chunks", body, ct).ConfigureAwait(false);
+            if (!resp.IsSuccessStatusCode) return null;
+
+            using var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync(ct).ConfigureAwait(false));
+            var root = doc.RootElement;
+            if (!root.TryGetProperty("chunkTransactionId", out var txEl)) return null;
+            chunkTxIds.Add(txEl.GetString()!);
+            if (uploadSessionId is null && root.TryGetProperty("uploadSessionId", out var sid)) uploadSessionId = sid.GetString();
+            if (salt is null && root.TryGetProperty("saltBase64", out var s)) salt = s.GetString();
+        }
+
+        return new Dictionary<string, object?>
+        {
+            ["fileName"] = fileName,
+            ["contentType"] = contentType,
+            ["size"] = content.Length,
+            ["hash"] = hash,
+            ["salt"] = salt ?? "",
+            ["chunkTransactionIds"] = chunkTxIds,
+            ["uploadSessionId"] = uploadSessionId ?? "",
+            ["masterKeyId"] = "server-managed",
+        };
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> AttachAllAsync(
+        IReadOnlyList<Models.DraftMedia> media,
+        IDictionary<string, object?> payload,
+        string senderWallet, string registerId, CancellationToken ct = default)
+    {
+        foreach (var m in media)
+        {
+            byte[] bytes;
+            try { bytes = Convert.FromBase64String(m.ContentBase64); }
+            catch (FormatException) { return false; }
+
+            var reference = await UploadAsync(bytes, m.FileName, m.ContentType, senderWallet, registerId, ct)
+                .ConfigureAwait(false);
+            if (reference is null) return false;
+
+            if (!string.IsNullOrEmpty(m.Scope))
+            {
+                payload[m.Scope] = reference;
+            }
+        }
+        return true;
+    }
+}

--- a/src/Apps/Sorcha.Wallet.Pwa/Services/Drafts/ISubmitQueue.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Services/Drafts/ISubmitQueue.cs
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using Sorcha.Wallet.Pwa.Services.Drafts.Models;
+
+namespace Sorcha.Wallet.Pwa.Services.Drafts;
+
+/// <summary>
+/// Feature 152 — outcome of attempting to submit a queued item, as classified from the server
+/// response (see <c>SubmitConflictClassifier</c>, US4).
+/// </summary>
+public enum SubmitOutcome
+{
+    /// <summary>Accepted (including an idempotent same-key replay).</summary>
+    Submitted,
+    /// <summary>Transient failure (network / 5xx) — retry later.</summary>
+    Retry,
+    /// <summary>Already submitted (here or elsewhere) — hold for the citizen.</summary>
+    AlreadySubmitted,
+    /// <summary>The workflow has moved on — hold for the citizen.</summary>
+    StepMovedOn,
+    /// <summary>The instance is closed — hold for the citizen.</summary>
+    InstanceClosed,
+}
+
+/// <summary>
+/// Feature 152 (US3) — device-local, encrypted outbox of completed action submissions made offline.
+/// Items are queued when there is no connectivity and drained (submitted) on reconnect. Retries are
+/// safe because each item reuses the server idempotency key. Stale items are held (US4), never
+/// silently dropped.
+/// </summary>
+public interface ISubmitQueue
+{
+    /// <summary>Enqueues a completed submission, assigning an id; returns the stored item.</summary>
+    Task<QueuedSubmission> EnqueueAsync(QueuedSubmission item, CancellationToken ct = default);
+
+    /// <summary>Lists all queue items (for inbox status).</summary>
+    Task<IReadOnlyList<QueuedSubmission>> ListAsync(CancellationToken ct = default);
+
+    /// <summary>Removes a queue item by id. Idempotent.</summary>
+    Task RemoveAsync(string id, CancellationToken ct = default);
+
+    /// <summary>
+    /// Attempts to submit every queued item (oldest first) via <paramref name="submit"/>. Per item:
+    /// <c>Submitted</c> → removed; <c>Retry</c> → left queued with attempts incremented; a stale
+    /// outcome → marked <see cref="QueuedSubmissionState.NeedsAttention"/> with the reason (never
+    /// dropped). One item's failure never blocks the rest.
+    /// </summary>
+    Task DrainAsync(Func<QueuedSubmission, CancellationToken, Task<SubmitOutcome>> submit, CancellationToken ct = default);
+}
+
+/// <summary>Default <see cref="ISubmitQueue"/> over the encrypted <c>submitQueue</c> store.</summary>
+public sealed class SubmitQueue : ISubmitQueue
+{
+    private const string StoreName = "submitQueue";
+
+    private readonly IEncryptedObjectStore _store;
+
+    /// <summary>Initialises a new instance.</summary>
+    public SubmitQueue(IEncryptedObjectStore store) => _store = store ?? throw new ArgumentNullException(nameof(store));
+
+    /// <inheritdoc />
+    public async Task<QueuedSubmission> EnqueueAsync(QueuedSubmission item, CancellationToken ct = default)
+    {
+        var key = string.IsNullOrEmpty(item.QueuedKey) ? Guid.NewGuid().ToString("N") : item.QueuedKey;
+        var stored = item with { QueuedKey = key, State = QueuedSubmissionState.Queued };
+        await _store.PutAsync(StoreName, key, stored, ct).ConfigureAwait(false);
+        return stored;
+    }
+
+    /// <inheritdoc />
+    public Task<IReadOnlyList<QueuedSubmission>> ListAsync(CancellationToken ct = default) =>
+        _store.ListAsync<QueuedSubmission>(StoreName, ct);
+
+    /// <inheritdoc />
+    public Task RemoveAsync(string id, CancellationToken ct = default) =>
+        _store.DeleteAsync(StoreName, id, ct);
+
+    /// <inheritdoc />
+    public async Task DrainAsync(
+        Func<QueuedSubmission, CancellationToken, Task<SubmitOutcome>> submit, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(submit);
+        var items = await ListAsync(ct).ConfigureAwait(false);
+        foreach (var item in items.Where(i => i.State is QueuedSubmissionState.Queued).OrderBy(i => i.QueuedKey))
+        {
+            ct.ThrowIfCancellationRequested();
+            var key = item.QueuedKey;
+            await _store.PutAsync(StoreName, key, item with { State = QueuedSubmissionState.Submitting }, ct).ConfigureAwait(false);
+
+            SubmitOutcome outcome;
+            try
+            {
+                outcome = await submit(item, ct).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch
+            {
+                outcome = SubmitOutcome.Retry;
+            }
+
+            switch (outcome)
+            {
+                case SubmitOutcome.Submitted:
+                    await RemoveAsync(key, ct).ConfigureAwait(false);
+                    break;
+                case SubmitOutcome.Retry:
+                    await _store.PutAsync(StoreName, key,
+                        item with { State = QueuedSubmissionState.Queued, Attempts = item.Attempts + 1 }, ct)
+                        .ConfigureAwait(false);
+                    break;
+                default:
+                    await _store.PutAsync(StoreName, key,
+                        item with
+                        {
+                            State = QueuedSubmissionState.NeedsAttention,
+                            ConflictReason = ToReason(outcome),
+                        }, ct).ConfigureAwait(false);
+                    break;
+            }
+        }
+    }
+
+    private static ConflictReason ToReason(SubmitOutcome o) => o switch
+    {
+        SubmitOutcome.AlreadySubmitted => ConflictReason.AlreadySubmitted,
+        SubmitOutcome.StepMovedOn => ConflictReason.StepMovedOn,
+        SubmitOutcome.InstanceClosed => ConflictReason.InstanceClosed,
+        _ => ConflictReason.None,
+    };
+}

--- a/src/Apps/Sorcha.Wallet.Pwa/Services/Drafts/ISubmitQueueDrainer.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Services/Drafts/ISubmitQueueDrainer.cs
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using Microsoft.Extensions.Logging;
+using Sorcha.Wallet.Pwa.Services.Applications;
+using Sorcha.Wallet.Pwa.Services.Drafts.Models;
+
+namespace Sorcha.Wallet.Pwa.Services.Drafts;
+
+/// <summary>
+/// Feature 152 (US3/US4) — flushes the offline submit queue by rebuilding each item's submission
+/// context from the action-context cache and POSTing it via <see cref="IApplicationActionClient"/>.
+/// The server response is classified (US4) into submit / retry / hold outcomes. Invoked on reconnect
+/// and app open.
+/// </summary>
+public interface ISubmitQueueDrainer
+{
+    /// <summary>Attempts to submit every queued item; safe to call repeatedly (idempotent server-side).</summary>
+    Task DrainAsync(CancellationToken ct = default);
+}
+
+/// <summary>Default <see cref="ISubmitQueueDrainer"/>.</summary>
+public sealed class SubmitQueueDrainer : ISubmitQueueDrainer
+{
+    private readonly ISubmitQueue _queue;
+    private readonly IApplicationActionClient _actionClient;
+    private readonly IActionContextCache _contextCache;
+    private readonly IDraftStore _drafts;
+    private readonly ILogger<SubmitQueueDrainer> _logger;
+
+    /// <summary>Initialises a new instance.</summary>
+    public SubmitQueueDrainer(
+        ISubmitQueue queue,
+        IApplicationActionClient actionClient,
+        IActionContextCache contextCache,
+        IDraftStore drafts,
+        ILogger<SubmitQueueDrainer> logger)
+    {
+        _queue = queue ?? throw new ArgumentNullException(nameof(queue));
+        _actionClient = actionClient ?? throw new ArgumentNullException(nameof(actionClient));
+        _contextCache = contextCache ?? throw new ArgumentNullException(nameof(contextCache));
+        _drafts = drafts ?? throw new ArgumentNullException(nameof(drafts));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    public Task DrainAsync(CancellationToken ct = default) => _queue.DrainAsync(SubmitOneAsync, ct);
+
+    private async Task<SubmitOutcome> SubmitOneAsync(QueuedSubmission item, CancellationToken ct)
+    {
+        var context = await BuildContextAsync(item, ct).ConfigureAwait(false);
+        if (context is null)
+        {
+            // Can't rebuild the action (e.g. cache evicted) — treat as transient; a later drain with
+            // connectivity will re-cache and retry.
+            return SubmitOutcome.Retry;
+        }
+
+        var result = await _actionClient.SubmitAsync(context, item.Payload, ct).ConfigureAwait(false);
+        var outcome = SubmitConflictClassifier.Classify(result);
+        if (outcome == SubmitOutcome.Submitted)
+        {
+            // Clear any lingering draft for this action now it's accepted.
+            try { await _drafts.DeleteAsync(item.InstanceId, item.ActionId, ct); }
+            catch (Exception ex) { _logger.LogDebug(ex, "Draft cleanup after queued submit failed."); }
+        }
+        return outcome;
+    }
+
+    private async Task<ApplicationFormContext?> BuildContextAsync(QueuedSubmission item, CancellationToken ct)
+    {
+        var cached = await _contextCache.GetAsync(item.InstanceId, item.ActionId, ct).ConfigureAwait(false);
+        if (cached is null || !Guid.TryParse(item.InstanceId, out var instanceGuid))
+        {
+            return null;
+        }
+
+        try
+        {
+            var action = System.Text.Json.JsonSerializer.Deserialize<Sorcha.Blueprint.Models.Action>(
+                cached.ActionJson,
+                new System.Text.Json.JsonSerializerOptions(System.Text.Json.JsonSerializerDefaults.Web));
+            if (action is null) return null;
+
+            return new ApplicationFormContext(
+                instanceGuid, action, cached.BlueprintId, cached.RegisterId, cached.SenderWallet,
+                cached.ActionId, string.IsNullOrWhiteSpace(cached.Title) ? "Application" : cached.Title);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Rebuilding submission context for {InstanceId} failed.", item.InstanceId);
+            return null;
+        }
+    }
+}

--- a/src/Apps/Sorcha.Wallet.Pwa/Services/Drafts/ISubmitQueueDrainer.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Services/Drafts/ISubmitQueueDrainer.cs
@@ -26,6 +26,7 @@ public sealed class SubmitQueueDrainer : ISubmitQueueDrainer
     private readonly IApplicationActionClient _actionClient;
     private readonly IActionContextCache _contextCache;
     private readonly IDraftStore _drafts;
+    private readonly IFileChunkUploader _uploader;
     private readonly ILogger<SubmitQueueDrainer> _logger;
 
     /// <summary>Initialises a new instance.</summary>
@@ -34,12 +35,14 @@ public sealed class SubmitQueueDrainer : ISubmitQueueDrainer
         IApplicationActionClient actionClient,
         IActionContextCache contextCache,
         IDraftStore drafts,
+        IFileChunkUploader uploader,
         ILogger<SubmitQueueDrainer> logger)
     {
         _queue = queue ?? throw new ArgumentNullException(nameof(queue));
         _actionClient = actionClient ?? throw new ArgumentNullException(nameof(actionClient));
         _contextCache = contextCache ?? throw new ArgumentNullException(nameof(contextCache));
         _drafts = drafts ?? throw new ArgumentNullException(nameof(drafts));
+        _uploader = uploader ?? throw new ArgumentNullException(nameof(uploader));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -56,7 +59,19 @@ public sealed class SubmitQueueDrainer : ISubmitQueueDrainer
             return SubmitOutcome.Retry;
         }
 
-        var result = await _actionClient.SubmitAsync(context, item.Payload, ct).ConfigureAwait(false);
+        // US5 — upload any offline-captured media now (online) and reference it in the payload.
+        var payload = new Dictionary<string, object?>(item.Payload);
+        if (item.Attachments.Count > 0)
+        {
+            var ok = await _uploader.AttachAllAsync(
+                item.Attachments, payload, context.SenderWallet, context.RegisterId, ct).ConfigureAwait(false);
+            if (!ok)
+            {
+                return SubmitOutcome.Retry; // media upload failed — retry the whole submission later
+            }
+        }
+
+        var result = await _actionClient.SubmitAsync(context, payload, ct).ConfigureAwait(false);
         var outcome = SubmitConflictClassifier.Classify(result);
         if (outcome == SubmitOutcome.Submitted)
         {

--- a/src/Apps/Sorcha.Wallet.Pwa/Services/Drafts/Models/DraftModels.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Services/Drafts/Models/DraftModels.cs
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+namespace Sorcha.Wallet.Pwa.Services.Drafts.Models;
+
+/// <summary>Feature 152 — lifecycle state of a local action draft.</summary>
+public enum DraftStatus
+{
+    /// <summary>Being filled; autosaved locally.</summary>
+    Editing = 0,
+    /// <summary>Marked complete by the citizen, awaiting submission.</summary>
+    ReadyToSubmit = 1,
+    /// <summary>Handed to the submit queue.</summary>
+    Queued = 2,
+    /// <summary>Successfully submitted (draft normally cleared).</summary>
+    Submitted = 3,
+    /// <summary>A deferred submit could not be applied; held for the citizen to resolve.</summary>
+    NeedsAttention = 4,
+}
+
+/// <summary>Feature 152 — why a held submission could not be applied (detect/hold/ask).</summary>
+public enum ConflictReason
+{
+    /// <summary>No conflict.</summary>
+    None = 0,
+    /// <summary>This action was already submitted (here or on another device).</summary>
+    AlreadySubmitted = 1,
+    /// <summary>The workflow has moved on; this is no longer the current action.</summary>
+    StepMovedOn = 2,
+    /// <summary>The instance is closed (completed / rejected / cancelled).</summary>
+    InstanceClosed = 3,
+}
+
+/// <summary>Feature 152 — a captured photo/file persisted with a draft (encrypted at rest).</summary>
+/// <param name="FileName">Original file name.</param>
+/// <param name="ContentType">MIME type.</param>
+/// <param name="ContentBase64">Base64 bytes (encrypted in the store; held in memory while editing).</param>
+/// <param name="CapturedAt">When captured.</param>
+public sealed record DraftMedia(string FileName, string ContentType, string ContentBase64, DateTimeOffset CapturedAt);
+
+/// <summary>
+/// Feature 152 — a citizen's in-progress action draft, persisted encrypted on the device. Keyed by
+/// <see cref="Key"/> (<c>instanceId:actionId</c>).
+/// </summary>
+public sealed record ActionDraft
+{
+    /// <summary>The action's instance id.</summary>
+    public required string InstanceId { get; init; }
+    /// <summary>The action id within the instance.</summary>
+    public required int ActionId { get; init; }
+    /// <summary>Flat JSON-Pointer-keyed form values, as the form renderer emits.</summary>
+    public Dictionary<string, object?> FormData { get; init; } = new();
+    /// <summary>Captured photos/files held with the draft.</summary>
+    public List<DraftMedia> Media { get; init; } = new();
+    /// <summary>Lifecycle state.</summary>
+    public DraftStatus Status { get; init; } = DraftStatus.Editing;
+    /// <summary>Set when <see cref="Status"/> is <see cref="DraftStatus.NeedsAttention"/>.</summary>
+    public ConflictReason ConflictReason { get; init; } = ConflictReason.None;
+    /// <summary>Last local save time.</summary>
+    public DateTimeOffset SavedAt { get; init; }
+
+    /// <summary>Composite store key for an instance+action.</summary>
+    public string Key => MakeKey(InstanceId, ActionId);
+
+    /// <summary>Builds the composite store key for an instance+action.</summary>
+    public static string MakeKey(string instanceId, int actionId) => $"{instanceId}:{actionId}";
+}
+
+/// <summary>Feature 152 — a locally cached action form context enabling offline open.</summary>
+public sealed record CachedActionContext
+{
+    /// <summary>The action's instance id.</summary>
+    public required string InstanceId { get; init; }
+    /// <summary>The action id.</summary>
+    public required int ActionId { get; init; }
+    /// <summary>Blueprint id (for re-resolution).</summary>
+    public required string BlueprintId { get; init; }
+    /// <summary>The action definition JSON (schema + layout) to render offline.</summary>
+    public required string ActionJson { get; init; }
+    /// <summary>Register the action submits to.</summary>
+    public string RegisterId { get; init; } = string.Empty;
+    /// <summary>The citizen's own wallet address (open-participant sender).</summary>
+    public string SenderWallet { get; init; } = string.Empty;
+    /// <summary>User-facing title.</summary>
+    public string Title { get; init; } = string.Empty;
+    /// <summary>When this context was cached (freshness).</summary>
+    public DateTimeOffset CachedAt { get; init; }
+
+    /// <summary>Composite store key.</summary>
+    public string Key => ActionDraft.MakeKey(InstanceId, ActionId);
+}
+
+/// <summary>Feature 152 — lifecycle state of a queued (deferred) submission.</summary>
+public enum QueuedSubmissionState
+{
+    /// <summary>Awaiting a flush.</summary>
+    Queued = 0,
+    /// <summary>Currently being sent.</summary>
+    Submitting = 1,
+    /// <summary>Accepted by the server.</summary>
+    Submitted = 2,
+    /// <summary>Held — could not be applied; see <see cref="QueuedSubmission.ConflictReason"/>.</summary>
+    NeedsAttention = 3,
+}
+
+/// <summary>
+/// Feature 152 — a completed action awaiting submission (outbox). Persisted encrypted; keyed by an
+/// autoincrement id assigned by the store.
+/// </summary>
+public sealed record QueuedSubmission
+{
+    /// <summary>Store id (0 until persisted; assigned by the autoincrement store).</summary>
+    public long Id { get; init; }
+    /// <summary>Target instance id.</summary>
+    public required string InstanceId { get; init; }
+    /// <summary>Target action id.</summary>
+    public required int ActionId { get; init; }
+    /// <summary>Blueprint id.</summary>
+    public required string BlueprintId { get; init; }
+    /// <summary>Register address.</summary>
+    public string RegisterId { get; init; } = string.Empty;
+    /// <summary>The citizen's sender wallet.</summary>
+    public string SenderWallet { get; init; } = string.Empty;
+    /// <summary>Nested submission payload (as the execute body expects).</summary>
+    public Dictionary<string, object?> Payload { get; init; } = new();
+    /// <summary>Captured media to submit as attachments.</summary>
+    public List<DraftMedia> Attachments { get; init; } = new();
+    /// <summary>Reused server idempotency key so a re-flush cannot double-submit.</summary>
+    public string IdempotencyKey { get; init; } = string.Empty;
+    /// <summary>Current state.</summary>
+    public QueuedSubmissionState State { get; init; } = QueuedSubmissionState.Queued;
+    /// <summary>Why it is held, when <see cref="State"/> is <see cref="QueuedSubmissionState.NeedsAttention"/>.</summary>
+    public ConflictReason ConflictReason { get; init; } = ConflictReason.None;
+    /// <summary>Flush attempts (for backoff).</summary>
+    public int Attempts { get; init; }
+    /// <summary>Last transient error / conflict detail.</summary>
+    public string? LastError { get; init; }
+}

--- a/src/Apps/Sorcha.Wallet.Pwa/Services/Drafts/Models/DraftModels.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Services/Drafts/Models/DraftModels.cs
@@ -36,7 +36,9 @@ public enum ConflictReason
 /// <param name="ContentType">MIME type.</param>
 /// <param name="ContentBase64">Base64 bytes (encrypted in the store; held in memory while editing).</param>
 /// <param name="CapturedAt">When captured.</param>
-public sealed record DraftMedia(string FileName, string ContentType, string ContentBase64, DateTimeOffset CapturedAt);
+/// <param name="Scope">The JSON-Pointer form field this media attaches to (e.g. "/proofOfAddress").</param>
+public sealed record DraftMedia(
+    string FileName, string ContentType, string ContentBase64, DateTimeOffset CapturedAt, string Scope = "");
 
 /// <summary>
 /// Feature 152 — a citizen's in-progress action draft, persisted encrypted on the device. Keyed by

--- a/src/Apps/Sorcha.Wallet.Pwa/Services/Drafts/Models/DraftModels.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Services/Drafts/Models/DraftModels.cs
@@ -109,8 +109,8 @@ public enum QueuedSubmissionState
 /// </summary>
 public sealed record QueuedSubmission
 {
-    /// <summary>Store id (0 until persisted; assigned by the autoincrement store).</summary>
-    public long Id { get; init; }
+    /// <summary>Store key (a GUID string assigned on enqueue; empty until persisted).</summary>
+    public string QueuedKey { get; init; } = string.Empty;
     /// <summary>Target instance id.</summary>
     public required string InstanceId { get; init; }
     /// <summary>Target action id.</summary>

--- a/src/Apps/Sorcha.Wallet.Pwa/Services/Drafts/SubmitConflictClassifier.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Services/Drafts/SubmitConflictClassifier.cs
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using Sorcha.Wallet.Pwa.Services.Applications;
+
+namespace Sorcha.Wallet.Pwa.Services.Drafts;
+
+/// <summary>
+/// Feature 152 (US4) — pure mapping from an action-submission result to a queue
+/// <see cref="SubmitOutcome"/>: detect (stale → hold), retry (transient), or submitted. Keeps the
+/// "detect / hold / ask" decision in one testable place. A deterministic client error is held
+/// rather than retried forever; a transient error is retried; a recognised conflict is held with a
+/// specific reason so the citizen can be told what changed.
+/// </summary>
+public static class SubmitConflictClassifier
+{
+    /// <summary>Classifies a submission result into a queue outcome.</summary>
+    public static SubmitOutcome Classify(ApplicationSubmissionResult result)
+    {
+        if (result.Status == ApplicationSubmissionStatus.Success)
+        {
+            return SubmitOutcome.Submitted;
+        }
+
+        // Transient: server/network/signing errors are worth retrying.
+        if (result.Status is ApplicationSubmissionStatus.ServerError or ApplicationSubmissionStatus.SigningFailed)
+        {
+            return SubmitOutcome.Retry;
+        }
+
+        // 4xx (ValidationFailed) — distinguish a recognised conflict from a transient throttle and
+        // from a deterministic rejection (which must NOT loop forever).
+        return HttpStatusOf(result.ErrorCode) switch
+        {
+            409 => SubmitOutcome.StepMovedOn,      // conflict — no longer the current action / already submitted
+            410 => SubmitOutcome.InstanceClosed,   // gone — instance closed
+            404 => SubmitOutcome.StepMovedOn,      // instance/action not found — moved on
+            408 or 429 => SubmitOutcome.Retry,     // timeout / rate-limit — transient
+            _ => SubmitOutcome.StepMovedOn,        // other deterministic 4xx — hold, don't infinite-retry
+        };
+    }
+
+    private static int? HttpStatusOf(string? errorCode)
+    {
+        if (string.IsNullOrEmpty(errorCode) || !errorCode.StartsWith("HTTP_", StringComparison.Ordinal))
+        {
+            return null;
+        }
+        return int.TryParse(errorCode.AsSpan(5), out var code) ? code : null;
+    }
+}

--- a/src/Apps/Sorcha.Wallet.Pwa/Services/IConnectivity.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Services/IConnectivity.cs
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using Microsoft.JSInterop;
+
+namespace Sorcha.Wallet.Pwa.Services;
+
+/// <summary>
+/// Feature 152 — reflects the browser's online/offline state (via the existing
+/// <c>SorchaConnectivity</c> JS bridge) so the wallet can drive offline UI and flush the submit
+/// queue on reconnect. <see cref="IsOnline"/> is a best-effort hint ("the browser has a network
+/// route", not "the backend is reachable"); an actual submit attempt remains the real test.
+/// </summary>
+public interface IConnectivity : IAsyncDisposable
+{
+    /// <summary>Last known online state.</summary>
+    bool IsOnline { get; }
+
+    /// <summary>Raised when connectivity flips; the argument is the new online state.</summary>
+    event Action<bool>? Changed;
+
+    /// <summary>Registers the browser online/offline listeners and seeds <see cref="IsOnline"/>. Idempotent.</summary>
+    Task InitializeAsync(CancellationToken ct = default);
+}
+
+/// <summary>Default <see cref="IConnectivity"/> over the <c>SorchaConnectivity</c> JS bridge.</summary>
+public sealed class BrowserConnectivity : IConnectivity
+{
+    private readonly IJSRuntime _js;
+    private DotNetObjectReference<BrowserConnectivity>? _ref;
+    private bool _initialised;
+
+    /// <summary>Initialises a new instance.</summary>
+    public BrowserConnectivity(IJSRuntime js) => _js = js ?? throw new ArgumentNullException(nameof(js));
+
+    /// <inheritdoc />
+    public bool IsOnline { get; private set; } = true;
+
+    /// <inheritdoc />
+    public event Action<bool>? Changed;
+
+    /// <inheritdoc />
+    public async Task InitializeAsync(CancellationToken ct = default)
+    {
+        if (_initialised) return;
+        _initialised = true;
+        _ref = DotNetObjectReference.Create(this);
+        try
+        {
+            IsOnline = await _js.InvokeAsync<bool>("SorchaConnectivity.register", ct, _ref).ConfigureAwait(false);
+        }
+        catch (JSException)
+        {
+            // Bridge unavailable (e.g. SSR/prerender) — assume online; a failed submit is the real test.
+            IsOnline = true;
+        }
+    }
+
+    /// <summary>Invoked from JS when the browser online/offline state changes.</summary>
+    [JSInvokable]
+    public void OnConnectivityChanged(bool isOnline)
+    {
+        if (isOnline == IsOnline) return;
+        IsOnline = isOnline;
+        Changed?.Invoke(isOnline);
+    }
+
+    /// <inheritdoc />
+    public async ValueTask DisposeAsync()
+    {
+        if (_ref is not null)
+        {
+            try { await _js.InvokeVoidAsync("SorchaConnectivity.unregister"); } catch { /* page teardown */ }
+            _ref.Dispose();
+            _ref = null;
+        }
+    }
+}

--- a/src/Apps/Sorcha.Wallet.Pwa/wwwroot/js/indexeddb-bridge.js
+++ b/src/Apps/Sorcha.Wallet.Pwa/wwwroot/js/indexeddb-bridge.js
@@ -36,7 +36,7 @@
   }
 
   const DB_NAME = "sorcha-wallet";
-  const DB_VERSION = 3;
+  const DB_VERSION = 4;
   const CONTENT_KEY_ID = "content-key/v1";
 
   let dbPromise = null;
@@ -58,6 +58,13 @@
         if (!db.objectStoreNames.contains("personas")) db.createObjectStore("personas");
         // v3 (Feature 114 US5) — citizen's own presentation activity log.
         if (!db.objectStoreNames.contains("presentationLog")) db.createObjectStore("presentationLog", { keyPath: "id" });
+        // v4 (Feature 152 — offline / field capture):
+        //   drafts        — keyed by id ("instanceId:actionId") — encrypted in-progress action drafts (form + media)
+        //   submitQueue  — keyed by id (GUID string)            — encrypted deferred submissions (outbox)
+        //   actionContext — keyed by id ("instanceId:actionId") — encrypted cached action form contexts for offline open
+        if (!db.objectStoreNames.contains("drafts")) db.createObjectStore("drafts", { keyPath: "id" });
+        if (!db.objectStoreNames.contains("submitQueue")) db.createObjectStore("submitQueue", { keyPath: "id" });
+        if (!db.objectStoreNames.contains("actionContext")) db.createObjectStore("actionContext", { keyPath: "id" });
       };
       req.onsuccess = () => resolve(req.result);
       req.onerror = () => reject(req.error);
@@ -242,10 +249,52 @@
     await del("credentials", id);
   }
 
+  // --- generic encrypted store ops (Feature 152) ----------------------------
+  // Reuse the credential content-key + XChaCha20 sealing for any store whose
+  // rows are { id, nonce, ciphertext, updatedAt }. Callers serialise their own
+  // object to JSON. listEnc/getEnc evict undecryptable rows (legacy-cipher /
+  // corrupt) rather than aborting, matching the credential cache behaviour.
+
+  async function putEnc(storeName, key, payloadJson) {
+    const { nonce, ciphertext } = await encryptString(payloadJson);
+    await put(storeName, { id: key, nonce, ciphertext, updatedAt: new Date().toISOString() });
+  }
+
+  async function getEnc(storeName, key) {
+    const row = await get(storeName, key);
+    if (!row) return null;
+    try {
+      return await decryptString(row.nonce, row.ciphertext);
+    } catch (e) {
+      console.warn("[Sorcha] evicting undecryptable row", storeName, key, e);
+      await del(storeName, key);
+      return null;
+    }
+  }
+
+  // Returns [{ id, json }] so callers know each row's key (e.g. autoincrement queue ids).
+  async function listEnc(storeName) {
+    const rows = await getAll(storeName);
+    const out = [];
+    const evict = [];
+    for (const row of rows) {
+      try {
+        out.push({ id: row.id, json: await decryptString(row.nonce, row.ciphertext) });
+      } catch (e) {
+        console.warn("[Sorcha] evicting undecryptable row", storeName, row && row.id, e);
+        if (row && row.id !== undefined) evict.push(row.id);
+      }
+    }
+    for (const id of evict) await del(storeName, id);
+    return out;
+  }
+
   globalThis.SorchaIndexedDb = {
     // raw store ops
     put, get, del, getAll, clear, wipe,
     // credentials (encrypted)
     putCredential, getCredential, listCredentials, deleteCredential,
+    // generic encrypted stores (Feature 152 — drafts / submitQueue / actionContext)
+    putEnc, getEnc, listEnc, delEnc: del,
   };
 })();

--- a/tests/Sorcha.UI.Core.Tests/Components/Forms/SorchaFormRendererDraftTests.cs
+++ b/tests/Sorcha.UI.Core.Tests/Components/Forms/SorchaFormRendererDraftTests.cs
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Collections.Generic;
+using System.Text.Json;
+using Bunit;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using MudBlazor.Services;
+using Sorcha.UI.Core.Components.Forms;
+using Sorcha.UI.Core.Services.Forms;
+using Xunit;
+using BlueprintAction = Sorcha.Blueprint.Models.Action;
+
+namespace Sorcha.UI.Core.Tests.Components.Forms;
+
+/// <summary>
+/// Feature 152 (US1) — the renderer can seed editable values from a saved draft
+/// (<see cref="SorchaFormRenderer.InitialFormData"/>) and surfaces edits to a host autosave
+/// (<see cref="SorchaFormRenderer.OnFormDataChanged"/>).
+/// </summary>
+public class SorchaFormRendererDraftTests : BunitContext
+{
+    public SorchaFormRendererDraftTests()
+    {
+        Services.AddMudServices();
+        Services.AddScoped<IFormSchemaService, FormSchemaService>();
+        JSInterop.Mode = JSRuntimeMode.Loose;
+    }
+
+    private static BlueprintAction MakeAction() => new()
+    {
+        Id = 1,
+        Title = "Apply",
+        Sender = "applicant",
+        DataSchemas = new[]
+        {
+            JsonDocument.Parse("""{"type":"object","properties":{"name":{"type":"string"}}}"""),
+        },
+    };
+
+    [Fact]
+    public void InitialFormData_SeedsEditableValue_IntoRenderedForm()
+    {
+        var cut = Render<SorchaFormRenderer>(p => p
+            .Add(x => x.Action, MakeAction())
+            .Add(x => x.IsSenderAction, true)
+            .Add(x => x.InitialFormData, new Dictionary<string, object?> { ["/name"] = "Ada Lovelace" }));
+
+        // Robust to MudBlazor's input binding: the seeded value is present in the rendered form
+        // (whether reflected as an input value attribute or bound text).
+        cut.WaitForAssertion(() => cut.Markup.Should().Contain("Ada Lovelace"));
+    }
+
+    [Fact]
+    public void OnFormDataChanged_ParameterIsAccepted_ForHostAutosave()
+    {
+        // The autosave forward fires from FormContext.OnDataChanged — the same event the renderer's
+        // existing persona edit-detection relies on, so it is exercised on real user edits. Here we
+        // assert the parameter is accepted and the form renders with it bound (the end-to-end
+        // autosave is covered by ApplicationInstance integration + the quickstart manual check;
+        // simulating MudBlazor's commit-on-blur through the auto-generated control is brittle).
+        var rendered = false;
+        var cut = Render<SorchaFormRenderer>(p => p
+            .Add(x => x.Action, MakeAction())
+            .Add(x => x.IsSenderAction, true)
+            .Add(x => x.OnFormDataChanged, (IReadOnlyDictionary<string, object?> _) => rendered = true));
+
+        cut.FindAll("input").Count.Should().BeGreaterThan(0);
+        rendered.Should().BeFalse("no edit has occurred yet");
+    }
+}

--- a/tests/Sorcha.Wallet.Pwa.Tests/Drafts/ActionContextCacheTests.cs
+++ b/tests/Sorcha.Wallet.Pwa.Tests/Drafts/ActionContextCacheTests.cs
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Sorcha.Wallet.Pwa.Services.Actions;
+using Sorcha.Wallet.Pwa.Services.Actions.Models;
+using Sorcha.Wallet.Pwa.Services.Applications;
+using Sorcha.Wallet.Pwa.Services.Drafts;
+using Sorcha.Wallet.Pwa.Services.Drafts.Models;
+using Xunit;
+
+namespace Sorcha.Wallet.Pwa.Tests.Drafts;
+
+/// <summary>
+/// Feature 152 US2 — `ActionContextCache` pre-caches each pending action's form context for offline
+/// open, reads cached contexts back, and tolerates per-item load failures.
+/// </summary>
+public sealed class ActionContextCacheTests
+{
+    private readonly Mock<IEncryptedObjectStore> _store = new();
+    private readonly Mock<IMyActionsClient> _actions = new();
+    private readonly Mock<IApplicationActionClient> _actionClient = new();
+
+    private ActionContextCache Create() => new(
+        _store.Object, _actions.Object, _actionClient.Object, TimeProvider.System,
+        NullLogger<ActionContextCache>.Instance);
+
+    private static PendingActionItem Pending(string instanceId) =>
+        new(instanceId, 1, "t", "wf", null, null, ActionUrgency.Normal, null, DateTimeOffset.UtcNow, null);
+
+    private static ApplicationFormContext FormCtx(Guid instanceId) =>
+        new(instanceId, new Sorcha.Blueprint.Models.Action(), "bp-1", "reg-1", "ws1qcitizen", 1, "Apply");
+
+    [Fact]
+    public async Task RefreshFromPendingAsync_CachesEachPendingContext()
+    {
+        var id1 = Guid.NewGuid();
+        var id2 = Guid.NewGuid();
+        _actions.Setup(a => a.GetPendingAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<PendingActionItem> { Pending(id1.ToString()), Pending(id2.ToString()) });
+        _actionClient.Setup(c => c.LoadFormAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Guid g, CancellationToken _) => FormCtx(g));
+
+        var cached = await Create().RefreshFromPendingAsync();
+
+        cached.Should().Be(2);
+        _store.Verify(s => s.PutAsync("actionContext", It.IsAny<string>(), It.IsAny<CachedActionContext>(),
+            It.IsAny<CancellationToken>()), Times.Exactly(2));
+    }
+
+    [Fact]
+    public async Task RefreshFromPendingAsync_OneLoadFailure_DoesNotAbortOthers()
+    {
+        var ok = Guid.NewGuid();
+        var bad = Guid.NewGuid();
+        _actions.Setup(a => a.GetPendingAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<PendingActionItem> { Pending(bad.ToString()), Pending(ok.ToString()) });
+        _actionClient.Setup(c => c.LoadFormAsync(bad, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("boom"));
+        _actionClient.Setup(c => c.LoadFormAsync(ok, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(FormCtx(ok));
+
+        var cached = await Create().RefreshFromPendingAsync();
+
+        cached.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task RefreshFromPendingAsync_PendingUnavailable_ReturnsZero()
+    {
+        _actions.Setup(a => a.GetPendingAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new System.Net.Http.HttpRequestException("offline"));
+
+        var cached = await Create().RefreshFromPendingAsync();
+
+        cached.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task GetAsync_ReturnsCachedContext()
+    {
+        var ctx = new CachedActionContext { InstanceId = "i", ActionId = 2, BlueprintId = "bp", ActionJson = "{}" };
+        _store.Setup(s => s.GetAsync<CachedActionContext>("actionContext", "i:2", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ctx);
+
+        var result = await Create().GetAsync("i", 2);
+
+        result.Should().BeSameAs(ctx);
+    }
+
+    [Fact]
+    public async Task GetAsync_UnknownAction_ReturnsNull()
+    {
+        _store.Setup(s => s.GetAsync<CachedActionContext>("actionContext", It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((CachedActionContext?)null);
+
+        var result = await Create().GetAsync("i", 99);
+
+        result.Should().BeNull();
+    }
+}

--- a/tests/Sorcha.Wallet.Pwa.Tests/Drafts/DraftStoreTests.cs
+++ b/tests/Sorcha.Wallet.Pwa.Tests/Drafts/DraftStoreTests.cs
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Moq;
+using Sorcha.Wallet.Pwa.Services.Drafts;
+using Sorcha.Wallet.Pwa.Services.Drafts.Models;
+using Xunit;
+
+namespace Sorcha.Wallet.Pwa.Tests.Drafts;
+
+/// <summary>
+/// Feature 152 US1 — `DraftStore` maps drafts onto the encrypted store under the
+/// <c>instanceId:actionId</c> key, stamps SavedAt, and round-trips form data + media.
+/// </summary>
+public sealed class DraftStoreTests
+{
+    private readonly Mock<IEncryptedObjectStore> _store = new();
+    private DraftStore Create() => new(_store.Object, TimeProvider.System);
+
+    [Fact]
+    public async Task SaveAsync_StampsSavedAt_AndPutsUnderCompositeKey()
+    {
+        ActionDraft? captured = null;
+        _store.Setup(s => s.PutAsync("drafts", "inst-1:3", It.IsAny<ActionDraft>(), It.IsAny<CancellationToken>()))
+            .Callback<string, string, ActionDraft, CancellationToken>((_, _, d, _) => captured = d)
+            .Returns(Task.CompletedTask);
+
+        await Create().SaveAsync(new ActionDraft { InstanceId = "inst-1", ActionId = 3 });
+
+        captured.Should().NotBeNull();
+        captured!.SavedAt.Should().BeAfter(DateTimeOffset.MinValue);
+    }
+
+    [Fact]
+    public async Task GetAsync_ReadsUnderCompositeKey()
+    {
+        var draft = new ActionDraft { InstanceId = "inst-1", ActionId = 3 };
+        _store.Setup(s => s.GetAsync<ActionDraft>("drafts", "inst-1:3", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(draft);
+
+        (await Create().GetAsync("inst-1", 3)).Should().BeSameAs(draft);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_DeletesUnderCompositeKey()
+    {
+        await Create().DeleteAsync("inst-1", 3);
+        _store.Verify(s => s.DeleteAsync("drafts", "inst-1:3", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task SaveThenRoundTrip_PreservesFormDataAndMedia()
+    {
+        // Simulate the encrypted store with an in-memory dictionary to prove the draft shape
+        // (form data + media) survives a serialise/deserialise round-trip via the store seam.
+        var backing = new System.Collections.Generic.Dictionary<string, ActionDraft>();
+        _store.Setup(s => s.PutAsync("drafts", It.IsAny<string>(), It.IsAny<ActionDraft>(), It.IsAny<CancellationToken>()))
+            .Callback<string, string, ActionDraft, CancellationToken>((_, k, d, _) => backing[k] = d)
+            .Returns(Task.CompletedTask);
+        _store.Setup(s => s.GetAsync<ActionDraft>("drafts", It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string _, string k, CancellationToken _) => backing.GetValueOrDefault(k));
+
+        var store = Create();
+        var draft = new ActionDraft { InstanceId = "i", ActionId = 1 };
+        draft.FormData["/name"] = "Ada";
+        draft.Media.Add(new DraftMedia("photo.jpg", "image/jpeg", "AQID", DateTimeOffset.UtcNow));
+
+        await store.SaveAsync(draft);
+        var loaded = await store.GetAsync("i", 1);
+
+        loaded!.FormData["/name"].Should().Be("Ada");
+        loaded.Media.Should().ContainSingle().Which.FileName.Should().Be("photo.jpg");
+    }
+}

--- a/tests/Sorcha.Wallet.Pwa.Tests/Drafts/FileChunkUploaderTests.cs
+++ b/tests/Sorcha.Wallet.Pwa.Tests/Drafts/FileChunkUploaderTests.cs
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Sorcha.Wallet.Pwa.Services.Drafts;
+using Sorcha.Wallet.Pwa.Services.Drafts.Models;
+using Xunit;
+
+namespace Sorcha.Wallet.Pwa.Tests.Drafts;
+
+/// <summary>
+/// Feature 152 US5 — `FileChunkUploader` chunks + uploads captured media via /api/file-chunks and
+/// builds the file-reference object embedded as a payload field value.
+/// </summary>
+public sealed class FileChunkUploaderTests
+{
+    [Fact]
+    public async Task UploadAsync_PostsChunk_AndBuildsReference()
+    {
+        var posted = 0;
+        var uploader = Create((req, _) =>
+        {
+            posted++;
+            req.RequestUri!.AbsolutePath.Should().Be("/api/file-chunks");
+            return Ok("""{"chunkTransactionId":"tx-1","uploadSessionId":"sess-1","saltBase64":"c2FsdA"}""");
+        });
+
+        var reference = await uploader.UploadAsync(
+            new byte[] { 1, 2, 3 }, "photo.jpg", "image/jpeg", "ws1qcitizen", "reg-1");
+
+        posted.Should().Be(1);
+        reference.Should().NotBeNull();
+        reference!["masterKeyId"].Should().Be("server-managed");
+        reference["uploadSessionId"].Should().Be("sess-1");
+        reference["fileName"].Should().Be("photo.jpg");
+        ((List<string>)reference["chunkTransactionIds"]!).Should().ContainSingle().Which.Should().Be("tx-1");
+        reference["hash"]!.ToString().Should().StartWith("sha256:");
+    }
+
+    [Fact]
+    public async Task UploadAsync_ChunkFails_ReturnsNull()
+    {
+        var uploader = Create((_, _) => new HttpResponseMessage(HttpStatusCode.InternalServerError));
+
+        var reference = await uploader.UploadAsync(new byte[] { 1 }, "f", "text/plain", "w", "r");
+
+        reference.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task AttachAllAsync_InjectsReferenceAtScope()
+    {
+        var uploader = Create((_, _) => Ok("""{"chunkTransactionId":"tx-1","uploadSessionId":"s","saltBase64":"x"}"""));
+        var payload = new Dictionary<string, object?>();
+        var media = new List<DraftMedia>
+        {
+            new("proof.jpg", "image/jpeg", Convert.ToBase64String(new byte[] { 9 }), DateTimeOffset.UtcNow, "/proofOfAddress"),
+        };
+
+        var ok = await uploader.AttachAllAsync(media, payload, "ws1q", "reg-1");
+
+        ok.Should().BeTrue();
+        payload.Should().ContainKey("/proofOfAddress");
+        payload["/proofOfAddress"].Should().BeAssignableTo<Dictionary<string, object?>>();
+    }
+
+    [Fact]
+    public async Task AttachAllAsync_UploadFails_ReturnsFalse()
+    {
+        var uploader = Create((_, _) => new HttpResponseMessage(HttpStatusCode.BadGateway));
+        var payload = new Dictionary<string, object?>();
+        var media = new List<DraftMedia>
+        {
+            new("p.jpg", "image/jpeg", Convert.ToBase64String(new byte[] { 1 }), DateTimeOffset.UtcNow, "/x"),
+        };
+
+        (await uploader.AttachAllAsync(media, payload, "w", "r")).Should().BeFalse();
+    }
+
+    private static FileChunkUploader Create(Func<HttpRequestMessage, CancellationToken, HttpResponseMessage> respond)
+    {
+        var http = new HttpClient(new StubHandler(respond)) { BaseAddress = new Uri("https://test.example.com") };
+        return new FileChunkUploader(http);
+    }
+
+    private static HttpResponseMessage Ok(string json) =>
+        new(HttpStatusCode.OK) { Content = new StringContent(json, Encoding.UTF8, "application/json") };
+
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, CancellationToken, HttpResponseMessage> _respond;
+        public StubHandler(Func<HttpRequestMessage, CancellationToken, HttpResponseMessage> respond) => _respond = respond;
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct) =>
+            Task.FromResult(_respond(request, ct));
+    }
+}

--- a/tests/Sorcha.Wallet.Pwa.Tests/Drafts/SubmitConflictClassifierTests.cs
+++ b/tests/Sorcha.Wallet.Pwa.Tests/Drafts/SubmitConflictClassifierTests.cs
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using FluentAssertions;
+using Sorcha.Wallet.Pwa.Services.Applications;
+using Sorcha.Wallet.Pwa.Services.Drafts;
+using Xunit;
+
+namespace Sorcha.Wallet.Pwa.Tests.Drafts;
+
+/// <summary>
+/// Feature 152 US4 — `SubmitConflictClassifier` maps a submission result to a queue outcome:
+/// submitted / retry (transient) / hold (stale conflict), never an infinite-retry on a
+/// deterministic rejection.
+/// </summary>
+public sealed class SubmitConflictClassifierTests
+{
+    private static ApplicationSubmissionResult Result(ApplicationSubmissionStatus status, string? code = null) =>
+        new(status, null, code, null);
+
+    [Fact]
+    public void Success_IsSubmitted() =>
+        SubmitConflictClassifier.Classify(Result(ApplicationSubmissionStatus.Success))
+            .Should().Be(SubmitOutcome.Submitted);
+
+    [Fact]
+    public void ServerError_IsRetry() =>
+        SubmitConflictClassifier.Classify(Result(ApplicationSubmissionStatus.ServerError, "HTTP_503"))
+            .Should().Be(SubmitOutcome.Retry);
+
+    [Fact]
+    public void SigningFailed_IsRetry() =>
+        SubmitConflictClassifier.Classify(Result(ApplicationSubmissionStatus.SigningFailed))
+            .Should().Be(SubmitOutcome.Retry);
+
+    [Theory]
+    [InlineData("HTTP_409", SubmitOutcome.StepMovedOn)]
+    [InlineData("HTTP_410", SubmitOutcome.InstanceClosed)]
+    [InlineData("HTTP_404", SubmitOutcome.StepMovedOn)]
+    [InlineData("HTTP_408", SubmitOutcome.Retry)]
+    [InlineData("HTTP_429", SubmitOutcome.Retry)]
+    [InlineData("HTTP_400", SubmitOutcome.StepMovedOn)]
+    [InlineData("HTTP_422", SubmitOutcome.StepMovedOn)]
+    public void ValidationFailed_MapsByStatusCode(string code, SubmitOutcome expected) =>
+        SubmitConflictClassifier.Classify(Result(ApplicationSubmissionStatus.ValidationFailed, code))
+            .Should().Be(expected);
+}

--- a/tests/Sorcha.Wallet.Pwa.Tests/Drafts/SubmitQueueTests.cs
+++ b/tests/Sorcha.Wallet.Pwa.Tests/Drafts/SubmitQueueTests.cs
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Sorcha.Wallet.Pwa.Services.Drafts;
+using Sorcha.Wallet.Pwa.Services.Drafts.Models;
+using Xunit;
+
+namespace Sorcha.Wallet.Pwa.Tests.Drafts;
+
+/// <summary>
+/// Feature 152 US3/US4 — `SubmitQueue` outbox: enqueue, drain (Submitted → removed, Retry → stays
+/// with attempts++, stale → NeedsAttention + reason), per-item isolation, idempotency-key reuse.
+/// </summary>
+public sealed class SubmitQueueTests
+{
+    private readonly FakeEncryptedStore _store = new();
+    private SubmitQueue Create() => new(_store);
+
+    private static QueuedSubmission Item(string idem = "idem-1") => new()
+    {
+        InstanceId = "inst-1", ActionId = 1, BlueprintId = "bp-1", IdempotencyKey = idem,
+    };
+
+    [Fact]
+    public async Task EnqueueAsync_AssignsKey_AndQueuedState()
+    {
+        var stored = await Create().EnqueueAsync(Item());
+
+        stored.QueuedKey.Should().NotBeNullOrEmpty();
+        stored.State.Should().Be(QueuedSubmissionState.Queued);
+    }
+
+    [Fact]
+    public async Task Drain_Submitted_RemovesItem()
+    {
+        var q = Create();
+        await q.EnqueueAsync(Item());
+
+        await q.DrainAsync((_, _) => Task.FromResult(SubmitOutcome.Submitted));
+
+        (await q.ListAsync()).Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Drain_Retry_LeavesQueued_AndIncrementsAttempts()
+    {
+        var q = Create();
+        await q.EnqueueAsync(Item());
+
+        await q.DrainAsync((_, _) => Task.FromResult(SubmitOutcome.Retry));
+
+        var items = await q.ListAsync();
+        items.Should().ContainSingle();
+        items[0].State.Should().Be(QueuedSubmissionState.Queued);
+        items[0].Attempts.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Drain_SubmitThrows_TreatedAsRetry()
+    {
+        var q = Create();
+        await q.EnqueueAsync(Item());
+
+        await q.DrainAsync((_, _) => throw new InvalidOperationException("network"));
+
+        (await q.ListAsync())[0].State.Should().Be(QueuedSubmissionState.Queued);
+    }
+
+    [Theory]
+    [InlineData(SubmitOutcome.AlreadySubmitted, ConflictReason.AlreadySubmitted)]
+    [InlineData(SubmitOutcome.StepMovedOn, ConflictReason.StepMovedOn)]
+    [InlineData(SubmitOutcome.InstanceClosed, ConflictReason.InstanceClosed)]
+    public async Task Drain_Stale_MarksNeedsAttention_WithReason(SubmitOutcome outcome, ConflictReason reason)
+    {
+        var q = Create();
+        await q.EnqueueAsync(Item());
+
+        await q.DrainAsync((_, _) => Task.FromResult(outcome));
+
+        var item = (await q.ListAsync()).Should().ContainSingle().Subject;
+        item.State.Should().Be(QueuedSubmissionState.NeedsAttention);
+        item.ConflictReason.Should().Be(reason);
+    }
+
+    [Fact]
+    public async Task Drain_OneItemStale_OthersStillSubmit()
+    {
+        var q = Create();
+        await q.EnqueueAsync(Item("a"));
+        await q.EnqueueAsync(Item("b"));
+
+        await q.DrainAsync((item, _) => Task.FromResult(
+            item.IdempotencyKey == "a" ? SubmitOutcome.InstanceClosed : SubmitOutcome.Submitted));
+
+        var remaining = await q.ListAsync();
+        remaining.Should().ContainSingle();
+        remaining[0].IdempotencyKey.Should().Be("a");
+        remaining[0].State.Should().Be(QueuedSubmissionState.NeedsAttention);
+    }
+
+    [Fact]
+    public async Task Drain_RetryThenList_PreservesIdempotencyKey()
+    {
+        var q = Create();
+        await q.EnqueueAsync(Item("stable-key"));
+
+        await q.DrainAsync((_, _) => Task.FromResult(SubmitOutcome.Retry));
+
+        (await q.ListAsync())[0].IdempotencyKey.Should().Be("stable-key");
+    }
+
+    /// <summary>In-memory stand-in for the IndexedDB-backed encrypted store.</summary>
+    private sealed class FakeEncryptedStore : IEncryptedObjectStore
+    {
+        private readonly Dictionary<string, object> _data = new();
+
+        public Task PutAsync<T>(string storeName, string key, T value, CancellationToken ct = default)
+        {
+            _data[$"{storeName}:{key}"] = value!;
+            return Task.CompletedTask;
+        }
+
+        public Task<T?> GetAsync<T>(string storeName, string key, CancellationToken ct = default) where T : class =>
+            Task.FromResult(_data.TryGetValue($"{storeName}:{key}", out var v) ? (T?)v : null);
+
+        public Task<IReadOnlyList<T>> ListAsync<T>(string storeName, CancellationToken ct = default) where T : class =>
+            Task.FromResult((IReadOnlyList<T>)_data
+                .Where(kv => kv.Key.StartsWith($"{storeName}:", StringComparison.Ordinal))
+                .Select(kv => kv.Value).OfType<T>().ToList());
+
+        public Task DeleteAsync(string storeName, string key, CancellationToken ct = default)
+        {
+            _data.Remove($"{storeName}:{key}");
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/tests/Sorcha.Wallet.Pwa.Tests/Pages/ActionsInReviewBannerTests.cs
+++ b/tests/Sorcha.Wallet.Pwa.Tests/Pages/ActionsInReviewBannerTests.cs
@@ -34,6 +34,10 @@ public sealed class ActionsInReviewBannerTests : ComponentTestFixture
         draftStore.Setup(s => s.ListAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(Array.Empty<Sorcha.Wallet.Pwa.Services.Drafts.Models.ActionDraft>());
         Services.AddSingleton(draftStore.Object);
+        var queue = new Mock<Sorcha.Wallet.Pwa.Services.Drafts.ISubmitQueue>();
+        queue.Setup(s => s.ListAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<Sorcha.Wallet.Pwa.Services.Drafts.Models.QueuedSubmission>());
+        Services.AddSingleton(queue.Object);
         _client.Setup(c => c.GetPendingAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Array.Empty<PendingActionItem>());
     }

--- a/tests/Sorcha.Wallet.Pwa.Tests/Pages/ActionsInReviewBannerTests.cs
+++ b/tests/Sorcha.Wallet.Pwa.Tests/Pages/ActionsInReviewBannerTests.cs
@@ -30,6 +30,10 @@ public sealed class ActionsInReviewBannerTests : ComponentTestFixture
         Services.AddSingleton(_client.Object);
         Services.AddSingleton(_pending.Object);
         Services.AddSingleton(Mock.Of<Sorcha.Wallet.Pwa.Services.Drafts.IActionContextCache>());
+        var draftStore = new Mock<Sorcha.Wallet.Pwa.Services.Drafts.IDraftStore>();
+        draftStore.Setup(s => s.ListAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<Sorcha.Wallet.Pwa.Services.Drafts.Models.ActionDraft>());
+        Services.AddSingleton(draftStore.Object);
         _client.Setup(c => c.GetPendingAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Array.Empty<PendingActionItem>());
     }

--- a/tests/Sorcha.Wallet.Pwa.Tests/Pages/ActionsInReviewBannerTests.cs
+++ b/tests/Sorcha.Wallet.Pwa.Tests/Pages/ActionsInReviewBannerTests.cs
@@ -29,6 +29,7 @@ public sealed class ActionsInReviewBannerTests : ComponentTestFixture
     {
         Services.AddSingleton(_client.Object);
         Services.AddSingleton(_pending.Object);
+        Services.AddSingleton(Mock.Of<Sorcha.Wallet.Pwa.Services.Drafts.IActionContextCache>());
         _client.Setup(c => c.GetPendingAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Array.Empty<PendingActionItem>());
     }

--- a/tests/Sorcha.Wallet.Pwa.Tests/Pages/ActionsInboxTests.cs
+++ b/tests/Sorcha.Wallet.Pwa.Tests/Pages/ActionsInboxTests.cs
@@ -35,7 +35,16 @@ public sealed class ActionsInboxTests : ComponentTestFixture
         Services.AddSingleton(_client.Object);
         Services.AddSingleton(_pending.Object);
         Services.AddSingleton(Mock.Of<Sorcha.Wallet.Pwa.Services.Drafts.IActionContextCache>());
+        Services.AddSingleton(EmptyDraftStore());
         _pending.Setup(p => p.GetAsync(It.IsAny<CancellationToken>())).ReturnsAsync((PendingApplicationView?)null);
+    }
+
+    private static Sorcha.Wallet.Pwa.Services.Drafts.IDraftStore EmptyDraftStore()
+    {
+        var m = new Mock<Sorcha.Wallet.Pwa.Services.Drafts.IDraftStore>();
+        m.Setup(s => s.ListAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<Sorcha.Wallet.Pwa.Services.Drafts.Models.ActionDraft>());
+        return m.Object;
     }
 
     private static PendingActionItem Item(string id, string title) =>

--- a/tests/Sorcha.Wallet.Pwa.Tests/Pages/ActionsInboxTests.cs
+++ b/tests/Sorcha.Wallet.Pwa.Tests/Pages/ActionsInboxTests.cs
@@ -34,6 +34,7 @@ public sealed class ActionsInboxTests : ComponentTestFixture
     {
         Services.AddSingleton(_client.Object);
         Services.AddSingleton(_pending.Object);
+        Services.AddSingleton(Mock.Of<Sorcha.Wallet.Pwa.Services.Drafts.IActionContextCache>());
         _pending.Setup(p => p.GetAsync(It.IsAny<CancellationToken>())).ReturnsAsync((PendingApplicationView?)null);
     }
 

--- a/tests/Sorcha.Wallet.Pwa.Tests/Pages/ActionsInboxTests.cs
+++ b/tests/Sorcha.Wallet.Pwa.Tests/Pages/ActionsInboxTests.cs
@@ -36,6 +36,7 @@ public sealed class ActionsInboxTests : ComponentTestFixture
         Services.AddSingleton(_pending.Object);
         Services.AddSingleton(Mock.Of<Sorcha.Wallet.Pwa.Services.Drafts.IActionContextCache>());
         Services.AddSingleton(EmptyDraftStore());
+        Services.AddSingleton(EmptySubmitQueue());
         _pending.Setup(p => p.GetAsync(It.IsAny<CancellationToken>())).ReturnsAsync((PendingApplicationView?)null);
     }
 
@@ -44,6 +45,14 @@ public sealed class ActionsInboxTests : ComponentTestFixture
         var m = new Mock<Sorcha.Wallet.Pwa.Services.Drafts.IDraftStore>();
         m.Setup(s => s.ListAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(Array.Empty<Sorcha.Wallet.Pwa.Services.Drafts.Models.ActionDraft>());
+        return m.Object;
+    }
+
+    private static Sorcha.Wallet.Pwa.Services.Drafts.ISubmitQueue EmptySubmitQueue()
+    {
+        var m = new Mock<Sorcha.Wallet.Pwa.Services.Drafts.ISubmitQueue>();
+        m.Setup(s => s.ListAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<Sorcha.Wallet.Pwa.Services.Drafts.Models.QueuedSubmission>());
         return m.Object;
     }
 

--- a/tests/Sorcha.Wallet.Pwa.Tests/Pages/ActionsQueueTests.cs
+++ b/tests/Sorcha.Wallet.Pwa.Tests/Pages/ActionsQueueTests.cs
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using Bunit;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Sorcha.UI.Testing;
+using Sorcha.Wallet.Pwa.Services;
+using Sorcha.Wallet.Pwa.Services.Actions;
+using Sorcha.Wallet.Pwa.Services.Actions.Models;
+using Sorcha.Wallet.Pwa.Services.Drafts;
+using Sorcha.Wallet.Pwa.Services.Drafts.Models;
+using Xunit;
+using ActionsPage = Sorcha.Wallet.Pwa.Pages.Actions;
+
+namespace Sorcha.Wallet.Pwa.Tests.Pages;
+
+/// <summary>
+/// Feature 152 US3/US4 — the inbox surfaces queued submissions and, for a held (NeedsAttention)
+/// item, shows the reason with discard / re-open choices; discard removes it (no silent loss).
+/// </summary>
+public sealed class ActionsQueueTests : ComponentTestFixture
+{
+    private readonly Mock<IMyActionsClient> _client = new();
+    private readonly Mock<IPendingApplicationClient> _pending = new();
+    private readonly Mock<IDraftStore> _drafts = new();
+    private readonly Mock<ISubmitQueue> _queue = new();
+
+    public ActionsQueueTests()
+    {
+        Services.AddSingleton(_client.Object);
+        Services.AddSingleton(_pending.Object);
+        Services.AddSingleton(Mock.Of<IActionContextCache>());
+        Services.AddSingleton(_drafts.Object);
+        Services.AddSingleton(_queue.Object);
+        _client.Setup(c => c.GetPendingAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<PendingActionItem>());
+        _pending.Setup(p => p.GetAsync(It.IsAny<CancellationToken>())).ReturnsAsync((PendingApplicationView?)null);
+        _drafts.Setup(d => d.ListAsync(It.IsAny<CancellationToken>())).ReturnsAsync(Array.Empty<ActionDraft>());
+    }
+
+    private QueuedSubmission Held() => new()
+    {
+        QueuedKey = "q1", InstanceId = "inst-1", ActionId = 1, BlueprintId = "bp-1",
+        State = QueuedSubmissionState.NeedsAttention, ConflictReason = ConflictReason.StepMovedOn,
+    };
+
+    [Fact]
+    public void NeedsAttentionItem_ShowsReason_AndDiscardReopen()
+    {
+        _queue.Setup(q => q.ListAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<QueuedSubmission> { Held() });
+
+        var cut = Render<ActionsPage>();
+
+        cut.Find("[data-testid=actions-queue-reason-q1]").TextContent.Should().Contain("moved on");
+        cut.FindAll("[data-testid=actions-queue-discard-q1]").Should().ContainSingle();
+        cut.FindAll("[data-testid=actions-queue-reopen-q1]").Should().ContainSingle();
+    }
+
+    [Fact]
+    public void Discard_RemovesQueuedItem()
+    {
+        _queue.Setup(q => q.ListAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<QueuedSubmission> { Held() });
+
+        var cut = Render<ActionsPage>();
+        cut.Find("[data-testid=actions-queue-discard-q1]").Click();
+
+        _queue.Verify(q => q.RemoveAsync("q1", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public void QueuedItem_ShowsQueuedStatus()
+    {
+        _queue.Setup(q => q.ListAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<QueuedSubmission>
+            {
+                new() { QueuedKey = "q2", InstanceId = "i", ActionId = 1, BlueprintId = "b", State = QueuedSubmissionState.Queued },
+            });
+
+        var cut = Render<ActionsPage>();
+
+        cut.FindAll("[data-testid=actions-queue-q2]").Should().ContainSingle();
+    }
+}


### PR DESCRIPTION
## Summary

Sub-project **C** of the PWA workflow-participation programme: makes Citizen Wallet workflow participation **field-first**. A consumer-tier citizen can open any of their pending actions **offline**, fill them, **capture photos**, save an **encrypted local draft**, and have it **submit automatically on reconnect** — with **detect/hold/ask** conflict handling so captured work is never silently lost. Builds on sub-project A.

Design: `docs/superpowers/specs/2026-06-13-pwa-offline-field-capture-design.md`; spec/plan/tasks in `specs/152-offline-field-capture/`.

## What's included (by user story)

- **Foundational** — IndexedDB v4 stores (`drafts`/`submitQueue`/`actionContext`) + generic encrypted ops reusing the credential XChaCha20 device key; `IEncryptedObjectStore` seam; `IConnectivity` (wraps the existing `SorchaConnectivity` JS bridge).
- **US2 — pre-cache for offline open**: `IActionContextCache` caches each pending action's form context; `ApplicationInstance` opens a prepared action offline (un-prepared → distinct "available when connected" state).
- **US1 — offline drafts**: `IDraftStore` (encrypted); `SorchaFormRenderer` gains `InitialFormData` (seed/resume) + `OnFormDataChanged` (autosave); debounced autosave + flush-on-leave + clear-on-submit; "Saved offline" badge.
- **US3 — queued submit**: `ISubmitQueue` outbox + `SubmitQueueDrainer`; offline submits queue and flush on reconnect/app-open; per-item status.
- **US4 — detect/hold/ask**: pure `SubmitConflictClassifier`; stale submits are **held** with a reason + Discard / Re-open choices (no silent loss).
- **US5 — photos + attachments**: `IFileChunkUploader` uploads captured media via the existing consumer-tier `/api/file-chunks` pipeline and references it in the payload (online + at offline drain). **No backend change** — the execute path already resolves staged chunks (Feature 085).

## Tests

`Sorcha.Wallet.Pwa.Tests` **262/0**, `Sorcha.UI.Core.Tests` **1382/0**. Snackbar gate clean; PWA builds 0 warnings / 0 errors. New coverage: encrypted draft store, submit-queue drain (submit/retry/hold/isolation/idempotency), conflict classifier (table-driven), action-context cache, file-chunk uploader, renderer seed param, queue/needs-attention UX.

## Notes / follow-ups

- **No backend change** — attachments reuse the existing chunk pipeline + Feature-085 execute handling.
- **Mid-edit media autosave**: captured media persists through the offline *submit queue*; persisting not-yet-submitted media into the *draft* during editing (capture → close without submitting) is a documented follow-up (autosave currently carries form data only).
- **Live walkthrough** against Docker/n1 (offline capture → reconnect → submit, conflict path) is a pre-merge manual check — not run in this session.
- Built on A (#1004, merged); branch was rebased onto master so this PR shows only C's diff.

Scope: sub-project C. B (catalogue) and D (dual-tier/org-role) remain separate cycles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)