### PR TITLE
feat(154): PWA service catalogue (sub-project B)

### DIFF
--- a/specs/154-service-catalogue/checklists/requirements.md
+++ b/specs/154-service-catalogue/checklists/requirements.md
@@ -1,0 +1,30 @@
+# Specification Quality Checklist: PWA Service Catalogue
+
+**Created**: 2026-06-14 | **Feature**: [spec.md](../spec.md)
+
+## Content Quality
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+- "Startable by a citizen" v1 = open first participant on the first action (carried in design/plan).
+- One new consumer-tier read endpoint; start reuses existing create-instance + fill/submit.
+- All items pass on first validation; ready for `/speckit.plan`.

--- a/specs/154-service-catalogue/contracts/endpoints.md
+++ b/specs/154-service-catalogue/contracts/endpoints.md
@@ -1,0 +1,23 @@
+# Endpoint Contracts: PWA Service Catalogue
+
+**Feature**: 154-service-catalogue | **Date**: 2026-06-14
+
+## NEW — list startable services
+
+```
+GET /api/catalogue            (Blueprint Service — Endpoints/CatalogueEndpoints.cs)
+  auth: RequireAuthorization() (consumer-tier capable; cross-tier "any-human")
+  returns 200: [ { blueprintId, title, description, registerId } ]   # startable + has register only
+```
+Reads `IPublishedBlueprintStore`; filters via the startable predicate (data-model). `.WithSummary`/
+`.WithDescription` + XML docs; appears in OpenAPI.
+
+## REUSED (unchanged)
+
+```
+POST /api/instances/   { blueprintId, registerId }   # CreateInstance (Program.cs:2153) — start a service
+GET  /api/instances/{id}, GET /api/blueprints/{id}, POST /…/execute   # ApplicationInstance fill/submit (A)
+```
+
+**Drift guard:** if `PublishedBlueprint` / `CreateInstanceRequest` shapes change, the catalogue
+endpoint test + client mapping test should fail.

--- a/specs/154-service-catalogue/data-model.md
+++ b/specs/154-service-catalogue/data-model.md
@@ -1,0 +1,35 @@
+# Phase 1 Data Model: PWA Service Catalogue
+
+**Feature**: 154-service-catalogue | **Date**: 2026-06-14
+
+## Server response — catalogue item (new)
+
+`GET /api/catalogue` returns `CatalogueItem[]`:
+
+| Field | Type | Source | Notes |
+|-------|------|--------|-------|
+| `blueprintId` | string | `PublishedBlueprint.BlueprintId` | Which service |
+| `title` | string | `Blueprint.Title` (fallback blueprintId) | Display name |
+| `description` | string? | `Blueprint.Description` | Short description |
+| `registerId` | string | `PublishedBlueprint.RegisterId` | Needed to start the instance |
+
+Only items that are **citizen-startable** (open first-action sender) and have a `registerId` are
+returned.
+
+## Startable predicate (server, pure)
+
+`IsCitizenStartable(Blueprint bp)`:
+1. `bp.Actions` non-empty; take the first by `Id`.
+2. Resolve its `Sender` participant in `bp.Participants`.
+3. Startable ⇔ that participant's `WalletAddress` is null/empty (open / late-bound).
+4. Unresolvable (no actions / no sender / no participant) ⇒ not startable (excluded).
+
+## Client DTO (PWA)
+
+`CatalogueItem(string BlueprintId, string Title, string? Description, string RegisterId)` — maps the
+response 1:1.
+
+## Start (reused)
+
+`POST /api/instances/` body `{ BlueprintId, RegisterId }` (existing `CreateInstanceRequest`) →
+returns the created instance (id) → navigate `applications/{instanceId}`.

--- a/specs/154-service-catalogue/plan.md
+++ b/specs/154-service-catalogue/plan.md
@@ -1,0 +1,72 @@
+# Implementation Plan: PWA Service Catalogue
+
+**Branch**: `154-service-catalogue` | **Date**: 2026-06-14 | **Spec**: [spec.md](./spec.md)
+
+**Source design**: `docs/superpowers/specs/2026-06-14-pwa-service-catalogue-design.md` | **Depends on**: A (merged).
+
+## Summary
+
+Turn the empty `Applications.razor` stub into a working "start something new" surface: a new
+consumer-tier `GET /api/catalogue` lists the services a citizen can start; the PWA browses them and,
+on tap, starts a new application via the **existing** `POST /api/instances/` (`CreateInstance`) and
+navigates into the existing `ApplicationInstance` fill/submit. One backend read endpoint; the rest is
+front-end reuse.
+
+## Technical Context
+
+**Language/Version**: C# 14 / .NET 10 (Blueprint Service minimal API + Blazor WASM PWA).
+**Primary Dependencies**: Blueprint Service `IPublishedBlueprintStore` (lists `PublishedBlueprint`
+{BlueprintId, RegisterId, Blueprint=Sorcha.Blueprint.Models.Blueprint}); PWA HttpClient (+ bearer
+chain), `Applications.razor`, `ApplicationInstance` (A), `IApplicationActionClient` create path.
+**Storage**: none new (reads the published-blueprint store).
+**Testing**: xUnit (Blueprint Service endpoint + the startable filter) + bUnit (catalogue page) +
+client mapping test.
+**Target Platform**: PWA `/wallet/` (consumer); Blueprint Service.
+**Project Type**: one backend read endpoint + PWA front-end.
+**Constraints**: consumer-tier; **only startable services listed**; base-relative nav; no `ISnackbar`;
+reuse `CreateInstance` (no change).
+**Scale/Scope**: 1 endpoint + a startable-filter helper + `ICatalogueClient` + catalogue UI + start flow.
+
+## Constitution Check
+
+| Principle | Status |
+|-----------|--------|
+| I. Microservices-First | ✅ one read endpoint in the owning service; no upward coupling |
+| II. Security First | ✅ consumer-tier; lists only startable services; no secrets; reuses create-instance authz |
+| III. API Documentation | ✅ new endpoint gets `.WithSummary/.WithDescription` + XML; OpenAPI auto |
+| IV. Testing (>85% new) | ✅ endpoint + startable filter + client + page tests |
+| V. Code Quality | ✅ nullable, async, DI, no warnings |
+| VI. Blueprint Standards | ✅ N/A (reads published blueprints) |
+| VII. DDD | ✅ Blueprint/Action/Participant terms; "service/catalogue" is the citizen-facing label |
+| VIII. Observability | ✅ structured logs; existing telemetry |
+
+**Result**: PASS.
+
+## Project Structure
+
+```text
+src/Services/Sorcha.Blueprint.Service/
+└── Endpoints/CatalogueEndpoints.cs        # NEW — GET /api/catalogue (consumer-tier) + startable filter
+    (mapped in Program.cs via app.MapCatalogueEndpoints())
+
+src/Apps/Sorcha.Wallet.Pwa/
+├── Services/Catalogue/ICatalogueClient.cs # NEW — typed client + CatalogueItem
+├── Pages/Applications.razor               # REPLACE stub — browse + search + start
+└── Extensions/ServiceCollectionExtensions.cs # MODIFY — register ICatalogueClient
+
+tests/
+├── Sorcha.Blueprint.Service.Tests/        # NEW — startable filter + endpoint shape
+└── Sorcha.Wallet.Pwa.Tests/Catalogue/     # NEW — client mapping + catalogue page bUnit
+```
+
+**Structure Decision**: one consumer-tier read endpoint in Blueprint Service; PWA catalogue page +
+client; start reuses `CreateInstance` + `ApplicationInstance`.
+
+## Open Decisions (research.md)
+
+- "Startable by a citizen" rule (v1: first action's sender participant is open / no hardcoded wallet).
+- Catalogue scoping to the caller's context (v1: published + startable; keep simple).
+- Endpoint auth (plain `RequireAuthorization`, cross-tier like `/api/actions/pending`).
+
+## Complexity Tracking
+> No violations.

--- a/specs/154-service-catalogue/quickstart.md
+++ b/specs/154-service-catalogue/quickstart.md
@@ -1,0 +1,20 @@
+# Quickstart: PWA Service Catalogue
+
+**Feature**: 154-service-catalogue | **Date**: 2026-06-14
+
+## Build & test
+```bash
+dotnet build src/Services/Sorcha.Blueprint.Service/Sorcha.Blueprint.Service.csproj
+dotnet test  tests/Sorcha.Blueprint.Service.Tests/Sorcha.Blueprint.Service.Tests.csproj
+dotnet test  tests/Sorcha.Wallet.Pwa.Tests/Sorcha.Wallet.Pwa.Tests.csproj
+```
+
+## Manual verification (Docker / n1)
+1. Publish a blueprint whose first action has an OPEN sender participant (citizen-startable) to a register.
+2. Sign into the PWA as a citizen; open the "applications" / catalogue surface.
+3. Confirm the service appears with name + description; a non-startable blueprint does NOT appear.
+4. Tap it → a new application starts → land in the first step's form → fill + submit (reuses A).
+5. Search narrows the list; empty catalogue shows a friendly empty state; a load failure shows a notice.
+
+## Guardrails
+- Consumer-tier; list only startable services; base-relative nav; no `ISnackbar`; reuse CreateInstance.

--- a/specs/154-service-catalogue/research.md
+++ b/specs/154-service-catalogue/research.md
@@ -1,0 +1,45 @@
+# Phase 0 Research: PWA Service Catalogue
+
+**Feature**: 154-service-catalogue | **Date**: 2026-06-14
+
+## Decision 1 — New consumer-tier catalogue endpoint (the one backend addition)
+
+`/api/blueprints` GET exists but is gated `CanManageBlueprints` (designer/admin) — NOT consumer. So
+B adds `GET /api/catalogue` in Blueprint Service, `.RequireAuthorization()` (cross-tier "any-human",
+like `/api/actions/pending`), reading `IPublishedBlueprintStore.GetAllAsync()`. Returns
+`CatalogueItem { BlueprintId, Title, Description, RegisterId }` for each **startable** published
+blueprint. No new store.
+
+## Decision 2 — "Startable by a citizen" rule (v1)
+
+A published blueprint is citizen-startable when its **first action's sender participant is open**
+(no hard-coded `WalletAddress` in the published blueprint) — i.e. a citizen can initiate by binding
+their own wallet (the same open-participant model A/D rely on). First action = the action with the
+lowest `Id` (or first in order). If sender/first-action can't be resolved, exclude (conservative —
+don't list something the citizen can't actually start). Curation flags are a later refinement.
+
+## Decision 3 — Title/description/register source
+
+From `PublishedBlueprint`: `RegisterId` (to start the instance) + `Blueprint` (Sorcha.Blueprint.
+Models.Blueprint) → `Title`, `Description`, `Participants` (Id/WalletAddress), `Actions` (Id/Sender).
+A published blueprint without a `RegisterId` is excluded (can't be started).
+
+## Decision 4 — Start flow reuses CreateInstance
+
+On tap → `POST /api/instances/` with `{ BlueprintId, RegisterId }` (`CreateInstanceRequest`) → on
+success navigate base-relative to `applications/{instanceId}` → existing `ApplicationInstance` renders
+the first action (A's fill/submit). No change to CreateInstance or ApplicationInstance. The PWA gets a
+small create call (reuse `IApplicationActionClient` host or a tiny method on the catalogue client).
+
+## Decision 5 — Scoping
+
+v1: list published + startable services. Deep org/home scoping (only services the citizen's context
+can run) is a refinement; the create/execute path already enforces access, so listing a non-runnable
+service degrades to a start failure (FR-006) rather than a security issue. Keep v1 simple.
+
+## Decision 6 — Testing
+
+- Blueprint Service: `IsCitizenStartable` filter (open vs hard-coded first-action sender; no
+  actions; missing register) + endpoint returns mapped items. xUnit.
+- PWA: `ICatalogueClient` JSON mapping (stub handler); `Applications.razor` bUnit (list, empty,
+  search-narrows, tap→create→navigate, load-failure notice).

--- a/specs/154-service-catalogue/spec.md
+++ b/specs/154-service-catalogue/spec.md
@@ -1,0 +1,126 @@
+# Feature Specification: PWA Service Catalogue
+
+**Feature Branch**: `154-service-catalogue`
+
+**Created**: 2026-06-14
+
+**Status**: Draft
+
+**Input**: User description: "PWA service catalogue (sub-project B): let a citizen browse the services they can start and begin a new application, dropping into the existing fill/submit flow. Adds one consumer-tier catalogue read endpoint; replaces the empty Applications.razor stub with browse + start-new over the existing CreateInstance + ApplicationInstance."
+
+**Source design**: `docs/superpowers/specs/2026-06-14-pwa-service-catalogue-design.md` (sub-project B; depends on A).
+
+## User Scenarios & Testing *(mandatory)*
+
+Sub-project A let a citizen do the work waiting on them. B is the other half of discovery: **start
+something new**. Today the wallet's "applications" area is an empty stub. This feature lets a citizen
+browse the services they can start and begin one, landing straight in the existing fill-and-submit
+flow.
+
+### User Story 1 - Start a service (Priority: P1)
+
+A citizen opens the wallet, browses the services available to them, taps one (e.g. "apply for a blue
+badge"), and is taken into filling and submitting its first step.
+
+**Why this priority**: This is the whole feature and the minimum viable loop — without it there is no
+way to begin a new application from the phone.
+
+**Independent Test**: With at least one startable service available, open the catalogue, pick one,
+confirm a new application begins and the first step's form is shown to fill and submit.
+
+**Acceptance Scenarios**:
+
+1. **Given** a signed-in citizen with startable services available, **When** they open the catalogue,
+   **Then** they see a list of services, each with a name and a short description.
+2. **Given** the catalogue is showing a service, **When** the citizen taps it, **Then** a new
+   application is started and they are taken into its first step to fill and submit.
+3. **Given** no startable services are available, **When** the citizen opens the catalogue, **Then**
+   they see a clear, friendly empty state rather than a blank or broken screen.
+
+---
+
+### User Story 2 - Find a service (Priority: P3)
+
+A citizen with many available services can search or filter to find the one they want.
+
+**Why this priority**: Convenience once the catalogue grows; the browse loop (US1) works without it.
+
+**Independent Test**: With several services, type a query and confirm the list narrows to matches.
+
+**Acceptance Scenarios**:
+
+1. **Given** several available services, **When** the citizen types a search term, **Then** the list
+   narrows to services whose name/description matches.
+2. **Given** a search with no matches, **When** the citizen searches, **Then** a clear "no matches"
+   state is shown.
+
+---
+
+### Edge Cases
+
+- **Only startable services appear** — services a citizen cannot initiate are not listed.
+- **Catalogue load failure** — a transient failure shows a non-blocking message, not a blank/broken
+  screen.
+- **Start failure** — if starting a service fails, the citizen is told and stays in the catalogue
+  (no half-started state shown as success).
+- **Empty catalogue** — a friendly empty state with no error.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The wallet MUST present a catalogue of the services a citizen can start, each with a
+  name and a short description.
+- **FR-002**: The catalogue MUST list only services the citizen is actually able to start (not
+  services that must be initiated by someone else).
+- **FR-003**: A citizen MUST be able to start a listed service, which begins a new application and
+  takes them into its first step to fill and submit (reusing the existing fill/submit flow).
+- **FR-004**: The catalogue MUST show a clear empty state when no startable services are available,
+  and a clear "no matches" state when a search returns nothing.
+- **FR-005**: A transient catalogue-load failure MUST surface a non-blocking message and never a
+  blank/broken screen.
+- **FR-006**: A failure to start a service MUST be surfaced to the citizen, leaving them in the
+  catalogue (no false "started" state).
+- **FR-007**: Searching/filtering MUST narrow the list to services whose name or description matches.
+- **FR-008**: The catalogue MUST be available to a citizen acting in their personal (consumer)
+  capacity and scoped to the services available in their context.
+
+### Scope Constraints (carried from the design)
+
+- **SCOPE-001**: Adds exactly one consumer-tier catalogue **read** endpoint; starting a service
+  reuses the existing create-application + fill/submit flow (no change to those).
+- **SCOPE-002**: Org-role catalogues (services started as an organisation) are out of scope
+  (sub-project D covers org-role work); this is the citizen/personal catalogue.
+- **SCOPE-003**: Offline catalogue browsing is out of scope (could layer on sub-project C later).
+- **SCOPE-004**: "Startable by a citizen" v1 = a service whose first step can be initiated by the
+  citizen (an open first participant); curation rules beyond that are a later refinement.
+
+### Key Entities
+
+- **Catalogue service** — a startable service: a name, a short description, and what's needed to begin
+  it (which service + where it runs).
+- **Started application** — a new application instance begun from a catalogue service (reuses the
+  existing application/instance concept).
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A citizen can, starting from the wallet, browse services and **begin a new application
+  end-to-end** (into the first step's form) **without leaving the wallet**.
+- **SC-002**: 100% of services shown are ones the citizen can actually start (no un-startable services
+  listed).
+- **SC-003**: Starting a service takes the citizen into its first step in **under a few seconds** for
+  a typical service.
+- **SC-004**: A catalogue-load or start failure **never** leaves the citizen on a blank/broken screen;
+  they always get a clear message and a way forward.
+
+## Assumptions
+
+- A way to create a new application from a service already exists and is reused; this feature adds the
+  catalogue (browse) and the start trigger, not the application machinery.
+- "Startable by a citizen" is determinable from the service definition (an open first participant);
+  v1 uses that, with curation as a later refinement.
+- The catalogue is scoped to the citizen's context (their org/home); a citizen sees services relevant
+  to them.
+- A citizen is signed in to the wallet in their personal capacity.

--- a/specs/154-service-catalogue/tasks.md
+++ b/specs/154-service-catalogue/tasks.md
@@ -1,0 +1,30 @@
+# Tasks: PWA Service Catalogue
+
+**Input**: design docs in `/specs/154-service-catalogue/`. **Tests**: INCLUDED (TDD). **Depends on A.**
+
+## Conventions
+- One consumer-tier read endpoint; start reuses CreateInstance + ApplicationInstance (no change).
+- List only citizen-startable services; base-relative nav; no `ISnackbar`.
+
+## Phase 1: Backend — catalogue endpoint
+- [ ] T001 (TDD) Failing tests `tests/Sorcha.Blueprint.Service.Tests/Catalogue/CatalogueStartableTests.cs`: the startable predicate — open first-action sender ⇒ startable; hard-coded sender ⇒ not; no actions / no sender / no register ⇒ excluded.
+- [ ] T002 Add `Endpoints/CatalogueEndpoints.cs`: `GET /api/catalogue` (RequireAuthorization), reads `IPublishedBlueprintStore`, maps startable published blueprints → `CatalogueItem{blueprintId,title,description,registerId}`; `IsCitizenStartable` helper; `.WithSummary/.WithDescription`. Map via `app.MapCatalogueEndpoints()` in Program.cs. Make T001 pass.
+- [ ] T003 (TDD) Endpoint test: returns only startable+with-register items mapped correctly (in-memory published store).
+
+## Phase 2: PWA — catalogue client + page (US1)
+- [ ] T004 (TDD) `tests/Sorcha.Wallet.Pwa.Tests/Catalogue/CatalogueClientTests.cs`: `ICatalogueClient` maps `/api/catalogue` JSON → `CatalogueItem[]`; transient failure → empty (page shows notice).
+- [ ] T005 Add `Services/Catalogue/ICatalogueClient.cs` (+ `HttpCatalogueClient`, `CatalogueItem`); a `StartAsync(item)` → `POST /api/instances/` returning the new instance id. DI register (bearer chain). Make T004 pass.
+- [ ] T006 (TDD) bUnit `tests/Sorcha.Wallet.Pwa.Tests/Pages/ApplicationsCatalogueTests.cs`: lists services; empty state; tap → StartAsync called → navigates base-relative to `applications/{id}`; load-failure notice.
+- [ ] T007 Replace `Pages/Applications.razor` stub with the catalogue: load via `ICatalogueClient`, render list (name+description), empty/loading/error states, tap → start → navigate. Make T006 pass.
+
+## Phase 3: US2 search
+- [ ] T008 [US2] (TDD) bUnit: typing a query narrows the list; no-match state.
+- [ ] T009 [US2] Add client-side search/filter to `Applications.razor`. Make T008 pass.
+
+## Phase 4: Polish + PR
+- [ ] T010 [P] snackbar gate clean; T011 [P] coverage ≥85% new; T012 [P] docs note; T013 clean build (Blueprint Service + PWA) + suites green.
+- [ ] T014 quickstart manual verification (publish a startable blueprint → browse → start → submit). Flag as pre-merge.
+- [ ] T015 PR + merge-on-green.
+
+## Order
+Backend endpoint → PWA client+page (US1 MVP) → search (US2) → polish → PR.

--- a/src/Apps/Sorcha.Wallet.Pwa/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Extensions/ServiceCollectionExtensions.cs
@@ -220,6 +220,13 @@ public static class ServiceCollectionExtensions
             .AddHttpMessageHandler<BearerTokenHandler>()
             .AddHttpMessageHandler<ServerClockHandler>();
 
+        // Feature 154 (B) — service catalogue: list startable services + start one (CreateInstance).
+        services.AddHttpClient<Sorcha.Wallet.Pwa.Services.Catalogue.ICatalogueClient,
+                               Sorcha.Wallet.Pwa.Services.Catalogue.HttpCatalogueClient>(c =>
+            c.BaseAddress = new Uri(gatewayBaseAddress))
+            .AddHttpMessageHandler<BearerTokenHandler>()
+            .AddHttpMessageHandler<ServerClockHandler>();
+
         // Feature 128 — shared has-any-device probe. Drives the wallet PWA
         // pairing-takeover trigger (sub-PR A3) and the Sorcha Web nag-banner
         // trigger (sub-PR B). Registered Singleton so the cached value +

--- a/src/Apps/Sorcha.Wallet.Pwa/Pages/Applications.razor
+++ b/src/Apps/Sorcha.Wallet.Pwa/Pages/Applications.razor
@@ -2,35 +2,153 @@
     SPDX-License-Identifier: MIT
     Copyright (c) 2026 Sorcha Contributors
 
-    Applications list page (Feature 125, T054). Lists blueprint-driven
-    applications available to the active context. v1 ships an empty-
-    state with a CTA pointing at the council web shell — the application
-    catalogue API lands alongside this page in a follow-up. Once the
-    catalogue endpoint exists, the list rows are tappable into
-    Pages/ApplicationInstance for the SorchaFormRenderer-hosted form.
+    Service catalogue (Feature 154 / sub-project B). Lists the services a citizen can start
+    (GET /api/catalogue — startable published blueprints), with search; tapping one starts a new
+    application (POST /api/instances/) and drops into the existing ApplicationInstance fill/submit.
 *@
 @page "/applications"
 @layout MainLayout
 @using Microsoft.AspNetCore.Authorization
+@using Sorcha.Wallet.Pwa.Services.Catalogue
 @attribute [Authorize]
-@using Sorcha.Wallet.Pwa.Services.Context
-@inject IUserContext UserContext
+@implements IDisposable
+@inject ICatalogueClient Catalogue
 @inject NavigationManager Nav
+@inject ILogger<Applications> Logger
 
-<PageTitle>Applications · Sorcha Wallet</PageTitle>
+<PageTitle>Start something · Sorcha Wallet</PageTitle>
 
 <MudContainer MaxWidth="MaxWidth.Small" Class="mt-4">
-    <MudText Typo="Typo.h5" Class="mb-3">Applications</MudText>
-    <MudPaper Class="pa-4" Elevation="1" data-testid="applications-empty-state">
-        <MudStack Spacing="2">
-            <MudText Typo="Typo.body1">
-                Application listings will appear here.
-            </MudText>
+    <MudText Typo="Typo.h5" Class="mb-3">Start something</MudText>
+
+    @if (_loadError)
+    {
+        <MudAlert Severity="Severity.Warning" Dense="true" Class="mb-2" data-testid="catalogue-error">
+            Couldn't load services just now. Please try again.
+        </MudAlert>
+    }
+
+    @if (_services is null)
+    {
+        <div class="catalogue-list" data-testid="catalogue-loading">
+            @for (var i = 0; i < 3; i++)
+            {
+                <div class="catalogue-row-skeleton" aria-hidden="true"></div>
+            }
+        </div>
+    }
+    else if (_services.Count == 0)
+    {
+        <MudPaper Class="pa-4" Elevation="0" data-testid="catalogue-empty">
+            <MudText Typo="Typo.subtitle1">No services to start right now</MudText>
             <MudText Typo="Typo.body2" Class="mud-text-secondary">
-                For now, start a council application from your council's website. Your
-                wallet will pick it up once you submit and you'll see the in-progress
-                state on Home.
+                When services you can apply for are available, they'll appear here.
             </MudText>
-        </MudStack>
-    </MudPaper>
+        </MudPaper>
+    }
+    else
+    {
+        <MudTextField @bind-Value="_search" @bind-Value:after="ApplyFilter" Immediate="true"
+                      Placeholder="Search services" Adornment="Adornment.Start"
+                      AdornmentIcon="@Icons.Material.Filled.Search" Variant="Variant.Outlined"
+                      Margin="Margin.Dense" Class="mb-3" data-testid="catalogue-search" />
+
+        @if (_filtered.Count == 0)
+        {
+            <MudText Typo="Typo.body2" Class="mud-text-secondary" data-testid="catalogue-no-matches">
+                No services match "@_search".
+            </MudText>
+        }
+        else
+        {
+            <div class="catalogue-list" data-testid="catalogue-list">
+                @foreach (var svc in _filtered)
+                {
+                    <button type="button" class="catalogue-row" data-testid="@($"catalogue-item-{svc.BlueprintId}")"
+                            disabled="@_starting" @onclick="@(() => StartAsync(svc))">
+                        <div class="catalogue-row__main">
+                            <MudText Typo="Typo.subtitle1">@svc.Title</MudText>
+                            @if (!string.IsNullOrWhiteSpace(svc.Description))
+                            {
+                                <MudText Typo="Typo.body2" Class="mud-text-secondary">@svc.Description</MudText>
+                            }
+                        </div>
+                        <MudIcon Icon="@Icons.Material.Filled.ChevronRight" />
+                    </button>
+                }
+            </div>
+        }
+    }
+
+    @if (_startError)
+    {
+        <MudAlert Severity="Severity.Error" Dense="true" Class="mt-3" data-testid="catalogue-start-error">
+            Couldn't start that service. Please try again.
+        </MudAlert>
+    }
 </MudContainer>
+
+@code {
+    private IReadOnlyList<CatalogueItem>? _services;
+    private List<CatalogueItem> _filtered = new();
+    private string _search = string.Empty;
+    private bool _loadError;
+    private bool _startError;
+    private bool _starting;
+
+    protected override Task OnInitializedAsync() => LoadAsync();
+
+    private async Task LoadAsync()
+    {
+        try
+        {
+            var services = await Catalogue.GetServicesAsync();
+            _services = services;
+            _loadError = false;
+            ApplyFilter();
+        }
+        catch (Exception ex)
+        {
+            Logger.LogWarning(ex, "Catalogue load failed.");
+            _services ??= Array.Empty<CatalogueItem>();
+            _loadError = true;
+        }
+        StateHasChanged();
+    }
+
+    private void ApplyFilter() =>
+        _filtered = FilterServices(_services ?? Array.Empty<CatalogueItem>(), _search);
+
+    /// <summary>Pure name/description filter (case-insensitive); empty query returns all.</summary>
+    internal static List<CatalogueItem> FilterServices(IReadOnlyList<CatalogueItem> all, string? search) =>
+        string.IsNullOrWhiteSpace(search)
+            ? all.ToList()
+            : all.Where(s =>
+                  s.Title.Contains(search, StringComparison.OrdinalIgnoreCase)
+                  || (s.Description?.Contains(search, StringComparison.OrdinalIgnoreCase) ?? false))
+                 .ToList();
+
+    private async Task StartAsync(CatalogueItem svc)
+    {
+        if (_starting) return;
+        _starting = true;
+        _startError = false;
+        try
+        {
+            var instanceId = await Catalogue.StartAsync(svc);
+            if (string.IsNullOrEmpty(instanceId))
+            {
+                _startError = true;
+                return;
+            }
+            Nav.NavigateTo($"applications/{instanceId}");
+        }
+        finally
+        {
+            _starting = false;
+        }
+    }
+
+    /// <inheritdoc />
+    public void Dispose() { }
+}

--- a/src/Apps/Sorcha.Wallet.Pwa/Services/Catalogue/ICatalogueClient.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Services/Catalogue/ICatalogueClient.cs
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Sorcha.Wallet.Pwa.Services.Catalogue;
+
+/// <summary>
+/// Feature 154 (B) — the citizen service catalogue client: lists the services a citizen can start
+/// (<c>GET /api/catalogue</c>) and starts one by creating a new application instance
+/// (<c>POST /api/instances/</c>). The PWA's bearer chain carries the consumer-tier token.
+/// </summary>
+public interface ICatalogueClient
+{
+    /// <summary>
+    /// Lists the startable services. A transient failure <b>throws</b> so the page can show a
+    /// non-blocking notice (distinct from a genuinely empty catalogue).
+    /// </summary>
+    Task<IReadOnlyList<CatalogueItem>> GetServicesAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Starts <paramref name="item"/> by creating a new application instance; returns the new
+    /// instance id, or <c>null</c> if the start failed.
+    /// </summary>
+    Task<string?> StartAsync(CatalogueItem item, CancellationToken ct = default);
+}
+
+/// <summary>Feature 154 — a startable service in the catalogue.</summary>
+public sealed record CatalogueItem(string BlueprintId, string Title, string? Description, string RegisterId);
+
+/// <summary>Default <see cref="ICatalogueClient"/> over the PWA's bearer-authed HttpClient.</summary>
+public sealed class HttpCatalogueClient : ICatalogueClient
+{
+    private readonly HttpClient _http;
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+    };
+
+    /// <summary>Initialises a new instance.</summary>
+    public HttpCatalogueClient(HttpClient http) => _http = http ?? throw new ArgumentNullException(nameof(http));
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<CatalogueItem>> GetServicesAsync(CancellationToken ct = default)
+    {
+        var items = await _http.GetFromJsonAsync<List<CatalogueItem>>("api/catalogue", JsonOptions, ct)
+            .ConfigureAwait(false);
+        return items ?? (IReadOnlyList<CatalogueItem>)Array.Empty<CatalogueItem>();
+    }
+
+    /// <inheritdoc />
+    public async Task<string?> StartAsync(CatalogueItem item, CancellationToken ct = default)
+    {
+        try
+        {
+            var response = await _http.PostAsJsonAsync(
+                "api/instances/",
+                new CreateInstanceBody(item.BlueprintId, item.RegisterId),
+                JsonOptions, ct).ConfigureAwait(false);
+            if (!response.IsSuccessStatusCode)
+            {
+                return null;
+            }
+            var created = await response.Content.ReadFromJsonAsync<CreatedInstance>(JsonOptions, ct).ConfigureAwait(false);
+            return string.IsNullOrEmpty(created?.Id) ? null : created!.Id;
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private sealed record CreateInstanceBody(
+        [property: JsonPropertyName("blueprintId")] string BlueprintId,
+        [property: JsonPropertyName("registerId")] string RegisterId);
+
+    private sealed record CreatedInstance([property: JsonPropertyName("id")] string? Id);
+}

--- a/src/Services/Sorcha.Blueprint.Service/Endpoints/CatalogueEndpoints.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Endpoints/CatalogueEndpoints.cs
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Linq;
+using BlueprintModel = Sorcha.Blueprint.Models.Blueprint;
+
+namespace Sorcha.Blueprint.Service.Endpoints;
+
+/// <summary>
+/// Feature 154 (B) — the citizen service catalogue: the consumer-tier read surface listing the
+/// published services a citizen can start. A service is citizen-startable when its first action's
+/// sender participant is open (no hard-coded wallet), so the citizen can initiate it by binding their
+/// own wallet. Starting a service reuses the existing <c>POST /api/instances/</c> (CreateInstance).
+/// </summary>
+public static class CatalogueEndpoints
+{
+    /// <summary>Maps <c>GET /api/catalogue</c>.</summary>
+    public static IEndpointRouteBuilder MapCatalogueEndpoints(this IEndpointRouteBuilder routes)
+    {
+        // Cross-tier "any-human" surface (like /api/actions/pending) — a consumer-tier citizen token
+        // is accepted. Lists only startable services; starting still goes through CreateInstance authz.
+        routes.MapGet("/api/catalogue", async (IPublishedBlueprintStore store) =>
+        {
+            var published = await store.GetAllLatestAsync();
+            return Results.Ok(BuildCatalogue(published));
+        })
+        .RequireAuthorization()
+        .WithName("GetServiceCatalogue")
+        .WithSummary("List the services a citizen can start")
+        .WithDescription(
+            "Returns the published services whose first action can be initiated by the citizen "
+            + "(an open first participant), each with a name, description, and the register it runs "
+            + "on. Consumer-tier; start a service via POST /api/instances/.");
+
+        return routes;
+    }
+
+    /// <summary>
+    /// Filters published blueprints to the citizen catalogue: only those that are citizen-startable
+    /// and have a register to run on, mapped to <see cref="CatalogueItem"/> and sorted by title.
+    /// </summary>
+    public static IReadOnlyList<CatalogueItem> BuildCatalogue(IEnumerable<PublishedBlueprint> published) =>
+        published
+            .Where(p => !string.IsNullOrEmpty(p.RegisterId) && p.Blueprint is not null && IsCitizenStartable(p.Blueprint))
+            .Select(p => new CatalogueItem(
+                BlueprintId: p.BlueprintId,
+                Title: string.IsNullOrWhiteSpace(p.Blueprint.Title) ? p.BlueprintId : p.Blueprint.Title,
+                Description: string.IsNullOrWhiteSpace(p.Blueprint.Description) ? null : p.Blueprint.Description,
+                RegisterId: p.RegisterId!))
+            .OrderBy(i => i.Title, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+    /// <summary>
+    /// True when the blueprint's first action (lowest <c>Id</c>) has a sender participant that is
+    /// open (null/empty <c>WalletAddress</c>), so a citizen can initiate it. False when there is no
+    /// action, the sender can't be resolved, or the first action's sender is bound to a wallet.
+    /// </summary>
+    public static bool IsCitizenStartable(BlueprintModel blueprint)
+    {
+        if (blueprint.Actions is null || blueprint.Actions.Count == 0)
+        {
+            return false;
+        }
+
+        var first = blueprint.Actions.OrderBy(a => a.Id).First();
+        if (string.IsNullOrEmpty(first.Sender))
+        {
+            return false;
+        }
+
+        var sender = blueprint.Participants?.FirstOrDefault(p => p.Id == first.Sender);
+        if (sender is null)
+        {
+            return false;
+        }
+
+        return string.IsNullOrEmpty(sender.WalletAddress);
+    }
+}
+
+/// <summary>Feature 154 — a startable service in the citizen catalogue.</summary>
+/// <param name="BlueprintId">The service's blueprint id.</param>
+/// <param name="Title">Display name.</param>
+/// <param name="Description">Short description, if any.</param>
+/// <param name="RegisterId">The register the service runs on (needed to start it).</param>
+public sealed record CatalogueItem(string BlueprintId, string Title, string? Description, string RegisterId);

--- a/src/Services/Sorcha.Blueprint.Service/Program.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Program.cs
@@ -1057,6 +1057,9 @@ app.MapActionEndpoints();
 // Map file chunk submission endpoints (Feature 085 — Stored Data Transactions)
 app.MapFileChunkEndpoints();
 
+// Feature 154 (B) — citizen service catalogue (consumer-tier: list startable services).
+app.MapCatalogueEndpoints();
+
 // Feature 111 — Timebound Presentation Lifecycle endpoints.
 var presentationGroup = app.MapGroup("/api/presentations")
     .WithTags("Presentations")
@@ -2787,6 +2790,9 @@ public interface IPublishedBlueprintStore
     Task<PublishedBlueprint?> GetVersionAsync(string blueprintId, int version);
     Task<IEnumerable<PublishedBlueprint>> GetVersionsAsync(string blueprintId);
     Task<IEnumerable<PublishedBlueprint>> GetByRegisterAsync(string registerId);
+
+    /// <summary>Feature 154 (catalogue) — the latest published version of every blueprint.</summary>
+    Task<IEnumerable<PublishedBlueprint>> GetAllLatestAsync();
 }
 
 /// <summary>
@@ -2913,6 +2919,15 @@ public class InMemoryPublishedBlueprintStore : IPublishedBlueprintStore
             .Where(p => string.Equals(p.RegisterId, registerId, StringComparison.OrdinalIgnoreCase))
             .GroupBy(p => p.BlueprintId)
             .Select(g => g.OrderByDescending(v => v.Version).First())
+            .ToList();
+        return Task.FromResult<IEnumerable<PublishedBlueprint>>(result);
+    }
+
+    public Task<IEnumerable<PublishedBlueprint>> GetAllLatestAsync()
+    {
+        var result = _published.Values
+            .Where(versions => versions.Count > 0)
+            .Select(versions => versions.OrderByDescending(v => v.Version).First())
             .ToList();
         return Task.FromResult<IEnumerable<PublishedBlueprint>>(result);
     }

--- a/tests/Sorcha.Blueprint.Service.Tests/Catalogue/CatalogueBuildTests.cs
+++ b/tests/Sorcha.Blueprint.Service.Tests/Catalogue/CatalogueBuildTests.cs
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using Sorcha.Blueprint.Service.Endpoints;
+using Xunit;
+using BlueprintModel = Sorcha.Blueprint.Models.Blueprint;
+using BpAction = Sorcha.Blueprint.Models.Action;
+using Participant = Sorcha.Blueprint.Models.Participant;
+
+namespace Sorcha.Blueprint.Service.Tests.Catalogue;
+
+/// <summary>
+/// Feature B (154) — BuildCatalogue lists only startable services that have a register, mapped +
+/// sorted by title.
+/// </summary>
+public sealed class CatalogueBuildTests
+{
+    private static PublishedBlueprint Pub(string id, string title, string? register, bool open) => new()
+    {
+        BlueprintId = id,
+        RegisterId = register,
+        Blueprint = new BlueprintModel
+        {
+            Title = title,
+            Actions = [new BpAction { Id = 1, Sender = "p" }],
+            Participants = [new Participant { Id = "p", WalletAddress = open ? null : "ws1qbound" }],
+        },
+    };
+
+    [Fact]
+    public void IncludesOnlyStartableWithRegister_SortedByTitle()
+    {
+        var published = new List<PublishedBlueprint>
+        {
+            Pub("b-zebra", "Zebra service", "reg-1", open: true),
+            Pub("b-apple", "Apple service", "reg-1", open: true),
+            Pub("b-bound", "Bound service", "reg-1", open: false),   // not startable
+            Pub("b-noreg", "No-register service", null, open: true), // no register
+        };
+
+        var items = CatalogueEndpoints.BuildCatalogue(published);
+
+        items.Select(i => i.Title).Should().Equal("Apple service", "Zebra service");
+        items.Should().OnlyContain(i => i.RegisterId == "reg-1");
+    }
+
+    [Fact]
+    public void MapsFields_TitleFallsBackToBlueprintId()
+    {
+        var p = Pub("b-1", "", "reg-1", open: true);
+        var items = CatalogueEndpoints.BuildCatalogue(new[] { p });
+
+        items.Should().ContainSingle();
+        items[0].BlueprintId.Should().Be("b-1");
+        items[0].Title.Should().Be("b-1", "blank title falls back to the blueprint id");
+        items[0].RegisterId.Should().Be("reg-1");
+    }
+}

--- a/tests/Sorcha.Blueprint.Service.Tests/Catalogue/CatalogueStartableTests.cs
+++ b/tests/Sorcha.Blueprint.Service.Tests/Catalogue/CatalogueStartableTests.cs
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using FluentAssertions;
+using Sorcha.Blueprint.Service.Endpoints;
+using Xunit;
+using BlueprintModel = Sorcha.Blueprint.Models.Blueprint;
+using BpAction = Sorcha.Blueprint.Models.Action;
+using Participant = Sorcha.Blueprint.Models.Participant;
+
+namespace Sorcha.Blueprint.Service.Tests.Catalogue;
+
+/// <summary>
+/// Feature B (154) — a published service is citizen-startable when its first action's sender
+/// participant is open (no hard-coded wallet), so a citizen can initiate it.
+/// </summary>
+public sealed class CatalogueStartableTests
+{
+    private static BlueprintModel Bp(BpAction[] actions, Participant[] participants) =>
+        new() { Actions = [.. actions], Participants = [.. participants] };
+
+    [Fact]
+    public void OpenFirstActionSender_IsStartable()
+    {
+        var bp = Bp(
+            [new BpAction { Id = 1, Sender = "applicant" }],
+            [new Participant { Id = "applicant", WalletAddress = null }]);
+
+        CatalogueEndpoints.IsCitizenStartable(bp).Should().BeTrue();
+    }
+
+    [Fact]
+    public void HardCodedFirstActionSender_IsNotStartable()
+    {
+        var bp = Bp(
+            [new BpAction { Id = 1, Sender = "analyst" }],
+            [new Participant { Id = "analyst", WalletAddress = "ws1qanalyst" }]);
+
+        CatalogueEndpoints.IsCitizenStartable(bp).Should().BeFalse();
+    }
+
+    [Fact]
+    public void UsesLowestIdAction_AsFirst()
+    {
+        var bp = Bp(
+            [new BpAction { Id = 2, Sender = "analyst" }, new BpAction { Id = 1, Sender = "applicant" }],
+            [new Participant { Id = "applicant", WalletAddress = null },
+             new Participant { Id = "analyst", WalletAddress = "ws1qanalyst" }]);
+
+        CatalogueEndpoints.IsCitizenStartable(bp).Should().BeTrue("the lowest-Id action is the first step");
+    }
+
+    [Fact]
+    public void NoActions_IsNotStartable() =>
+        CatalogueEndpoints.IsCitizenStartable(Bp([], [])).Should().BeFalse();
+
+    [Fact]
+    public void SenderParticipantMissing_IsNotStartable()
+    {
+        var bp = Bp([new BpAction { Id = 1, Sender = "ghost" }], [new Participant { Id = "other" }]);
+        CatalogueEndpoints.IsCitizenStartable(bp).Should().BeFalse();
+    }
+}

--- a/tests/Sorcha.Wallet.Pwa.Tests/Catalogue/CatalogueClientTests.cs
+++ b/tests/Sorcha.Wallet.Pwa.Tests/Catalogue/CatalogueClientTests.cs
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Sorcha.Wallet.Pwa.Services.Catalogue;
+using Xunit;
+
+namespace Sorcha.Wallet.Pwa.Tests.Catalogue;
+
+/// <summary>
+/// Feature 154 (B) — HttpCatalogueClient maps /api/catalogue and starts a service via /api/instances/.
+/// </summary>
+public sealed class CatalogueClientTests
+{
+    [Fact]
+    public async Task GetServicesAsync_MapsItems()
+    {
+        var client = Create((req, _) =>
+        {
+            req.RequestUri!.AbsolutePath.Should().Be("/api/catalogue");
+            return Ok("""[{"blueprintId":"bp-1","title":"Blue Badge","description":"Apply for a blue badge","registerId":"reg-1"}]""");
+        });
+
+        var items = await client.GetServicesAsync();
+
+        items.Should().ContainSingle();
+        items[0].BlueprintId.Should().Be("bp-1");
+        items[0].Title.Should().Be("Blue Badge");
+        items[0].RegisterId.Should().Be("reg-1");
+    }
+
+    [Fact]
+    public async Task GetServicesAsync_TransientFailure_Throws()
+    {
+        var client = Create((_, _) => throw new HttpRequestException("offline"));
+        await client.Invoking(c => c.GetServicesAsync()).Should().ThrowAsync<HttpRequestException>();
+    }
+
+    [Fact]
+    public async Task StartAsync_PostsCreateInstance_ReturnsNewId()
+    {
+        var client = Create((req, _) =>
+        {
+            req.RequestUri!.AbsolutePath.Should().Be("/api/instances/");
+            return new HttpResponseMessage(HttpStatusCode.Created)
+            {
+                Content = new StringContent("""{"id":"11111111-1111-1111-1111-111111111111"}""", Encoding.UTF8, "application/json"),
+            };
+        });
+
+        var id = await client.StartAsync(new CatalogueItem("bp-1", "Blue Badge", null, "reg-1"));
+
+        id.Should().Be("11111111-1111-1111-1111-111111111111");
+    }
+
+    [Fact]
+    public async Task StartAsync_Failure_ReturnsNull()
+    {
+        var client = Create((_, _) => new HttpResponseMessage(HttpStatusCode.BadRequest));
+        (await client.StartAsync(new CatalogueItem("bp-1", "x", null, "reg-1"))).Should().BeNull();
+    }
+
+    private static HttpCatalogueClient Create(Func<HttpRequestMessage, CancellationToken, HttpResponseMessage> respond)
+    {
+        var http = new HttpClient(new StubHandler(respond)) { BaseAddress = new Uri("https://test.example.com") };
+        return new HttpCatalogueClient(http);
+    }
+
+    private static HttpResponseMessage Ok(string json) =>
+        new(HttpStatusCode.OK) { Content = new StringContent(json, Encoding.UTF8, "application/json") };
+
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, CancellationToken, HttpResponseMessage> _respond;
+        public StubHandler(Func<HttpRequestMessage, CancellationToken, HttpResponseMessage> respond) => _respond = respond;
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct) =>
+            Task.FromResult(_respond(request, ct));
+    }
+}

--- a/tests/Sorcha.Wallet.Pwa.Tests/Pages/ApplicationsCatalogueTests.cs
+++ b/tests/Sorcha.Wallet.Pwa.Tests/Pages/ApplicationsCatalogueTests.cs
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Bunit;
+using FluentAssertions;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Sorcha.UI.Testing;
+using Sorcha.Wallet.Pwa.Services.Catalogue;
+using Xunit;
+using CataloguePage = Sorcha.Wallet.Pwa.Pages.Applications;
+
+namespace Sorcha.Wallet.Pwa.Tests.Pages;
+
+/// <summary>
+/// Feature 154 (B) — the catalogue page lists startable services, handles empty/error, and starts a
+/// service (create instance → navigate into the existing fill/submit flow).
+/// </summary>
+public sealed class ApplicationsCatalogueTests : ComponentTestFixture
+{
+    private readonly Mock<ICatalogueClient> _catalogue = new();
+
+    public ApplicationsCatalogueTests() => Services.AddSingleton(_catalogue.Object);
+
+    private static CatalogueItem Svc(string id, string title) => new(id, title, "desc", "reg-1");
+
+    [Fact]
+    public void ListsServices()
+    {
+        _catalogue.Setup(c => c.GetServicesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<CatalogueItem> { Svc("a", "Blue Badge"), Svc("b", "Bus Pass") });
+
+        var cut = Render<CataloguePage>();
+
+        cut.FindAll("[data-testid^=catalogue-item-]").Should().HaveCount(2);
+    }
+
+    [Fact]
+    public void EmptyCatalogue_ShowsEmptyState()
+    {
+        _catalogue.Setup(c => c.GetServicesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<CatalogueItem>());
+
+        var cut = Render<CataloguePage>();
+
+        cut.FindAll("[data-testid=catalogue-empty]").Should().ContainSingle();
+    }
+
+    [Fact]
+    public void LoadFailure_ShowsNotice()
+    {
+        _catalogue.Setup(c => c.GetServicesAsync(It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new System.Net.Http.HttpRequestException("offline"));
+
+        var cut = Render<CataloguePage>();
+
+        cut.FindAll("[data-testid=catalogue-error]").Should().ContainSingle();
+    }
+
+    [Fact]
+    public void TapService_StartsAndNavigates()
+    {
+        _catalogue.Setup(c => c.GetServicesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<CatalogueItem> { Svc("a", "Blue Badge") });
+        _catalogue.Setup(c => c.StartAsync(It.IsAny<CatalogueItem>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync("11111111-1111-1111-1111-111111111111");
+        var nav = Services.GetRequiredService<NavigationManager>();
+
+        var cut = Render<CataloguePage>();
+        cut.Find("[data-testid=catalogue-item-a]").Click();
+
+        _catalogue.Verify(c => c.StartAsync(It.IsAny<CatalogueItem>(), It.IsAny<CancellationToken>()), Times.Once);
+        nav.Uri.Should().EndWith("applications/11111111-1111-1111-1111-111111111111");
+    }
+
+    [Fact]
+    public void StartFailure_ShowsError_NoNavigation()
+    {
+        _catalogue.Setup(c => c.GetServicesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<CatalogueItem> { Svc("a", "Blue Badge") });
+        _catalogue.Setup(c => c.StartAsync(It.IsAny<CatalogueItem>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string?)null);
+
+        var cut = Render<CataloguePage>();
+        cut.Find("[data-testid=catalogue-item-a]").Click();
+
+        cut.FindAll("[data-testid=catalogue-start-error]").Should().ContainSingle();
+    }
+
+    [Theory]
+    [InlineData("badge", 1)]
+    [InlineData("pass", 1)]
+    [InlineData("", 2)]
+    [InlineData("zzz", 0)]
+    public void FilterServices_NarrowsByNameOrDescription(string query, int expected)
+    {
+        var all = new List<CatalogueItem> { new("a", "Blue Badge", "mobility", "r"), new("b", "Bus Pass", "travel", "r") };
+        CataloguePage.FilterServices(all, query).Count.Should().Be(expected);
+    }
+}


### PR DESCRIPTION
## Summary

Sub-project **B** (final piece of the PWA workflow-participation programme): a citizen can browse the services they can start and begin a new application, landing in the existing fill/submit flow. Replaces the empty `Applications.razor` stub. Builds on A.

Design: `docs/superpowers/specs/2026-06-14-pwa-service-catalogue-design.md`; spec/plan/tasks in `specs/154-service-catalogue/`.

## What's included

- **Backend (one new consumer-tier read endpoint)** — `GET /api/catalogue` (Blueprint Service) lists the published services a citizen can start. A service is **citizen-startable** when its first action's sender participant is open (no hard-coded wallet) and it has a register to run on. Adds `IPublishedBlueprintStore.GetAllLatestAsync`; pure `IsCitizenStartable` + `BuildCatalogue` helpers (unit-tested). **No change** to instance creation.
- **PWA (US1)** — `ICatalogueClient` + the rebuilt `Applications.razor`: lists services (name + description), loading/empty/error states, tap → `StartAsync` (`POST /api/instances/`) → navigate base-relative to `applications/{instanceId}` (existing `ApplicationInstance` fill/submit), start-failure notice.
- **PWA (US2)** — client-side search/filter (pure `FilterServices`, name/description, case-insensitive) + no-match state.

## Tests

`Sorcha.Blueprint.Service.Tests` **882/0** (+7: startable predicate, BuildCatalogue), `Sorcha.Wallet.Pwa.Tests` **285/0** (+13: client mapping/start, page list/empty/load-error/tap-navigate/start-error, filter). Snackbar gate clean; PWA + Blueprint.Service build with 0 new warnings (2 pre-existing NU1903 MessagePack-transitive warnings only).

## Notes / follow-ups (as designed)

- "Startable" v1 = open first-action sender; richer curation (a blueprint flag / registry) is a later refinement.
- Catalogue scoping: v1 lists published+startable services; deep org/home scoping is a refinement (the create/execute path already enforces access — a non-runnable service degrades to a start failure, not a security issue).
- **Live validation** (publish a startable blueprint → browse → start → submit) is a pre-merge manual check — not run here.

This completes the A/B/C/D programme (A, C, D merged; B here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)