### PR TITLE
fix(n1): passkey relying-party = parent domain sorcha.dev

### DIFF
--- a/docker-compose.n1.yml
+++ b/docker-compose.n1.yml
@@ -47,7 +47,13 @@ services:
     image: sorchadev/tenant-service:latest
     environment:
       <<: *jwt-env
-      Fido2__ServerDomain: n1.sorcha.dev
+      # Passkey relying-party = the PARENT domain sorcha.dev (not the per-host
+      # subdomain) so one passkey works across every *.sorcha.dev installation and
+      # matches the native apps' Associated Domains entitlement (webcredentials:sorcha.dev)
+      # + the AASA/assetlinks served at https://sorcha.dev/.well-known/. WebAuthn allows
+      # the RP ID to be a registrable parent of the ceremony origin, which stays the
+      # actual host the app/web runs on (https://n1.sorcha.dev).
+      Fido2__ServerDomain: sorcha.dev
       Fido2__ServerName: Sorcha
       Fido2__Origins__0: https://n1.sorcha.dev
       # n1 is the shared dev/demo node. Walkthrough setup scripts create


### PR DESCRIPTION
Flip n1's Fido2:ServerDomain from n1.sorcha.dev to the parent sorcha.dev so the
WebAuthn RP ID matches the native apps' Associated Domains entitlement
(webcredentials:sorcha.dev) and the AASA/assetlinks served at the apex. The
ceremony origin stays https://n1.sorcha.dev (the host the app/web runs on);
WebAuthn permits the RP ID to be a registrable parent of the origin.

Already applied live on the n1 host + verified (assertion-options returns
rpId=sorcha.dev); this keeps it across future deploys. Breaking for existing
n1.sorcha.dev-bound passkeys (re-register once) — acceptable pre-release.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013cig9QGC7HdJXeYt8SHhrJ
