### PR TITLE
docs(skill): record iOS CFBundleVersion/TestFlight 409 gotcha

### DIFF
--- a/.claude/skills/sorcha-app/references/passkeys.md
+++ b/.claude/skills/sorcha-app/references/passkeys.md
@@ -48,8 +48,10 @@ user must re-register (or have the account reset; see "Account reset" below).
    so the committed Capacitor project stays generic (mirrors how team/profile are applied). Android
    needs **no** app-side entitlement.
 
-4. **TestFlight build number** — the committed `ios_beta` lane uses a static build number, which
-   collides on re-upload. Bump it: `increment_build_number(build_number: latest_testflight_build_number(...) + 1)`.
+4. **TestFlight build number** — now handled automatically (#1052): both iOS lanes inject a
+   monotonic **epoch-seconds** `CURRENT_PROJECT_VERSION` via `build_app xcargs` (see `ios_version_xcargs`
+   in the Fastfile), so re-uploads never collide. No manual bump needed. (Historically the committed
+   lane used a static build number that collided 409 on re-upload — see troubleshooting → TestFlight.)
 
 5. **Capacitor secure origin** — the installed app MUST load from the real HTTPS origin
    (`capacitor.config.json` `server.url = https://n1.sorcha.dev/wallet`), **not** the bundled

--- a/.claude/skills/sorcha-app/references/troubleshooting.md
+++ b/.claude/skills/sorcha-app/references/troubleshooting.md
@@ -123,6 +123,21 @@ upload step fails)
 → Bake the answer into `Info.plist`. Sorcha uses only standard crypto (Ed25519/P-256/RSA/AES/SHA) →
    `ITSAppUsesNonExemptEncryption=false` (Category 5 Part 2 exemption). Already committed.
 
+**`ios_beta` upload rejected: `The bundle version must be higher than the previously uploaded
+version: 'N'`** (HTTP 409, `cfBundleVersion` / `ENTITY_ERROR.ATTRIBUTE.INVALID.DUPLICATE`). NB this
+can masquerade as a "`match` failure" — a CI run that errors early near `match` may actually be
+fine there; run the lane locally with `--verbose` and read to the END: `match`/archive/sign/export
+all succeed and the real death is the final `upload_to_testflight`.
+→ The committed Capacitor project pins `CURRENT_PROJECT_VERSION = 1` and Info.plist resolves
+   `CFBundleVersion = $(CURRENT_PROJECT_VERSION)`, so **every iOS build is version `1`**. CI exports
+   `SORCHA_VERSION_CODE` (the run number) but **only the Android lane consumes it** — the iOS lanes
+   ignored it. Once TestFlight holds any build, `1` is always rejected as lower/duplicate.
+→ Fixed (#1052): both iOS lanes inject a **monotonic epoch-seconds** build number at archive time via
+   `build_app(xcargs: ios_version_xcargs)` → `CURRENT_PROJECT_VERSION=#{Time.now.utc.to_i}` (+
+   `MARKETING_VERSION` from `SORCHA_VERSION_NAME`). Epoch (~1.78e9) always exceeds any prior upload;
+   the Android run-number scheme can't (run numbers are small — too low to beat an existing build).
+   The committed pbxproj stays generic (xcargs overrides at build time only). No manual bump needed.
+
 **Demo account / sign-in info requested**
 → Only for **App Review** (external TestFlight first build + App Store), never internal testing. When
    you do go external/prod: Sorcha needs a working **demo login** AND a **publicly reachable backend**


### PR DESCRIPTION
Adds the build-number gotcha (the apparent 'match failure' was really a 409 duplicate `cfBundleVersion` on upload, fixed #1052) to the sorcha-app skill troubleshooting. Doc-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)