### PR TITLE
feat(mobile): prestage iOS + Play store lanes (gated on dev accounts)

### DIFF
--- a/.claude/skills/sorcha-app/references/finishing-accounts.md
+++ b/.claude/skills/sorcha-app/references/finishing-accounts.md
@@ -1,0 +1,61 @@
+# Finishing the store lanes once the developer accounts exist
+
+Everything is prestaged. When the accounts are active, the only work is: register a couple of
+identifiers, create the credentials, **place them on the Mac under `~/.sorcha-signing`**, and run
+the lanes. The lanes already exist (`mobile/wallet/fastlane/Fastfile`) and fail loud with the exact
+missing-file path until the credentials are present.
+
+Secrets live ONLY on the Mac. Never copy them to Windows or the repo.
+
+## iOS (ios_adhoc / ios_beta)
+
+Prereq: Apple Developer Program active (Individual is fine).
+
+1. **Register the App ID** `app.sorcha.wallet` — https://developer.apple.com/account/resources/identifiers/list → +.
+2. **Register device UDIDs** (for ad-hoc installs) — https://developer.apple.com/account/resources/devices/list → +.
+3. **Create an App Store Connect API key** — https://appstoreconnect.apple.com/access/integrations/api → + (Access: App Manager).
+   Download the **`.p8` (once)**; note the **Key ID** and **Issuer ID**.
+4. **Create a private match repo**, e.g. `Sorcha-Platform/ios-certs` (empty private repo).
+5. **Place on the Mac:**
+   ```bash
+   mkdir -p ~/.sorcha-signing
+   mv ~/Downloads/AuthKey_XXXXXX.p8 ~/.sorcha-signing/asc_api_key.p8
+   printf '{"key_id":"XXXXXXXXXX","issuer_id":"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"}\n' > ~/.sorcha-signing/asc_api_key.json
+   chmod 600 ~/.sorcha-signing/asc_api_key.*
+   ```
+   And export the match repo + a chosen passphrase (add to ~/.zprofile so CI/login shells see them; passphrase also to your password manager):
+   ```bash
+   export MATCH_GIT_URL="git@github.com:Sorcha-Platform/ios-certs.git"   # or HTTPS
+   export MATCH_PASSWORD="<choose a strong passphrase>"
+   ```
+6. **Run** (I drive these): first `bundle exec fastlane match adhoc` (creates+stores certs), then
+   `ios_adhoc`; later `ios_beta` for TestFlight. Orchestrator: `trigger-build.ps1 -Lane ios_adhoc`.
+   - Note: first real run may need a small signing-settings tweak in the Xcode project (manual
+     signing + profile mapping) — expected; I'll finalize it then.
+
+## Android internal (android_internal)
+
+Prereq: Play Console account active + app record created.
+
+1. **Create the app** in Play Console → "Sorcha Wallet", and set up the **Internal testing** track + testers.
+2. **Enrol Play App Signing** (default); register the **upload key SHA-256** (in your password manager,
+   from `make-upload-keystore.sh`) when prompted.
+3. **Service account for CI:** Google Cloud Console → enable the Play Android Developer API
+   (https://console.cloud.google.com/apis/library/androidpublisher.googleapis.com) → create a service
+   account + JSON key (https://console.cloud.google.com/iam-admin/serviceaccounts). In Play Console →
+   Users and permissions → invite the service-account email → grant "Release to testing tracks".
+4. **Place on the Mac:**
+   ```bash
+   mv ~/Downloads/<service-account>.json ~/.sorcha-signing/play_service_account.json
+   chmod 600 ~/.sorcha-signing/play_service_account.json
+   ```
+5. **⚠️ Manual first upload:** build one AAB and upload it **by hand** in the Play UI once — the API
+   refuses automated uploads until a first manual AAB exists. Build it with:
+   `trigger-build.ps1 -Lane android_internal` will fail at the API upload the first time; instead use
+   the AAB it produced at `mobile/wallet/android/app/build/outputs/bundle/release/app-release.aab`
+   (or run gradle `bundle Release` directly) and upload that in the console. After that, `android_internal` automates.
+
+## Hand-off phrase
+Say **"I have the accounts"** and tell me which (Apple / Google / both) are active. I'll: confirm the
+credential files are in place (or tell you exactly what's missing), run `match`, then the lanes, fix
+any first-run signing wiring, and validate `mobile-pipeline` prestage PR before merging.

--- a/.claude/skills/sorcha-app/references/secrets-map.md
+++ b/.claude/skills/sorcha-app/references/secrets-map.md
@@ -11,15 +11,15 @@ build time on the Mac, so GitHub only ever sees workflow YAML and logs.
 | Upload keystore | `~/.sorcha-signing/sorcha-wallet-upload.jks` | RSA-2048, alias `sorcha-wallet-upload`, validity ~27y. Mode 600. |
 | Keystore credentials | `~/.sorcha-signing/keystore.properties` | `storeFile/storePassword/keyAlias/keyPassword`. Mode 600. Read by `app/build.gradle` (the committed signing block references this path; no secret in gradle). |
 | Password backup | Stuart's password manager | The store/key password + the keystore SHA-256. Generated once by `make-upload-keystore.sh`. Under Play App Signing the upload key is resettable. |
-| Play service-account JSON | `~/.sorcha-signing/` (TBD) | For `fastlane supply` (android_internal). **Not yet created** — needs Play account. |
+| Play service-account JSON | `~/.sorcha-signing/play_service_account.json` | For `fastlane supply` (android_internal). Create once Play account exists. |
 
 ## iOS (not yet — needs Apple Developer Program + Xcode 17)
 
 | Secret | Location (Mac) | Notes |
 |--------|----------------|-------|
-| App Store Connect API key | `~/.sorcha-signing/` (TBD `.p8`) | + Key ID + Issuer ID. Avoids 2FA in CI (pilot/match). |
-| Certs + provisioning profiles | `fastlane match` private git repo | Managed by `match`; decrypted into the Mac keychain at build time. **Repo not yet created.** |
-| Device UDIDs | match / ASC | For the ad-hoc profile. |
+| App Store Connect API key | `~/.sorcha-signing/asc_api_key.p8` + `asc_api_key.json` (`{key_id,issuer_id}`) | Avoids 2FA in CI (build_app/pilot/match). Create once Apple enrolment active. |
+| Certs + provisioning profiles | `fastlane match` private git repo (`MATCH_GIT_URL`), encrypted with `MATCH_PASSWORD` | Decrypted into the Mac keychain at build time. Repo + passphrase set at finish time. |
+| Device UDIDs | Apple dev portal (Devices) → match adhoc profile | For the `ios_adhoc` profile. |
 
 ## Service / infra credentials (Mac)
 

--- a/mobile/wallet/fastlane/Fastfile
+++ b/mobile/wallet/fastlane/Fastfile
@@ -1,59 +1,130 @@
 # Sorcha Wallet — fastlane lanes.
 #
-# The app is Blazor WASM wrapped by Capacitor, so every lane starts with the shared web
-# step (build-web.sh): dotnet publish -> www -> rewrite base href -> cap sync. These lanes
-# are headless-runnable and identical whether invoked by a human, a git tag, or CI.
+# The app is Blazor WASM wrapped by Capacitor 8, so every build lane starts with the shared
+# web step (build-web.sh): dotnet publish -> www -> rewrite base href -> cap sync. Lanes are
+# headless-runnable and identical whether invoked by a human, a git tag, or CI.
 #
-# Lanes are named to match the pipeline's intent->lane mapping:
-#   android_adhoc     signed release APK         (no store account needed)
-#   android_internal  AAB -> Play Internal track (needs Play account + service-account JSON)
-#   ios_adhoc         signed ad-hoc IPA          (needs Apple Dev Program + device UDIDs)
-#   ios_beta          IPA -> TestFlight          (needs Apple Dev Program + ASC API key)
-# Only android_adhoc is wired today; the rest are stubs that fail loud until accounts exist.
+#   android_adhoc     signed release APK         (no store account needed)        [PROVEN]
+#   android_internal  AAB -> Play Internal track (Play account + service-account) [prestaged]
+#   ios_adhoc         signed ad-hoc IPA          (Apple Dev Program + match)      [prestaged]
+#   ios_beta          IPA -> TestFlight          (Apple Dev Program + ASC key)    [prestaged]
+#
+# The iOS / android_internal lanes are wired but gated on credentials placed on THIS Mac under
+# ~/.sorcha-signing (see references/finishing-accounts.md in the sorcha-app skill). They fail
+# loud with the exact missing-file + instructions until those exist. Nothing secret is in here.
 
 opt_out_usage
 skip_docs
 
-# Anchor paths on the Fastfile's own dir (__dir__ = .../mobile/wallet/fastlane), which
-# fastlane sets reliably, so paths don't depend on the invocation cwd.
+# Anchor paths on the Fastfile's own dir (__dir__ = .../mobile/wallet/fastlane), set reliably
+# by fastlane, so paths don't depend on the invocation cwd.
 WALLET_DIR = File.expand_path("..", __dir__)          # .../mobile/wallet
 REPO_ROOT  = File.expand_path("../../..", __dir__)     # repo root
 WEB_STEP   = File.join(REPO_ROOT, "mobile", "scripts", "build-web.sh")
+SIGN_DIR   = File.join(ENV["HOME"], ".sorcha-signing") # Mac-only signing material
+
+# ---- shared helpers ------------------------------------------------------
 
 def web_build
   sh("bash", WEB_STEP)
 end
 
-desc "Signed ad-hoc release APK. web -> Capacitor -> gradle assembleRelease. No store account needed."
-lane :android_adhoc do
-  web_build
-  # Version is injected by CI (tag -> name, run number -> code). Falls back to the
-  # values baked into build.gradle for local/manual builds.
+# Version injected by CI (tag -> name, run number -> code); falls back to build.gradle values.
+def version_props
   props = {}
   props["sorchaVersionName"] = ENV["SORCHA_VERSION_NAME"] unless ENV["SORCHA_VERSION_NAME"].to_s.empty?
   props["sorchaVersionCode"] = ENV["SORCHA_VERSION_CODE"] unless ENV["SORCHA_VERSION_CODE"].to_s.empty?
+  props
+end
+
+# App Store Connect API key (Mac-only). Place:
+#   ~/.sorcha-signing/asc_api_key.p8           (downloaded once from App Store Connect)
+#   ~/.sorcha-signing/asc_api_key.json         {"key_id":"XXXX","issuer_id":"....."}
+def asc_api_key
+  require "json"
+  p8   = File.join(SIGN_DIR, "asc_api_key.p8")
+  meta = File.join(SIGN_DIR, "asc_api_key.json")
+  unless File.exist?(p8) && File.exist?(meta)
+    UI.user_error!("Missing App Store Connect API key. Put the .p8 at #{p8} and {\"key_id\",\"issuer_id\"} JSON at #{meta}. See the sorcha-app skill: references/finishing-accounts.md")
+  end
+  m = JSON.parse(File.read(meta))
+  app_store_connect_api_key(key_id: m["key_id"], issuer_id: m["issuer_id"], key_filepath: p8)
+end
+
+IOS_PROJECT = File.join(WALLET_DIR, "ios", "App", "App.xcodeproj")
+IOS_OUTPUT  = File.join(WALLET_DIR, "ios", "App", "output")
+
+# ---- Android -------------------------------------------------------------
+
+desc "Signed ad-hoc release APK. web -> Capacitor -> gradle assembleRelease. No store account needed."
+lane :android_adhoc do
+  web_build
   gradle(
     project_dir: File.join(WALLET_DIR, "android"),
     task: "assemble",
     build_type: "Release",
     flags: "--no-daemon",
-    properties: props
+    properties: version_props
   )
   apk = lane_context[SharedValues::GRADLE_APK_OUTPUT_PATH]
   UI.success("Signed ad-hoc APK: #{apk}")
 end
 
-desc "AAB to Play Internal testing track. Requires Play account + service-account JSON (BLOCKED until set up)."
+desc "AAB -> Play Internal testing track. Requires ~/.sorcha-signing/play_service_account.json + the app record (and a manual first AAB upload)."
 lane :android_internal do
-  UI.user_error!("android_internal is not wired yet: needs a Play Console account, the app record, and a service-account JSON. See references/secrets-map.md.")
+  json_key = File.join(SIGN_DIR, "play_service_account.json")
+  unless File.exist?(json_key)
+    UI.user_error!("Missing Play service-account JSON at #{json_key}. See the sorcha-app skill: references/finishing-accounts.md")
+  end
+  web_build
+  gradle(
+    project_dir: File.join(WALLET_DIR, "android"),
+    task: "bundle",
+    build_type: "Release",
+    flags: "--no-daemon",
+    properties: version_props
+  )
+  upload_to_play_store(
+    track: "internal",
+    package_name: "app.sorcha.wallet",
+    json_key: json_key,
+    aab: lane_context[SharedValues::GRADLE_AAB_OUTPUT_PATH],
+    skip_upload_metadata: true,
+    skip_upload_images: true,
+    skip_upload_screenshots: true
+  )
+  UI.success("Uploaded AAB to Play Internal track.")
 end
 
-desc "Signed ad-hoc IPA. Requires Apple Developer Program + registered device UDIDs (BLOCKED until set up)."
+# ---- iOS (Capacitor 8 = SPM, no CocoaPods; build the .xcodeproj directly) -
+
+desc "Signed ad-hoc IPA. Requires Apple Developer Program, a match repo (MATCH_GIT_URL/MATCH_PASSWORD), and registered device UDIDs."
 lane :ios_adhoc do
-  UI.user_error!("ios_adhoc is not wired yet: needs Apple Developer Program enrolment, a match repo, and device UDIDs.")
+  key = asc_api_key
+  web_build
+  match(type: "adhoc", api_key: key, readonly: false)
+  build_app(
+    project: IOS_PROJECT,
+    scheme: "App",
+    export_method: "ad-hoc",
+    output_directory: IOS_OUTPUT,
+    output_name: "SorchaWallet-adhoc.ipa"
+  )
+  UI.success("Ad-hoc IPA: #{lane_context[SharedValues::IPA_OUTPUT_PATH]}")
 end
 
-desc "IPA to TestFlight. Requires Apple Developer Program + App Store Connect API key (BLOCKED until set up)."
+desc "IPA -> TestFlight. Requires Apple Developer Program + ASC API key + a match repo."
 lane :ios_beta do
-  UI.user_error!("ios_beta is not wired yet: needs Apple Developer Program enrolment and an App Store Connect API key.")
+  key = asc_api_key
+  web_build
+  match(type: "appstore", api_key: key, readonly: false)
+  build_app(
+    project: IOS_PROJECT,
+    scheme: "App",
+    export_method: "app-store",
+    output_directory: IOS_OUTPUT,
+    output_name: "SorchaWallet-appstore.ipa"
+  )
+  upload_to_testflight(api_key: key, skip_waiting_for_build_processing: true)
+  UI.success("Uploaded to TestFlight.")
 end

--- a/mobile/wallet/fastlane/Matchfile
+++ b/mobile/wallet/fastlane/Matchfile
@@ -1,0 +1,12 @@
+# fastlane match — stores iOS signing certs + provisioning profiles in a PRIVATE git repo,
+# encrypted with MATCH_PASSWORD. Nothing secret is in this file.
+#
+# Set before running the iOS lanes (on the Mac only):
+#   export MATCH_GIT_URL="git@github.com:Sorcha-Platform/ios-certs.git"   (or HTTPS)
+#   export MATCH_PASSWORD="<the encryption passphrase you choose>"        (store in your pw manager)
+# See the sorcha-app skill: references/finishing-accounts.md
+
+git_url(ENV["MATCH_GIT_URL"])          # required at runtime; lanes fail loud if unset
+storage_mode("git")
+app_identifier(["app.sorcha.wallet"])
+# 'type' is supplied per-lane by the Fastfile (adhoc / appstore / development).


### PR DESCRIPTION
Prestages the store lanes so finishing is place-creds-and-run once Apple/Google enrolments exist. Real ios_adhoc/ios_beta (match + build_app + TestFlight) and android_internal (supply) in the Fastfile; they fail loud with the exact missing-credential path until ~/.sorcha-signing files exist. Adds Matchfile + references/finishing-accounts.md runbook + concrete secrets-map paths. Inert until creds present; android_adhoc regression-tested green. Validate with real accounts, then merge.