### PR TITLE
fix(verify): support Ed25519 holder/issuer keys end-to-end

### DIFF
--- a/.claude/skills/verifiable-credentials/SKILL.md
+++ b/.claude/skills/verifiable-credentials/SKILL.md
@@ -304,6 +304,22 @@ Status mutations follow the same projector seam: `CredentialStore.PatchStatusAsy
 
 Worked-example blueprint (council issuing Assured Identity to a late-bound citizen applicant) is in `.claude/skills/blueprint-builder/SKILL.md` and `.claude/skills/sorcha-architecture/SKILL.md` § "Citizen Wallet PWA (Feature 114)".
 
+### Holder→device delegation: algorithm support & the `/verify` diagnostic panel
+
+The citizen presentation chain is **curve-mixed by construction**, so any single-algorithm assumption is a bug:
+
+| Key | Curve | Why |
+|-----|-------|-----|
+| **Device** / KB-JWT | always **EC P-256 / ES256** | WebCrypto non-extractable key in the browser |
+| **Holder** (signs the device delegation; the credential's `cnf.jwk`) | **derives from the wallet algorithm** — Ed25519 (OKP/EdDSA) for the default Sorcha wallet, P-256 for a P-256 wallet (`HolderKeyService`, slot 108) | the holder *is* the citizen's wallet |
+| **Issuer** (credential JWS) | Ed25519 **or** P-256 (org VC-issuance key) | org wallets are frequently Ed25519 |
+
+`VerifiablePresentationValidator.VerifyJwsSignature` dispatches on the JWS header `alg` and verifies **both** `ES256` (EC, via `ECDsa`) and `EdDSA` (Ed25519/OKP, via **BouncyCastle** — pure-managed so it works in a Blazor WASM host where libsodium P/Invoke does not). `DeviceDelegationIssuer` emits the **honest** header `alg` from the holder key type (`EdDSA` for Ed25519) — a hardcoded `ES256` over an Ed25519 signature is unverifiable and was the cause of *"Delegation credential signature verification failed against holder key."* on default (Ed25519) wallets.
+
+The decoded key facts ride the **Feature 155 verdict trail** (`VerificationOutcome.Layers`), not a separate structure: the `LivePresentation` layer's `Detail` carries `holder-key` (`"OKP / Ed25519"` or `"EC / P-256"`) and `delegation` (`"{alg} · device key {kty/crv}"`), alongside the existing `IssuerSignature` layer's `alg`. The **Open Verifier PWA** (`Sorcha.Verifier`) renders every layer's `Detail` dictionary generically (`Outcome.razor`), so an operator reads `holder-key  OKP / Ed25519` in the "Live presentation" panel with no browser dev tools — no bespoke diagnostic surface required.
+
+> ⚠ Latent (deferred): `DeviceEnrolmentResponse.HolderPublicJwk` is still typed `EcP256PublicJwk` and coerces an Ed25519 holder JWK to a `Y=""` P-256 shape (`CitizenWalletEndpoints.ParseHolderJwk`). It is a *verifier-convenience copy that no consumer reads* — the verifier takes the holder key from the credential's `cnf.jwk`, not this field — so it is not on the failure path. Widen it to a faithful JWK when a consumer actually needs it.
+
 ## MAUI Blazor UI
 
 The **server** already has `Sorcha.Wallet.Service.Credentials.ICredentialStore`. The UI needs a separate render-mode-agnostic abstraction — use `ICredentialUiStore` under `Sorcha.UI.Core/Services/Credentials/` to avoid naming collision. Platform services (`SecureStorage`, biometrics) hide behind `IBiometricGate` and `IQrScanner`. Razor components never touch MAUI APIs directly.

--- a/src/Common/Sorcha.Verifier.Engine/Sorcha.Verifier.Engine.csproj
+++ b/src/Common/Sorcha.Verifier.Engine/Sorcha.Verifier.Engine.csproj
@@ -8,6 +8,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <!-- Pure-managed Ed25519 verification (WASM-safe — the verifier engine runs in the citizen
+         wallet PWA's Blazor WASM host, where libsodium P/Invoke is unavailable). -->
+    <PackageReference Include="BouncyCastle.Cryptography" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Common/Sorcha.Verifier.Engine/VerifiablePresentationValidator.cs
+++ b/src/Common/Sorcha.Verifier.Engine/VerifiablePresentationValidator.cs
@@ -6,6 +6,8 @@ using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
 using Microsoft.Extensions.Logging;
+using Org.BouncyCastle.Crypto.Parameters;
+using Org.BouncyCastle.Crypto.Signers;
 using Sorcha.Verifier.Engine.Models;
 
 namespace Sorcha.Verifier.Engine;
@@ -148,11 +150,17 @@ public sealed class VerifiablePresentationValidator : IVerifiablePresentationVal
                 errors.Add("Credential is missing cnf.jwk (holder key binding).");
                 return Failure(errors, BuildLayers(false));
             }
+            // Record the holder key's type/curve for the LivePresentation layer — the curve the holder
+            // key binds with (Ed25519 for the default wallet, P-256 otherwise) is the fact that made an
+            // ES256-only verifier reject Ed25519-holder presentations, so it's the first thing to surface.
+            layerState.HolderKey = DescribeJwk(holderJwk);
 
             // ── 4. Validate holder→device delegation credential ───────────────────
             JsonElement deviceJwk = default;
             if (!string.IsNullOrWhiteSpace(delegationCredential))
             {
+                layerState.DelegationAlg = HeaderAlg(delegationCredential);
+
                 var delegationErrors = await ValidateDelegationAsync(
                     delegationCredential, holderJwk, layerState, ct);
                 if (delegationErrors.Count > 0)
@@ -168,6 +176,7 @@ public sealed class VerifiablePresentationValidator : IVerifiablePresentationVal
                     errors.Add("Delegation credential is missing cnf.jwk (device key).");
                     return Failure(errors, BuildLayers(false));
                 }
+                layerState.DeviceKey = DescribeJwk(deviceJwk);
             }
             else
             {
@@ -546,9 +555,16 @@ public sealed class VerifiablePresentationValidator : IVerifiablePresentationVal
     // ─────────────────────────── JWS verification ────────────────────────────────
 
     /// <summary>
-    /// Verify an ES256 JWS using a JWK. Returns true and the deserialised payload on success;
-    /// false otherwise. Only ES256 is supported in v1 (matches the citizen wallet's WebCrypto
-    /// non-extractable EC P-256 key).
+    /// Verify a compact JWS using a JWK, dispatching on the protected-header <c>alg</c>:
+    /// <c>ES256</c> over an EC P-256 (<c>kty:"EC"</c>) key, or <c>EdDSA</c> over an Ed25519
+    /// (<c>kty:"OKP"</c>, <c>crv:"Ed25519"</c>) key. Returns true and the deserialised payload
+    /// on success; false otherwise.
+    ///
+    /// <para>Both algorithms are needed because every key in the chain can be either curve:
+    /// the device/KB-JWT key is always WebCrypto P-256, but the holder key (delegation signer)
+    /// and the issuer key derive from the underlying wallet algorithm — and the default Sorcha
+    /// wallet is Ed25519. An ES256-only verifier rejected every Ed25519-holder presentation with
+    /// "signature verification failed against holder key" even though the chain was sound.</para>
     /// </summary>
     internal static bool VerifyJwsSignature(string compactJws, JsonElement publicJwk, out JsonElement payload)
     {
@@ -562,30 +578,17 @@ public sealed class VerifiablePresentationValidator : IVerifiablePresentationVal
             var header = JsonSerializer.Deserialize<JsonElement>(headerBytes);
             var alg = header.TryGetProperty("alg", out var a) && a.ValueKind == JsonValueKind.String
                 ? a.GetString() : null;
-            if (!string.Equals(alg, "ES256", StringComparison.Ordinal)) return false;
-
-            // Reconstruct the EC public key from the JWK
-            var x = publicJwk.GetProperty("x").GetString();
-            var y = publicJwk.GetProperty("y").GetString();
-            if (x is null || y is null) return false;
-
-            using var ecdsa = ECDsa.Create(new ECParameters
-            {
-                Curve = ECCurve.NamedCurves.nistP256,
-                Q = new ECPoint
-                {
-                    X = Base64Url.DecodeFromChars(x),
-                    Y = Base64Url.DecodeFromChars(y),
-                },
-            });
 
             var signingInput = Encoding.ASCII.GetBytes($"{parts[0]}.{parts[1]}");
             var signature = Base64Url.DecodeFromChars(parts[2]);
 
-            if (!ecdsa.VerifyData(signingInput, signature, HashAlgorithmName.SHA256))
+            bool verified = alg switch
             {
-                return false;
-            }
+                "ES256" => VerifyEs256(publicJwk, signingInput, signature),
+                "EdDSA" => VerifyEdDsa(publicJwk, signingInput, signature),
+                _ => false,
+            };
+            if (!verified) return false;
 
             var payloadBytes = Base64Url.DecodeFromChars(parts[1]);
             payload = JsonSerializer.Deserialize<JsonElement>(payloadBytes);
@@ -595,6 +598,69 @@ public sealed class VerifiablePresentationValidator : IVerifiablePresentationVal
         {
             return false;
         }
+    }
+
+    /// <summary>Verify an ES256 (ECDSA P-256, SHA-256) JWS against an EC JWK.</summary>
+    private static bool VerifyEs256(JsonElement publicJwk, byte[] signingInput, byte[] signature)
+    {
+        var x = publicJwk.TryGetProperty("x", out var xe) ? xe.GetString() : null;
+        var y = publicJwk.TryGetProperty("y", out var ye) ? ye.GetString() : null;
+        if (x is null || y is null) return false;
+
+        using var ecdsa = ECDsa.Create(new ECParameters
+        {
+            Curve = ECCurve.NamedCurves.nistP256,
+            Q = new ECPoint
+            {
+                X = Base64Url.DecodeFromChars(x),
+                Y = Base64Url.DecodeFromChars(y),
+            },
+        });
+        return ecdsa.VerifyData(signingInput, signature, HashAlgorithmName.SHA256);
+    }
+
+    /// <summary>
+    /// Verify an EdDSA (Ed25519) JWS against an OKP JWK. The JOSE EdDSA signature is the raw
+    /// 64-byte Ed25519 signature and the JWK <c>x</c> is the raw 32-byte public key — exactly
+    /// what BouncyCastle's pure-managed <see cref="Ed25519Signer"/> consumes (WASM-safe; no
+    /// libsodium P/Invoke).
+    /// </summary>
+    private static bool VerifyEdDsa(JsonElement publicJwk, byte[] signingInput, byte[] signature)
+    {
+        var crv = publicJwk.TryGetProperty("crv", out var ce) ? ce.GetString() : null;
+        if (!string.Equals(crv, "Ed25519", StringComparison.Ordinal)) return false;
+        var x = publicJwk.TryGetProperty("x", out var xe) ? xe.GetString() : null;
+        if (x is null) return false;
+
+        var publicKey = Base64Url.DecodeFromChars(x);
+        if (publicKey.Length != Ed25519PublicKeyParameters.KeySize) return false;
+
+        var verifier = new Ed25519Signer();
+        verifier.Init(forSigning: false, new Ed25519PublicKeyParameters(publicKey, 0));
+        verifier.BlockUpdate(signingInput, 0, signingInput.Length);
+        return verifier.VerifySignature(signature);
+    }
+
+    /// <summary>Reads the protected-header <c>alg</c> from a compact JWS; null if unavailable.</summary>
+    private static string? HeaderAlg(string jwt)
+        => TryParseJwtHeader(jwt) is { } h ? TryGetString(h, "alg") : null;
+
+    /// <summary>
+    /// Summarise a public JWK as a compact "kty/crv" label for the verdict-trail Detail. Tolerates
+    /// both EC (P-256) and OKP (Ed25519); returns null members it cannot read rather than throwing —
+    /// the verdict trail must never break verification.
+    /// </summary>
+    private static string? DescribeJwk(JsonElement jwk)
+    {
+        if (jwk.ValueKind != JsonValueKind.Object) return null;
+        var kty = jwk.TryGetProperty("kty", out var k) ? k.GetString() : null;
+        var crv = jwk.TryGetProperty("crv", out var c) ? c.GetString() : null;
+        return (kty, crv) switch
+        {
+            (null, null) => null,
+            (_, null) => kty,
+            _ => $"{kty} / {crv}",
+        };
     }
 }
 
@@ -637,6 +703,9 @@ internal sealed class LayerState
     public string? KbAudience;
     public string? KbJwtAlg;
     public double? KbJwtAgeSeconds;
+    public string? HolderKey;     // credential cnf.jwk "kty / crv" (e.g. "OKP / Ed25519")
+    public string? DelegationAlg; // device-delegation JWS header alg (e.g. "EdDSA")
+    public string? DeviceKey;     // delegation cnf.jwk "kty / crv" (always "EC / P-256" today)
 
     // IssuerSignature
     public IssuerLayer IssuerSignature = IssuerLayer.NotChecked;
@@ -676,6 +745,15 @@ internal sealed class LayerState
                 kbJwtNote += $" · age {age:0}s";
             }
             detail["kb-jwt"] = kbJwtNote;
+            // Surface the holder/device key curves + the delegation algorithm. The holder key curve is
+            // the diagnostic that explains Ed25519-vs-P-256 behaviour (the default Sorcha wallet is
+            // Ed25519, so its credential cnf.jwk is OKP / Ed25519 and the delegation is EdDSA-signed).
+            if (!string.IsNullOrEmpty(HolderKey)) detail["holder-key"] = HolderKey;
+            if (!string.IsNullOrEmpty(DelegationAlg) || !string.IsNullOrEmpty(DeviceKey))
+            {
+                detail["delegation"] =
+                    $"{DelegationAlg ?? "?"} · device key {DeviceKey ?? "?"}";
+            }
 
             layers.Add(new ValidationLayerResult
             {

--- a/src/Services/Sorcha.Wallet.Service/Services/Implementation/DeviceDelegationIssuer.cs
+++ b/src/Services/Sorcha.Wallet.Service/Services/Implementation/DeviceDelegationIssuer.cs
@@ -95,20 +95,42 @@ public sealed class DeviceDelegationIssuer : IDeviceDelegationIssuer
             }
         };
 
+        // Sign first so the header advertises the holder key's *real* JOSE algorithm. The holder
+        // key derives from the underlying wallet algorithm — Ed25519 for the default Sorcha wallet,
+        // EC P-256 for a P-256 wallet — so a hardcoded "ES256" header over an Ed25519 signature is
+        // unverifiable by any conformant verifier. Two-pass: build header with a placeholder alg to
+        // get the signing input, but the alg is known from SignAsync's return, so we sign over the
+        // honest header in one pass below.
+        var payloadJson = JsonSerializer.SerializeToUtf8Bytes(payload);
+        var payloadB64 = Base64Url.EncodeToString(payloadJson);
+
+        // We need the JOSE alg before computing the signing input, but the holder algorithm is a
+        // property of the key, not the signature — resolve it via the public JWK's key type so the
+        // signed header is correct on the first and only pass.
+        var joseAlg = ResolveJoseAlg(holderJwk);
         var header = new
         {
-            alg = "ES256",
+            alg = joseAlg,
             typ = "vc+sd-jwt",
             kid = $"did:sorcha:holder:{holderThumbprint}#0"
         };
-
         var headerJson = JsonSerializer.SerializeToUtf8Bytes(header);
-        var payloadJson = JsonSerializer.SerializeToUtf8Bytes(payload);
         var headerB64 = Base64Url.EncodeToString(headerJson);
-        var payloadB64 = Base64Url.EncodeToString(payloadJson);
         var signingInput = Encoding.ASCII.GetBytes($"{headerB64}.{payloadB64}");
 
-        var (signature, _) = await _holderKeys.SignAsync(citizenWalletAddress, signingInput, ct);
+        var (signature, signingAlg) = await _holderKeys.SignAsync(citizenWalletAddress, signingInput, ct);
+
+        // Defence in depth: the header alg derived from the JWK must agree with the algorithm the
+        // signer actually used. A mismatch means the holder key material and JWK have diverged —
+        // fail closed rather than emit a credential whose header lies about its own signature.
+        var signerJoseAlg = ToJoseAlg(signingAlg);
+        if (!string.Equals(joseAlg, signerJoseAlg, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"Holder JWK advertises '{joseAlg}' but the signer used '{signerJoseAlg}' " +
+                $"(wallet {citizenWalletAddress}); refusing to issue a delegation with a mismatched alg header.");
+        }
+
         var compactJwt = $"{headerB64}.{payloadB64}.{Base64Url.EncodeToString(signature)}";
 
         _logger.LogInformation(
@@ -126,6 +148,34 @@ public sealed class DeviceDelegationIssuer : IDeviceDelegationIssuer
             listId,
             holderJwk);
     }
+
+    /// <summary>
+    /// Resolves the JOSE <c>alg</c> for a delegation header from the holder public JWK's key type:
+    /// <c>OKP</c>/<c>Ed25519</c> → <c>EdDSA</c>, <c>EC</c>/<c>P-256</c> → <c>ES256</c>. The header alg
+    /// must match the curve the holder key signs with so the verifier picks the right primitive.
+    /// </summary>
+    private static string ResolveJoseAlg(JsonElement holderJwk)
+    {
+        var kty = holderJwk.TryGetProperty("kty", out var k) ? k.GetString() : null;
+        var crv = holderJwk.TryGetProperty("crv", out var c) ? c.GetString() : null;
+        return (kty, crv) switch
+        {
+            ("OKP", "Ed25519") => "EdDSA",
+            ("EC", "P-256") => "ES256",
+            _ => throw new NotSupportedException(
+                $"Unsupported holder key type for delegation issuance: kty='{kty}', crv='{crv}'. " +
+                "Only Ed25519 (OKP) and P-256 (EC) holder keys are supported.")
+        };
+    }
+
+    /// <summary>Maps an <see cref="IHolderKeyService"/> algorithm string to its JOSE <c>alg</c> name.</summary>
+    private static string ToJoseAlg(string algorithm) => algorithm.ToUpperInvariant() switch
+    {
+        "ED25519" or "EDDSA" => "EdDSA",
+        "ES256" or "P-256" or "P256" or "NIST-P256" or "NISTP256" or "ECDSA-P256" => "ES256",
+        _ => throw new NotSupportedException(
+            $"Unsupported holder signing algorithm for delegation issuance: '{algorithm}'.")
+    };
 
     /// <summary>
     /// RFC 7638 thumbprint over an EC P-256 JWK. Required members in lex order:

--- a/tests/Sorcha.Verifier.Tests/Services/Ed25519HolderDelegationTests.cs
+++ b/tests/Sorcha.Verifier.Tests/Services/Ed25519HolderDelegationTests.cs
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Sorcha.Verifier.Engine;
+using Sorcha.Verifier.Engine.Models;
+using Xunit;
+
+namespace Sorcha.Verifier.Tests.Services;
+
+/// <summary>
+/// Regression tests for the citizen-wallet holder→device delegation chain when the
+/// holder key is <b>Ed25519</b> (the default Sorcha wallet algorithm).
+///
+/// <para>Before this fix the verifier's JWS check was ES256/EC-only, so an Ed25519
+/// holder key (OKP <c>cnf.jwk</c>, EdDSA-signed delegation) failed with
+/// "Delegation credential signature verification failed against holder key." — even
+/// though the chain was cryptographically sound. These tests pin both algorithms.</para>
+/// </summary>
+public sealed class Ed25519HolderDelegationTests
+{
+    private const string Vct = "https://sorcha.dev/vc/test/v1";
+    private const string Nonce = "verifier-nonce-abc";
+    private const string ClientId = "did:sorcha:verifier:00000000000000000000000000000001";
+
+    private readonly Mock<IStatusListCache> _statusList = new();
+    private readonly VerifiablePresentationValidator _validator;
+
+    public Ed25519HolderDelegationTests()
+    {
+        _statusList
+            .Setup(s => s.CheckAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(StatusListVerdict.Active);
+        _validator = new VerifiablePresentationValidator(
+            _statusList.Object, TimeProvider.System,
+            NullLogger<VerifiablePresentationValidator>.Instance);
+    }
+
+    private static VerifierSession Session() => new()
+    {
+        SessionId = "sess-ed25519",
+        ClientId = ClientId,
+        Nonce = Nonce,
+        RequiredVct = Vct,
+        RequiredClaims = ["givenName"],
+        OptionalClaims = [],
+        Purpose = "test",
+        CreatedAt = DateTimeOffset.UtcNow,
+        ExpiresAt = DateTimeOffset.UtcNow.AddMinutes(5),
+    };
+
+    private static Dictionary<string, System.Text.Json.JsonElement> Claims(params (string Name, string Value)[] pairs)
+    {
+        var d = new Dictionary<string, System.Text.Json.JsonElement>();
+        foreach (var (n, v) in pairs)
+            d[n] = System.Text.Json.JsonSerializer.SerializeToElement(v);
+        return d;
+    }
+
+    [Fact]
+    public async Task ValidateAsync_Ed25519HolderKey_AcceptsDelegationChain()
+    {
+        var bundle = TestVpFactory.MintEd25519Holder(
+            Vct, Claims(("givenName", "Stuart")), ClientId, Nonce);
+
+        var outcome = await _validator.ValidateAsync(Session(), bundle.VpToken, bundle.Delegation);
+
+        outcome.Accepted.Should().BeTrue(string.Join(", ", outcome.Errors));
+        outcome.DisclosedClaims.Should().ContainKey("givenName");
+    }
+
+    [Fact]
+    public async Task ValidateAsync_Ed25519HolderKey_LivePresentationLayerReportsOkpAndEdDsa()
+    {
+        // The Feature 155 verdict trail (rendered by the Open Verifier PWA) must surface the holder
+        // key's curve and the delegation algorithm, so an operator can see the Ed25519 (OKP) holder key
+        // that explains the curve-specific behaviour — without browser dev tools.
+        var bundle = TestVpFactory.MintEd25519Holder(
+            Vct, Claims(("givenName", "Stuart")), ClientId, Nonce);
+
+        var outcome = await _validator.ValidateAsync(Session(), bundle.VpToken, bundle.Delegation);
+
+        outcome.Accepted.Should().BeTrue(string.Join(", ", outcome.Errors));
+        var live = outcome.Layers.Should().ContainSingle(l => l.Layer == ValidationLayer.LivePresentation).Subject;
+        live.Status.Should().Be(LayerStatus.Pass);
+        live.Detail.Should().ContainKey("holder-key").WhoseValue.Should().Be("OKP / Ed25519");
+        live.Detail.Should().ContainKey("delegation").WhoseValue.Should().Contain("EdDSA");
+        live.Detail["delegation"].Should().Contain("EC / P-256"); // device key stays P-256
+    }
+}

--- a/tests/Sorcha.Verifier.Tests/Services/TestVpFactory.cs
+++ b/tests/Sorcha.Verifier.Tests/Services/TestVpFactory.cs
@@ -8,6 +8,10 @@ using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
+using Org.BouncyCastle.Crypto.Generators;
+using Org.BouncyCastle.Crypto.Parameters;
+using Org.BouncyCastle.Crypto.Signers;
+using Org.BouncyCastle.Security;
 
 namespace Sorcha.Verifier.Tests.Services;
 
@@ -126,6 +130,144 @@ internal static class TestVpFactory
         var vpToken = $"{credentialJwt}{disclosureSegments}~{kbJwt}";
 
         return new Bundle(vpToken, delegation, issuer, holder, device, statusListUri, statusListIndex);
+    }
+
+    /// <summary>
+    /// As <see cref="Mint"/>, but the holder key is an <b>Ed25519</b> (OKP) key — the default
+    /// Sorcha wallet algorithm. The credential's <c>cnf.jwk</c> is therefore an OKP JWK and the
+    /// device delegation credential is signed by the holder with an honest <c>alg:"EdDSA"</c>
+    /// header. The issuer and device keys stay EC P-256 (issuers vary; the device key is always
+    /// a WebCrypto non-extractable P-256 key). Mirrors the real on-the-wire shape an Ed25519
+    /// citizen wallet produces.
+    /// </summary>
+    public static Ed25519Bundle MintEd25519Holder(
+        string vct,
+        Dictionary<string, JsonElement> disclosedClaims,
+        string verifierClientId,
+        string verifierNonce,
+        DateTimeOffset? delegationExpiresAt = null,
+        string statusListUri = "https://verify.test/status/00000000000000000000000000000000/citizen-devices/0.statuslist+jwt",
+        int statusListIndex = 7)
+    {
+        var issuer = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        var device = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+
+        var holder = new Ed25519KeyPairGenerator();
+        holder.Init(new Ed25519KeyGenerationParameters(new SecureRandom()));
+        var holderPair = holder.GenerateKeyPair();
+        var holderPriv = (Ed25519PrivateKeyParameters)holderPair.Private;
+        var holderPub = (Ed25519PublicKeyParameters)holderPair.Public;
+
+        var holderJwk = ToOkpJwk(holderPub);
+        var deviceJwk = ToJwk(device);
+        var holderThumbprint = ThumbprintOkp(holderJwk);
+        var deviceThumbprint = Thumbprint(deviceJwk);
+
+        var disclosures = new List<string>();
+        var sdHashes = new List<string>();
+        foreach (var (name, value) in disclosedClaims)
+        {
+            var (segment, hash) = MintDisclosure(name, value);
+            disclosures.Add(segment);
+            sdHashes.Add(hash);
+        }
+
+        var credentialPayload = new Dictionary<string, object>
+        {
+            ["iss"] = "did:sorcha:org:test",
+            ["iat"] = DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
+            ["vct"] = vct,
+            ["_sd"] = sdHashes,
+            ["_sd_alg"] = "sha-256",
+            ["cnf"] = new Dictionary<string, object> { ["jwk"] = JsonDocument.Parse(holderJwk).RootElement },
+        };
+        var credentialJwt = SignEs256(
+            new Dictionary<string, object> { ["alg"] = "ES256", ["typ"] = "vc+sd-jwt" },
+            credentialPayload, issuer);
+
+        var exp = (delegationExpiresAt ?? DateTimeOffset.UtcNow.AddDays(365)).ToUnixTimeSeconds();
+        var delegationPayload = new Dictionary<string, object>
+        {
+            ["iss"] = $"did:sorcha:holder:{holderThumbprint}",
+            ["sub"] = $"did:sorcha:device:{deviceThumbprint}",
+            ["iat"] = DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
+            ["exp"] = exp,
+            ["vct"] = "https://sorcha.dev/vc/citizen-device-delegation/v1",
+            ["delegated_capabilities"] = new[] { "presentation.holder-key-binding" },
+            ["cnf"] = new Dictionary<string, object> { ["jwk"] = JsonDocument.Parse(deviceJwk).RootElement },
+            ["status"] = new Dictionary<string, object>
+            {
+                ["status_list"] = new Dictionary<string, object>
+                {
+                    ["uri"] = statusListUri,
+                    ["idx"] = statusListIndex,
+                },
+            },
+        };
+        // Honest EdDSA header — the holder key is Ed25519, so the delegation JWS is an EdDSA signature.
+        var delegation = SignEdDsa(
+            new Dictionary<string, object> { ["alg"] = "EdDSA", ["typ"] = "vc+sd-jwt" },
+            delegationPayload, holderPriv);
+
+        var kbHeader = new Dictionary<string, object>
+        {
+            ["alg"] = "ES256",
+            ["typ"] = "kb+jwt",
+            ["kid"] = deviceThumbprint,
+        };
+        var kbPayload = new Dictionary<string, object>
+        {
+            ["iat"] = DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
+            ["exp"] = DateTimeOffset.UtcNow.AddSeconds(120).ToUnixTimeSeconds(),
+            ["aud"] = verifierClientId,
+            ["nonce"] = verifierNonce,
+            ["sd_hash"] = "placeholder",
+        };
+        var kbJwt = SignEs256(kbHeader, kbPayload, device);
+
+        var disclosureSegments = string.Concat(disclosures.Select(d => "~" + d));
+        var vpToken = $"{credentialJwt}{disclosureSegments}~{kbJwt}";
+
+        return new Ed25519Bundle(vpToken, delegation, issuer, statusListUri, statusListIndex);
+    }
+
+    public sealed record Ed25519Bundle(
+        string VpToken,
+        string Delegation,
+        ECDsa IssuerKey,
+        string StatusListUri,
+        int StatusListIndex);
+
+    public static string SignEdDsa(Dictionary<string, object> header, Dictionary<string, object> payload, Ed25519PrivateKeyParameters signer)
+    {
+        var headerSeg = Base64Url.EncodeToString(JsonSerializer.SerializeToUtf8Bytes(header));
+        var payloadSeg = Base64Url.EncodeToString(JsonSerializer.SerializeToUtf8Bytes(payload));
+        var signingInput = Encoding.ASCII.GetBytes($"{headerSeg}.{payloadSeg}");
+        var ed = new Ed25519Signer();
+        ed.Init(true, signer);
+        ed.BlockUpdate(signingInput, 0, signingInput.Length);
+        var sig = ed.GenerateSignature();
+        return $"{headerSeg}.{payloadSeg}.{Base64Url.EncodeToString(sig)}";
+    }
+
+    public static string ToOkpJwk(Ed25519PublicKeyParameters pub) =>
+        JsonSerializer.Serialize(new
+        {
+            kty = "OKP",
+            crv = "Ed25519",
+            x = Base64Url.EncodeToString(pub.GetEncoded()),
+        });
+
+    private static string ThumbprintOkp(string jwkJson)
+    {
+        using var doc = JsonDocument.Parse(jwkJson);
+        var root = doc.RootElement;
+        var canonical =
+            $"{{\"crv\":\"{root.GetProperty("crv").GetString()}\"," +
+            $"\"kty\":\"{root.GetProperty("kty").GetString()}\"," +
+            $"\"x\":\"{root.GetProperty("x").GetString()}\"}}";
+        var hash = SHA256.HashData(Encoding.UTF8.GetBytes(canonical));
+        return Base64Url.EncodeToString(hash);
     }
 
     /// <summary>Mint a single SD-JWT disclosure segment for a name/value pair, returning (segment, sha256-hash).</summary>

--- a/tests/Sorcha.Verifier.Tests/Sorcha.Verifier.Tests.csproj
+++ b/tests/Sorcha.Verifier.Tests/Sorcha.Verifier.Tests.csproj
@@ -20,6 +20,7 @@
     </PackageReference>
     <PackageReference Include="Moq" />
     <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="BouncyCastle.Cryptography" />
   </ItemGroup>
 
 </Project>

--- a/tests/Sorcha.Wallet.Service.Tests/Services/DeviceDelegationIssuerTests.cs
+++ b/tests/Sorcha.Wallet.Service.Tests/Services/DeviceDelegationIssuerTests.cs
@@ -111,6 +111,39 @@ public sealed class DeviceDelegationIssuerTests
     }
 
     [Fact]
+    public async Task IssueAsync_Ed25519Holder_HeaderAlgIsEdDsa()
+    {
+        // The default Sorcha wallet is Ed25519, so the citizen-holder key (and therefore the
+        // delegation signature) is EdDSA. The JWS header MUST advertise the real algorithm — a
+        // hardcoded "ES256" over an Ed25519 signature is unverifiable by any conformant verifier.
+        var holderKeys = new Mock<IHolderKeyService>();
+        var okpJwk = JsonSerializer.SerializeToElement(new
+        {
+            kty = "OKP",
+            crv = "Ed25519",
+            x = Base64Url.EncodeToString(new byte[32])
+        });
+        holderKeys.Setup(s => s.GetHolderPublicJwkAsync(CitizenWallet, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(okpJwk);
+        holderKeys.Setup(s => s.GetHolderJwkThumbprintAsync(CitizenWallet, It.IsAny<CancellationToken>()))
+            .ReturnsAsync("holder-thumb-okp");
+        holderKeys.Setup(s => s.SignAsync(CitizenWallet, It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string _, byte[] _, CancellationToken _) => (new byte[64], "ED25519"));
+
+        var issuer = new DeviceDelegationIssuer(
+            holderKeys.Object, _statusList.Object, Mock.Of<ILogger<DeviceDelegationIssuer>>());
+
+        var result = await issuer.IssueAsync(
+            PlatformUserId, CitizenWallet, OrgId, OrgWallet,
+            MakeDeviceJwk(), "Stuart's iPhone 16", "iOS 19 / Safari 19");
+
+        var header = JsonDocument.Parse(Decode(result.CompactJwt.Split('.')[0])).RootElement;
+        header.GetProperty("alg").GetString().Should().Be("EdDSA");
+        header.GetProperty("typ").GetString().Should().Be("vc+sd-jwt");
+        header.GetProperty("kid").GetString().Should().StartWith("did:sorcha:holder:");
+    }
+
+    [Fact]
     public async Task IssueAsync_PayloadShapesMatchSchema()
     {
         var result = await IssueAsync();


### PR DESCRIPTION
## Problem

Presenting a credential from a default (Ed25519) wallet failed verification with:

> Delegation credential signature verification failed against holder key.

The citizen presentation chain is **curve-mixed**: the device/KB-JWT key is always EC P-256, but the **holder** key (which signs the device delegation and is the credential's `cnf.jwk`) and the **issuer** key derive from the underlying wallet algorithm — and the default Sorcha wallet is **Ed25519**. The verifier's JWS check was ES256/EC-only, so it rejected every Ed25519-holder presentation even though the chain was cryptographically sound. `DeviceDelegationIssuer` compounded it by hardcoding `alg=ES256` in the delegation header over an actual Ed25519 signature.

## Fix

- **`VerifiablePresentationValidator.VerifyJwsSignature`** now dispatches on the JWS header `alg` and verifies **both** `ES256` (EC, `ECDsa`) and `EdDSA` (Ed25519/OKP, via **BouncyCastle** — pure-managed, WASM-safe). Also fixes issuer-side Ed25519 verification (org VC-issuance keys are frequently Ed25519).
- **`DeviceDelegationIssuer`** emits the **honest** header `alg` from the holder key type (`EdDSA` for Ed25519) instead of a hardcoded `ES256`, with a fail-closed guard if the JWK and signer algorithm ever disagree.

## Diagnostic (folded into the F155 verdict trail)

Rather than a parallel "show your working" structure, the decoded key facts ride **Feature 155's `VerificationOutcome.Layers`**: the `LivePresentation` layer `Detail` now carries `holder-key` (`"OKP / Ed25519"` | `"EC / P-256"`) and `delegation` (`"{alg} · device key {kty/crv}"`). The **Open Verifier PWA** renders each layer's `Detail` generically (`Outcome.razor`), so an operator reads `holder-key  OKP / Ed25519` in the "Live presentation" panel with no dev tools — **no new UI code**.

## Deferred

`DeviceEnrolmentResponse.HolderPublicJwk` still coerces an Ed25519 holder JWK to a `Y=""` P-256 shape — an unused verifier-convenience field, not on the failure path. Documented in the verifiable-credentials skill.

## Tests
- `Sorcha.Verifier.Tests` — **61/61** (new: Ed25519 holder chain accepts; `LivePresentation` layer reports `OKP / Ed25519` + `EdDSA`)
- `Sorcha.Wallet.Service.Tests` — **844/844** (new: delegation header is `EdDSA` for an Ed25519 holder; existing P-256 `ES256` test unchanged)
- Full solution build: **0 errors**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
