### PR TITLE
feat(153): PWA dual-tier / org-role work (sub-project D)

### DIFF
--- a/specs/153-dual-tier-org-role/checklists/requirements.md
+++ b/specs/153-dual-tier-org-role/checklists/requirements.md
@@ -1,0 +1,38 @@
+# Specification Quality Checklist: PWA Dual-Tier / Org-Role Work
+
+**Purpose**: Validate specification completeness and quality before planning
+**Created**: 2026-06-14
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- "Capacity" is the stakeholder term for the consumer/platform tier + org context; the spec abstracts
+  tokens/audiences into capability language. Concrete mechanics live in the design doc + plan.
+- Primary risk (org-context-at-execute) is carried as SC-001/FR-006 and flagged in the design for
+  **live validation** before merge.
+- All items pass on first validation; ready for `/speckit.plan`.

--- a/specs/153-dual-tier-org-role/contracts/consumed-endpoints.md
+++ b/specs/153-dual-tier-org-role/contracts/consumed-endpoints.md
@@ -1,0 +1,19 @@
+# Consumed Endpoints (read-only): PWA Dual-Tier / Org-Role Work
+
+**Feature**: 153-dual-tier-org-role | **Date**: 2026-06-14
+
+D adds **no endpoints** and changes none. It consumes existing ones unchanged.
+
+| Use | Route | Notes |
+|-----|-------|-------|
+| Switch to an org capacity (re-mint platform/org token) | `POST /api/auth/switch-org` (Tenant `AuthEndpoints.cs:956`) | Verifies membership (403 if not a member); re-mints at the tier appropriate to the org (downgrade-not-refuse). **Cannot** mint a personal/consumer token (requires an org) — hence the home-token restore. |
+| List the user's org memberships (switcher options) | `GET /api/auth/me/organizations` (`IUserOrgMembershipsClient`) | Drives entitlement-aware switcher. |
+| Org-role pending actions + count (active token) | `GET /api/actions/pending`, `/api/actions/pending/count` | From A; capacity-agnostic — returns the member's org-role actions when the active token is the org token. |
+| Execute an org-role action (active token) | `POST /api/instances/{id}/actions/{actionId}/execute` | From A; needs `org_id`+roles (present in the org token). **Live-validate** in an org context. |
+
+**Boundary (do NOT weaken):** the only elevation path is `switch-org`, which enforces membership +
+tier server-side. The PWA never mints/forges a platform capacity; a non-entitled switch returns 403
+and the UI stays in the current capacity.
+
+**Drift guard:** if `switch-org`'s response shape or tier behaviour changes, the context-switch +
+home-restore tests should fail — re-align rather than work around.

--- a/specs/153-dual-tier-org-role/data-model.md
+++ b/specs/153-dual-tier-org-role/data-model.md
@@ -1,0 +1,47 @@
+# Phase 1 Data Model: PWA Dual-Tier / Org-Role Work
+
+**Feature**: 153-dual-tier-org-role | **Date**: 2026-06-14
+
+No new server model; device-local additions only.
+
+## Active capacity (existing, reused)
+
+`IUserContext.ActiveContextOrgId : Guid?` — `null` ⇒ **Personal** (consumer); a value ⇒ acting as
+that organisation (platform/org). Display label resolved from `IUserOrgMembershipsClient`
+(`MainLayout.ActiveLabel`). `OnContextChanged` fires on every switch.
+
+## Home (personal) token slot (new)
+
+Extend `IAccessTokenStore` with a second persisted record (IndexedDB `device` store, key
+`home-access-token`):
+
+| Op | Behaviour |
+|----|-----------|
+| `SetHomeAsync(record)` | Persist the personal/consumer token snapshot |
+| `GetHomeAsync()` | Return it, or null if absent/expired (purge on expiry, like the active token) |
+| `ClearHomeAsync()` | Remove it (called on sign-out alongside `ClearAsync`) |
+
+`AccessTokenRecord` shape is unchanged (reused for both active + home).
+
+## Capacity transitions (client-owned, in ManagedUserContext)
+
+```
+Personal --(switch to Org X)--> snapshot active(consumer) → Home; switch-org re-mint → active = Org X token
+Org X    --(switch to Org Y)--> switch-org re-mint → active = Org Y token (Home unchanged)
+Org *    --(switch to Personal)--> active = Home token (restored); if Home missing/expired → signed-out/refresh
+sign out --> ClearAsync + ClearHomeAsync
+```
+
+## Inbox capacity framing (Actions.razor)
+
+- `actingAsOrgLabel : string?` — non-null ⇒ render the "acting as <Org>" banner; sourced from the
+  active context label.
+- The pending list + count come from the **active** token (unchanged) — in an org context they are
+  the member's org-role actions.
+
+## Invariants
+
+- After return to Personal, the active token is a **consumer** token (or signed-out) — never a
+  residual platform token (FR-004 / SC-002).
+- The wallet never holds a capacity the server didn't grant (switch-org is the only elevation path;
+  it enforces membership + tier) (FR-009 / SC-004).

--- a/specs/153-dual-tier-org-role/plan.md
+++ b/specs/153-dual-tier-org-role/plan.md
@@ -1,0 +1,80 @@
+# Implementation Plan: PWA Dual-Tier / Org-Role Work
+
+**Branch**: `153-dual-tier-org-role` | **Date**: 2026-06-14 | **Spec**: [spec.md](./spec.md)
+
+**Source design**: `docs/superpowers/specs/2026-06-14-pwa-dual-tier-org-role-design.md`
+
+**Depends on**: A (`151`, inbox) merged; reuses Feature 125 context-switch infrastructure.
+
+## Summary
+
+Let a citizen-and-org-member do their org-role workflow work in the PWA by lighting up the **existing**
+context switcher. The org switch already re-mints + stores a platform/org token
+(`ManagedUserContext.SetActiveContextAsync` → `/api/auth/switch-org`); the inbox (A) already lists the
+member's actions (org-role actions bind to the member's own wallet, so they surface). The two real
+gaps: (1) returning to **Personal** currently keeps the org token (consumer-gated surfaces would 403),
+so we **cache the personal/home token and restore it**; (2) the inbox/badge need to **refresh + frame
+"acting as <Org>"** on a capacity switch. No back-end change.
+
+## Technical Context
+
+**Language/Version**: C# 14 / .NET 10 (Blazor WASM PWA).
+**Primary Dependencies**: `Sorcha.Wallet.Pwa` — `IUserContext`/`ManagedUserContext`,
+`IAccessTokenStore`/`AccessTokenRecord`, `IActiveContextStore`, `MainLayout` (hosts
+`ContextChipSwitcher` + `ActiveLabel`), A's `Actions.razor`/`IMyActionsClient`, `ApplicationInstance`,
+`IUserOrgMembershipsClient`.
+**Storage**: device-local IndexedDB (existing token + active-context stores; add a personal/home token slot).
+**Testing**: xUnit + bUnit; mock `IUserContext`/token store/memberships. No backend tests (no backend change).
+**Target Platform**: Blazor WASM PWA at `/wallet/` (consumer + platform tokens, by capacity).
+**Project Type**: front-end feature reusing existing auth/context infra.
+**Performance Goals**: capacity switch + inbox refresh feel instant.
+**Constraints**: no backend change; **must not weaken the F136 entitlement/audience boundary**
+(server 403 stands); base-relative nav; no `ISnackbar`; consumer-gated personal surfaces must keep
+working after returning to Personal.
+**Scale/Scope**: tier-aware token storage + Personal-restore + inbox capacity framing/refresh +
+switcher entitlement polish. No new endpoints.
+
+## Constitution Check
+
+| Principle | Applies? | Status |
+|-----------|----------|--------|
+| I. Microservices-First | front-end only | ✅ PASS |
+| II. Security First | **capacity/tier boundary** | ✅ PASS — relies on server entitlement/audience gates (403); never elevates client-side; personal-restore prevents wrong-tier use of consumer surfaces |
+| III. API Documentation | no new APIs | ✅ N/A |
+| IV. Testing (>85% new) | yes | ✅ PLANNED — token-store/restore + context-aware inbox bUnit + switcher entitlement |
+| V. Code Quality | yes | ✅ PLANNED — nullable, async, DI, no warnings |
+| VI. Blueprint Standards | no | ✅ N/A |
+| VII. DDD | yes | ✅ PASS — "capacity" UI term over tier/org context; Action/Participant terms unchanged |
+| VIII. Observability | front-end | ✅ PASS — structured logs on switch (existing) |
+
+**Result**: PASS. No violations.
+
+## Project Structure
+
+```text
+specs/153-dual-tier-org-role/
+├── plan.md, research.md, data-model.md, quickstart.md, contracts/, checklists/, tasks.md
+
+src/Apps/Sorcha.Wallet.Pwa/
+├── Services/IAccessTokenStore.cs (+ AccessTokenRecord)   # MODIFY — capacity/tier marker + home-token slot
+├── Services/Context/IUserContext.cs (ManagedUserContext) # MODIFY — restore home token on return to Personal
+├── Services/ (sign-in/token capture)                     # MODIFY — capture the personal/home token at sign-in
+├── MainLayout.razor                                      # MODIFY — capacity indicator + refresh inbox/badge on switch
+├── Pages/Actions.razor                                   # MODIFY — "acting as <Org>" framing; refresh on context change
+└── ContextChipSwitcher usage                             # REUSE — entitlement-aware (memberships only)
+```
+
+**Structure Decision**: PWA-contained, reusing the Feature-125 context infra + A's inbox. The new
+mechanism is the **home-token capture + restore** so Personal works after an org excursion; the rest
+is framing/refresh + entitlement polish.
+
+## Open Decisions (resolved in research.md)
+
+- How to restore the personal capacity on return to Personal (no `switch-org`-to-personal exists):
+  cache the home consumer token at sign-in and restore it (refresh if expired).
+- How the capacity is known (derive tier from the active JWT `aud` vs. an explicit marker on the record).
+- How the inbox frames + refreshes per capacity.
+
+## Complexity Tracking
+
+> No Constitution violations. Section intentionally empty.

--- a/specs/153-dual-tier-org-role/quickstart.md
+++ b/specs/153-dual-tier-org-role/quickstart.md
@@ -1,0 +1,46 @@
+# Quickstart: PWA Dual-Tier / Org-Role Work
+
+**Feature**: 153-dual-tier-org-role | **Date**: 2026-06-14
+
+## What this adds
+
+A citizen who is also an org member can switch into their organisation on the phone, do their
+org-role workflow actions, and switch back to personal — reusing the existing context switcher.
+
+## Where the code lives
+
+```
+src/Apps/Sorcha.Wallet.Pwa/
+├── Services/IAccessTokenStore.cs            (modify — home-token slot: Get/Set/ClearHomeAsync)
+├── Services/Context/IUserContext.cs         (modify — snapshot on leave Personal; restore on return)
+├── MainLayout.razor                         (modify — refresh inbox/badge on context switch; capacity label already exists)
+├── Pages/Actions.razor                      (modify — "acting as <Org>" banner + refresh on OnContextChanged)
+└── (reuse) ContextChipSwitcher, IUserOrgMembershipsClient, ApplicationInstance, A's inbox
+```
+
+## Build & test
+
+```bash
+dotnet build src/Apps/Sorcha.Wallet.Pwa/Sorcha.Wallet.Pwa.csproj
+dotnet test  tests/Sorcha.Wallet.Pwa.Tests/Sorcha.Wallet.Pwa.Tests.csproj
+```
+
+## Manual verification (Docker / n1) — includes the PRIMARY live-validation
+
+1. Sign in as a person who is both a citizen and a member of an org (e.g. the AssuredIdentity
+   verification analyst).
+2. Confirm the capacity indicator shows **Personal** and personal wallet/credentials work.
+3. Switch to the org via the chip → indicator shows **acting as <Org>**.
+4. Open the inbox → the org-role action (e.g. analyst "Action 2") is listed, framed as org work.
+5. **Open + submit it → it is accepted** (this is the primary org-context-at-execute validation).
+6. Switch back to **Personal** → indicator returns to Personal **and personal wallet/credentials
+   still work** (no 403 — home token restored).
+7. Switch capacity with the inbox open → inbox + count refresh to the new capacity, no reload.
+8. As a person with no org memberships → only Personal is offered.
+
+## Guardrails
+
+- **Never** elevate capacity client-side; rely on the server (`switch-org` 403). Show the failure.
+- After returning to Personal the active token MUST be consumer (or signed-out) — never a residual
+  platform token.
+- Base-relative nav; no `ISnackbar`; no backend change.

--- a/specs/153-dual-tier-org-role/research.md
+++ b/specs/153-dual-tier-org-role/research.md
@@ -1,0 +1,70 @@
+# Phase 0 Research: PWA Dual-Tier / Org-Role Work
+
+**Feature**: 153-dual-tier-org-role | **Date**: 2026-06-14
+
+Grounded against the live PWA + Tenant auth. No open NEEDS CLARIFICATION.
+
+## Decision 1 — Reuse the existing context switch (no new switch mechanism)
+
+`ManagedUserContext.SetActiveContextAsync(orgId)` (`Services/Context/IUserContext.cs:104`) already
+POSTs `/api/auth/switch-org`, stores the returned token, persists the active context, and fires
+`OnContextChanged`. `/api/auth/switch-org` (Tenant `AuthEndpoints.cs:956`) re-mints at the tier
+appropriate to the target org (`TierResolver.ResolvePreference`, downgrade-not-refuse), verifying
+membership (403 if not a member). D reuses this unchanged.
+
+## Decision 2 — Restore the personal capacity on return to Personal (the core gap)
+
+Today, switching back to Personal (`orgId == null`) **keeps the org token** (`IUserContext.cs:143`
+"keep the user's existing token in v1"). Because platform tokens carry `aud=:platform`, the citizen's
+**consumer-gated** surfaces (e.g. `/api/v1/wallet/*` under `RequireConsumerAudience`) would 403 after
+an org excursion. `/api/auth/switch-org` **cannot** mint a personal/consumer token (it requires an
+org). So D **caches the personal/home token** and restores it:
+
+- **Snapshot on leaving Personal**: when switching from Personal → org, capture the currently-active
+  (consumer) token as the home token before it's overwritten.
+- **Restore on return**: when switching org → Personal, set the home token active again.
+- **Persistence**: add home-token slot to `IAccessTokenStore` (`GetHomeAsync/SetHomeAsync/
+  ClearHomeAsync`, IndexedDB key `home-access-token`; cleared on sign-out).
+- **Expiry edge**: if the home token expired during the excursion, restore yields a signed-out/refresh
+  state via the existing expiry handling — acceptable v1 (a refresh-token renewal is a refinement).
+
+No backend change; the F136 entitlement/audience gates are untouched.
+
+## Decision 3 — Capacity is derived from the active context
+
+The acting capacity = `IUserContext.ActiveContextOrgId` (null ⇒ Personal). The display label already
+resolves in `MainLayout` (`ActiveLabel`, Feature 125) from `IUserOrgMembershipsClient`. No need to
+parse the JWT for tier in the UI — the active context is the source of truth, and the token tier
+follows it (org ⇒ platform/org, Personal ⇒ consumer home token).
+
+## Decision 4 — Inbox surfaces org-role work + frames capacity
+
+A's `Actions.razor` lists `/api/actions/pending` for the **active** token; in an org context that
+returns the member's org-role actions (bound to their own wallet — verified: pre-baked participant
+binding, `InstanceProjectionResolver`). D adds:
+- an **"acting as <Org>"** banner when in an org context;
+- a **refresh on context switch** (subscribe `IUserContext.OnContextChanged` → reload list + count).
+`MainLayout` already exposes `OutstandingWorkChanged` + `RefreshTodoCountAsync` (A/C) — hook the
+context-change there so the badge + mounted inbox refresh.
+
+## Decision 5 — Execute org-role action in-context
+
+`ApplicationInstance` → `/execute` uses the active token; in an org context that token carries
+`org_id` + roles, which `ActionExecutionService` needs (issuance config + participant-ownership). No
+submit-path change. **PRIMARY RISK — live-validate**: run the AssuredIdentity analyst Action 2 from
+the PWA in the org context before trusting D (carried as SC-001/FR-006).
+
+## Decision 6 — Entitlement-aware switcher (mostly existing)
+
+The switcher lists only the user's memberships (`IUserOrgMembershipsClient`); `switch-org` 403s a
+non-member and `SetActiveContextAsync` returns `false` (unchanged). D ensures the UI surfaces the
+failure (FR-008) and never elevates client-side.
+
+## Decision 7 — Testing seams
+
+- Token-store home get/set/clear: InMemory store test.
+- `ManagedUserContext` restore-on-Personal + snapshot-on-leave: unit test with a stub token store +
+  stub HttpMessageHandler for switch-org.
+- Inbox capacity banner + refresh-on-context-change: bUnit with a stub `IUserContext`.
+- Switcher entitlement: covered by existing membership wiring; add a focused assertion if cheap.
+No backend tests (no backend change). Live validation noted for execute-in-context.

--- a/specs/153-dual-tier-org-role/spec.md
+++ b/specs/153-dual-tier-org-role/spec.md
@@ -1,0 +1,185 @@
+# Feature Specification: PWA Dual-Tier / Org-Role Work
+
+**Feature Branch**: `153-dual-tier-org-role`
+
+**Created**: 2026-06-14
+
+**Status**: Draft
+
+**Input**: User description: "PWA dual-tier / org-role work (sub-project D): let the same human do their organisational-role workflow work on the phone by lighting up org-role work on the existing context switcher. Tier-aware session; reuse the existing switch-org re-mint + ContextChipSwitcher; the inbox surfaces org-role pending actions when in an org context framed as acting-as-Org; execute org-role actions under the platform/org token; entitlement-aware. No backend change."
+
+**Source design**: `docs/superpowers/specs/2026-06-14-pwa-dual-tier-org-role-design.md` (sub-project D; depends on A).
+
+## User Scenarios & Testing *(mandatory)*
+
+A person who is both a citizen and a member of an organisation uses one wallet on their phone. Today
+the phone only does their personal (citizen) work. This feature lets them switch into their
+organisation and do the workflow work that is theirs **as a member of that organisation** (for
+example, an analyst verifying an application), then switch back to personal — without ever weakening
+the boundary between the two.
+
+### User Story 1 - Know which capacity I'm acting in (Priority: P1)
+
+At any time the wallet clearly shows whether the person is acting **personally** or **as a member of
+a named organisation**, and switching between them is obvious and reliable.
+
+**Why this priority**: Acting in the wrong capacity is confusing and risky; the indicator and a
+reliable switch are the foundation everything else builds on.
+
+**Independent Test**: With a member of at least one organisation, confirm the wallet shows the
+current capacity (Personal vs. the org name) and that switching updates it.
+
+**Acceptance Scenarios**:
+
+1. **Given** a signed-in member of one or more organisations, **When** they look at the wallet,
+   **Then** it shows their current capacity (Personal, or "acting as <Org>").
+2. **Given** they switch to an organisation, **When** the switch succeeds, **Then** the capacity
+   indicator updates to that organisation.
+3. **Given** they switch back to Personal, **When** the switch succeeds, **Then** the indicator
+   returns to Personal **and their personal/citizen surfaces keep working** (no loss of access to
+   their own wallet/credentials).
+
+---
+
+### User Story 2 - See and do my organisation-role work (Priority: P1)
+
+While acting as an organisation, the person sees the workflow actions that are theirs to do **in that
+organisation role** and can complete them, clearly framed as organisation work.
+
+**Why this priority**: This is the point of the feature — performing org-role workflow work on the
+phone. It is the slice that proves the whole capability.
+
+**Independent Test**: With a member who has an outstanding org-role action, switch to that
+organisation, see the action in the inbox framed as org work, open it, and complete it successfully.
+
+**Acceptance Scenarios**:
+
+1. **Given** a person acting as an organisation with an outstanding org-role action, **When** they
+   open the inbox, **Then** that action is listed and clearly framed as "acting as <Org>".
+2. **Given** such an action, **When** they open and submit it, **Then** it is accepted (performed in
+   the organisation capacity).
+3. **Given** they are acting personally, **When** they open the inbox, **Then** org-role actions are
+   not presented as personal work (capacity and listing stay consistent).
+
+---
+
+### User Story 3 - Switching keeps everything consistent (Priority: P2)
+
+When the person switches capacity, the inbox, the outstanding-work count, and what they can do update
+to match the new capacity, with no stale or cross-capacity leakage.
+
+**Why this priority**: A switch that leaves the UI showing the previous capacity's work is
+misleading; consistency makes the switch trustworthy. Builds on US1/US2.
+
+**Independent Test**: Switch capacity and confirm the inbox + count refresh to the new capacity
+without a manual reload.
+
+**Acceptance Scenarios**:
+
+1. **Given** the inbox is open, **When** the person switches capacity, **Then** the inbox and count
+   refresh to the new capacity's outstanding work.
+2. **Given** a switch fails (e.g. the server declines), **When** it fails, **Then** the current
+   capacity is unchanged and the person is told it didn't switch.
+
+---
+
+### User Story 4 - Only offer capacities I'm entitled to (Priority: P3)
+
+The wallet only offers organisations the person is actually a member of, and never lets a person
+elevate into a capacity they aren't entitled to.
+
+**Why this priority**: Safety/clarity guardrail; the server already refuses unentitled elevation, and
+the UI should match it (only show real memberships).
+
+**Independent Test**: A person with no org memberships sees only Personal; a member sees exactly
+their organisations; an attempt to enter a capacity they lack is refused without elevating.
+
+**Acceptance Scenarios**:
+
+1. **Given** a person with no org memberships, **When** they look for a capacity switch, **Then**
+   only Personal is available.
+2. **Given** a member, **When** they open the switcher, **Then** exactly their organisations are
+   listed.
+3. **Given** the server refuses a capacity (not entitled / not a member), **When** the switch is
+   attempted, **Then** it is declined and the person stays in their current capacity.
+
+### Edge Cases
+
+- **Return to Personal must restore personal access** — after acting as an organisation, returning to
+  Personal must leave the person able to use their own wallet/credential surfaces (not stuck holding
+  an organisation-only capacity).
+- **Switch failure** — a declined or failed switch leaves the current capacity intact, with a clear
+  message; never a half-switched state.
+- **No org-role work** — acting as an organisation with nothing outstanding shows a friendly empty
+  state, not an error.
+- **Member with no personal wallet** — out of scope: such a member may see no personal actions;
+  documented, not addressed here.
+- **The capacity boundary must not be weakened** — a person can never reach an organisation capacity
+  they aren't entitled to via the wallet.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The wallet MUST always show the person's current acting capacity — Personal, or
+  "acting as <Org>".
+- **FR-002**: A member MUST be able to switch from Personal to any organisation they belong to, and
+  back.
+- **FR-003**: Switching to an organisation MUST put the person in that organisation's capacity for
+  workflow work (so org-role actions can be performed).
+- **FR-004**: Returning to Personal MUST restore the person's personal capacity such that their own
+  wallet/credential surfaces continue to work (no residual organisation-only capacity).
+- **FR-005**: While acting as an organisation, the inbox MUST surface the person's org-role
+  outstanding actions, clearly framed as that organisation's work.
+- **FR-006**: The person MUST be able to open and submit an org-role action while acting as that
+  organisation, and it MUST be accepted.
+- **FR-007**: On a capacity switch, the inbox and outstanding-work count MUST refresh to the new
+  capacity without a manual reload.
+- **FR-008**: A failed/declined switch MUST leave the current capacity unchanged with a clear message.
+- **FR-009**: The wallet MUST offer only organisations the person is actually a member of, and MUST
+  NOT allow elevating into a capacity the person is not entitled to (it relies on the server's
+  refusal and does not work around it).
+
+### Scope Constraints (carried from the design)
+
+- **SCOPE-001**: No back-end change — reuse the existing organisation-switch + token re-mint and the
+  existing pending-actions/execute surfaces.
+- **SCOPE-002**: Single active capacity at a time (switch re-mints); holding personal + organisation
+  capacities simultaneously is out of scope.
+- **SCOPE-003**: An organisation-only member with no personal wallet is out of scope.
+- **SCOPE-004**: The entitlement/audience boundary (server refusal of unentitled elevation) is NOT
+  weakened by anything here.
+
+### Key Entities
+
+- **Acting capacity** — Personal (citizen) or a specific organisation; determines which token/tier is
+  active and which work is shown.
+- **Home (personal) session** — the person's personal/citizen capacity, restorable when returning to
+  Personal.
+- **Org-role outstanding action** — a workflow action that is the person's to do as a member of an
+  organisation (reuses the existing outstanding-action concept).
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A member can, on the phone, switch into their organisation, complete an org-role action,
+  and switch back to Personal — **end to end in the wallet**, with no web app needed.
+- **SC-002**: After returning to Personal, the person's own wallet/credential surfaces work in
+  **100%** of cases (no residual organisation-only capacity).
+- **SC-003**: On a capacity switch, the inbox + count reflect the new capacity **without a manual
+  reload**.
+- **SC-004**: A person can **never** enter an organisation capacity they are not entitled to via the
+  wallet (the server refusal is always respected).
+- **SC-005**: The current acting capacity is unambiguous to the person at all times.
+
+## Assumptions
+
+- The organisation switch + token re-mint already exists (`/api/auth/switch-org`) and re-mints at the
+  capacity appropriate to the target org; this feature reuses it and adds restoring the personal
+  capacity on return.
+- The pending-actions and execute surfaces are capacity-agnostic and already return/accept the
+  person's org-role actions (bound to their own wallet) when acting in the organisation capacity.
+- Organisation membership listing already exists; the switcher reflects real memberships only.
+- The entitlement/audience boundary is enforced server-side and is not modified here.
+- A person is signed in to the wallet; sign-in itself stays personal/citizen.

--- a/specs/153-dual-tier-org-role/tasks.md
+++ b/specs/153-dual-tier-org-role/tasks.md
@@ -1,0 +1,123 @@
+# Tasks: PWA Dual-Tier / Org-Role Work
+
+**Input**: Design docs from `/specs/153-dual-tier-org-role/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/, quickstart.md
+**Tests**: INCLUDED (TDD). **Depends on A** (inbox) + Feature 125 context infra (both merged).
+
+## Conventions
+
+- **No backend change.** Reuse `switch-org`, `me/organizations`, `/api/actions/pending`, `/execute`.
+- **Never weaken the F136 boundary** — only `switch-org` elevates; the PWA never forges a capacity.
+- After return to Personal the active token MUST be consumer (or signed-out) — never residual platform.
+- Base-relative nav; no `ISnackbar`; bUnit `JSRuntimeMode.Loose`; thin JS adapters untested (logic is).
+
+---
+
+## Phase 1: Setup / Foundational — home-token slot
+
+- [ ] T001 (TDD) Failing tests in `tests/Sorcha.Wallet.Pwa.Tests/` for the home-token slot on
+  `IAccessTokenStore` (InMemory): SetHome/GetHome round-trip; GetHome returns null after ClearHome;
+  GetHome purges an expired home record.
+- [ ] T002 Add `GetHomeAsync` / `SetHomeAsync` / `ClearHomeAsync` to `IAccessTokenStore`;
+  implement in `InMemoryAccessTokenStore` and `IndexedDbAccessTokenStore` (key `home-access-token`,
+  same expiry-purge as the active token). Make T001 pass.
+- [ ] T003 Ensure sign-out clears the home token too (call `ClearHomeAsync` wherever `ClearAsync` is
+  called on sign-out).
+
+**Checkpoint**: a personal/home token can be cached + restored + cleared.
+
+---
+
+## Phase 2: US1 — Capacity switch + personal restore (Priority: P1) 🎯 core
+
+**Goal**: reliable Personal ⇄ Org switch; returning to Personal restores personal access.
+**Independent Test**: switch to org then back to Personal; confirm a consumer token is active again.
+
+- [ ] T004 (TDD) Failing tests for `ManagedUserContext` capacity transitions
+  (`tests/.../Context/`): switching Personal→Org snapshots the current (consumer) token as Home and
+  stores the org token active; switching Org→Personal restores the Home token as active; switch
+  failure (switch-org non-2xx) leaves capacity + token unchanged and returns false. Use a stub
+  `IAccessTokenStore` + stub `HttpMessageHandler`.
+- [ ] T005 [US1] In `ManagedUserContext.SetActiveContextAsync`: before overwriting the token on a
+  Personal→Org switch, `SetHomeAsync(current active token)`; on Org→Personal, `GetHomeAsync()` and
+  `SetAsync` it active (replace the line-143 "keep existing token" gap). Preserve the no-op + failure
+  semantics. Make T004 pass.
+- [ ] T006 [US1] Capacity indicator: confirm `MainLayout` `ActiveLabel` reflects Personal vs
+  "<Org>" across a switch (Feature 125 wiring); add the "acting as" framing string if missing. bUnit
+  or assert via the existing label.
+
+**Checkpoint**: Personal ⇄ Org switching is reliable and personal access survives the round trip.
+
+---
+
+## Phase 3: US2 — See & do org-role work, framed (Priority: P1)
+
+**Goal**: in an org capacity the inbox shows org-role actions framed "acting as <Org>", performable.
+**Independent Test**: in an org context, the inbox lists the org-role action with the banner; open+submit works (execute live-validated).
+
+- [ ] T007 [P] [US2] (TDD) Failing bUnit test: `Actions.razor` renders an "acting as <Org>" banner
+  (`data-testid=actions-acting-as`) when the stubbed `IUserContext.ActiveContextOrgId` is set, and no
+  banner when Personal.
+- [ ] T008 [US2] `Actions.razor`: inject `IUserContext` (+ label source); render the
+  "acting as <Org>" banner in an org context. The pending list already uses the active token (org
+  actions surface). Make T007 pass.
+- [ ] T009 [US2] Confirm execute path: `ApplicationInstance` submits with the active (org) token; no
+  code change expected. Document the **live-validation** requirement (analyst Action 2) in the PR.
+
+**Checkpoint**: org-role work is visible + framed; execute rides the active token.
+
+---
+
+## Phase 4: US3 — Switch keeps inbox/count consistent (Priority: P2)
+
+**Goal**: a capacity switch refreshes the inbox + count to the new capacity, no reload.
+**Independent Test**: switch with the inbox open; list + badge update.
+
+- [ ] T010 [P] [US3] (TDD) Failing bUnit test: `Actions.razor` reloads its list when
+  `IUserContext.OnContextChanged` fires (stub raises the event → `GetPendingAsync` re-invoked).
+- [ ] T011 [US3] `Actions.razor`: subscribe to `IUserContext.OnContextChanged` (and unsubscribe on
+  dispose) → `RefreshAsync`. Make T010 pass.
+- [ ] T012 [US3] `MainLayout`: on context change, refresh the To-do count + raise
+  `OutstandingWorkChanged` (reuse the A/C hooks) so the badge + mounted inbox follow the capacity.
+
+**Checkpoint**: switching is visually consistent; no stale cross-capacity work.
+
+---
+
+## Phase 5: US4 — Entitlement-aware switcher (Priority: P3)
+
+**Goal**: only real memberships offered; failed/declined switch surfaces + stays put.
+**Independent Test**: no-membership user sees only Personal; a declined switch shows a message.
+
+- [ ] T013 [P] [US4] (TDD) Failing test: a `SetActiveContextAsync` that returns false (server
+  declined) leaves `ActiveContextOrgId` unchanged; the UI shows a non-blocking notice.
+- [ ] T014 [US4] Surface a switch failure to the user (inline feedback / chip state); confirm the
+  switcher lists only `IUserOrgMembershipsClient` memberships (existing) and never offers elevation.
+
+**Checkpoint**: capacity choices are safe + honest.
+
+---
+
+## Phase 6: Polish + PR
+
+- [ ] T015 [P] `scripts/check-no-snackbar.ps1` clean.
+- [ ] T016 [P] New-code coverage ≥85% (token-store home, ManagedUserContext transitions, inbox
+  banner/refresh); add tests for any uncovered branch.
+- [ ] T017 [P] Docs: note dual-tier/org-role capacity in the PWA/`sorcha-architecture` as appropriate.
+- [ ] T018 Clean build (PWA + UI.Core) 0 warnings; `Sorcha.Wallet.Pwa.Tests` + `Sorcha.UI.Core.Tests` green.
+- [ ] T019 `quickstart.md` manual verification — **including the primary live-validation** (analyst
+  Action 2 from the PWA in org context + personal-restore). Record results / flag as pre-merge.
+- [ ] T020 PR + merge-on-green.
+
+---
+
+## Dependencies & order
+
+- Setup (home-token slot) → US1 (restore) → US2 (framing) → US3 (refresh) → US4 (entitlement) → polish.
+- US1 is the core (personal-restore correctness). US2 is the value slice (live-validate execute).
+- Tests precede implementation in each phase.
+
+## Implementation strategy
+
+MVP = Setup + US1 + US2 (switch in, do org work, switch back safely). US3/US4 harden consistency +
+safety. No backend change throughout; live-validate execute-in-context before trusting D.

--- a/src/Apps/Sorcha.Wallet.Pwa/MainLayout.razor
+++ b/src/Apps/Sorcha.Wallet.Pwa/MainLayout.razor
@@ -479,6 +479,9 @@
     {
         UpdateActiveLabel();
         await InvokeAsync(StateHasChanged);
+        // Feature 153 (US3) — the To-do badge follows the active capacity (and the mounted inbox
+        // re-loads via its own OnContextChanged subscription).
+        await RefreshTodoCountAsync();
     }
 
     public async ValueTask DisposeAsync()

--- a/src/Apps/Sorcha.Wallet.Pwa/MainLayout.razor
+++ b/src/Apps/Sorcha.Wallet.Pwa/MainLayout.razor
@@ -38,6 +38,7 @@
 @inject CitizenWalletHubConnection CitizenHub
 @inject IConnectivity Connectivity
 @inject Sorcha.Wallet.Pwa.Services.Drafts.ISubmitQueueDrainer SubmitQueueDrainer
+@inject Sorcha.UI.Core.Services.Feedback.IInlineFeedback Feedback
 
 @* Feature 141 — dark mode now follows IThemeService (previously the provider
    was unbound, so the wallet never rendered dark). *@
@@ -468,7 +469,11 @@
         var ok = await UserContext.SetActiveContextAsync(orgId);
         if (!ok)
         {
-            // Surface the failure inline; toast will be replaced by ErrorRecoveryScaffold in PR-F.
+            // Feature 153 (US4) — a declined/failed switch leaves the current capacity unchanged;
+            // tell the user inline rather than silently no-op'ing.
+            Feedback.ShowWarning(orgId is null
+                ? "Couldn't switch back to personal. Please try again."
+                : "Couldn't switch to that organisation. You may not have access, or the connection failed.");
             return;
         }
         UpdateActiveLabel();

--- a/src/Apps/Sorcha.Wallet.Pwa/Pages/Actions.razor
+++ b/src/Apps/Sorcha.Wallet.Pwa/Pages/Actions.razor
@@ -14,6 +14,7 @@
 @using Sorcha.Wallet.Pwa.Services.Actions
 @using Sorcha.Wallet.Pwa.Services.Actions.Models
 @using Sorcha.Wallet.Pwa.Services.Drafts.Models
+@using Sorcha.Wallet.Pwa.Services.Context
 @attribute [Authorize]
 @implements IDisposable
 @inject IMyActionsClient MyActions
@@ -21,6 +22,7 @@
 @inject Sorcha.Wallet.Pwa.Services.Drafts.IActionContextCache ActionContextCache
 @inject Sorcha.Wallet.Pwa.Services.Drafts.IDraftStore DraftStore
 @inject Sorcha.Wallet.Pwa.Services.Drafts.ISubmitQueue SubmitQueue
+@inject Sorcha.Wallet.Pwa.Services.Context.IUserContext UserContext
 @inject NavigationManager Nav
 
 <PageTitle>Things to do · Sorcha Wallet</PageTitle>
@@ -29,6 +31,14 @@
     <div class="actions-header">
         <MudText Typo="Typo.h5">Things to do</MudText>
     </div>
+
+    @if (UserContext.ActiveContextOrgId is not null)
+    {
+        <MudAlert Severity="Severity.Info" Dense="true" Class="mb-2 actions-acting-as"
+                  Icon="@Icons.Material.Filled.Business" data-testid="actions-acting-as">
+            Acting as @ActingAsLabel — showing this organisation's work.
+        </MudAlert>
+    }
 
     @if (_refreshError)
     {
@@ -183,16 +193,25 @@
     /// </summary>
     [CascadingParameter] public MainLayout? Shell { get; set; }
 
+    // "Acting as <Org>" label — the shell resolves the org name (Feature 125); fall back to a
+    // generic label when the shell isn't available (e.g. under test).
+    private string ActingAsLabel => string.IsNullOrWhiteSpace(Shell?.ActiveLabel) ? "your organisation" : Shell!.ActiveLabel;
+
     protected override async Task OnInitializedAsync()
     {
         if (Shell is not null)
         {
             Shell.OutstandingWorkChanged += OnWorkChanged;
         }
+        // Feature 153 (US3) — re-load when the active capacity changes so the inbox never shows the
+        // previous capacity's work.
+        UserContext.OnContextChanged += OnContextChangedAsync;
         await RefreshAsync();
     }
 
     private void OnWorkChanged() => _ = InvokeAsync(RefreshAsync);
+
+    private Task OnContextChangedAsync(UserContextChangedEventArgs args) => InvokeAsync(RefreshAsync);
 
     /// <inheritdoc />
     public void Dispose()
@@ -201,6 +220,7 @@
         {
             Shell.OutstandingWorkChanged -= OnWorkChanged;
         }
+        UserContext.OnContextChanged -= OnContextChangedAsync;
     }
 
     /// <summary>

--- a/src/Apps/Sorcha.Wallet.Pwa/Services/Context/IUserContext.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Services/Context/IUserContext.cs
@@ -111,6 +111,18 @@ public sealed class ManagedUserContext : IUserContext
             // Non-Personal switch: acquire a JWT scoped to the target org.
             try
             {
+                // Feature 153 — leaving Personal: snapshot the current (consumer) token as the home
+                // token so we can restore personal capacity on return. switch-org cannot mint a
+                // consumer token (it requires an org), so this snapshot is the only way back.
+                if (_active is null)
+                {
+                    var current = await _tokenStore.GetAsync(ct).ConfigureAwait(false);
+                    if (current is not null)
+                    {
+                        await _tokenStore.SetHomeAsync(current, ct).ConfigureAwait(false);
+                    }
+                }
+
                 var response = await _http.PostAsJsonAsync(
                     "/api/auth/switch-org", new { OrganizationId = targetOrg }, ct).ConfigureAwait(false);
                 if (!response.IsSuccessStatusCode)
@@ -140,8 +152,22 @@ public sealed class ManagedUserContext : IUserContext
                 return false;
             }
         }
-        // Personal context (orgId == null) — keep the user's existing token in v1.
-        // Personal-as-Public-Org switch-org plumbing is a small follow-up.
+        else
+        {
+            // Feature 153 — returning to Personal: restore the snapshotted personal/home (consumer)
+            // token so consumer-gated surfaces keep working (a platform/org token would 403 them).
+            // If the home token is missing/expired, leave the current token; the normal expiry/
+            // re-auth flow handles it.
+            var home = await _tokenStore.GetHomeAsync(ct).ConfigureAwait(false);
+            if (home is not null)
+            {
+                await _tokenStore.SetAsync(home, ct).ConfigureAwait(false);
+            }
+            else
+            {
+                _logger.LogWarning("Return to Personal: no valid home token to restore; keeping current token.");
+            }
+        }
 
         var previous = _active;
         _active = orgId;

--- a/src/Apps/Sorcha.Wallet.Pwa/Services/IAccessTokenStore.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Services/IAccessTokenStore.cs
@@ -22,6 +22,19 @@ public interface IAccessTokenStore
 
     /// <summary>Remove the stored token (sign out).</summary>
     Task ClearAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Feature 153 (D) — the personal/home (consumer) token, snapshotted when the citizen switches
+    /// into an org capacity so it can be restored on return to Personal. Returns null if absent or
+    /// expired. Separate slot from the active token.
+    /// </summary>
+    Task<AccessTokenRecord?> GetHomeAsync(CancellationToken ct = default);
+
+    /// <summary>Persist the personal/home token snapshot.</summary>
+    Task SetHomeAsync(AccessTokenRecord record, CancellationToken ct = default);
+
+    /// <summary>Remove the home token (sign out, alongside <see cref="ClearAsync"/>).</summary>
+    Task ClearHomeAsync(CancellationToken ct = default);
 }
 
 /// <summary>The wallet's stored access token plus the identity context it carries.</summary>
@@ -35,12 +48,23 @@ public sealed record AccessTokenRecord(string AccessToken, DateTimeOffset Expire
 public sealed class InMemoryAccessTokenStore : IAccessTokenStore
 {
     private AccessTokenRecord? _record;
+    private AccessTokenRecord? _home;
     /// <inheritdoc />
     public Task<AccessTokenRecord?> GetAsync(CancellationToken ct = default) => Task.FromResult(_record);
     /// <inheritdoc />
     public Task SetAsync(AccessTokenRecord record, CancellationToken ct = default) { _record = record; return Task.CompletedTask; }
     /// <inheritdoc />
     public Task ClearAsync(CancellationToken ct = default) { _record = null; return Task.CompletedTask; }
+    /// <inheritdoc />
+    public Task<AccessTokenRecord?> GetHomeAsync(CancellationToken ct = default)
+    {
+        if (_home is not null && _home.ExpiresAt <= DateTimeOffset.UtcNow) _home = null;
+        return Task.FromResult(_home);
+    }
+    /// <inheritdoc />
+    public Task SetHomeAsync(AccessTokenRecord record, CancellationToken ct = default) { _home = record; return Task.CompletedTask; }
+    /// <inheritdoc />
+    public Task ClearHomeAsync(CancellationToken ct = default) { _home = null; return Task.CompletedTask; }
 }
 
 /// <summary>IndexedDB-backed <see cref="IAccessTokenStore"/>.</summary>
@@ -48,6 +72,7 @@ public sealed class IndexedDbAccessTokenStore : IAccessTokenStore
 {
     private const string StoreName = "device";
     private const string Key = "access-token";
+    private const string HomeKey = "home-access-token";
 
     private readonly IJSRuntime _js;
 
@@ -78,5 +103,30 @@ public sealed class IndexedDbAccessTokenStore : IAccessTokenStore
     public async Task ClearAsync(CancellationToken ct = default)
     {
         await _js.InvokeVoidAsync("SorchaIndexedDb.del", ct, StoreName, Key);
+    }
+
+    /// <inheritdoc />
+    public async Task<AccessTokenRecord?> GetHomeAsync(CancellationToken ct = default)
+    {
+        var row = await _js.InvokeAsync<AccessTokenRecord?>("SorchaIndexedDb.get", ct, StoreName, HomeKey);
+        if (row is null) return null;
+        if (row.ExpiresAt <= DateTimeOffset.UtcNow)
+        {
+            await ClearHomeAsync(ct);
+            return null;
+        }
+        return row;
+    }
+
+    /// <inheritdoc />
+    public async Task SetHomeAsync(AccessTokenRecord record, CancellationToken ct = default)
+    {
+        await _js.InvokeVoidAsync("SorchaIndexedDb.put", ct, StoreName, record, HomeKey);
+    }
+
+    /// <inheritdoc />
+    public async Task ClearHomeAsync(CancellationToken ct = default)
+    {
+        await _js.InvokeVoidAsync("SorchaIndexedDb.del", ct, StoreName, HomeKey);
     }
 }

--- a/src/Apps/Sorcha.Wallet.Pwa/Services/IAuthService.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Services/IAuthService.cs
@@ -254,6 +254,7 @@ public sealed class AuthService : IAuthService
         // Clear the token first so the UI flips to signed-out immediately even
         // if the wider purge throws; then wipe every per-device store.
         await _store.ClearAsync(ct);
+        await _store.ClearHomeAsync(ct); // Feature 153 — drop the personal/home capacity snapshot too.
         await _purge.PurgeAsync(ct);
     }
 

--- a/tests/Sorcha.Wallet.Pwa.Tests/Pages/ActionsActingAsTests.cs
+++ b/tests/Sorcha.Wallet.Pwa.Tests/Pages/ActionsActingAsTests.cs
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using Bunit;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Sorcha.UI.Testing;
+using Sorcha.Wallet.Pwa.Services;
+using Sorcha.Wallet.Pwa.Services.Actions;
+using Sorcha.Wallet.Pwa.Services.Actions.Models;
+using Sorcha.Wallet.Pwa.Services.Context;
+using Sorcha.Wallet.Pwa.Services.Drafts;
+using Sorcha.Wallet.Pwa.Services.Drafts.Models;
+using Xunit;
+using ActionsPage = Sorcha.Wallet.Pwa.Pages.Actions;
+
+namespace Sorcha.Wallet.Pwa.Tests.Pages;
+
+/// <summary>
+/// Feature 153 (D, US2) — the inbox frames org-role work: an "acting as &lt;Org&gt;" banner shows
+/// when the active capacity is an organisation, and is absent when acting personally.
+/// </summary>
+public sealed class ActionsActingAsTests : ComponentTestFixture
+{
+    private readonly Mock<IUserContext> _userContext = new();
+
+    public ActionsActingAsTests()
+    {
+        Services.AddSingleton(Mock.Of<IMyActionsClient>(c =>
+            c.GetPendingAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>())
+                == System.Threading.Tasks.Task.FromResult((IReadOnlyList<PendingActionItem>)Array.Empty<PendingActionItem>())));
+        Services.AddSingleton(Mock.Of<IPendingApplicationClient>());
+        Services.AddSingleton(Mock.Of<IActionContextCache>());
+        var drafts = new Mock<IDraftStore>();
+        drafts.Setup(d => d.ListAsync(It.IsAny<CancellationToken>())).ReturnsAsync(Array.Empty<ActionDraft>());
+        Services.AddSingleton(drafts.Object);
+        var queue = new Mock<ISubmitQueue>();
+        queue.Setup(q => q.ListAsync(It.IsAny<CancellationToken>())).ReturnsAsync(Array.Empty<QueuedSubmission>());
+        Services.AddSingleton(queue.Object);
+        Services.AddSingleton(_userContext.Object);
+    }
+
+    [Fact]
+    public void OrgContext_ShowsActingAsBanner()
+    {
+        _userContext.SetupGet(c => c.ActiveContextOrgId).Returns(Guid.NewGuid());
+
+        var cut = Render<ActionsPage>();
+
+        cut.FindAll("[data-testid=actions-acting-as]").Should().ContainSingle();
+    }
+
+    [Fact]
+    public void PersonalContext_NoActingAsBanner()
+    {
+        _userContext.SetupGet(c => c.ActiveContextOrgId).Returns((Guid?)null);
+
+        var cut = Render<ActionsPage>();
+
+        cut.FindAll("[data-testid=actions-acting-as]").Should().BeEmpty();
+    }
+}

--- a/tests/Sorcha.Wallet.Pwa.Tests/Pages/ActionsContextRefreshTests.cs
+++ b/tests/Sorcha.Wallet.Pwa.Tests/Pages/ActionsContextRefreshTests.cs
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Bunit;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Sorcha.UI.Testing;
+using Sorcha.Wallet.Pwa.Services;
+using Sorcha.Wallet.Pwa.Services.Actions;
+using Sorcha.Wallet.Pwa.Services.Actions.Models;
+using Sorcha.Wallet.Pwa.Services.Context;
+using Sorcha.Wallet.Pwa.Services.Drafts;
+using Sorcha.Wallet.Pwa.Services.Drafts.Models;
+using Xunit;
+using ActionsPage = Sorcha.Wallet.Pwa.Pages.Actions;
+
+namespace Sorcha.Wallet.Pwa.Tests.Pages;
+
+/// <summary>
+/// Feature 153 (D, US3) — the inbox re-loads when the active capacity changes, so it never shows the
+/// previous capacity's work.
+/// </summary>
+public sealed class ActionsContextRefreshTests : ComponentTestFixture
+{
+    private readonly Mock<IMyActionsClient> _client = new();
+    private readonly FakeUserContext _userContext = new();
+
+    public ActionsContextRefreshTests()
+    {
+        _client.Setup(c => c.GetPendingAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<PendingActionItem>());
+        Services.AddSingleton(_client.Object);
+        Services.AddSingleton(Mock.Of<IPendingApplicationClient>());
+        Services.AddSingleton(Mock.Of<IActionContextCache>());
+        var drafts = new Mock<IDraftStore>();
+        drafts.Setup(d => d.ListAsync(It.IsAny<CancellationToken>())).ReturnsAsync(Array.Empty<ActionDraft>());
+        Services.AddSingleton(drafts.Object);
+        var queue = new Mock<ISubmitQueue>();
+        queue.Setup(q => q.ListAsync(It.IsAny<CancellationToken>())).ReturnsAsync(Array.Empty<QueuedSubmission>());
+        Services.AddSingleton(queue.Object);
+        Services.AddSingleton<IUserContext>(_userContext);
+    }
+
+    [Fact]
+    public async Task ContextChange_ReloadsInbox()
+    {
+        var cut = Render<ActionsPage>();
+        _client.Invocations.Clear();
+
+        await cut.InvokeAsync(() => _userContext.RaiseContextChanged(null, Guid.NewGuid()));
+
+        _client.Verify(c => c.GetPendingAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()),
+            Times.AtLeastOnce());
+    }
+
+    private sealed class FakeUserContext : IUserContext
+    {
+        public Guid? ActiveContextOrgId { get; private set; }
+        public event Func<UserContextChangedEventArgs, Task>? OnContextChanged;
+        public Task InitializeAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public Task<bool> SetActiveContextAsync(Guid? orgId, CancellationToken ct = default)
+        { ActiveContextOrgId = orgId; return Task.FromResult(true); }
+        public Task RaiseContextChanged(Guid? from, Guid? to)
+        {
+            ActiveContextOrgId = to;
+            return OnContextChanged?.Invoke(new UserContextChangedEventArgs(from, to)) ?? Task.CompletedTask;
+        }
+    }
+}

--- a/tests/Sorcha.Wallet.Pwa.Tests/Pages/ActionsInReviewBannerTests.cs
+++ b/tests/Sorcha.Wallet.Pwa.Tests/Pages/ActionsInReviewBannerTests.cs
@@ -38,6 +38,7 @@ public sealed class ActionsInReviewBannerTests : ComponentTestFixture
         queue.Setup(s => s.ListAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(Array.Empty<Sorcha.Wallet.Pwa.Services.Drafts.Models.QueuedSubmission>());
         Services.AddSingleton(queue.Object);
+        Services.AddSingleton(Mock.Of<Sorcha.Wallet.Pwa.Services.Context.IUserContext>());
         _client.Setup(c => c.GetPendingAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Array.Empty<PendingActionItem>());
     }

--- a/tests/Sorcha.Wallet.Pwa.Tests/Pages/ActionsInboxTests.cs
+++ b/tests/Sorcha.Wallet.Pwa.Tests/Pages/ActionsInboxTests.cs
@@ -37,6 +37,7 @@ public sealed class ActionsInboxTests : ComponentTestFixture
         Services.AddSingleton(Mock.Of<Sorcha.Wallet.Pwa.Services.Drafts.IActionContextCache>());
         Services.AddSingleton(EmptyDraftStore());
         Services.AddSingleton(EmptySubmitQueue());
+        Services.AddSingleton(Mock.Of<Sorcha.Wallet.Pwa.Services.Context.IUserContext>());
         _pending.Setup(p => p.GetAsync(It.IsAny<CancellationToken>())).ReturnsAsync((PendingApplicationView?)null);
     }
 

--- a/tests/Sorcha.Wallet.Pwa.Tests/Pages/ActionsQueueTests.cs
+++ b/tests/Sorcha.Wallet.Pwa.Tests/Pages/ActionsQueueTests.cs
@@ -37,6 +37,7 @@ public sealed class ActionsQueueTests : ComponentTestFixture
         Services.AddSingleton(Mock.Of<IActionContextCache>());
         Services.AddSingleton(_drafts.Object);
         Services.AddSingleton(_queue.Object);
+        Services.AddSingleton(Mock.Of<Sorcha.Wallet.Pwa.Services.Context.IUserContext>());
         _client.Setup(c => c.GetPendingAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Array.Empty<PendingActionItem>());
         _pending.Setup(p => p.GetAsync(It.IsAny<CancellationToken>())).ReturnsAsync((PendingApplicationView?)null);

--- a/tests/Sorcha.Wallet.Pwa.Tests/Services/Context/CapacitySwitchTests.cs
+++ b/tests/Sorcha.Wallet.Pwa.Tests/Services/Context/CapacitySwitchTests.cs
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Sorcha.Wallet.Pwa.Services;
+using Sorcha.Wallet.Pwa.Services.Context;
+using Xunit;
+
+namespace Sorcha.Wallet.Pwa.Tests.Services.Context;
+
+/// <summary>
+/// Feature 153 (D, US1) — capacity transitions in <see cref="ManagedUserContext"/>: switching into
+/// an org snapshots the personal/home token and activates the org token; returning to Personal
+/// restores the home token (so consumer-gated surfaces keep working); a declined switch is a no-op.
+/// </summary>
+public sealed class CapacitySwitchTests
+{
+    private static readonly Guid Org = Guid.NewGuid();
+
+    private static AccessTokenRecord Consumer() =>
+        new("consumer.jwt", DateTimeOffset.UtcNow.AddHours(1), Email: "c@x");
+
+    private static ManagedUserContext Create(IAccessTokenStore tokens, StubHandler handler) =>
+        new(new InMemoryActiveContextStore(),
+            tokens,
+            new HttpClient(handler) { BaseAddress = new Uri("https://test.example.com") },
+            NullLogger<ManagedUserContext>.Instance);
+
+    [Fact]
+    public async Task SwitchToOrg_SnapshotsHome_AndActivatesOrgToken()
+    {
+        var tokens = new InMemoryAccessTokenStore();
+        await tokens.SetAsync(Consumer()); // signed in personally
+        var ctx = Create(tokens, OkSwitch("org.jwt"));
+
+        var ok = await ctx.SetActiveContextAsync(Org);
+
+        ok.Should().BeTrue();
+        ctx.ActiveContextOrgId.Should().Be(Org);
+        (await tokens.GetAsync())!.AccessToken.Should().Be("org.jwt", "the org token is now active");
+        (await tokens.GetHomeAsync())!.AccessToken.Should().Be("consumer.jwt", "the personal token was snapshotted");
+    }
+
+    [Fact]
+    public async Task SwitchBackToPersonal_RestoresHomeToken()
+    {
+        var tokens = new InMemoryAccessTokenStore();
+        await tokens.SetAsync(Consumer());
+        var ctx = Create(tokens, OkSwitch("org.jwt"));
+        await ctx.SetActiveContextAsync(Org);          // → org
+        (await tokens.GetAsync())!.AccessToken.Should().Be("org.jwt");
+
+        var ok = await ctx.SetActiveContextAsync(null); // → Personal
+
+        ok.Should().BeTrue();
+        ctx.ActiveContextOrgId.Should().BeNull();
+        (await tokens.GetAsync())!.AccessToken.Should().Be("consumer.jwt",
+            "returning to Personal must restore the consumer token (no residual platform token)");
+    }
+
+    [Fact]
+    public async Task SwitchToOrg_ServerDeclines_IsNoOp()
+    {
+        var tokens = new InMemoryAccessTokenStore();
+        await tokens.SetAsync(Consumer());
+        var ctx = Create(tokens, new StubHandler((_, _) => new HttpResponseMessage(HttpStatusCode.Forbidden)));
+
+        var ok = await ctx.SetActiveContextAsync(Org);
+
+        ok.Should().BeFalse();
+        ctx.ActiveContextOrgId.Should().BeNull("a declined switch leaves the capacity unchanged");
+        (await tokens.GetAsync())!.AccessToken.Should().Be("consumer.jwt", "token unchanged on a declined switch");
+    }
+
+    private static StubHandler OkSwitch(string jwt) => new((_, _) =>
+        new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent($$"""{"accessToken":"{{jwt}}","expiresIn":3600}""", Encoding.UTF8, "application/json"),
+        });
+
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, CancellationToken, HttpResponseMessage> _respond;
+        public StubHandler(Func<HttpRequestMessage, CancellationToken, HttpResponseMessage> respond) => _respond = respond;
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct) =>
+            Task.FromResult(_respond(request, ct));
+    }
+}

--- a/tests/Sorcha.Wallet.Pwa.Tests/Services/HomeTokenStoreTests.cs
+++ b/tests/Sorcha.Wallet.Pwa.Tests/Services/HomeTokenStoreTests.cs
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Sorcha.Wallet.Pwa.Services;
+using Xunit;
+
+namespace Sorcha.Wallet.Pwa.Tests.Services;
+
+/// <summary>
+/// Feature 153 (D) — the home/personal token slot on <see cref="IAccessTokenStore"/>: snapshot the
+/// consumer token when leaving Personal so it can be restored on return (separate from the active
+/// token slot).
+/// </summary>
+public sealed class HomeTokenStoreTests
+{
+    private static AccessTokenRecord Token(string jwt, DateTimeOffset expiresAt) =>
+        new(jwt, expiresAt, Email: null);
+
+    [Fact]
+    public async Task SetHome_ThenGetHome_RoundTrips()
+    {
+        var store = new InMemoryAccessTokenStore();
+        var home = Token("home.jwt", DateTimeOffset.UtcNow.AddHours(1));
+
+        await store.SetHomeAsync(home);
+
+        (await store.GetHomeAsync())!.AccessToken.Should().Be("home.jwt");
+    }
+
+    [Fact]
+    public async Task HomeSlot_IsSeparateFromActiveSlot()
+    {
+        var store = new InMemoryAccessTokenStore();
+        await store.SetAsync(Token("active.jwt", DateTimeOffset.UtcNow.AddHours(1)));
+        await store.SetHomeAsync(Token("home.jwt", DateTimeOffset.UtcNow.AddHours(1)));
+
+        (await store.GetAsync())!.AccessToken.Should().Be("active.jwt");
+        (await store.GetHomeAsync())!.AccessToken.Should().Be("home.jwt");
+    }
+
+    [Fact]
+    public async Task ClearHome_RemovesHome_ButLeavesActive()
+    {
+        var store = new InMemoryAccessTokenStore();
+        await store.SetAsync(Token("active.jwt", DateTimeOffset.UtcNow.AddHours(1)));
+        await store.SetHomeAsync(Token("home.jwt", DateTimeOffset.UtcNow.AddHours(1)));
+
+        await store.ClearHomeAsync();
+
+        (await store.GetHomeAsync()).Should().BeNull();
+        (await store.GetAsync()).Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task GetHome_Expired_ReturnsNull()
+    {
+        var store = new InMemoryAccessTokenStore();
+        await store.SetHomeAsync(Token("home.jwt", DateTimeOffset.UtcNow.AddSeconds(-1)));
+
+        (await store.GetHomeAsync()).Should().BeNull("an expired home token must not be restored");
+    }
+}


### PR DESCRIPTION
## Summary

Sub-project **D** of the PWA workflow-participation programme: a citizen who is also an org member can do their **organisation-role** workflow work on the phone (e.g. an analyst verifying an application), then switch back to personal — reusing the existing context switcher, with the F136 boundary intact. Builds on A.

Scope (per design): *light up org-role work on the existing switcher* — the hard auth plumbing already exists. Design: `docs/superpowers/specs/2026-06-14-pwa-dual-tier-org-role-design.md`; spec/plan/tasks in `specs/153-dual-tier-org-role/`.

## What's included (by user story)

- **Foundational** — a **home-token slot** on `IAccessTokenStore` (`Get/Set/ClearHomeAsync`) to snapshot the personal/consumer token; cleared on sign-out.
- **US1 — capacity switch + personal restore**: `ManagedUserContext` snapshots the consumer token when leaving Personal and **restores it on return** (closing the v1 gap where returning kept the org/platform token and would 403 consumer-gated surfaces). Declined switch stays a no-op.
- **US2 — org-role inbox framing**: an "acting as <Org>" banner when in an org capacity; the inbox lists the member's org-role actions (they bind to the member's own wallet) under the active token; execute rides the active token.
- **US3 — switch consistency**: the inbox re-loads on `OnContextChanged`; the To-do badge follows the active capacity.
- **US4 — entitlement-aware**: a failed/declined switch surfaces inline; the switcher lists only real memberships; never elevates client-side.

## No backend change

Reuses `/api/auth/switch-org`, `/api/auth/me/organizations`, `/api/actions/pending`, `/execute`. The F136 entitlement/audience gates (server 403 on unentitled elevation) are untouched.

## Tests

`Sorcha.Wallet.Pwa.Tests` **272/0**, `Sorcha.UI.Core.Tests` **1382/0**; snackbar gate clean; PWA builds 0/0. New: home-token slot, capacity transitions (snapshot/restore/declined-no-op), acting-as banner, context-change reload.

## ⚠️ Primary risk — needs live validation before trusting

The org-context-at-execute path must be **live-validated**: run the AssuredIdentity analyst "Action 2" from the PWA in the org context, and confirm personal surfaces still work after switching back. Not run in this session (no live stack here) — flagged as a pre-merge manual check.

Known edge (documented, out of scope): an org-only member with no personal wallet sees no actions.

Scope: sub-project D. B (catalogue) remains its own cycle (design committed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)