### PR TITLE
feat(haip): [B1] return raw vp_token on verifier result poll

### DIFF
--- a/specs/160-verify-haip-vptoken/plan.md
+++ b/specs/160-verify-haip-vptoken/plan.md
@@ -1,0 +1,37 @@
+# Implementation Plan: HAIP returns raw vp_token on verifier result poll (PR B1)
+
+**Branch**: `160-verify-haip-vptoken` | **Spec**: `./spec.md`
+**Scope**: `src/Services/Sorcha.Haip.Service` only + its test project.
+
+## Technical approach
+Purely additive change across three files plus a test.
+
+1. **Model** — `src/Services/Sorcha.Haip.Service/Models/VerifierModels.cs`
+   Add two nullable string properties to `PresentationRequest`:
+   - `SubmittedVpToken` — the raw `vp_token` posted by the holder.
+   - `PresentationSubmission` — the OID4VP `presentation_submission` posted alongside it.
+   (Nullable so existing serialized Redis records deserialize cleanly.)
+
+2. **Store** — `src/Services/Sorcha.Haip.Service/Services/PresentationRequestStore.cs`
+   Extend `MarkCompletedAsync` with optional `string? vpToken = null, string? presentationSubmission = null`
+   params; set them on the request inside the existing compare-and-set loop (before re-serialize), so
+   the raw token is persisted atomically with the result and shares the same TTL. No new key/TTL.
+
+3. **Endpoint (capture)** — `Endpoints/VerifierEndpoints.cs` `HandleDirectPost`
+   Pass the already-bound `vp_token` and `presentation_submission` form values into
+   `MarkCompletedAsync(...)`.
+
+4. **Endpoint (return)** — `Endpoints/VerifierEndpoints.cs` `GetVerificationResult`
+   Add `vpToken = request.SubmittedVpToken` and `presentationSubmission = request.PresentationSubmission`
+   to both response branches (pre- and post-result). Existing fields unchanged.
+
+## Testing
+- Extend the HAIP verifier tests: create a request via the store, mark completed with a sample
+  `vpToken` + `presentationSubmission`, re-`GetAsync`, and assert both round-trip. If an
+  endpoint-level harness exists, add a create → direct-post → poll test asserting the raw token is
+  returned post-submission and null pre-submission.
+
+## Risks / notes
+- Backward-compat: new fields are additive + nullable; old Redis records and the Blueprint result
+  consumer are unaffected (FR-004).
+- No auth change (deferred to B3); no change to validation behaviour.

--- a/specs/160-verify-haip-vptoken/spec.md
+++ b/specs/160-verify-haip-vptoken/spec.md
@@ -1,0 +1,66 @@
+# Feature Specification: HAIP returns raw vp_token on verifier result poll (PR B1)
+
+**Feature Branch**: `160-verify-haip-vptoken`
+**Created**: 2026-06-25
+**Status**: Ready for planning
+**Parent design**: `docs/superpowers/specs/2026-06-25-verify-unification-design.md` (stage B1)
+
+## Summary
+The Verify-unification design computes the rich verdict **client-side** on both verifier hosts. For
+that, a verifier polling HAIP for a presentation result needs the **raw submitted presentation** back,
+not just HAIP's pass/fail verdict. Today HAIP discards the raw `vp_token` after validating it. This
+feature makes HAIP **persist and return the raw `vp_token` (and `presentation_submission`)** alongside
+its existing `VerificationResult`, so a client can re-validate locally and build the 4-layer trail.
+
+This wave is **purely additive** to the verifier result response. No auth changes, no UI.
+
+## User Scenarios & Testing
+
+### Primary (verifier client re-validates locally)
+1. A verifier creates a presentation request (existing `POST /api/v1/verifier/requests`).
+2. A holder wallet submits its `vp_token` via `direct_post` (existing).
+3. The verifier polls the result endpoint and receives — in addition to today's fields — the **raw
+   `vp_token`** and **`presentation_submission`** that the holder submitted.
+4. The verifier can now feed that raw token to a local validator to produce its own rich verdict.
+
+### Acceptance scenarios
+- **Given** a request that no holder has answered yet, **when** the result is polled, **then** the
+  response contains a null `vpToken` (nothing submitted) and the existing `state`.
+- **Given** a holder has submitted a `vp_token` via `direct_post`, **when** the result is polled,
+  **then** the response includes the exact raw `vp_token` string and the `presentation_submission`
+  the holder posted, alongside the existing `result`.
+- **Given** a request whose TTL has expired, **when** the result is polled, **then** behaviour is
+  unchanged from today (the stored request is gone, so no raw token leaks beyond TTL).
+
+## Functional Requirements
+- **FR-001**: The stored presentation request MUST retain the raw `vp_token` submitted via
+  `direct_post`, scoped to the request's existing TTL (no new retention window).
+- **FR-002**: The stored presentation request MUST retain the `presentation_submission` submitted
+  alongside the `vp_token`, when present.
+- **FR-003**: The verifier result endpoint response MUST include the raw `vp_token` and
+  `presentation_submission` once a holder has submitted; both MUST be null/absent before submission.
+- **FR-004**: Existing response fields (`requestId`, `state`, `result`) MUST be unchanged
+  (additive only — no breaking change to the Blueprint Service consumer).
+- **FR-005**: Behaviour for not-found and expired requests MUST be unchanged.
+
+## Key Entities
+- **PresentationRequest** (stored): gains `SubmittedVpToken` and `PresentationSubmission` fields,
+  populated on `direct_post`, returned on the result poll.
+
+## Success Criteria
+- **SC-001**: A poll after submission returns the byte-identical `vp_token` the holder posted.
+- **SC-002**: The Blueprint Service result consumer continues to work unchanged (no field removed
+  or renamed).
+- **SC-003**: The raw token is never returned before submission or after TTL expiry.
+
+## Assumptions
+- HAIP's `direct_post` is `vp_token`-only; holder→device binding is carried inside the token's
+  KB-JWT. There is no separate "delegation credential" form field to capture, so this wave does not
+  add one. (Client-side validation of any device-delegated model is a PR B2 concern.)
+- The verifier-tier authorization allowance on create/poll (today `RequireService`) is **out of
+  scope here** and deferred to PR B3, where the hosts actually call HAIP and the tier can be
+  verified live.
+
+## Out of scope
+- Any UI change. Any change to HAIP's own server-side validation. Auth-tier changes (→ B3).
+- Separate delegation-credential capture (→ B2 if needed).

--- a/specs/160-verify-haip-vptoken/tasks.md
+++ b/specs/160-verify-haip-vptoken/tasks.md
@@ -1,0 +1,19 @@
+# Tasks: HAIP returns raw vp_token on verifier result poll (PR B1)
+
+**Branch**: `160-verify-haip-vptoken` | **Plan**: `./plan.md`
+
+- [x] **T001** — Add `SubmittedVpToken` (string?) and `PresentationSubmission` (string?) to
+  `PresentationRequest` in `src/Services/Sorcha.Haip.Service/Models/VerifierModels.cs`, with XML doc
+  summaries.
+- [x] **T002** — Extend `PresentationRequestStore.MarkCompletedAsync` with optional
+  `vpToken` / `presentationSubmission` params; set them on the request inside the CAS loop before
+  re-serialize. (`src/Services/Sorcha.Haip.Service/Services/PresentationRequestStore.cs`)
+- [x] **T003** — In `HandleDirectPost`, pass the bound `vp_token` + `presentation_submission` to
+  `MarkCompletedAsync`. (`Endpoints/VerifierEndpoints.cs`)
+- [x] **T004** — In `GetVerificationResult`, add `vpToken` + `presentationSubmission` to both
+  response branches. (`Endpoints/VerifierEndpoints.cs`)
+- [x] **T005** — Test: round-trip a `vpToken` + `presentationSubmission` through
+  create → MarkCompletedAsync → GetAsync (and an endpoint-level poll test if a harness exists);
+  assert raw token returned post-submission, null pre-submission, existing fields intact.
+- [x] **T006** — `dotnet build` + run the HAIP test project green; XML doc summaries on all new
+  public members (no build warnings).

--- a/src/Services/Sorcha.Haip.Service/Endpoints/VerifierEndpoints.cs
+++ b/src/Services/Sorcha.Haip.Service/Endpoints/VerifierEndpoints.cs
@@ -237,8 +237,9 @@ public static class VerifierEndpoints
                 ct: ct);
         }
 
-        // Store the result
-        await store.MarkCompletedAsync(requestId, result, ct);
+        // Store the result + the raw submitted presentation (PR B1) so a verifier client can
+        // re-validate locally and build its own rich verdict.
+        await store.MarkCompletedAsync(requestId, result, vp_token, presentation_submission, ct);
 
         // Feature 111: relay the outcome to Blueprint Service for lifecycle transaction writing.
         if (callbackRelay is not null)
@@ -281,7 +282,10 @@ public static class VerifierEndpoints
             {
                 requestId = request.Id,
                 state = request.State.ToString(),
-                result = (VerificationResult?)null
+                result = (VerificationResult?)null,
+                // PR B1: raw submitted presentation for client-side re-validation (null pre-submission).
+                vpToken = request.SubmittedVpToken,
+                presentationSubmission = request.PresentationSubmission
             });
         }
 
@@ -289,7 +293,10 @@ public static class VerifierEndpoints
         {
             requestId = request.Id,
             state = request.State.ToString(),
-            result = request.Result
+            result = request.Result,
+            // PR B1: raw submitted presentation so a verifier client can build its own rich verdict.
+            vpToken = request.SubmittedVpToken,
+            presentationSubmission = request.PresentationSubmission
         });
     }
 

--- a/src/Services/Sorcha.Haip.Service/Models/VerifierModels.cs
+++ b/src/Services/Sorcha.Haip.Service/Models/VerifierModels.cs
@@ -40,6 +40,19 @@ public class PresentationRequest
 
     /// <summary>The result.</summary>
     public VerificationResult? Result { get; set; }
+
+    /// <summary>
+    /// The raw <c>vp_token</c> string the holder submitted via <c>direct_post</c>, retained so a
+    /// verifier client can re-validate the presentation locally and build its own rich verdict
+    /// (Verify-unification PR B1). Null until a holder has submitted; shares the request's TTL.
+    /// </summary>
+    public string? SubmittedVpToken { get; set; }
+
+    /// <summary>
+    /// The OID4VP <c>presentation_submission</c> the holder submitted alongside the
+    /// <see cref="SubmittedVpToken"/>, when present. Null until submission.
+    /// </summary>
+    public string? PresentationSubmission { get; set; }
 }
 
 [JsonConverter(typeof(JsonStringEnumConverter))]

--- a/src/Services/Sorcha.Haip.Service/Services/PresentationRequestStore.cs
+++ b/src/Services/Sorcha.Haip.Service/Services/PresentationRequestStore.cs
@@ -93,6 +93,8 @@ public class PresentationRequestStore
     public async Task MarkCompletedAsync(
         Guid requestId,
         VerificationResult result,
+        string? vpToken = null,
+        string? presentationSubmission = null,
         CancellationToken ct = default)
     {
         var key = $"haip:vp-request:{requestId}";
@@ -117,6 +119,10 @@ public class PresentationRequestStore
 
             request.State = newState;
             request.Result = result;
+            // PR B1: retain the raw submitted presentation so a verifier client can re-validate
+            // locally and build its own rich verdict. Persisted atomically with the result; same TTL.
+            request.SubmittedVpToken = vpToken;
+            request.PresentationSubmission = presentationSubmission;
             var newJson = JsonSerializer.Serialize(request);
 
             if (await _cache.TryUpdateIfMatchAsync(key, json, newJson, ttl, ct))

--- a/tests/Sorcha.Haip.Service.Tests/Services/PresentationRequestStoreTests.cs
+++ b/tests/Sorcha.Haip.Service.Tests/Services/PresentationRequestStoreTests.cs
@@ -119,6 +119,46 @@ public class PresentationRequestStoreTests
     }
 
     [Fact]
+    public async Task MarkCompletedAsync_PersistsRawVpTokenAndSubmission()
+    {
+        // PR B1: the raw submitted presentation must round-trip so a verifier client can
+        // re-validate locally and build its own rich verdict.
+        var created = await _store.CreateAsync(
+            "https://test.example/haip", "TestCredential",
+            null, null, "https://test.example/haip");
+
+        const string vpToken = "eyJhbGciOiJFUzI1NiJ9.payload~disclosure~kbjwt";
+        const string submission = "{\"id\":\"sub-1\",\"definition_id\":\"pd-1\"}";
+
+        var result = new VerificationResult { IsValid = true };
+
+        await _store.MarkCompletedAsync(created.Id, result, vpToken, submission);
+
+        var updated = await _store.GetAsync(created.Id);
+        updated.Should().NotBeNull();
+        updated!.SubmittedVpToken.Should().Be(vpToken);
+        updated.PresentationSubmission.Should().Be(submission);
+        // Existing fields remain intact (additive change).
+        updated.State.Should().Be(PresentationRequestState.Verified);
+        updated.Result!.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task GetAsync_BeforeSubmission_HasNoRawVpToken()
+    {
+        // FR-003: the raw token is null before a holder has submitted.
+        var created = await _store.CreateAsync(
+            "https://test.example/haip", "TestCredential",
+            null, null, "https://test.example/haip");
+
+        var retrieved = await _store.GetAsync(created.Id);
+
+        retrieved.Should().NotBeNull();
+        retrieved!.SubmittedVpToken.Should().BeNull();
+        retrieved.PresentationSubmission.Should().BeNull();
+    }
+
+    [Fact]
     public async Task MarkCompletedAsync_SecondCallAfterTerminal_IsIdempotentNoOp()
     {
         // Review M4: the CAS completion is first-writer-wins. A second callback for an


### PR DESCRIPTION
Verify-unification stage B1. HAIP now persists the raw submitted vp_token +
presentation_submission on the presentation request (atomically with the
result, same TTL) and returns them from GET /verifier/requests/{id}/result, so
a verifier client can re-validate the presentation locally and build its own
rich 4-layer verdict instead of consuming HAIP's lighter server verdict.

Purely additive: existing result fields unchanged; no auth change (verifier-tier
allowance deferred to B3); HAIP's own validation untouched. direct_post is
vp_token-only so no separate delegation field is captured (B2 concern).

Spec: specs/160-verify-haip-vptoken/. Design:
docs/superpowers/specs/2026-06-25-verify-unification-design.md (stage B1).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
