### PR TITLE
chore(mobile): declare iOS export-compliance exemption in Info.plist

### DIFF
--- a/mobile/wallet/ios/App/App/Info.plist
+++ b/mobile/wallet/ios/App/App/Info.plist
@@ -4,6 +4,11 @@
 <dict>
     <key>CAPACITOR_DEBUG</key>
 	<string>$(CAPACITOR_DEBUG)</string>
+	<!-- Export compliance: Sorcha uses only standard, published crypto (Ed25519, P-256,
+	     RSA, AES, SHA) that qualifies for the Category 5 Part 2 exemption — no proprietary
+	     algorithms. Declaring exempt here stops TestFlight prompting on every build. -->
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>


### PR DESCRIPTION
Sorcha Wallet uses only standard, published crypto (Ed25519, P-256, RSA,
AES, SHA) that qualifies for the EAR Category 5 Part 2 exemption — no
proprietary algorithms. Set ITSAppUsesNonExemptEncryption=false so TestFlight
stops asking the encryption questionnaire on every upload (matches the
exemption already declared in App Store Connect).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
