### PR TITLE
chore(ui): remove phantom OrganizationAdmin role from auth checks

### DIFF
--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Components/Layout/MainLayout.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Components/Layout/MainLayout.razor
@@ -156,7 +156,7 @@
                             </MudNavLink>
                         </Authorized>
                     </AuthorizeView>
-                    <AuthorizeView Roles="Administrator,OrganizationAdmin,SystemAdmin">
+                    <AuthorizeView Roles="Administrator,SystemAdmin">
                         <Authorized Context="orgAdminContext">
                             <MudNavLink Href="admin/credentials" Icon="@Icons.Material.Filled.VerifiedUser">
                                 @Loc.T("nav.issuedCredentials")

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Admin/IssuedCredentials.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Admin/IssuedCredentials.razor
@@ -3,7 +3,7 @@
 
 @page "/admin/credentials"
 @rendermode @(new InteractiveWebAssemblyRenderMode(prerender: false))
-@attribute [Authorize(Roles = "Administrator,OrganizationAdmin,SystemAdmin")]
+@attribute [Authorize(Roles = "Administrator,SystemAdmin")]
 @using Microsoft.AspNetCore.Authorization
 @using Microsoft.AspNetCore.Components.Authorization
 @using Sorcha.UI.Core.Components.Admin

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Admin/OrganizationUserDetail.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Admin/OrganizationUserDetail.razor
@@ -3,7 +3,7 @@
 
 @page "/admin/organizations/{OrgId:guid}/users/{UserId:guid}"
 @rendermode @(new InteractiveWebAssemblyRenderMode(prerender: false))
-@attribute [Authorize(Roles = "Administrator,OrganizationAdmin,SystemAdmin")]
+@attribute [Authorize(Roles = "Administrator,SystemAdmin")]
 @using Microsoft.AspNetCore.Authorization
 @using Microsoft.AspNetCore.Components.Authorization
 @using System.Security.Claims

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Admin/Organizations.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Admin/Organizations.razor
@@ -4,7 +4,7 @@
 @page "/admin/organizations"
 @page "/admin/organizations/{OrgId:guid}"
 @rendermode @(new InteractiveWebAssemblyRenderMode(prerender: false))
-@attribute [Authorize(Roles = "Administrator,OrganizationAdmin,SystemAdmin")]
+@attribute [Authorize(Roles = "Administrator,SystemAdmin")]
 @using Microsoft.AspNetCore.Authorization
 @using Microsoft.AspNetCore.Components.Authorization
 @using System.Security.Claims

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Home.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Home.razor
@@ -277,8 +277,7 @@ else
         // AlertsPanel or the admin stat grid, so polling those endpoints
         // for them just produces 401 noise in the console.
         _canSeeAdminDashboard = authState.User.IsInRole("Administrator")
-                                || authState.User.IsInRole("SystemAdmin")
-                                || authState.User.IsInRole("OrganizationAdmin");
+                                || authState.User.IsInRole("SystemAdmin");
         _isSystemAdmin = authState.User.IsInRole("SystemAdmin");
         _platformUserId = authState.User.FindFirst("platform_user_id")?.Value ?? string.Empty;
 


### PR DESCRIPTION
## What

`OrganizationAdmin` is referenced as a **role** in five UI authorization checks, but it is **not** a value in the `UserRole` enum (`SystemAdmin, Administrator, Designer, Auditor, Consumer`). It exists only as a `PermissionFlags` bit and as the `IOrganizationAdminService` *service* name. So it never matched in any check — pure dead weight.

Removed from:
- `MainLayout.razor` nav block → `Roles="Administrator,SystemAdmin"`
- `IssuedCredentials.razor`, `Organizations.razor`, `OrganizationUserDetail.razor` → `[Authorize(Roles = "Administrator,SystemAdmin")]`
- `Home.razor` → dropped the always-false `|| IsInRole("OrganizationAdmin")` clause

## Why it's safe

Behaviour-preserving: since no user is ever in an `OrganizationAdmin` role, these were OR-list filler / always-false operands. The accessible set is unchanged (`Administrator`/`SystemAdmin` already covered every case). The `IOrganizationAdminService` service name is unrelated and untouched.

## Context

Surfaced while diagnosing the missing-admin-menu bug (PR #1013). Not the cause of that bug (the OR-lists still authorized admins via `Administrator`/`SystemAdmin`), but worth removing so the role surface is honest.

## Verification

`dotnet build Sorcha.UI.Web.Client` → **Build succeeded, 0 warnings, 0 errors**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)