### PR TITLE
docs(sorcha-app): capture Play-permission + TestFlight internal learnings

### DIFF
--- a/.claude/skills/sorcha-app/references/finishing-accounts.md
+++ b/.claude/skills/sorcha-app/references/finishing-accounts.md
@@ -7,18 +7,24 @@ missing-file path until the credentials are present.
 
 Secrets live ONLY on the Mac. Never copy them to Windows or the repo.
 
-## STATUS (2026-06-23)
-- **iOS `ios_adhoc` PROVEN end-to-end** — signed ad-hoc IPA built on the Mac node (team **HY5HSW5FUT**,
-  bundle `app.sorcha.wallet`, profile `match AdHoc app.sorcha.wallet`, match repo
-  `Sorcha-Platform/ios-certs`). Two lane fixes needed (PR #1024, both in the Fastfile now): `setup_ci`
-  for the headless keychain, and `apply_match_signing` for manual signing. One infra fix: a **Little
-  Snitch** allow rule for `*.apple.com` (it was blocking Homebrew Ruby → ASC API; see troubleshooting).
-  `ios_beta` (TestFlight) uses the same signing path — should work when wanted. Creds in
-  `~/.sorcha-signing`: `asc_api_key.p8` + `asc_api_key.json` (key MBZVZTN4VX) + `ios-match.env`
-  (MATCH_GIT_URL + MATCH_PASSWORD; deliberately NOT in `~/.zprofile`, so iOS lanes must `source` it).
-  ⚠ Watch the json key name — it's `issuer_id`, not `issure_id` (a typo silently breaks ASC auth).
-- **Android `android_internal`** — first AAB uploaded manually to Play Internal (versionCode 1). Lane
-  automates once `~/.sorcha-signing/play_service_account.json` is placed. Still outstanding.
+## STATUS (2026-06-23) — BOTH PLATFORMS LIVE IN TESTING
+- **iOS `ios_adhoc` + `ios_beta` PROVEN end-to-end** — signed ad-hoc IPA **and** TestFlight upload both
+  work (App Store Connect app id `6783321595`, team **HY5HSW5FUT**, bundle `app.sorcha.wallet`, profiles
+  `match AdHoc/AppStore app.sorcha.wallet`, match repo `Sorcha-Platform/ios-certs`). App installed/testing
+  on Stuart's iPhone via TestFlight Internal. Fixes (PR #1024, in Fastfile): `setup_ci` (headless
+  keychain) + `apply_match_signing` (manual signing). Export-compliance baked into `Info.plist`
+  (`ITSAppUsesNonExemptEncryption=false`, PR #1025) so TestFlight stops prompting. Infra fix: a **Little
+  Snitch** allow rule for `*.apple.com` (was blocking Homebrew Ruby → ASC API; see troubleshooting).
+  Creds in `~/.sorcha-signing`: `asc_api_key.p8` + `asc_api_key.json` (key MBZVZTN4VX, issuer 3c58937d-…)
+  + `ios-match.env` (MATCH_GIT_URL + MATCH_PASSWORD; deliberately NOT in `~/.zprofile`, so iOS lanes must
+  `source` it — `trigger-build.ps1` does NOT, so iOS via that script needs the source added or run inline).
+  ⚠ json key name is `issuer_id` not `issure_id` (typo silently breaks ASC auth).
+- **Android** — manual AAB (versionCode 1) on Play Internal works for testing NOW. `android_internal`
+  lane builds+signs the AAB fine but the **automated upload is still blocked on the Play permission grant**:
+  service account `sorcha-play-ci@sorcha-494515.iam.gserviceaccount.com` (JSON at
+  `~/.sorcha-signing/play_service_account.json`) needs **"Release to testing tracks"** on the Sorcha
+  Wallet app in Play Console → Users and permissions. Once granted, re-run with `SORCHA_VERSION_CODE=2`
+  (vc1 is taken). Note in `deploy/mobile-artifacts/PLAY-SERVICE-ACCOUNT-NOTE.md`.
 
 ## iOS (ios_adhoc / ios_beta)
 

--- a/.claude/skills/sorcha-app/references/troubleshooting.md
+++ b/.claude/skills/sorcha-app/references/troubleshooting.md
@@ -93,6 +93,38 @@ process alive, socket to `17.56.x:443` ends in `CLOSE_WAIT`)
 → `$ANDROID_HOME/build-tools/36.0.0/apksigner verify --print-certs <apk> | grep SHA-256` and compare
    to the keystore SHA-256 (in the password manager / `make-upload-keystore.sh` output).
 
+## Play Store upload (android_internal)
+
+**`Google Api Error: Invalid request - The caller does not have permission`** (AAB builds fine,
+upload step fails)
+→ The service account authenticated but isn't authorised to release **this app's** tracks.
+→ Play Console → **Users and permissions** → invite/select the SA email
+   (`sorcha-play-ci@sorcha-494515.iam.gserviceaccount.com`) → **App permissions → add Sorcha Wallet**
+   → grant **"Release to testing tracks"** (or app-scoped Admin while testing). Allow a few minutes to
+   propagate. Grant must be **app-level**, not only account-level.
+
+**`Version code N has already been used`** on upload
+→ The manual first upload was **versionCode 1**. Automated lane runs must use a higher code — pass
+   `SORCHA_VERSION_CODE=<n>` (CI derives it from the run number; for a manual lane run bump it by hand).
+
+## TestFlight (iOS internal testing)
+
+**TestFlight asks for a "redeem code" / "an error occurred, try again later"**
+→ You're on the *external/public* path or there's no testable build for your Apple ID yet. **Internal
+   testing needs no code.** Fixes: (1) the build must be **Ready to Test** — finish Processing + answer
+   the **export-compliance** question; (2) add yourself under **TestFlight → Internal Testing** as a
+   tester (internal testers must be **team users** in Users and Access, max 100) and enable the build
+   for the group; (3) the iPhone's TestFlight must be signed in with the **exact** invited Apple ID.
+
+**Encryption questionnaire on every upload**
+→ Bake the answer into `Info.plist`. Sorcha uses only standard crypto (Ed25519/P-256/RSA/AES/SHA) →
+   `ITSAppUsesNonExemptEncryption=false` (Category 5 Part 2 exemption). Already committed.
+
+**Demo account / sign-in info requested**
+→ Only for **App Review** (external TestFlight first build + App Store), never internal testing. When
+   you do go external/prod: Sorcha needs a working **demo login** AND a **publicly reachable backend**
+   the build points at (a LAN/dev box fails review "can't sign in").
+
 ## Disk
 **Mac data volume low (~tens of GiB)** — Android SDK + gems ~8–10 GiB; **Xcode 17 needs ~40 GiB transient**.
 Free space (old simulators, prior Xcode after upgrade, `~/Library/Developer/Xcode/DerivedData`) before upgrading Xcode.


### PR DESCRIPTION
- troubleshooting.md: Play "caller does not have permission" (grant SA on the
  app), versionCode-already-used, TestFlight redeem-code/internal-testing flow,
  per-build encryption questionnaire, demo-account-only-for-review.
- finishing-accounts.md: STATUS now BOTH PLATFORMS LIVE IN TESTING — iOS adhoc
  + TestFlight proven (app id 6783321595, export-compliance baked in); Android
  manual AAB works, automation pending the Play permission grant.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
