### PR TITLE
docs(spec): D (dual-tier/org-role) + B (service catalogue) designs

### DIFF
--- a/docs/superpowers/specs/2026-06-14-pwa-dual-tier-org-role-design.md
+++ b/docs/superpowers/specs/2026-06-14-pwa-dual-tier-org-role-design.md
@@ -1,0 +1,127 @@
+# PWA Dual-Tier / Org-Role Work — Design (Sub-project D)
+
+**Date:** 2026-06-14
+**Status:** Design — ready to speckit specify/plan/tasks (implementation deferred to a focused session)
+**Decision owner:** Stuart Fraser
+**Parent programme:** PWA workflow participation (A/B/C/D). Depends on **A** (inbox) and benefits from **C** (offline).
+
+---
+
+## 1. Context & scope decision
+
+The goal of D is to let the **same human** do their **organisational-role** workflow work on the
+phone (e.g. a verification analyst performing the issuing "Action 2" of AssuredIdentity), not only
+their personal/citizen (consumer-tier) work — deliberately bringing platform-tier work to the PWA,
+which sits at `/wallet/` (consumer tier) under the F136 audience model.
+
+**Scope decision (2026-06-13):** *Light up org-role work on the existing context switcher* — NOT a
+from-scratch dual-tier auth build. Grounding (below) showed the hard plumbing already exists.
+
+### Grounding (verified read-only — the findings that shape D)
+
+- **The auth plumbing largely exists.** `/api/auth/switch-org` already re-mints a **platform-tier,
+  org-scoped** token; the PWA's `IUserContext` / `ManagedUserContext` already calls it; `MainLayout`
+  already hosts `ContextChipSwitcher` + `IUserOrgMembershipsClient` (Feature 125). Switching to an
+  org context in the PWA *already yields a platform/org token*.
+- **Tier = audience** (`SorchaAudiences`); entitlement gate (`TierResolver`): Platform only for
+  members holding `SystemAdmin|Administrator|Designer|Auditor`; an **explicit** `tier=platform`
+  request by a non-entitled user is **refused 403**; a destination-derived preference **downgrades
+  to entitlement**. These gates are the security boundary and **must not be weakened**.
+- **Org-role actions already surface in the inbox.** In Sorcha's model the org-role action's
+  participant is bound to the **member's own personal wallet** (pre-baked at publish — e.g. the
+  analyst's wallet seeded into `instance.ParticipantWallets` by `InstanceProjectionResolver`), so
+  `GET /api/actions/pending` returns it via the member's `platform_user_id` **regardless of tier**
+  (`ActionEndpoints.ResolveUserWalletAddressesAsync`).
+- **Executing an org-role/issuing action needs the platform/org token.** `ActionExecutionService`
+  uses `org_id` (+ roles) for credential-issuance config (Feature 120) and participant-ownership
+  verification (`ActionExecutionService.cs:~2409`). So the action must be performed **while in the
+  org context** (platform token carries `org_id`), which the existing switch-org provides.
+- **PWA login hardcodes `tier="consumer"`** in three places (`IAuthService.SignInAsync` /
+  `VerifyTwoFactorAsync` / `SignInWithPasskeyAsync`); `AccessTokenRecord` has **no tier field** — the
+  session doesn't know which "hat" it's wearing.
+- **No backend change required.** `/api/actions/pending`, `/execute`, and `/api/auth/switch-org` are
+  all tier-agnostic / already exist. The F136 gates stay untouched.
+
+---
+
+## 2. What D actually delivers
+
+A user who is both a citizen and an org member can, on the phone:
+1. See which **context/hat** they're in (Personal = consumer; **<Org>** = platform/org).
+2. Switch to an **org context** via the existing chip → the PWA holds the platform/org token.
+3. See their **org-role pending actions** in the same "Things to do" inbox, clearly framed as
+   **"acting as <Org>"**, and **perform** them (execute succeeds because `org_id` is present).
+4. Switch back to Personal for their own citizen work.
+
+**Out of scope:** holding consumer + platform sessions *simultaneously* (D uses the existing
+single-active-context model — switch re-mints, matching the web app); a from-scratch role picker at
+first sign-in (sign-in stays consumer; role is reached via the switcher); org-only members with no
+personal wallet (documented edge — see risks).
+
+---
+
+## 3. Design
+
+- **Tier-aware session.** Add a `tier`/context marker to the stored session (derive from the JWT
+  `aud` via `SorchaAudiences`, or store alongside `AccessTokenRecord`). The PWA shell reflects it:
+  Personal vs. "acting as <Org>". This is the core new state — everything else is framing over the
+  existing switch.
+- **Context switch = existing mechanism.** Reuse `IUserContext.SetActiveContextAsync(orgId)` →
+  `/api/auth/switch-org` (already implemented) to obtain the platform/org token; Personal context
+  returns to the consumer token (re-mint or stored). No new auth endpoint.
+- **Inbox framing (reuse A).** `Actions.razor` already lists `/api/actions/pending` for the active
+  token. In an org context it will return the member's org-role actions (bound to their personal
+  wallet); add an "acting as <Org>" banner/affordance so the user knows the hat. The count badge
+  (US2 of A) reflects the active context.
+- **Execute in-context.** Because the active token in an org context carries `org_id`, the existing
+  `ApplicationInstance` → `/execute` path performs the org-role action correctly (issuance config +
+  participant-ownership checks pass). No change to the submit path beyond using the active token.
+- **Entitlement respect.** Only show/enable the org switcher for members who actually hold
+  org memberships/roles (existing `IUserOrgMembershipsClient`). Never force `tier=platform` for a
+  non-entitled user — the server 403 stands; the UI simply doesn't offer it.
+
+### Components
+- Tier/context marker on the session + shell indicator ("acting as <Org>").
+- Reuse: `IUserContext` / `ContextChipSwitcher` / `IUserOrgMembershipsClient` (already in PWA), A's
+  inbox + `ApplicationInstance`.
+- Small: an "acting as <Org>" banner in the inbox; ensure the inbox + badge refresh on context switch.
+
+---
+
+## 4. Risks / must-validate-live
+
+- **Org-context-at-execute (primary risk).** The whole feature hinges on an org-role/issuing action
+  executing correctly under the platform/org token (org_id + roles present). This must be
+  **live-validated** (run the AssuredIdentity analyst Action 2 from the PWA in the org context)
+  before D is trusted — it depends on subtle `ActionExecutionService` org-context behaviour.
+- **Org-only member, no personal wallet.** `/api/actions/pending` resolves only the member's
+  personal wallet(s); an org member with no personal wallet would see no actions. Real members
+  (analyst) have one. If org-only membership becomes a real case, a follow-up would resolve the org
+  wallet or add an org-context list parameter (a backend change — explicitly NOT in D).
+- **Token lifecycle on switch.** Returning to Personal must restore a consumer token (re-mint or
+  cached); ensure the bearer handler always sends the active-context token and the inbox refreshes.
+- **Security boundary.** Do NOT add any path that lets a non-entitled user obtain a platform token;
+  rely on the server entitlement gate (403). The PWA only *offers* org context to entitled members.
+
+---
+
+## 5. Likely user stories (for speckit)
+
+- **US1 (P1):** Tier-aware session + "which hat am I in" shell indicator (Personal vs. acting-as-Org).
+- **US2 (P1):** Switch to an org context and see + perform my org-role pending actions in the inbox
+  ("acting as <Org>" framing); execute succeeds in-context. *(The proof slice — live-validate.)*
+- **US3 (P2):** Switch back to Personal cleanly; inbox/badge reflect the active context throughout.
+- **US4 (P3):** Entitlement-aware affordance (switcher only for members with org roles; never
+  force-elevate; honest messaging if a context can't be entered).
+
+**No backend change anticipated.** If org-only-no-personal-wallet must be supported, that is a
+separate backend follow-up, not part of D.
+
+---
+
+## 6. Definition of done (D)
+
+A citizen who is also an org member can, on the phone, switch into their organisation, see and
+perform the workflow actions that are theirs to do *as that org member* (clearly framed as such),
+and switch back to personal — reusing the existing switch-org + inbox + execute infrastructure, with
+the F136 entitlement/audience gates intact, validated live against the AssuredIdentity analyst flow.

--- a/docs/superpowers/specs/2026-06-14-pwa-service-catalogue-design.md
+++ b/docs/superpowers/specs/2026-06-14-pwa-service-catalogue-design.md
@@ -1,0 +1,110 @@
+# PWA Service Catalogue — Design (Sub-project B)
+
+**Date:** 2026-06-14
+**Status:** Design — ready to speckit specify/plan/tasks (implementation deferred to a focused session)
+**Decision owner:** Stuart Fraser
+**Parent programme:** PWA workflow participation (A/B/C/D). Depends on **A** (open/fill/submit + inbox).
+
+---
+
+## 1. Context & scope
+
+Sub-project A gave the citizen an inbox of work *waiting on them* and the ability to open/fill/submit
+an action they already have. B is the other half of discovery: **browse the services available and
+start a new one** — e.g. "apply for a blue badge" — turning the empty-stub `Applications.razor` into
+a real catalogue.
+
+**Scope:** a citizen (consumer-tier) can browse the services they're entitled to start, tap one, and
+begin a new application that drops them into the existing fill/submit flow. Out of scope: org-role
+catalogues (D), offline catalogue browsing (could layer on C later), designer/admin surfaces.
+
+### Grounding (verified read-only)
+
+- **`Applications.razor` is an empty stub** (route `/applications`): its own comment says the
+  *application catalogue API lands in a follow-up* and it currently shows an empty-state CTA pointing
+  at the council web shell.
+- **Starting an application already exists:** `POST /api/instances/` (`CreateInstance`,
+  Blueprint Service `Program.cs:2153`, request `CreateInstanceRequest` `:4114`) creates a workflow
+  instance from a published blueprint. After creation, the citizen's first action is reachable via
+  the existing `ApplicationInstance` page (route `applications/{instanceId}`) that A already drives.
+- **Published blueprints** live in `IPublishedBlueprintStore`; `/api/blueprints` exposes
+  version/lookup endpoints, but **there is no citizen-facing "services I can start" catalogue
+  endpoint** (filtered to what a consumer in their org context may initiate). This is B's one
+  backend addition.
+
+---
+
+## 2. The one backend gap
+
+B needs a **catalogue read endpoint** — "list the services a citizen may start" — consumer-tier,
+scoped to the citizen's org/home context. Shape (to be finalised in speckit):
+
+```
+GET /api/catalogue            (or /api/services)   — Blueprint Service
+  auth: consumer-tier capable (RequireAuthorization; resolves org from token)
+  returns: [ { blueprintId, title, description, category?, startActionSummary? } ]
+  filtered to blueprints flagged citizen-startable in the caller's context
+```
+
+Decisions for speckit: where "citizen-startable" is declared (a blueprint flag / a published-service
+registry), how it's scoped to the org/home context, and whether the catalogue is curated vs. "all
+published blueprints with an open first action". The simplest v1: list published blueprints whose
+first action is citizen-initiable (open participant) in the caller's org context.
+
+Everything else is front-end and reuses existing pieces.
+
+---
+
+## 3. Design
+
+- **`ICatalogueClient`** (PWA): typed client over the new `GET /api/catalogue`, returning catalogue
+  items. Bearer chain (consumer-tier token).
+- **`Applications.razor`** (replace the stub): render the catalogue — searchable/grouped list of
+  startable services with title + description; empty-state when none. Tapping an item starts it.
+- **Start flow:** on tap → `POST /api/instances/` (`CreateInstance`) for the chosen blueprint →
+  on success navigate to `applications/{instanceId}` (base-relative) → the **existing**
+  `ApplicationInstance` (A) renders the first action to fill + submit. No new form/submit code.
+- **Entry point:** A already left a catalogue CTA on the inbox empty-state; wire it to
+  `/applications`. The `Cards.razor` "add" affordances also point at `/applications` — they light up
+  once the catalogue is real.
+- **Reuse:** `ApplicationInstance` (open/fill/submit), the shared `SorchaFormRenderer`, A's
+  navigation conventions (base-relative). With C present, a started application's first action gets
+  drafts/offline for free.
+
+### Components
+- New: `GET /api/catalogue` (Blueprint Service) + `ICatalogueClient` (PWA) + catalogue UI in
+  `Applications.razor` + the start→CreateInstance→navigate flow.
+- Reuse: `CreateInstance` endpoint, `ApplicationInstance`, form renderer.
+
+---
+
+## 4. Likely user stories (for speckit)
+
+- **US1 (P1):** Browse the services I can start (catalogue list with title/description; empty-state).
+- **US2 (P1):** Start a service → new instance created → land in the fill/submit flow. *(MVP loop.)*
+- **US3 (P2):** Find a service (search/filter/group by category).
+- **US4 (P3):** Sensible scoping/curation — only services actually startable in my context appear;
+  honest messaging when the catalogue is empty.
+
+---
+
+## 5. Risks / decisions
+
+- **Catalogue definition (main decision):** what makes a blueprint "citizen-startable" and how it's
+  scoped to the caller's org/home context — needs a clear rule (blueprint flag vs. registry vs.
+  "published + open first action"). Resolve in speckit research; keep v1 simple.
+- **Backend touch:** unlike A/C, B adds one consumer-tier read endpoint. Keep it read-only and
+  reuse the existing published-blueprint store; no change to instance creation.
+- **Auth:** consumer-tier; do not expose blueprints the citizen can't start; resolve org/home from
+  the token (no org parameter).
+- **Live validation:** start a real service end-to-end (catalogue → CreateInstance → first action →
+  submit) before trusting B.
+
+---
+
+## 6. Definition of done (B)
+
+A citizen can open the wallet, browse the services available to them, pick one, and be taken
+straight into filling and submitting its first action — turning `Applications.razor` from an
+empty stub into a working "start something new" surface, on top of A's fill/submit flow and one new
+consumer-tier catalogue endpoint.


### PR DESCRIPTION
## Summary

Design docs for the two remaining sub-projects of the PWA workflow-participation programme, captured ready to `/speckit.specify` next session (implementation deferred — both are correctness-sensitive enough to warrant focused effort + live validation rather than rushing).

- **D — dual-tier / org-role** (`docs/superpowers/specs/2026-06-14-pwa-dual-tier-org-role-design.md`): scope is *light up org-role work on the existing context switcher*. Grounding showed the hard plumbing already exists (`switch-org` re-mints a platform/org token; `ContextChipSwitcher`/`IUserContext` already in the PWA; org-role actions surface via the member's personal wallet; `/execute` needs the `org_id` token). **No backend change.** Primary risk: org-context-at-execute needs **live validation** (AssuredIdentity analyst Action 2 from the PWA).
- **B — service catalogue** (`docs/superpowers/specs/2026-06-14-pwa-service-catalogue-design.md`): browse startable services + start-new → existing `CreateInstance` → `ApplicationInstance` fill/submit. One new **consumer-tier catalogue read endpoint** is the only backend addition.

Each doc has grounded findings (file:line), likely user stories, risks, and DoD.

## Tests

Docs only — no code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)