### PR TITLE
fix(136): classify returnTo by path before host allowlist

### DIFF
--- a/src/Services/Sorcha.Tenant.Service/Services/RequestedTierResolver.cs
+++ b/src/Services/Sorcha.Tenant.Service/Services/RequestedTierResolver.cs
@@ -78,16 +78,27 @@ public static class RequestedTierResolver
             return null;
         }
 
-        // Absolute URL: an allow-listed consumer host is a consumer destination (the allowlist itself
-        // fail-closes on open-redirects). Otherwise fall back to classifying the URL's path.
         if (Uri.TryCreate(returnTo, UriKind.Absolute, out var absolute))
         {
+            // A recognised /app or /wallet path expresses tier intent directly and MUST win over the
+            // host heuristic. The platform's own host (localhost, n1.sorcha.dev, ...) is in the allowlist
+            // for redirect-safety, NOT as a consumer-host marker — without path-first, a self-referential
+            // /app return (RedirectToLogin sends the absolute current URL) is mis-classified Consumer and
+            // an entitled admin is minted a roleless consumer token, losing the entire admin surface.
+            var byPath = ClassifyPath(absolute.AbsolutePath);
+            if (byPath is not null)
+            {
+                return byPath;
+            }
+
+            // No tier-bearing path → an allow-listed *external consumer* host (e.g. a council page) is a
+            // consumer destination. The allowlist itself fail-closes on open-redirects.
             if (allowlist is not null && allowlist.IsAllowed(returnTo))
             {
                 return Tier.Consumer;
             }
 
-            return ClassifyPath(absolute.AbsolutePath);
+            return null;
         }
 
         return ClassifyPath(returnTo);

--- a/tests/Sorcha.Tenant.Service.Tests/Services/RequestedTierResolverTests.cs
+++ b/tests/Sorcha.Tenant.Service.Tests/Services/RequestedTierResolverTests.cs
@@ -103,6 +103,29 @@ public sealed class RequestedTierResolverTests
             .Should().Be(Tier.Platform);
     }
 
+    [Theory]
+    [InlineData("https://localhost/app/orgs")]
+    [InlineData("https://n1.sorcha.dev/app/designer/blueprint")]
+    [InlineData("http://localhost/app/")]
+    public void ClassifyReturnTo_AllowlistedOwnHost_AppPath_IsPlatform(string returnTo)
+    {
+        // Regression: the platform's own host is allow-listed for redirect-safety, NOT as a consumer
+        // host. A self-referential /app return (RedirectToLogin sends the absolute current URL) must
+        // classify Platform — host-first classification minted an entitled admin a roleless consumer
+        // token, hiding the entire admin menu.
+        var ownHostAllowlist = new ReturnToAllowlistOptions { Hosts = ["localhost", "n1.sorcha.dev"] };
+        RequestedTierResolver.ClassifyReturnTo(returnTo, ownHostAllowlist).Should().Be(Tier.Platform);
+    }
+
+    [Fact]
+    public void ClassifyReturnTo_AllowlistedOwnHost_WalletPath_IsConsumer()
+    {
+        // /wallet self-return still classifies Consumer — path-first preserves the wallet boundary.
+        var ownHostAllowlist = new ReturnToAllowlistOptions { Hosts = ["localhost", "n1.sorcha.dev"] };
+        RequestedTierResolver.ClassifyReturnTo("https://n1.sorcha.dev/wallet/home", ownHostAllowlist)
+            .Should().Be(Tier.Consumer);
+    }
+
     // --- default (rule 3) ---
 
     [Theory]


### PR DESCRIPTION
## Problem

Logging into the `/app` web SPA as the system admin (`admin@sorcha.local`) produced a **consumer-tier** JWT (`aud: …:consumer`) with **no role claims**, so every `AuthorizeView Roles="…"` block in `MainLayout.razor` correctly evaluated to *not authorized* and the **entire admin menu disappeared**.

## Root cause

The return-to allowlist (`Auth:ReturnToAllowlist:Hosts`) contains the platform's **own** hosts (`localhost`, `n1.sorcha.dev`) — they must be there for redirect-*safety*. But `RequestedTierResolver.ClassifyReturnTo` checked the host allowlist **before** the path and treated any allowlisted host as a **consumer** destination.

`RedirectToLogin.razor` sends the absolute current URL (`https://<own-host>/app/…`) as `returnTo`. That host matched the allowlist → classified **Consumer** → `ResolvePreference` minted a consumer token (consumer is always entitled) → roles omitted by design → admin surface hidden.

(API login worked only because it sends no `returnTo` → `?? Platform`.)

## Fix

Classify a recognised `/app` (→ Platform) or `/wallet` (→ Consumer) **path first**; fall back to the allowlist→Consumer rule only for external hosts with no tier-bearing path (e.g. council pages). Encodes the precedence **explicit path intent beats host heuristic**.

## Why it's safe

- **No privilege escalation:** `tier = preference ∩ entitlement`. The entitlement gate (`TierResolver.ResolvePreference`) is untouched — a non-admin with an `/app` return is still downgraded to Consumer; an explicit over-request is still refused (403). This only lets an *already-entitled* admin land on the correct tier.
- **No open-redirect change:** the redirect destination is governed by `IsValidReturnUrl` (separate, untouched). Token is delivered to the authenticated user via the `/app` fragment, never to the `returnTo` host.
- Non-allowlisted absolute URLs already fell through to path classification — only the allowlisted-own-host + `/app|/wallet` case changes.

## Tests

- New: `ClassifyReturnTo_AllowlistedOwnHost_AppPath_IsPlatform` (regression guard) + `…_WalletPath_IsConsumer`.
- Existing `RequestedTierResolverTests` (incl. external-consumer-host → Consumer) unchanged and passing.
- Full `Sorcha.Tenant.Service.Tests` suite green: **1317 passed, 0 failed, 8 skipped**.

## Post-merge

Server-side fix in token minting — users must sign out/in once to pick up a fresh `…:platform` token. Needs a Tenant-service deploy on n1.

## Follow-ups (not in this PR)

- Defense-in-depth: `/app` SPA should reject a `…:consumer`-audience token and force platform re-auth, rather than silently rendering a roleless menu.
- Cleanup: phantom `OrganizationAdmin` role string in 5 UI spots (not a `UserRole`; harmless OR-list filler today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)