### PR TITLE
test(tenant): de-flake CRL serial assertion (canonical DER INTEGER)

### DIFF
--- a/tests/Sorcha.Tenant.Service.Tests/Trust/InternalCaTrustProviderTests.cs
+++ b/tests/Sorcha.Tenant.Service.Tests/Trust/InternalCaTrustProviderTests.cs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Sorcha Contributors
 
+using System.Numerics;
 using System.Security.Cryptography;
 using FluentAssertions;
 using Microsoft.Extensions.Configuration;
@@ -228,10 +229,14 @@ public class InternalCaTrustProviderTests
         parsed.Should().NotBeNull();
         currentCrlNumber.Should().Be(crl.Version);
 
-        // Round-trip: rebuild the CRL with the same entries and verify the DER shape.
-        // Simplest check — the revoked serial must appear somewhere in the DER bytes.
-        var serialBytes = Convert.FromHexString(enrolment.SerialNumber);
-        IndexOfSequence(crl.CrlDer, serialBytes).Should().BeGreaterThanOrEqualTo(0,
+        // The revoked serial must appear in the signed CRL bytes. Compare against the serial's
+        // CANONICAL DER INTEGER content (two's-complement big-endian), not the raw hex bytes:
+        // DER prepends a 0x00 sign byte when the leading bit is set and strips non-canonical
+        // leading zeros, so a raw-byte scan is non-deterministic across random serials (the source
+        // of an intermittent flake). Normalising to the DER INTEGER content makes this exact.
+        var serial = new BigInteger(Convert.FromHexString(enrolment.SerialNumber), isUnsigned: true, isBigEndian: true);
+        var derSerial = serial.ToByteArray(isUnsigned: false, isBigEndian: true);
+        IndexOfSequence(crl.CrlDer, derSerial).Should().BeGreaterThanOrEqualTo(0,
             "revoked serial number must be present in the signed CRL bytes");
     }
 


### PR DESCRIPTION
## Summary

Fixes the intermittent `InternalCaTrustProviderTests.GetOrPublishCrl_AfterRevocation_IncludesSerialNumber` failure that has been red-flaking unrelated PRs in `build-and-test`.

The test scanned the signed CRL DER for the serial's **raw hex bytes**. DER encodes the serial as an ASN.1 INTEGER — it prepends a `0x00` sign byte when the leading bit is set and strips non-canonical leading zeros — so for some random serials the raw needle isn't a contiguous subsequence → spurious `-1` → failure (~serial-dependent, hence intermittent).

Fix: normalise the serial to its **canonical DER INTEGER content** (`BigInteger` two's-complement, big-endian) before the byte scan, matching exactly how the serial is encoded inside the CRL.

## Tests

Test-only change. Full `Sorcha.Tenant.Service.Tests` suite run **3×, all green (1313 passed / 0 failed / 8 skipped)** — exercising different random serials each run; deterministic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)