### PR TITLE
feat(136): entitlement-gated tier upgrade on refresh + /app self-heal

### DIFF
--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/Shared/Authentication/AuthenticationService.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/Shared/Authentication/AuthenticationService.cs
@@ -123,6 +123,51 @@ public class AuthenticationService : IAuthenticationService
     }
 
     /// <inheritdoc />
+    public async Task<bool> TryUpgradeTierAsync(string profileName, string tier)
+    {
+        var entry = await _tokenCache.GetTokenAsync(profileName);
+        if (entry is null || string.IsNullOrEmpty(entry.RefreshToken))
+        {
+            return false;
+        }
+
+        try
+        {
+            // Hit the JSON refresh endpoint with a tier hint. The server gates the upgrade on
+            // entitlement (spec 136), so this can never exceed the holder's entitlement: an admin
+            // is upgraded to platform, a citizen is left on consumer. Unlike RefreshTokenAsync this
+            // must NOT clear the cached token on failure — a non-entitled holder legitimately keeps
+            // their current (consumer) token and carries on.
+            var response = await _httpClient.PostAsJsonAsync(
+                "/api/auth/token/refresh",
+                new TierUpgradeRequest(entry.RefreshToken, tier));
+
+            if (!response.IsSuccessStatusCode)
+            {
+                return false;
+            }
+
+            var tokenResponse = await response.Content.ReadFromJsonAsync<TokenResponse>();
+            if (tokenResponse is null || !tokenResponse.IsValid())
+            {
+                return false;
+            }
+
+            var cacheEntry = TokenCacheEntry.FromTokenResponse(tokenResponse, profileName);
+            await _tokenCache.StoreTokenAsync(profileName, cacheEntry);
+            return true;
+        }
+        catch (Exception)
+        {
+            // Best-effort, non-destructive: a failed upgrade leaves the existing token intact.
+            return false;
+        }
+    }
+
+    /// <summary>Wire shape for the tier-hinted JSON refresh (matches Tenant <c>TokenRefreshRequest</c>).</summary>
+    private sealed record TierUpgradeRequest(string RefreshToken, string Tier);
+
+    /// <inheritdoc />
     public async Task LogoutAsync(string profileName)
     {
         // Clear local token cache — server-side revocation is handled

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/Shared/Authentication/IAuthenticationService.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/Shared/Authentication/IAuthenticationService.cs
@@ -33,6 +33,18 @@ public interface IAuthenticationService
     Task<bool> RefreshTokenAsync(string profileName);
 
     /// <summary>
+    /// Attempts a one-shot trust-tier upgrade (spec 136 defense-in-depth). Re-mints the cached
+    /// token at the requested tier via the JSON refresh endpoint, which the server gates on
+    /// entitlement — an entitled holder is upgraded, a non-entitled one is left on their current
+    /// tier (the call simply returns false / a same-tier token). Used by the <c>/app</c> platform
+    /// host to self-heal a stale consumer-tier token for an entitled admin. Never throws.
+    /// </summary>
+    /// <param name="profileName">Profile name.</param>
+    /// <param name="tier">Requested human tier hint (e.g. <c>"platform"</c>).</param>
+    /// <returns>True if a new token was minted and cached, false otherwise.</returns>
+    Task<bool> TryUpgradeTierAsync(string profileName, string tier);
+
+    /// <summary>
     /// Logs out the user and clears cached tokens
     /// </summary>
     /// <param name="profileName">Profile name</param>

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Components/Layout/MainLayout.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Components/Layout/MainLayout.razor
@@ -17,6 +17,8 @@
 @inject TenantHubConnection TenantHub
 @inject IInboxApiService InboxApi
 @inject ILocalizationService Loc
+@inject IAuthenticationService AuthService
+@inject Sorcha.UI.Core.Services.Configuration.IConfigurationService ConfigService
 
 <MudThemeProvider Theme="SorchaMudTheme.Default" IsDarkMode="@_isDarkMode" />
 <MudPopoverProvider />
@@ -324,6 +326,23 @@
             var authState = await AuthStateProvider.GetAuthenticationStateAsync();
             if (authState.User.Identity?.IsAuthenticated == true)
             {
+                // Spec 136 defense-in-depth: /app is the PLATFORM host. If this session is holding a
+                // consumer-tier token (e.g. a stale/leaked token from a /wallet session on the same
+                // origin), silently attempt a one-shot platform upgrade. The server gates it on
+                // entitlement — an admin is upgraded (roles restored, admin menu returns), a citizen
+                // stays consumer (no loop). Without this an entitled admin with a consumer token sees
+                // a silently roleless admin surface. Runs once (firstRender + _tokenRefreshStarted).
+                var aud = authState.User.FindFirst("aud")?.Value;
+                if (aud is not null && aud.EndsWith(":consumer", StringComparison.Ordinal))
+                {
+                    var profileName = await ConfigService.GetActiveProfileNameAsync();
+                    if (await AuthService.TryUpgradeTierAsync(profileName, "platform"))
+                    {
+                        (AuthStateProvider as CustomAuthenticationStateProvider)?.NotifyAuthenticationStateChanged();
+                        authState = await AuthStateProvider.GetAuthenticationStateAsync();
+                    }
+                }
+
                 await RefreshUnreadCount();
             }
 

--- a/src/Services/Sorcha.Tenant.Service/Endpoints/AuthEndpoints.cs
+++ b/src/Services/Sorcha.Tenant.Service/Endpoints/AuthEndpoints.cs
@@ -571,7 +571,12 @@ public static class AuthEndpoints
             });
         }
 
-        var response = await tokenService.RefreshTokenAsync(request.RefreshToken, cancellationToken);
+        // Spec 136 defense-in-depth: an optional tier hint lets the platform host re-evaluate the
+        // minted tier against entitlement (e.g. self-heal a stale consumer token for an entitled
+        // admin). Unknown/absent hint → null → tier-preserving refresh (FR-012). The entitlement
+        // gate inside RefreshTokenAsync ensures this can never exceed the holder's entitlement.
+        var requestedTier = RequestedTierResolver.ParseTierHint(request.Tier);
+        var response = await tokenService.RefreshTokenAsync(request.RefreshToken, cancellationToken, requestedTier);
 
         if (response == null)
         {

--- a/src/Services/Sorcha.Tenant.Service/Models/Dtos/AuthDtos.cs
+++ b/src/Services/Sorcha.Tenant.Service/Models/Dtos/AuthDtos.cs
@@ -49,6 +49,15 @@ public record TokenRefreshRequest
     /// The refresh token.
     /// </summary>
     public required string RefreshToken { get; init; }
+
+    /// <summary>
+    /// Optional trust-tier hint (spec 136). When set to a human tier (<c>consumer</c>/<c>platform</c>)
+    /// the refresh re-evaluates the minted tier against the holder's entitlement (FR-016-style, like
+    /// org-switch): an entitled holder is upgraded, a non-entitled one is left unchanged — it can never
+    /// exceed entitlement. Absent (the default) preserves the refresh token's existing tier (FR-012).
+    /// Used by the <c>/app</c> platform host to self-heal a stale lower-tier token.
+    /// </summary>
+    public string? Tier { get; init; }
 }
 
 /// <summary>

--- a/src/Services/Sorcha.Tenant.Service/Services/ITokenService.cs
+++ b/src/Services/Sorcha.Tenant.Service/Services/ITokenService.cs
@@ -51,10 +51,18 @@ public interface ITokenService
     /// </summary>
     /// <param name="refreshToken">The refresh token.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
+    /// <param name="requestedTier">
+    /// Optional trust-tier hint (spec 136). When supplied, the minted access token's tier is
+    /// re-evaluated against the holder's entitlement (<see cref="TierResolver.ResolvePreference"/>
+    /// with <c>isExplicit:false</c>) — upgrading an entitled holder or leaving a non-entitled one
+    /// unchanged; it can never exceed entitlement. When <c>null</c> (the default) the refresh
+    /// preserves the refresh token's existing tier (FR-012).
+    /// </param>
     /// <returns>New token response or null if refresh token is invalid.</returns>
     Task<TokenResponse?> RefreshTokenAsync(
         string refreshToken,
-        CancellationToken cancellationToken = default);
+        CancellationToken cancellationToken = default,
+        Tier? requestedTier = null);
 
     /// <summary>
     /// Revokes a token by its JTI.

--- a/src/Services/Sorcha.Tenant.Service/Services/TokenService.cs
+++ b/src/Services/Sorcha.Tenant.Service/Services/TokenService.cs
@@ -217,7 +217,8 @@ public class TokenService : ITokenService
     /// <inheritdoc />
     public async Task<TokenResponse?> RefreshTokenAsync(
         string refreshToken,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default,
+        Tier? requestedTier = null)
     {
         if (string.IsNullOrWhiteSpace(refreshToken))
         {
@@ -278,9 +279,21 @@ public class TokenService : ITokenService
                 organization = await _organizationRepository.GetByIdAsync(orgGuid, cancellationToken);
             }
 
-            // A refresh re-mints an access token of the SAME tier as the refresh token (spec 136,
-            // FR-012). The tier was stamped at issuance; absent (legacy tokens) defaults to platform.
+            // A plain refresh re-mints an access token of the SAME tier as the refresh token (spec
+            // 136, FR-012). The tier was stamped at issuance; absent (legacy tokens) defaults to
+            // platform.
             var tier = ParseTierClaim(principal.FindFirst("tier")?.Value);
+
+            // An explicit requestedTier opts into an entitlement-gated re-evaluation (FR-016-style,
+            // mirroring org-switch): the tier follows the holder's current roles. With isExplicit:false
+            // a non-entitled request downgrades rather than 403s, so it can never exceed entitlement —
+            // an entitled admin is upgraded (roles restored), a citizen stays consumer. The /app
+            // platform host uses this to self-heal a stale lower-tier token (defense-in-depth for the
+            // shared-origin tier-leak class of bug).
+            if (requestedTier is not null)
+            {
+                tier = TierResolver.ResolvePreference(requestedTier.Value, isExplicit: false, user.Roles).Tier;
+            }
 
             // Generate new access token with claims rebuilt from current user state
             var newAccessTokenJti = Guid.NewGuid().ToString();

--- a/tests/Sorcha.Tenant.Service.Tests/Services/TokenServiceTierTests.cs
+++ b/tests/Sorcha.Tenant.Service.Tests/Services/TokenServiceTierTests.cs
@@ -154,4 +154,120 @@ public sealed class TokenServiceTierTests
 
         await act.Should().ThrowAsync<ArgumentOutOfRangeException>();
     }
+
+    // --- Refresh tier upgrade (spec 136 defense-in-depth) ---
+
+    /// <summary>
+    /// Builds a TokenService whose repositories resolve <paramref name="user"/>/<paramref name="org"/>
+    /// so a refresh-token round-trip works (the plain <see cref="CreateService"/> returns a null user).
+    /// </summary>
+    private static TokenService CreateServiceForRefresh(UserIdentity user, Organization org)
+    {
+        var config = new JwtConfiguration
+        {
+            InstallationName = Installation,
+            SigningKey = "tier-tests-signing-key-min-32-characters-long-enough!!",
+            Issuer = "urn:sorcha:test",
+            AccessTokenLifetimeMinutes = 60,
+            RefreshTokenLifetimeHours = 24,
+            ValidateIssuer = false,
+            ValidateAudience = false,
+            ValidateLifetime = false,
+        };
+
+        var revocation = new Mock<ITokenRevocationService>();
+        revocation.Setup(r => r.TrackTokenAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string?>(),
+            It.IsAny<DateTimeOffset>(), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+        revocation.Setup(r => r.IsTokenRevokedAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        var identity = new Mock<IIdentityRepository>();
+        identity.Setup(i => i.GetUserByIdAsync(user.Id, It.IsAny<CancellationToken>())).ReturnsAsync(user);
+
+        var orgs = new Mock<IOrganizationRepository>();
+        orgs.Setup(o => o.GetByIdAsync(org.Id, It.IsAny<CancellationToken>())).ReturnsAsync(org);
+
+        var participants = new Mock<IParticipantRepository>();
+        participants.Setup(p => p.GetByUserAndOrgAsync(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ParticipantIdentity?)null);
+
+        return new TokenService(
+            Options.Create(config), revocation.Object, identity.Object, orgs.Object,
+            participants.Object, NullLogger<TokenService>.Instance);
+    }
+
+    private static (UserIdentity user, Organization org) AdminSubject() => (
+        new UserIdentity
+        {
+            Id = Guid.NewGuid(),
+            OrganizationId = Guid.NewGuid(),
+            PlatformUserId = Guid.NewGuid(),
+            Email = "admin@sorcha.local",
+            DisplayName = "System Administrator",
+            Roles = [UserRole.Administrator, UserRole.SystemAdmin, UserRole.Consumer],
+            Status = IdentityStatus.Active,
+        },
+        new Organization { Id = Guid.NewGuid(), Name = "Sorcha Local", Subdomain = "system" });
+
+    private static (UserIdentity user, Organization org) CitizenSubject() => (
+        new UserIdentity
+        {
+            Id = Guid.NewGuid(),
+            OrganizationId = Guid.NewGuid(),
+            PlatformUserId = Guid.NewGuid(),
+            Email = "citizen@example.com",
+            DisplayName = "Citizen",
+            Roles = [UserRole.Consumer],
+            Status = IdentityStatus.Active,
+        },
+        new Organization { Id = Guid.NewGuid(), Name = "Public", Subdomain = "public" });
+
+    [Fact]
+    public async Task RefreshToken_PlatformHint_EntitledAdmin_UpgradesToPlatformWithRoles()
+    {
+        var (user, org) = AdminSubject();
+        var svc = CreateServiceForRefresh(user, org);
+
+        // Start from a CONSUMER token (the stale/leaked-token scenario), then request platform.
+        var consumer = await svc.GenerateUserTokenAsync(user, org, user.PlatformUserId, Tier.Consumer);
+        var refreshed = await svc.RefreshTokenAsync(consumer.RefreshToken, requestedTier: Tier.Platform);
+
+        refreshed.Should().NotBeNull();
+        var token = Decode(refreshed!.AccessToken);
+        token.Audiences.Should().ContainSingle().Which.Should().Be("test:platform");
+        token.Claims.Should().Contain(c => c.Value == "SystemAdmin", "an entitled admin is upgraded and roles are restored");
+        token.Claims.Should().Contain(c => c.Value == "Administrator");
+    }
+
+    [Fact]
+    public async Task RefreshToken_PlatformHint_NonEntitledCitizen_StaysConsumer()
+    {
+        var (user, org) = CitizenSubject();
+        var svc = CreateServiceForRefresh(user, org);
+
+        var consumer = await svc.GenerateUserTokenAsync(user, org, user.PlatformUserId, Tier.Consumer);
+        var refreshed = await svc.RefreshTokenAsync(consumer.RefreshToken, requestedTier: Tier.Platform);
+
+        refreshed.Should().NotBeNull();
+        var token = Decode(refreshed!.AccessToken);
+        token.Audiences.Should().ContainSingle().Which.Should().Be("test:consumer",
+            "a non-entitled holder is downgraded to their entitlement, never escalated (FR-008)");
+        token.Claims.Should().NotContain(c => c.Type == System.Security.Claims.ClaimTypes.Role || c.Type == "role");
+    }
+
+    [Fact]
+    public async Task RefreshToken_NoHint_PreservesConsumerTier()
+    {
+        var (user, org) = AdminSubject();
+        var svc = CreateServiceForRefresh(user, org);
+
+        // No tier hint → FR-012 tier-preserving refresh, even for an entitled admin.
+        var consumer = await svc.GenerateUserTokenAsync(user, org, user.PlatformUserId, Tier.Consumer);
+        var refreshed = await svc.RefreshTokenAsync(consumer.RefreshToken);
+
+        refreshed.Should().NotBeNull();
+        var token = Decode(refreshed!.AccessToken);
+        token.Audiences.Should().ContainSingle().Which.Should().Be("test:consumer");
+        token.Claims.Should().NotContain(c => c.Type == System.Security.Claims.ClaimTypes.Role || c.Type == "role");
+    }
 }


### PR DESCRIPTION
## Why

Defense-in-depth follow-up to #1013. On a shared-origin deployment (`/app` + `/wallet` on one host), an entitled admin can end up with a **consumer-tier** token in the `/app` SPA (e.g. carried from a `/wallet` session). A consumer token omits role claims *by design*, so the admin is silently authenticated-but-roleless — the admin menu vanishes with no path to recover. Because the token hides roles, **the client cannot tell an admin from a citizen** to fix it selectively: the decision must be **server-gated** on entitlement.

## What

**Server**
- `TokenRefreshRequest` gains an optional `tier` hint; `ITokenService`/`TokenService.RefreshTokenAsync` gain an optional `requestedTier`.
- When supplied, the minted access-token tier is re-evaluated via `TierResolver.ResolvePreference(requestedTier, isExplicit:false, user.Roles)` — the **same entitlement-gated re-mint `switch-org` already uses**. It can never exceed entitlement: an admin upgrades to platform (roles restored), a citizen stays consumer.
- No hint → preserves the refresh token's tier (FR-012). Existing callers (`AuthEndpoints`, `ServiceAuthEndpoints`) are unaffected (optional last param).

**Client (`/app` platform host only)**
- `AuthenticationService.TryUpgradeTierAsync` POSTs the JSON refresh endpoint with `tier=platform`; **non-destructive on failure** (a non-entitled holder keeps their consumer token — no redirect loop).
- `MainLayout` one-shot on first render: if the session token's `aud` ends `:consumer`, attempt the upgrade and re-notify auth state.

## Why it's safe (and doesn't break citizens)

- `isExplicit:false` ⇒ a non-entitled request **downgrades, never 403/escalates** — strictly bounded by server-authoritative roles. Same invariant as #1013.
- **Citizen-on-`/app` is preserved**: `/app/my-*`, `/get`, `/setup/add-device` etc. are legitimate consumer surfaces. A citizen's one-shot upgrade attempt simply returns consumer; their token is untouched; no loop. A naive "reject consumer on `/app`" guard would have looped them — this avoids that by upgrading-if-entitled rather than rejecting.
- Requires a valid, non-revoked refresh token (already enforced). Same trust as a fresh login.

## Tests

- `RefreshToken_PlatformHint_EntitledAdmin_UpgradesToPlatformWithRoles`
- `RefreshToken_PlatformHint_NonEntitledCitizen_StaysConsumer`
- `RefreshToken_NoHint_PreservesConsumerTier`
- Full `Sorcha.Tenant.Service.Tests` green (**1316 passed, 0 failed**); web client builds clean (0/0).

## Relationship to other PRs

- #1013 — the root-cause classification fix (an admin no longer *gets* a consumer token via `/app` login). This PR is belt-and-braces for any *already-cached* wrong-tier token.
- #1014 — unrelated dead-`OrganizationAdmin`-role cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)