### PR TITLE
fix(gateway): route /api/catalogue to blueprint-cluster

### DIFF
--- a/src/Services/Sorcha.ApiGateway/appsettings.json
+++ b/src/Services/Sorcha.ApiGateway/appsettings.json
@@ -410,6 +410,8 @@
       },
       "blueprint-credentials": { "ClusterId": "blueprint-cluster", "AuthorizationPolicy": "RequireAuthenticated", "Match": { "Path": "/api/v1/credentials/{**catch-all}" } },
       "blueprint-blueprints":  { "ClusterId": "blueprint-cluster", "AuthorizationPolicy": "RequireAuthenticated", "Match": { "Path": "/api/blueprints/{**catch-all}" } },
+      "blueprint-catalogue":      { "ClusterId": "blueprint-cluster", "AuthorizationPolicy": "RequireAuthenticated", "Order": 1, "Match": { "Path": "/api/catalogue" } },
+      "blueprint-catalogue-sub":  { "ClusterId": "blueprint-cluster", "AuthorizationPolicy": "RequireAuthenticated", "Match": { "Path": "/api/catalogue/{**catch-all}" } },
       "blueprint-instances-list": { "ClusterId": "blueprint-cluster", "AuthorizationPolicy": "RequireAuthenticated", "Order": 1, "Match": { "Path": "/api/instances" } },
       "blueprint-instances":   { "ClusterId": "blueprint-cluster", "AuthorizationPolicy": "RequireAuthenticated", "Match": { "Path": "/api/instances/{**catch-all}" } },
       "blueprint-templates":   { "ClusterId": "blueprint-cluster", "AuthorizationPolicy": "RequireAuthenticated", "Match": { "Path": "/api/templates/{**catch-all}" } },


### PR DESCRIPTION
Sub-project B (#1009) added `GET /api/catalogue` but no YARP gateway route, so the PWA catalogue (called through the gateway) 404'd — caught by live endpoint probing during the n1 deploy (blueprint-service served 401 directly; gateway returned 404). Adds `blueprint-catalogue` (exact `/api/catalogue`, Order 1) + `blueprint-catalogue-sub` (`/api/catalogue/{**}`) → blueprint-cluster, mirroring `blueprint-instances`. Gateway config only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)