### PR TITLE
fix(mobile): make iOS lanes headless-signable (keychain + manual signing)

### DIFF
--- a/.claude/skills/sorcha-app/references/finishing-accounts.md
+++ b/.claude/skills/sorcha-app/references/finishing-accounts.md
@@ -7,6 +7,19 @@ missing-file path until the credentials are present.
 
 Secrets live ONLY on the Mac. Never copy them to Windows or the repo.
 
+## STATUS (2026-06-23)
+- **iOS `ios_adhoc` PROVEN end-to-end** — signed ad-hoc IPA built on the Mac node (team **HY5HSW5FUT**,
+  bundle `app.sorcha.wallet`, profile `match AdHoc app.sorcha.wallet`, match repo
+  `Sorcha-Platform/ios-certs`). Two lane fixes needed (PR #1024, both in the Fastfile now): `setup_ci`
+  for the headless keychain, and `apply_match_signing` for manual signing. One infra fix: a **Little
+  Snitch** allow rule for `*.apple.com` (it was blocking Homebrew Ruby → ASC API; see troubleshooting).
+  `ios_beta` (TestFlight) uses the same signing path — should work when wanted. Creds in
+  `~/.sorcha-signing`: `asc_api_key.p8` + `asc_api_key.json` (key MBZVZTN4VX) + `ios-match.env`
+  (MATCH_GIT_URL + MATCH_PASSWORD; deliberately NOT in `~/.zprofile`, so iOS lanes must `source` it).
+  ⚠ Watch the json key name — it's `issuer_id`, not `issure_id` (a typo silently breaks ASC auth).
+- **Android `android_internal`** — first AAB uploaded manually to Play Internal (versionCode 1). Lane
+  automates once `~/.sorcha-signing/play_service_account.json` is placed. Still outstanding.
+
 ## iOS (ios_adhoc / ios_beta)
 
 Prereq: Apple Developer Program active (Individual is fine).

--- a/.claude/skills/sorcha-app/references/troubleshooting.md
+++ b/.claude/skills/sorcha-app/references/troubleshooting.md
@@ -59,6 +59,32 @@ Hard-won fixes. Symptom → cause → fix.
 **Blazor app loads blank / 404s assets in the webview**
 → `<base href="/wallet/">` not rewritten. `build-web.sh` rewrites it to `/`; confirm `www/index.html`.
 
+## iOS signing (first real ios_adhoc / ios_beta run)
+
+**`match` hangs forever at `Creating authorization token for App Store Connect API`** (no error,
+process alive, socket to `17.56.x:443` ends in `CLOSE_WAIT`)
+→ The Mac runs **Little Snitch** (per-app outbound firewall). It silently denies the **Homebrew
+   Ruby** process (ad-hoc signed, no Team ID) to Apple's developer endpoints, while `curl`/`nc`
+   (system binaries) are allowed — so the network "looks fine". Headless over SSH/daemon there's no
+   GUI to answer LS's approval prompt, so the connect just times out.
+→ Diagnose: `source ~/.zprofile && ruby -rsocket -e 'p Socket.tcp("17.56.10.18",443,connect_timeout:8)'`
+   times out, but `curl -m5 https://api.appstoreconnect.apple.com/v1/apps` returns 401 fast → it's
+   Little Snitch, not the network. Confirm: `systemextensionsctl list | grep -i littlesnitch`.
+→ Fix: add a Little Snitch **allow** rule, *Any Process* → `*.apple.com` :443 (covers `developer.apple.com`,
+   `api.appstoreconnect.apple.com`, `developerservices2.apple.com`, `idmsa`, `contentdelivery`). "Any
+   Process" avoids churn when Homebrew bumps Ruby's Cellar path. Must be a permanent rule — the CI
+   daemon is headless too.
+
+**`match` itself hangs importing the cert / "User interaction is not allowed" on the keychain**
+→ `login.keychain` is locked over SSH and under the runner LaunchDaemon (no GUI session).
+→ The lanes call `setup_ci(force: true)` before `match` (temporary keychain). Already in the Fastfile.
+
+**`archive` fails: `Signing for "App" requires a development team`**
+→ Capacitor's generated Xcode project uses *automatic* signing with no team; `match` is *manual*.
+→ The `apply_match_signing` helper (Fastfile) sets manual signing + `DEVELOPMENT_TEAM` +
+   `PROVISIONING_PROFILE_SPECIFIER` from match's `sigh_<bundle>_<type>_{team-id,profile-name}` env
+   vars before `build_app`. Team ID is **HY5HSW5FUT**; ad-hoc profile **`match AdHoc app.sorcha.wallet`**.
+
 **`sdkmanager` "fails" but everything actually installed**
 → `set -o pipefail` + `yes | sdkmanager` — `yes` dies SIGPIPE (141), tripping the pipe. `bootstrap-mac.sh`
    reads `${PIPESTATUS[1]}` (sdkmanager's own code) instead. Not a real failure.

--- a/mobile/wallet/fastlane/Fastfile
+++ b/mobile/wallet/fastlane/Fastfile
@@ -54,6 +54,26 @@ end
 IOS_PROJECT = File.join(WALLET_DIR, "ios", "App", "App.xcodeproj")
 IOS_OUTPUT  = File.join(WALLET_DIR, "ios", "App", "output")
 
+# Capacitor's generated Xcode project ships with automatic signing and no team, so an
+# archive fails with "Signing requires a development team". match uses MANUAL signing, so
+# pin the App target to the match-provisioned profile before build_app. We read match's
+# exported env vars (sigh_<bundle>_<type>_{profile-name,team-id}) rather than hardcoding the
+# team id, so this stays correct if the team/profile changes. Edits the pbxproj at build
+# time (the committed project stays generic; CI checks out fresh each run).
+def apply_match_signing(profile_type)
+  bundle = "app.sorcha.wallet"
+  prefix = "sigh_#{bundle}_#{profile_type}"
+  update_code_signing_settings(
+    use_automatic_signing: false,
+    path: IOS_PROJECT,
+    team_id: ENV.fetch("#{prefix}_team-id"),
+    code_sign_identity: "Apple Distribution",
+    profile_name: ENV.fetch("#{prefix}_profile-name"),
+    bundle_identifier: bundle,
+    targets: ["App"]
+  )
+end
+
 # ---- Android -------------------------------------------------------------
 
 desc "Signed ad-hoc release APK. web -> Capacitor -> gradle assembleRelease. No store account needed."
@@ -101,8 +121,14 @@ end
 desc "Signed ad-hoc IPA. Requires Apple Developer Program, a match repo (MATCH_GIT_URL/MATCH_PASSWORD), and registered device UDIDs."
 lane :ios_adhoc do
   key = asc_api_key
+  # Headless keychain: match imports the signing cert's private key into a keychain, but
+  # login.keychain is locked over SSH and under the CI runner LaunchDaemon (no GUI session),
+  # which silently hangs. setup_ci creates+unlocks a temporary keychain and points match at
+  # it via MATCH_KEYCHAIN_NAME/PASSWORD, so codesign finds the identity. Idempotent; no-op-safe.
+  setup_ci(force: true)
   web_build
   match(type: "adhoc", api_key: key, readonly: false)
+  apply_match_signing("adhoc")
   build_app(
     project: IOS_PROJECT,
     scheme: "App",
@@ -116,8 +142,14 @@ end
 desc "IPA -> TestFlight. Requires Apple Developer Program + ASC API key + a match repo."
 lane :ios_beta do
   key = asc_api_key
+  # Headless keychain: match imports the signing cert's private key into a keychain, but
+  # login.keychain is locked over SSH and under the CI runner LaunchDaemon (no GUI session),
+  # which silently hangs. setup_ci creates+unlocks a temporary keychain and points match at
+  # it via MATCH_KEYCHAIN_NAME/PASSWORD, so codesign finds the identity. Idempotent; no-op-safe.
+  setup_ci(force: true)
   web_build
   match(type: "appstore", api_key: key, readonly: false)
+  apply_match_signing("appstore")
   build_app(
     project: IOS_PROJECT,
     scheme: "App",


### PR DESCRIPTION
First real `ios_adhoc` run on the Mac build node surfaced two blockers (and one infra blocker resolved outside this PR — see below). Both lane-side fixes are here so the iOS lanes run unattended over SSH **and** under the CI runner LaunchDaemon.

## Fixes
1. **`setup_ci(force: true)` before `match`** — `match` imports the signing cert's private key into a keychain, but `login.keychain` is locked over SSH / under the runner daemon (no GUI session) and silently hangs. `setup_ci` creates + unlocks a temporary keychain and points `match` at it. Applied to `ios_adhoc` and `ios_beta`.
2. **`apply_match_signing` helper after `match`** — Capacitor's generated Xcode project ships *automatic* signing with no team, so `archive` fails with *"Signing requires a development team"*. The helper switches the `App` target to **manual** signing using match's exported `sigh_<bundle>_<type>_{team-id,profile-name}` env vars (no hardcoded team id). It edits the pbxproj at build time so the committed project stays generic and CI (fresh checkout each run) re-applies it.

## Proven end-to-end
Signed ad-hoc IPA produced and verified: `app.sorcha.wallet`, team `HY5HSW5FUT`, embedded profile `match AdHoc app.sorcha.wallet`.

## Infra note (not code)
The Mac build node runs **Little Snitch**, which was silently denying the Homebrew Ruby process outbound to Apple's developer endpoints (`developer.apple.com`, `api.appstoreconnect.apple.com`) — `match` hung on the first ASC API call. Resolved by adding a Little Snitch allow rule. Documented in the `sorcha-app` skill runbook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)