### PR TITLE
fix(register): seal canonical contentHash on system-blueprint publish (SSR provenance)

### DIFF
--- a/.specify/MASTER-TASKS.md
+++ b/.specify/MASTER-TASKS.md
@@ -77,6 +77,7 @@ This document now tracks **remaining work for the first production release**, or
 | OPS-008 | Log aggregation and structured logging review | P2 | 8h | 📋 | Serilog configured; central aggregation needed |
 | OPS-009 | CI/CD pipeline hardening (release tags, changelog, artifact signing) | P2 | 8h | 📋 | PR/merge CI works; release workflow incomplete |
 | OPS-010 | Documentation & API Portal — OpenAPI enrichment, admin/onboarding guides | P1 | 16h | ✅ | Config-gated `/openapi` route, `/admin/dashboard` proxy, 132 endpoints enriched with `.Produces<T>()`, 11 admin/onboarding docs |
+| OPS-011 | Read-through durability for the published-blueprint store | P2 | 12h | 📋 | `IPublishedBlueprintStore` is `InMemoryPublishedBlueprintStore` (Program.cs:96) — empty after any blueprint-service restart, repopulated solely by `BlueprintRecoveryService` reading the registers (the register/Mongo is the durable source). Works today (recovery is reliable), but recovery is a single point of repopulation: a register offline at boot or a future provenance gap silently strands blueprints until re-publish. **Make it a read-through cache** (in-memory hot tier backed by Redis or a re-read of the register on miss) — NOT a pure-Redis replacement (that taxes every blueprint read on the workflow hot path). Becomes worthwhile when blueprint-service scales to multiple replicas (avoid N independent recoveries + faster cold start). Surfaced 2026-06-18 during the SSR-provenance fix (B-strong); see [[1017-verify-ed25519-fix]] sibling discussion. |
 
 ---
 

--- a/src/Services/Sorcha.Register.Service/Services/SystemRegisterService.cs
+++ b/src/Services/Sorcha.Register.Service/Services/SystemRegisterService.cs
@@ -9,6 +9,7 @@ using Sorcha.Register.Core.Managers;
 using Sorcha.Register.Models;
 using Sorcha.Register.Models.Constants;
 using Sorcha.Register.Models.Enums;
+using Sorcha.ServiceClients.Register;
 using Sorcha.ServiceClients.SystemWallet;
 using Sorcha.ServiceClients.Validator;
 
@@ -269,7 +270,13 @@ public class SystemRegisterService
             ["transactionType"] = BlueprintPublishTransactionType,
             ["BlueprintId"] = blueprintId,
             ["publishedBy"] = publishedBy,
-            ["SystemWalletAddress"] = signResult.WalletAddress
+            ["SystemWalletAddress"] = signResult.WalletAddress,
+            // Feature 138 US4 — seal the canonical content hash the BlueprintRecoveryService recomputes
+            // and compares on recovery. The normal (user) publish path writes this; without it here the
+            // seeded system blueprints fail provenance ("no_provenance") on every restart and never
+            // re-enter the (in-memory) published store. Use the shared helper so producer and consumer
+            // hash the identical canonical form by construction.
+            ["contentHash"] = BlueprintContentHash.Compute(canonicalJson)
         };
 
         // Merge additional metadata if provided

--- a/tests/Sorcha.Register.Service.Tests/Unit/SystemRegisterBlueprintTests.cs
+++ b/tests/Sorcha.Register.Service.Tests/Unit/SystemRegisterBlueprintTests.cs
@@ -266,6 +266,52 @@ public class SystemRegisterBlueprintTests
     }
 
     [Fact]
+    public async Task PublishBlueprintAsync_SealsCanonicalContentHash_SoRecoveryProvenancePasses()
+    {
+        // Feature 138 US4 / SSR provenance: a seeded system blueprint MUST carry the same canonical
+        // contentHash in its control-tx TrackingData that the normal publish path seals. Without it,
+        // BlueprintRecoveryService rejects the blueprint with "no_provenance" on every restart, so the
+        // genesis system blueprints never re-enter the published store (the in-memory store is empty
+        // after a restart and recovery is its only repopulation path).
+        const string blueprintStr = """{"title":"Register Creation","actions":[]}""";
+        var blueprintJson = JsonSerializer.Deserialize<JsonElement>(blueprintStr);
+        var expectedContentHash = Sorcha.ServiceClients.Register.BlueprintContentHash.Compute(blueprintStr);
+
+        _mockSigningService
+            .Setup(s => s.SignAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SystemSignResult
+            {
+                Signature = new byte[64],
+                PublicKey = new byte[32],
+                Algorithm = "ED25519",
+                WalletAddress = "system-wallet-addr"
+            });
+
+        TransactionSubmission? captured = null;
+        _mockValidatorClient
+            .Setup(v => v.SubmitTransactionAsync(It.IsAny<TransactionSubmission>(), It.IsAny<CancellationToken>()))
+            .Callback<TransactionSubmission, CancellationToken>((s, _) => captured = s)
+            .ReturnsAsync(new TransactionSubmissionResult
+            {
+                Success = true,
+                TransactionId = "test-tx-id",
+                RegisterId = SystemRegisterConstants.SystemRegisterId
+            });
+
+        await _service.PublishBlueprintAsync(
+            "register-creation-v1", blueprintJson, "system",
+            new Dictionary<string, string> { ["seedReason"] = "bootstrap" });
+
+        captured.Should().NotBeNull();
+        captured!.Metadata.Should().ContainKey("contentHash");
+        captured.Metadata["contentHash"].Should().Be(
+            expectedContentHash,
+            "the recovery path recomputes BlueprintContentHash.Compute and compares against this value");
+    }
+
+    [Fact]
     public async Task PublishBlueprintAsync_ValidatorRejects_ThrowsInvalidOperation()
     {
         // Arrange


### PR DESCRIPTION
## Problem

`BlueprintRecoveryService` (Feature 138 US4) rejects any recovered blueprint whose sealed `contentHash` is empty — `no_provenance`, fail-closed. The **normal** user publish path writes `TrackingData["contentHash"]` (register-service `Program.cs:1963`), but the **system seed path** (`SystemRegisterService.PublishBlueprintAsync`) wrote only `seedReason`. So the genesis-seeded SSR governance blueprints (`register-creation-v1`, `register-governance-v1`, `create-organisation-v1`, `join-private-register-v1`) are rejected on every restart and never re-enter the (in-memory) published store.

This is the real mechanism behind the long-standing **"blueprint cache cold after restart"** note — which claimed `BlueprintRecoveryService fails with Unauthorized`. That was **stale**: there is no auth failure. User/workflow blueprints recover fine (they carry a `contentHash`); only the hashless genesis system blueprints were rejected — and those are **benign** (seeded into + consumed from the SSR by register-service/validator-service, not executed via the blueprint-service store). Verified live: a full AssuredIdentity Phase 1 ran on a freshly-restarted n1 with **no manual re-publish**.

## Fix (B-strong)

Seal the canonical content hash at the system-blueprint publish chokepoint:

```csharp
["contentHash"] = BlueprintContentHash.Compute(canonicalJson)
```

Using the **same shared helper** `BlueprintRecoveryService` recomputes, so producer and consumer hash the identical canonical form *by construction* (no reliance on two SHA-256 paths agreeing). Covers both the bootstrapper seed and the `POST /api/system-register/blueprints` endpoint.

**Scope note:** takes effect on the **next fresh SSR bootstrap**. A standing node (e.g. current n1) keeps the benign provenance noise until a re-genesis — acceptable, since it isn't a functional break.

## Why not the alternatives
- **A (seal at genesis):** same idea, but the system blueprints are published post-genesis by the bootstrapper, so sealing here *is* the right seam — no genesis-format change.
- **B-origin (trust SSR by embedded root, skip the check):** principled (the genesis-rooted ledger seal is the real provenance) but special-cases the trust boundary. B-strong keeps the *identical* provenance check for everyone.
- **Durable store (read-through):** the actual fragility (in-memory store, recovery is sole repopulation path) — tracked separately as **MASTER-TASKS OPS-011**, deliberately not pure-Redis (that taxes every blueprint read on the workflow hot path).

## Tests
- `Sorcha.Register.Service.Tests` — **317 pass** (new `PublishBlueprintAsync_SealsCanonicalContentHash_SoRecoveryProvenancePasses`, watched fail-first for `no contentHash key`)
- Full solution build: **0 errors**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
