### PR TITLE
fix(ci): include .well-known in the Pages artifact (passkey AASA/assetlinks)

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -50,10 +50,26 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@v5
 
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
+      # NOTE: actions/upload-pages-artifact hardcodes `--exclude=".[^/]*"` in its tar,
+      # which strips every top-level dot-folder — including .well-known (the AASA /
+      # assetlinks.json that native iOS/Android passkeys require). Its `include-hidden-files`
+      # input does not exist, so it silently no-ops. Archive the artifact ourselves with a
+      # plain `tar .` so dotfiles are included, then upload it as the github-pages artifact.
+      - name: Archive Pages artifact (include .well-known)
+        shell: bash
+        run: |
+          tar --dereference --hard-dereference \
+            --directory docs/site \
+            -cvf "$RUNNER_TEMP/artifact.tar" \
+            --exclude=.git --exclude=.github \
+            .
+
+      - name: Upload Pages artifact
+        uses: actions/upload-artifact@v4
         with:
-          path: docs/site
+          name: github-pages
+          path: ${{ runner.temp }}/artifact.tar
+          retention-days: "1"
           include-hidden-files: true
 
       - name: Deploy to GitHub Pages


### PR DESCRIPTION
actions/upload-pages-artifact@v4 hardcodes `--exclude=".[^/]*"` in its tar, which
strips every top-level dot-folder from the Pages artifact — including .well-known,
i.e. the apple-app-site-association and assetlinks.json that native iOS/Android
passkey sign-in requires. Its `include-hidden-files` input does not exist, so the
value we passed was a silent no-op (verified by downloading the deployed artifact:
no .well-known, no .nojekyll).

Archive the artifact ourselves with a plain `tar .` (dotfiles included) and upload
it as the github-pages artifact, which actions/deploy-pages consumes unchanged.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013cig9QGC7HdJXeYt8SHhrJ
