### PR TITLE
docs(skill): iOS certs-branch + epoch build-number facts (sorcha-app)

### DIFF
--- a/.claude/skills/sorcha-app/references/secrets-map.md
+++ b/.claude/skills/sorcha-app/references/secrets-map.md
@@ -13,13 +13,15 @@ build time on the Mac, so GitHub only ever sees workflow YAML and logs.
 | Password backup | Stuart's password manager | The store/key password + the keystore SHA-256. Generated once by `make-upload-keystore.sh`. Under Play App Signing the upload key is resettable. |
 | Play service-account JSON | `~/.sorcha-signing/play_service_account.json` | For `fastlane supply` (android_internal). Create once Play account exists. |
 
-## iOS (not yet — needs Apple Developer Program + Xcode 17)
+## iOS (ACTIVE — Apple Developer Program live, team `HY5HSW5FUT`)
 
 | Secret | Location (Mac) | Notes |
 |--------|----------------|-------|
-| App Store Connect API key | `~/.sorcha-signing/asc_api_key.p8` + `asc_api_key.json` (`{key_id,issuer_id}`) | Avoids 2FA in CI (build_app/pilot/match). Create once Apple enrolment active. |
-| Certs + provisioning profiles | `fastlane match` private git repo (`MATCH_GIT_URL`), encrypted with `MATCH_PASSWORD` | Decrypted into the Mac keychain at build time. Repo + passphrase set at finish time. |
+| App Store Connect API key | `~/.sorcha-signing/asc_api_key.p8` + `asc_api_key.json` (`{key_id,issuer_id}`) | Avoids 2FA in CI (build_app/pilot/match). Read by the `asc_api_key` helper in the Fastfile. |
+| Certs + provisioning profiles | `fastlane match` repo `Sorcha-Platform/ios-certs` (`MATCH_GIT_URL` in `~/.sorcha-signing/ios-match.env`), encrypted with `MATCH_PASSWORD` | **Stored on the `master` branch** — the default branch (`main`) holds only a README. ⚠️ Do NOT conclude "certs missing" by browsing the default branch / `gh api …/HEAD`; check `master`. Contents: `Y8B6P8VGRB.cer` + `.p12` (Apple Distribution), `AppStore_app.sorcha.wallet.mobileprovision`, `AdHoc_app.sorcha.wallet.mobileprovision`. Decrypted into the temp keychain at build time → identity `Apple Distribution: STUART JOHNSTON FRASER (HY5HSW5FUT)`. |
 | Device UDIDs | Apple dev portal (Devices) → match adhoc profile | For the `ios_adhoc` profile. |
+
+> **iOS build number = epoch, automatic.** `ios_version_xcargs` in the Fastfile injects `CURRENT_PROJECT_VERSION=Time.now.utc.to_i` at archive time → CFBundleVersion is a monotonic epoch that always exceeds the prior TestFlight upload. **Never bump it by hand.** A TestFlight `-19232 "bundle version must be higher than … <N>"` error means the Mac lane-runner checkout (`~/projects/Sorcha`) is **stale** (predates the epoch fix) — `git fetch origin master && git reset --hard origin/master` there before running, don't touch the version.
 
 ## Service / infra credentials (Mac)
 

--- a/.claude/skills/sorcha-app/references/troubleshooting.md
+++ b/.claude/skills/sorcha-app/references/troubleshooting.md
@@ -79,6 +79,20 @@ process alive, socket to `17.56.x:443` ends in `CLOSE_WAIT`)
 → `login.keychain` is locked over SSH and under the runner LaunchDaemon (no GUI session).
 → The lanes call `setup_ci(force: true)` before `match` (temporary keychain). Already in the Fastfile.
 
+**"The iOS certs look missing — `ios-certs` repo only has a README"**
+→ FALSE ALARM. match stores the cert + profiles on the **`master`** branch; the repo's **default branch
+   (`main`) holds only a README**. `gh api …/ios-certs/…/HEAD` or the GitHub UI default view shows `main`
+   → looks empty. The certs ARE there: `git ls-remote origin master`, or just run `match` — it checks out
+   `master` and decrypts `Y8B6P8VGRB.cer/.p12` + the AppStore/AdHoc profiles. Distribution cert is valid;
+   nothing to recreate or revoke. (See secrets-map.md.) Don't go down the "bootstrap new certs" path.
+
+**CI `build.yml` `ios_beta` dies at `match` with `git_add … exit status 1`, but a direct Mac run works**
+→ Environment divergence: the unattended workflow runs in the runner's checkout under `bash --noprofile
+   --norc`, where match's git op on the `ios-certs` clone fails; driving the lane directly in
+   `~/projects/Sorcha` (git-authed, `source ~/.zprofile` + `~/.sorcha-signing/ios-match.env`) succeeds.
+   Stopgap: run `ios_beta` directly on the Mac (nohup) to ship to TestFlight. **TODO: fix the runner-env git
+   setup so the unattended workflow signs too** (a build that only works when driven by hand is wrong).
+
 **`archive` fails: `Signing for "App" requires a development team`**
 → Capacitor's generated Xcode project uses *automatic* signing with no team; `match` is *manual*.
 → The `apply_match_signing` helper (Fastfile) sets manual signing + `DEVELOPMENT_TEAM` +
@@ -137,6 +151,12 @@ all succeed and the real death is the final `upload_to_testflight`.
    `MARKETING_VERSION` from `SORCHA_VERSION_NAME`). Epoch (~1.78e9) always exceeds any prior upload;
    the Android run-number scheme can't (run numbers are small — too low to beat an existing build).
    The committed pbxproj stays generic (xcargs overrides at build time only). No manual bump needed.
+→ **Recurrence cause = STALE Mac checkout (2026-06-28).** If you drive `ios_beta` directly on the Mac
+   (`~/projects/Sorcha`), that checkout can be behind `origin/master` and predate the epoch fix — so the
+   build silently uses the old fixed/low version and the 409 returns. **Always `git fetch origin master &&
+   git reset --hard origin/master` in `~/projects/Sorcha` before a direct run.** (The `nohup` lane-runner
+   script must do this; the CI runner already checks out fresh.) Don't re-derive this or bump the version —
+   it's epoch + a stale checkout, every time.
 
 **Demo account / sign-in info requested**
 → Only for **App Review** (external TestFlight first build + App Store), never internal testing. When


### PR DESCRIPTION
Bakes the iOS signing facts into the sorcha-app skill so future sessions don't re-derive them: (1) match certs live on the ios-certs master branch (default main is README-only); (2) iOS CFBundleVersion is a Time.now epoch — never bump manually, a 409 means a stale Mac checkout (git fetch+reset); (3) CI vs direct-run match git divergence (TODO). Verified: ios_beta uploaded to TestFlight 2026-06-28. Doc/skill-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)