### PR TITLE
docs(sorcha-app): mobile pipeline complete — all 4 lanes proven

### DIFF
--- a/.claude/skills/sorcha-app/references/finishing-accounts.md
+++ b/.claude/skills/sorcha-app/references/finishing-accounts.md
@@ -7,7 +7,12 @@ missing-file path until the credentials are present.
 
 Secrets live ONLY on the Mac. Never copy them to Windows or the repo.
 
-## STATUS (2026-06-23) — BOTH PLATFORMS LIVE IN TESTING
+## STATUS (2026-06-23) — PIPELINE COMPLETE, ALL LANES PROVEN END-TO-END
+**All four lanes proven on real accounts:** `android_adhoc` (CI), `android_internal` (Play Internal —
+versionCode 2 uploaded via `supply`), `ios_adhoc` (signed IPA), `ios_beta` (TestFlight). The Play SA
+needed **account-level Admin** (Users and permissions → SA → Account permissions → Admin); a narrower
+track grant kept failing. Android testing live via vc1 (manual) + vc2 (automated); iOS via TestFlight Internal.
+
 - **iOS `ios_adhoc` + `ios_beta` PROVEN end-to-end** — signed ad-hoc IPA **and** TestFlight upload both
   work (App Store Connect app id `6783321595`, team **HY5HSW5FUT**, bundle `app.sorcha.wallet`, profiles
   `match AdHoc/AppStore app.sorcha.wallet`, match repo `Sorcha-Platform/ios-certs`). App installed/testing

--- a/.claude/skills/sorcha-app/references/troubleshooting.md
+++ b/.claude/skills/sorcha-app/references/troubleshooting.md
@@ -99,9 +99,12 @@ process alive, socket to `17.56.x:443` ends in `CLOSE_WAIT`)
 upload step fails)
 → The service account authenticated but isn't authorised to release **this app's** tracks.
 → Play Console → **Users and permissions** → invite/select the SA email
-   (`sorcha-play-ci@sorcha-494515.iam.gserviceaccount.com`) → **App permissions → add Sorcha Wallet**
-   → grant **"Release to testing tracks"** (or app-scoped Admin while testing). Allow a few minutes to
-   propagate. Grant must be **app-level**, not only account-level.
+   (`sorcha-play-ci@sorcha-494515.iam.gserviceaccount.com`). **What actually worked (2026-06-23):**
+   open the SA → **Account permissions** tab → tick **Admin (all permissions)** → Apply. A narrower
+   "Release to testing tracks" grant kept returning the permission error (didn't take / wrong scope);
+   account-level Admin succeeded immediately. The separate **Setup → API access** page is now merged
+   into Users and permissions on most accounts — the SA invite there IS the grant; don't hunt for it.
+   Verify the SA shows **Status = Active** (not pending) before retrying.
 
 **`Version code N has already been used`** on upload
 → The manual first upload was **versionCode 1**. Automated lane runs must use a higher code — pass


### PR DESCRIPTION
android_internal now proven end-to-end (versionCode 2 to Play Internal). The
Play service account needed account-level Admin (a narrower "Release to testing
tracks" grant kept returning the permission error). Setup->API access is now
merged into Users and permissions on most accounts.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
