### PR TITLE
fix(wallet-app): iOS Associated Domains entitlement for passkey sign-in

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -11,6 +11,7 @@ on:
       - 'src/Apps/Sorcha.UI/Sorcha.UI.Web/wwwroot/index.html'
       - 'src/Apps/Sorcha.UI/Sorcha.UI.Web/wwwroot/*.html'
       - 'src/Apps/Sorcha.UI/Sorcha.UI.Web/wwwroot/.well-known/apple-app-site-association'
+      - 'src/Apps/Sorcha.UI/Sorcha.UI.Web/wwwroot/.well-known/assetlinks.json'
       - 'src/Apps/Sorcha.UI/Sorcha.UI.Web/wwwroot/landing.css'
       - 'src/Apps/Sorcha.UI/Sorcha.UI.Web/wwwroot/landing.js'
       - 'src/Apps/Sorcha.UI/Sorcha.UI.Web/wwwroot/consent-banner.js'

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -10,6 +10,7 @@ on:
       - 'docs/site/**'
       - 'src/Apps/Sorcha.UI/Sorcha.UI.Web/wwwroot/index.html'
       - 'src/Apps/Sorcha.UI/Sorcha.UI.Web/wwwroot/*.html'
+      - 'src/Apps/Sorcha.UI/Sorcha.UI.Web/wwwroot/.well-known/apple-app-site-association'
       - 'src/Apps/Sorcha.UI/Sorcha.UI.Web/wwwroot/landing.css'
       - 'src/Apps/Sorcha.UI/Sorcha.UI.Web/wwwroot/landing.js'
       - 'src/Apps/Sorcha.UI/Sorcha.UI.Web/wwwroot/consent-banner.js'

--- a/.specify/MASTER-TASKS.md
+++ b/.specify/MASTER-TASKS.md
@@ -192,6 +192,7 @@ These are the **Tier 1** trust improvements identified in the transaction archit
 | AUTH-010 | Load testing for OIDC token exchange flow | P2 | 8h | 📋 | Token exchange is latency-sensitive; needs production-scale load testing |
 | AUTH-011 | PassKey/WebAuthn authentication (Fido2NetLib) — org 2FA + public primary auth | P1 | 40h | ✅ | Feature 055: Org passkey 2FA, public passkey signup/sign-in, social login, method management |
 | AUTH-012 | Server-rendered auth pages (Razor Pages in Tenant Service) | P1 | 30h | ✅ | Login, signup, logout, OAuth/OIDC callbacks, email verification, password reset — eliminates WASM download for unauth users |
+| AUTH-013 | Org-configurable verification/passkey domains — admin + control feature | P3 | 24h | 📋 | Future enhancement (not part of current passkey-fix work). Passkey (WebAuthn) RP domains and the iOS Associated Domains / `apple-app-site-association` (AASA) are currently a single platform-wide value (`Fido2:ServerDomain`, set to the parent `sorcha.dev` so passkeys roam across all `*.sorcha.dev` subdomains; AASA served at the apex). Fine for the single-installation model, but orgs will want to bring/configure their own domains for passkeys and credential/verification surfaces. Need an admin + control feature to let organisations register and manage their own domains (RP IDs, associated-domains entries, AASA app lists), with the platform validating domain ownership and propagating the entitlement/AASA changes. |
 
 ---
 

--- a/docs/site/CNAME
+++ b/docs/site/CNAME
@@ -1,1 +1,1 @@
-www.sorcha.dev
+sorcha.dev

--- a/mobile/wallet/fastlane/Fastfile
+++ b/mobile/wallet/fastlane/Fastfile
@@ -70,7 +70,15 @@ def apply_match_signing(profile_type)
     code_sign_identity: "Apple Distribution",
     profile_name: ENV.fetch("#{prefix}_profile-name"),
     bundle_identifier: bundle,
-    targets: ["App"]
+    targets: ["App"],
+    # Wire the committed App.entitlements (Associated Domains: webcredentials:sorcha.dev)
+    # at build time so the committed Capacitor project stays generic (mirrors how team/
+    # profile are applied here, not committed). Required for native passkey sign-in in the
+    # WKWebView — see App/App.entitlements. The match-provisioned profile MUST carry the
+    # Associated Domains capability (enable it on the App ID via `produce enable_services
+    # associated_domains:"on"` then re-run match) or build_app fails "provisioning profile
+    # doesn't include the com.apple.developer.associated-domains entitlement".
+    entitlements_file_path: "App/App.entitlements"
   )
 end
 

--- a/mobile/wallet/ios/App/App/App.entitlements
+++ b/mobile/wallet/ios/App/App/App.entitlements
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<!--
+	  Associated Domains — required for native WebAuthn/passkey sign-in inside the
+	  Capacitor WKWebView. iOS refuses navigator.credentials.get() (NotAllowedError,
+	  surfaced as "Passkey sign-in was cancelled") unless the app is associated with
+	  the relying-party domain via this entitlement AND a matching
+	  apple-app-site-association file served at https://<domain>/.well-known/.
+
+	  webcredentials uses the PARENT domain sorcha.dev (not a per-host subdomain) so a
+	  single passkey roams across every *.sorcha.dev installation (n1, future nodes).
+	  WebAuthn permits the RP ID to be a registrable parent of the page origin, so
+	  RP ID sorcha.dev is valid from origin n1.sorcha.dev. The server must mint/verify
+	  passkeys with Fido2:ServerDomain = sorcha.dev to match. Apple does NOT support
+	  wildcards for webcredentials — the parent-domain entry is how "all subdomains"
+	  is achieved.
+	-->
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>webcredentials:sorcha.dev</string>
+	</array>
+</dict>
+</plist>

--- a/scripts/copy-landing-to-site.js
+++ b/scripts/copy-landing-to-site.js
@@ -139,9 +139,13 @@ for (const file of textAssets) copyText(file)
 for (const file of binAssets) copyBinary(file)
 for (const redirect of redirects) writeRedirect(redirect)
 
-// Apple App Site Association — served at https://sorcha.dev/.well-known/apple-app-site-association
-// (no extension, nested path) so the iOS Sorcha Wallet app can do native passkey sign-in
-// (Associated Domains: webcredentials:sorcha.dev). copyText mkdirs the nested .well-known dir.
-// The Pages artifact upload sets include-hidden-files, and docs/site/.nojekyll stops Jekyll
-// from stripping the dot-folder, so the file ships to the apex verbatim.
+// Native-app domain association files, served at the apex for passkey sign-in.
+// copyText mkdirs the nested .well-known dir; the Pages artifact upload sets
+// include-hidden-files and docs/site/.nojekyll stops Jekyll stripping the dot-folder,
+// so they ship to the apex verbatim.
+//   iOS  — apple-app-site-association (no extension): Associated Domains
+//          webcredentials:sorcha.dev.
+//   Android — assetlinks.json: Digital Asset Links (get_login_creds) for
+//          app.sorcha.wallet. No app-side entitlement; association is server-side only.
 copyText('.well-known/apple-app-site-association')
+copyText('.well-known/assetlinks.json')

--- a/scripts/copy-landing-to-site.js
+++ b/scripts/copy-landing-to-site.js
@@ -54,7 +54,11 @@ const binAssets = [
 const linkRewrites = []
 
 // Injected into <head> so the public page advertises the canonical URL.
-const canonicalTag = '    <link rel="canonical" href="https://www.sorcha.dev">\n'
+// Canonical is the apex sorcha.dev: GitHub Pages is configured apex-primary (the
+// apple-app-site-association AASA for iOS passkeys must be served at the apex with a
+// 200, and the apex can only do that when it is the primary domain — www then 301s
+// to the apex). See docs/site/CNAME + .well-known/apple-app-site-association.
+const canonicalTag = '    <link rel="canonical" href="https://sorcha.dev">\n'
 
 // Standalone redirect stubs for app-only routes the static host doesn't have.
 const redirects = [
@@ -134,3 +138,10 @@ for (const { file, rewrite } of pages) copyText(file, rewrite ? rewriteIndex : u
 for (const file of textAssets) copyText(file)
 for (const file of binAssets) copyBinary(file)
 for (const redirect of redirects) writeRedirect(redirect)
+
+// Apple App Site Association — served at https://sorcha.dev/.well-known/apple-app-site-association
+// (no extension, nested path) so the iOS Sorcha Wallet app can do native passkey sign-in
+// (Associated Domains: webcredentials:sorcha.dev). copyText mkdirs the nested .well-known dir.
+// The Pages artifact upload sets include-hidden-files, and docs/site/.nojekyll stops Jekyll
+// from stripping the dot-folder, so the file ships to the apex verbatim.
+copyText('.well-known/apple-app-site-association')

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web/wwwroot/.well-known/apple-app-site-association
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web/wwwroot/.well-known/apple-app-site-association
@@ -1,0 +1,5 @@
+{
+  "webcredentials": {
+    "apps": ["HY5HSW5FUT.app.sorcha.wallet"]
+  }
+}

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web/wwwroot/.well-known/assetlinks.json
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web/wwwroot/.well-known/assetlinks.json
@@ -1,0 +1,12 @@
+[
+  {
+    "relation": ["delegate_permission/common.get_login_creds"],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "app.sorcha.wallet",
+      "sha256_cert_fingerprints": [
+        "DD:D9:8C:D5:7C:03:92:03:32:BD:B5:DA:5B:5E:D9:35:DC:11:A5:27:06:50:D5:E5:15:F9:89:85:7C:F0:ED:97"
+      ]
+    }
+  }
+]

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web/wwwroot/.well-known/assetlinks.json
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web/wwwroot/.well-known/assetlinks.json
@@ -5,7 +5,8 @@
       "namespace": "android_app",
       "package_name": "app.sorcha.wallet",
       "sha256_cert_fingerprints": [
-        "DD:D9:8C:D5:7C:03:92:03:32:BD:B5:DA:5B:5E:D9:35:DC:11:A5:27:06:50:D5:E5:15:F9:89:85:7C:F0:ED:97"
+        "DD:D9:8C:D5:7C:03:92:03:32:BD:B5:DA:5B:5E:D9:35:DC:11:A5:27:06:50:D5:E5:15:F9:89:85:7C:F0:ED:97",
+        "25:6E:9C:E0:C6:CE:D4:10:71:76:43:66:F4:DE:3B:E2:6D:F3:01:66:09:49:71:FE:EA:C0:DF:94:83:01:2C:27"
       ]
     }
   }


### PR DESCRIPTION
Fixes native passkey sign-in in the Sorcha Wallet mobile apps, which fail with **"Passkey sign-in was cancelled"** — the OS refuses `navigator.credentials.get()` inside the Capacitor WebView unless the app is associated with the relying-party domain. Uses **parent RP `sorcha.dev`** so one passkey roams across every `*.sorcha.dev` installation.

## iOS app
- `mobile/wallet/ios/App/App/App.entitlements` — `com.apple.developer.associated-domains = webcredentials:sorcha.dev`.
- `mobile/wallet/fastlane/Fastfile` — wires `CODE_SIGN_ENTITLEMENTS` at build time via `apply_match_signing` (`entitlements_file_path`), keeping the committed Capacitor project generic.

## Web — domain-association files at the apex (existing CI pipeline)
sorcha.dev is published by this repo's `gh-pages.yml` from the embedded `wwwroot` content (single source of truth), so both association files live there and ride the same pipeline:
- **iOS:** `wwwroot/.well-known/apple-app-site-association` — `webcredentials` app list.
- **Android:** `wwwroot/.well-known/assetlinks.json` — Digital Asset Links (`get_login_creds`) for `app.sorcha.wallet`. **No app-side entitlement** — association is server-side only.
- `copy-landing-to-site.js` copies both nested files into `docs/site` (already `.nojekyll` + `include-hidden-files`).
- **Apex-primary flip:** `docs/site/CNAME` `www.sorcha.dev` → `sorcha.dev`; canonical → apex. Apple's AASA fetcher does not follow redirects and the apex currently 301s to www, so the apex must be primary to serve at **200** (www then 301s to apex). **No DNS change** — apex already has the Pages A/AAAA records; www is already a CNAME into Pages.
- `gh-pages.yml` triggers on both files.

## Backlog
- `AUTH-013` — orgs will want their own passkey/verification domains → future admin + control feature.

## Follow-ups (not in this PR)
1. **Android Play fingerprint:** `assetlinks.json` currently carries only the **upload-key** SHA-256 (covers ad-hoc / direct-install). The **Play App Signing** key SHA-256 (Play Console → App integrity) must be appended for Play-distributed installs.
2. **iOS portal:** enable Associated Domains on App ID `app.sorcha.wallet` + re-run `match` + rebuild `ios_beta` → TestFlight (without it `build_app` fails the entitlement check).
3. **n1 server:** `Fido2:ServerDomain = sorcha.dev` (breaking — existing `n1.sorcha.dev` passkeys re-register).
4. **Verify** Android System WebView actually resolves `navigator.credentials.get()` once `assetlinks.json` is live (Android WebView passkey support is newer/more restricted than iOS WKWebView).

(Supersedes the closed StuartF303/sorcha.dev#2.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)