### PR TITLE
fix(tenant): default email signup org to 'public', not nonexistent 'default'

### DIFF
--- a/src/Services/Sorcha.Tenant.Service/Pages/Auth/Signup.cshtml.cs
+++ b/src/Services/Sorcha.Tenant.Service/Pages/Auth/Signup.cshtml.cs
@@ -150,7 +150,9 @@ public class SignupModel : PageModel
 
         try
         {
-            var orgSubdomain = string.IsNullOrWhiteSpace(OrgSubdomain) ? "default" : OrgSubdomain;
+            // Default to the public org — self-registration is only enabled on the
+            // seeded Public org (subdomain "public"); a "default" org does not exist.
+            var orgSubdomain = string.IsNullOrWhiteSpace(OrgSubdomain) ? "public" : OrgSubdomain;
             var result = await _registrationService.RegisterAsync(
                 orgSubdomain, Email, Password, DisplayName, ct);
 

--- a/tests/Sorcha.Tenant.Service.Tests/Pages/SignupModelTests.cs
+++ b/tests/Sorcha.Tenant.Service.Tests/Pages/SignupModelTests.cs
@@ -95,7 +95,7 @@ public class SignupModelTests
     {
         // Arrange
         _registrationService
-            .Setup(s => s.RegisterAsync("default", "user@test.com", "StrongPassword1!", "Test User", It.IsAny<CancellationToken>()))
+            .Setup(s => s.RegisterAsync("public", "user@test.com", "StrongPassword1!", "Test User", It.IsAny<CancellationToken>()))
             .ReturnsAsync(new RegistrationResult(true, UserId: Guid.NewGuid(), Message: "Verification email sent"));
 
         var model = CreateModel();
@@ -122,7 +122,7 @@ public class SignupModelTests
             ["Password"] = ["Password must be at least 8 characters."]
         };
         _registrationService
-            .Setup(s => s.RegisterAsync("default", "user@test.com", "weak", "Test User", It.IsAny<CancellationToken>()))
+            .Setup(s => s.RegisterAsync("public", "user@test.com", "weak", "Test User", It.IsAny<CancellationToken>()))
             .ReturnsAsync(new RegistrationResult(false, ValidationErrors: validationErrors, Error: "Validation failed."));
 
         var model = CreateModel();
@@ -146,7 +146,7 @@ public class SignupModelTests
     {
         // Arrange
         _registrationService
-            .Setup(s => s.RegisterAsync("default", "existing@test.com", "StrongPassword1!", "Test User", It.IsAny<CancellationToken>()))
+            .Setup(s => s.RegisterAsync("public", "existing@test.com", "StrongPassword1!", "Test User", It.IsAny<CancellationToken>()))
             .ReturnsAsync(new RegistrationResult(false, Error: "A user with this email already exists.", ErrorStatusCode: 409));
 
         var model = CreateModel();
@@ -169,7 +169,7 @@ public class SignupModelTests
     {
         // Arrange — registration succeeds but no tokens are returned (email verification required)
         _registrationService
-            .Setup(s => s.RegisterAsync("default", "new@test.com", "StrongPassword1!", "New User", It.IsAny<CancellationToken>()))
+            .Setup(s => s.RegisterAsync("public", "new@test.com", "StrongPassword1!", "New User", It.IsAny<CancellationToken>()))
             .ReturnsAsync(new RegistrationResult(true, UserId: Guid.NewGuid(), Message: "Verification email sent"));
 
         var model = CreateModel();


### PR DESCRIPTION
The email self-signup handler fell back to org subdomain "default" when no
OrgSubdomain was supplied, but the seeded Public org (the only org with
SelfRegistrationEnabled) has subdomain "public". On any deployment this meant
bare /auth/signup email registration failed with "Organization not found"
(surfaced as the generic "Registration failed."). Default to "public".

Confirmed live on n1: the same form succeeds ("Check your email") once the
org resolves to public.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
