### PR TITLE
respplugin:speckit:Add a "Running the tests" section to the repo README

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,16 @@ See `walkthroughs/README.md` for the full list and setup instructions.
 
 For building from source, running tests, project structure, coding conventions, and contributing — see **[DEVELOPMENT.md](DEVELOPMENT.md)**.
 
+## Running the tests
+
+Run the full test suite from the repository root (.NET 10 SDK required — see [DEVELOPMENT.md](DEVELOPMENT.md)):
+
+```bash
+dotnet test
+```
+
+For filtered runs, coverage collection, and other test options, see **[DEVELOPMENT.md](DEVELOPMENT.md)**.
+
 ## License
 
 MIT License — see [LICENSE](LICENSE) for details.

--- a/specs/171-running-tests-docs/checklists/requirements.md
+++ b/specs/171-running-tests-docs/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Running the Tests README Section
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-06-28
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Items marked incomplete require spec updates before `/speckit-clarify` or `/speckit-plan`
+- The spec names `dotnet test` and `DEVELOPMENT.md` in the **Assumptions** section only, as the concrete grounding for an otherwise technology-agnostic spec; functional requirements and success criteria remain implementation-agnostic.
+- All items pass on the first validation iteration. Spec is ready for `/speckit-plan` (clarification optional — scope is small and unambiguous).

--- a/specs/171-running-tests-docs/data-model.md
+++ b/specs/171-running-tests-docs/data-model.md
@@ -1,0 +1,28 @@
+# Phase 1 Data Model: Running the Tests README Section
+
+This feature introduces no runtime data, persistence, or code entities. The only "entity" is a documentation block, modeled here for completeness per the spec's Key Entities.
+
+## Entity: README "Running the tests" section
+
+A new, short Markdown block in the root `README.md`.
+
+| Attribute | Type | Description | Validation rule |
+|-----------|------|-------------|-----------------|
+| Heading/title | Markdown `##` heading | The section title | MUST read exactly "Running the tests" (FR-001) |
+| Description | One-line prose | Brief framing of what the command does | SHOULD be a single short sentence (FR-006) |
+| Command | Fenced code block | The suite-runner command | MUST be `dotnet test` in a copyable fenced block; MUST be accurate (FR-002, FR-003) |
+| Deep-guide pointer | Markdown link | Reference to fuller guidance | SHOULD link to `DEVELOPMENT.md` for detail (FR-006); MUST NOT duplicate it |
+
+### Relationships
+
+- **Complements** the existing `## Development` section (which links to `DEVELOPMENT.md`). The two coexist; the new section is the quick path, `## Development` / `DEVELOPMENT.md` is the deep path.
+
+### State transitions
+
+N/A — static documentation. The section is either absent (before) or present (after). No lifecycle.
+
+### Invariants (from requirements)
+
+- Additive only: no pre-existing README section is removed or semantically changed (FR-004, SC-004).
+- Documentation-only: zero non-documentation files change (FR-005, SC-003).
+- Short: heading + one-line description + command (+ optional pointer) (FR-006).

--- a/specs/171-running-tests-docs/plan.md
+++ b/specs/171-running-tests-docs/plan.md
@@ -1,0 +1,81 @@
+# Implementation Plan: Running the Tests README Section
+
+**Branch**: `171-running-tests-docs` | **Date**: 2026-06-28 | **Spec**: [spec.md](./spec.md)
+
+**Input**: Feature specification from `/specs/171-running-tests-docs/spec.md`
+
+## Summary
+
+Add a short, discoverable **"Running the tests"** section to the root `README.md` that surfaces the project's standard test command (`dotnet test`) in copyable form, placed near the existing `## Development` section so build/test guidance stays together. The change is documentation-only and additive — no existing README content is removed or semantically altered, and the deeper guide in `DEVELOPMENT.md` (already referenced) remains the canonical source for detailed test guidance.
+
+Technical approach: a single Markdown edit to `README.md` inserting one new `##`-level section (heading + one-line description + fenced `dotnet test` command + a pointer to `DEVELOPMENT.md`). No code, config, or build changes.
+
+## Technical Context
+
+**Language/Version**: Markdown (GitHub-flavored) documentation; underlying project is .NET 10 / C# 14 (unchanged by this feature)
+
+**Primary Dependencies**: None — documentation edit only. The documented command depends on the existing .NET 10 SDK toolchain already required to build the project.
+
+**Storage**: N/A
+
+**Testing**: Manual review of the rendered `README.md`; verification that the documented `dotnet test` command matches the project's actual suite runner (per CLAUDE.md and `DEVELOPMENT.md`)
+
+**Target Platform**: Repository root `README.md` (rendered on GitHub and in local editors)
+
+**Project Type**: Documentation change to an existing multi-service .NET solution
+
+**Performance Goals**: A reader locates the test command in under 30 seconds of scanning (SC-001)
+
+**Constraints**: Additive and documentation-only (FR-004, FR-005); short and focused (FR-006); consistent with existing README tone/formatting (FR-007); must not duplicate or contradict the existing `## Development` section
+
+**Scale/Scope**: One section (~4–6 lines) in one file (`README.md`)
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+The Sorcha Constitution (v1.1.0) principles are evaluated for relevance to a documentation-only change:
+
+| Principle | Applies? | Status |
+|-----------|----------|--------|
+| I. Microservices-First Architecture | No | No service/code change |
+| II. Security First | No | No secrets, inputs, or sensitive data introduced |
+| III. API Documentation | No | No API surface added or changed (this is repo-level prose, not XML/OpenAPI docs) |
+| IV. Testing Requirements | Indirect (supports) | Documents the existing `dotnet test` flow; adds no code requiring coverage. The documented command itself must be accurate (FR-003) |
+| V. Code Quality | No | No code; no compiler warnings possible |
+| VI. Blueprint Creation Standards | No | N/A |
+| VII. Domain-Driven Design | No | N/A |
+| VIII. Observability by Default | No | N/A |
+
+Documentation Sync Policy (CLAUDE.md): satisfied by design — this *is* the documentation update, and it stays consistent with `DEVELOPMENT.md` rather than duplicating it.
+
+**Result**: PASS — no violations. No entries required in Complexity Tracking.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/171-running-tests-docs/
+├── plan.md              # This file (/speckit-plan command output)
+├── research.md          # Phase 0 output (/speckit-plan command)
+├── data-model.md        # Phase 1 output (/speckit-plan command)
+├── quickstart.md        # Phase 1 output (/speckit-plan command)
+├── spec.md              # Feature specification
+└── checklists/          # Existing checklists for this feature
+```
+
+No `contracts/` directory is produced: this feature exposes no external interface (API, CLI command, schema, or grammar). It edits human-facing prose only, so a contract artifact would be empty by definition.
+
+### Source Code (repository root)
+
+```text
+README.md                # The single file changed: insert "## Running the tests" near "## Development"
+DEVELOPMENT.md           # Unchanged; remains the canonical deep test/build guide referenced by README
+```
+
+**Structure Decision**: No source tree is created or modified. The feature is a localized, additive edit to the existing root `README.md`. The new section is placed adjacent to the existing `## Development` section (currently the last content section before `## License`/`## Links`) so build and test information stay co-located, satisfying FR-007 and the spec's placement assumption.
+
+## Complexity Tracking
+
+> No constitution violations — section intentionally left empty.

--- a/specs/171-running-tests-docs/quickstart.md
+++ b/specs/171-running-tests-docs/quickstart.md
@@ -1,0 +1,76 @@
+# Quickstart / Validation Guide: Running the Tests README Section
+
+This guide validates the feature end-to-end: that the new README section exists, is correctly titled, contains the accurate test command, and that the change is additive and documentation-only.
+
+## Prerequisites
+
+- Repository checked out on branch `171-running-tests-docs`.
+- .NET 10 SDK installed (only needed for Scenario C, which actually runs the documented command).
+- A Markdown viewer or GitHub rendering for visual review.
+
+## Validation scenarios
+
+### Scenario A — Section is present and correctly titled (FR-001, AC-1)
+
+1. Open the root `README.md`.
+2. Scan the headings (or search for "Running the tests").
+3. **Expected**: A `## Running the tests` section exists, near the `## Development` section.
+
+```bash
+grep -n "^## Running the tests" README.md
+```
+
+**Pass when**: the grep returns exactly one match.
+
+### Scenario B — Documented command is present and copyable (FR-002, AC-2)
+
+1. Read the new section.
+2. **Expected**: a fenced code block containing `dotnet test`.
+
+```bash
+# The section contains a fenced 'dotnet test' command
+grep -n "dotnet test" README.md
+```
+
+**Pass when**: `dotnet test` appears within the new section's fenced block.
+
+### Scenario C — Command is accurate and actually runs the suite (FR-003, SC-002, AC-3)
+
+1. From the repository root, copy the command from the section verbatim and run it (prerequisites met).
+
+```bash
+dotnet test
+```
+
+**Pass when**: the test suite executes (tests start running). A passing/failing test outcome is out of scope — the point is the command is not stale/typo'd and the suite runs.
+
+### Scenario D — Change is additive and documentation-only (FR-004, FR-005, SC-003, SC-004)
+
+1. Inspect the diff for this feature.
+
+```bash
+git diff --stat master -- README.md          # only README.md should appear
+git diff --name-only master                  # confirm no non-doc files changed
+```
+
+**Pass when**:
+- Only `README.md` (and the `specs/171-running-tests-docs/` planning docs) are modified.
+- The `README.md` diff is purely an insertion — no existing section is removed or reworded (review the `git diff README.md` hunks to confirm only added lines around the new section, plus at most minimal surrounding navigation).
+
+### Scenario E — No duplication/contradiction with existing Development guidance (edge case, FR-006)
+
+1. Confirm the existing `## Development` section and its `DEVELOPMENT.md` pointer remain intact.
+2. **Expected**: the new section references `DEVELOPMENT.md` for deeper detail rather than reproducing it.
+
+**Pass when**: `## Development` is unchanged and the new section defers depth to `DEVELOPMENT.md`.
+
+## Success-criteria mapping
+
+| Criterion | Validated by |
+|-----------|--------------|
+| SC-001 (find command in <30s) | Scenario A + B (single scan locates titled section + command) |
+| SC-002 (command runs) | Scenario C |
+| SC-003 (docs-only) | Scenario D |
+| SC-004 (existing content preserved) | Scenario D + E |
+
+See [data-model.md](./data-model.md) for the section's attribute rules and [research.md](./research.md) for the command/placement decisions.

--- a/specs/171-running-tests-docs/research.md
+++ b/specs/171-running-tests-docs/research.md
@@ -1,0 +1,33 @@
+# Phase 0 Research: Running the Tests README Section
+
+All Technical Context items are known; no `NEEDS CLARIFICATION` markers remained. The research below records the decisions that ground the (trivial) implementation.
+
+## Decision 1 — Documented test command
+
+- **Decision**: Document `dotnet test` (run from the repository root) as the full-suite command.
+- **Rationale**: `CLAUDE.md` ("Build & Test") and the project's standard workflow use `dotnet test` to run all tests across the 50+ test projects. This is the project's actual suite runner, satisfying FR-003 and SC-002. Optionally mention `dotnet restore && dotnet build` as the preceding steps already shown in CLAUDE.md's Quick Start, but keep the section short (FR-006).
+- **Alternatives considered**:
+  - A per-project filtered command (`dotnet test --filter ...`) — rejected: that is detail for `DEVELOPMENT.md`, not the "run the whole suite" entry point.
+  - A coverage variant (`dotnet test --collect:"XPlat Code Coverage"`) — rejected for the short section; belongs in the deeper guide.
+
+## Decision 2 — Placement within README
+
+- **Decision**: Insert a new `## Running the tests` section immediately adjacent to the existing `## Development` section (README.md line ~276).
+- **Rationale**: FR-007 and the spec's placement assumption want test info next to build/development info. The `## Development` section already points to `DEVELOPMENT.md`; placing the quick command directly before/after it gives readers the fast path up front while preserving the deep-link.
+- **Alternatives considered**:
+  - Adding it under `## Quick Start` — rejected: Quick Start is Docker-run oriented (running the platform), not building/testing from source.
+  - Replacing the `## Development` pointer — rejected: violates FR-004 (must be additive, not alter existing content).
+
+## Decision 3 — Relationship to existing content
+
+- **Decision**: The new section complements, not duplicates, the `## Development` section. It contains a one-line description, the fenced command, and a pointer to `DEVELOPMENT.md` for deeper detail.
+- **Rationale**: Edge cases in the spec require no duplication/contradiction with the existing `DEVELOPMENT.md` pointer (FR-004, SC-004). Keeping `DEVELOPMENT.md` as the canonical deep guide avoids documentation drift.
+- **Alternatives considered**: Reproducing prerequisites inline — rejected; instead reference the existing Prerequisites/Development guidance so there is a single source of truth.
+
+## Decision 4 — Prerequisite handling
+
+- **Decision**: Note that the .NET 10 SDK is required (or point to the README's existing Prerequisites / `DEVELOPMENT.md`) so a missing toolchain produces an understandable failure rather than a mysterious one.
+- **Rationale**: Spec edge case — "if prerequisites are not installed, the section should make the dependency clear or point to where prerequisites are listed."
+- **Alternatives considered**: Silent omission — rejected; fails the edge-case expectation.
+
+**Output**: No open questions. Ready for Phase 1.

--- a/specs/171-running-tests-docs/spec.md
+++ b/specs/171-running-tests-docs/spec.md
@@ -1,0 +1,66 @@
+# Feature Specification: Running the Tests README Section
+
+**Feature Branch**: `171-running-tests-docs`
+
+**Created**: 2026-06-28
+
+**Status**: Draft
+
+**Input**: User description: "Add a short 'Running the tests' section to the repo README documenting the test command; docs-only, additive."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Discover how to run the tests from the README (Priority: P1)
+
+A developer or evaluator who has just cloned (or is browsing) the repository opens the root `README.md` to understand the project. They want to run the test suite to confirm their environment is healthy, but the README currently only points them to a separate `DEVELOPMENT.md` file under a general "Development" heading. They scan the README and find a clearly titled "Running the tests" section that gives them the exact command to run the tests, so they can verify the build without leaving the README or hunting through other docs.
+
+**Why this priority**: This is the entire feature. Without a discoverable, correctly named section containing the test command, the change delivers no value. It is independently testable and shippable on its own.
+
+**Independent Test**: Open the root `README.md`, locate a "Running the tests" section, and confirm it contains the documented test command. The section can be reviewed and validated in isolation by reading the rendered README.
+
+**Acceptance Scenarios**:
+
+1. **Given** the root `README.md`, **When** a reader scans its headings, **Then** a section titled "Running the tests" is present.
+2. **Given** the "Running the tests" section, **When** a reader follows it, **Then** the documented command to run the full test suite is shown in a copyable form.
+3. **Given** a developer with the documented prerequisites met, **When** they copy and run the command from the section verbatim, **Then** the project's tests execute.
+
+---
+
+### Edge Cases
+
+- The new section must not duplicate or contradict the existing "Development" section that points to `DEVELOPMENT.md`; it complements it (a quick command up front, with the deeper guide still referenced).
+- The documented command must match the command the project actually uses, so a reader copying it does not hit an error.
+- If a reader's prerequisites (e.g. SDK/toolchain) are not installed, the section should make the dependency clear or point to where prerequisites are listed, so the failure is understandable rather than mysterious.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The root `README.md` MUST contain a clearly identifiable section titled "Running the tests".
+- **FR-002**: The section MUST document the command used to run the project's full test suite, presented in a copyable (code-formatted) form.
+- **FR-003**: The documented command MUST be accurate — i.e. it MUST be the command the project actually uses to run its tests.
+- **FR-004**: The change MUST be additive — it MUST NOT remove or alter existing README content beyond inserting the new section (and any minimal surrounding navigation needed to place it).
+- **FR-005**: The change MUST be documentation-only — no source code, configuration, build, or test behavior is modified.
+- **FR-006**: The section MUST remain short and focused on the test command, deferring deeper detail to the existing development guide rather than reproducing it.
+- **FR-007**: The section SHOULD be placed where a reader naturally looks for it (near build/development information) and SHOULD remain consistent with the README's existing tone and formatting.
+
+### Key Entities
+
+- **README "Running the tests" section**: A new, short documentation block in the root `README.md` whose purpose is to surface the test command; attributes are its heading/title, the documented command, and an optional brief pointer to the fuller development guide.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A reader can locate the test command in the README in under 30 seconds of scanning, without opening any other file.
+- **SC-002**: 100% of the test commands shown in the section run successfully (no typos or stale commands) when prerequisites are met.
+- **SC-003**: The change touches documentation only — zero non-documentation files are modified.
+- **SC-004**: Existing README content is preserved — no pre-existing section is removed or semantically changed by the addition.
+
+## Assumptions
+
+- The "repo README" refers to the root `README.md` at the repository top level.
+- The documented test command is the project's standard suite-runner command (`dotnet test`), consistent with the existing build/test guidance; deeper test guidance continues to live in `DEVELOPMENT.md`, which the README already references.
+- "Short" means a few lines — a heading, a one-line description, and the command (optionally with a pointer to `DEVELOPMENT.md`) — not a full testing guide.
+- The section is placed near the existing "Development" content so build and test information stay together.
+- No translations or localized README variants are in scope.

--- a/specs/171-running-tests-docs/tasks.md
+++ b/specs/171-running-tests-docs/tasks.md
@@ -1,0 +1,112 @@
+# Tasks: Running the Tests README Section
+
+**Input**: Design documents from `/specs/171-running-tests-docs/`
+
+**Prerequisites**: plan.md ✅, spec.md ✅, research.md ✅
+
+**Organization**: Single user story (P1 only); no shared infrastructure required.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (US1)
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Verify the current state of `README.md` before editing.
+
+- [ ] T001 Read `README.md` to identify the placement point adjacent to the `## Development` section
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: No shared infrastructure is required for a documentation-only change.
+
+> This phase is intentionally empty — there are no blocking technical prerequisites for a Markdown edit.
+
+**Checkpoint**: Foundation ready — user story implementation can begin immediately.
+
+---
+
+## Phase 3: User Story 1 — Discover how to run the tests from the README (Priority: P1) 🎯 MVP
+
+**Goal**: Insert a clearly titled `## Running the tests` section into `README.md` containing `dotnet test` in copyable form, placed adjacent to the existing `## Development` section.
+
+**Independent Test**: Open `README.md`, locate the "Running the tests" heading, confirm the `dotnet test` command appears in a fenced code block, and confirm no existing section is removed or altered.
+
+### Implementation for User Story 1
+
+- [ ] T002 [US1] Insert `## Running the tests` section in `README.md` immediately before or after the existing `## Development` section (research Decision 2), containing: a one-line description, a fenced `dotnet test` command block, a prerequisite note (.NET 10 SDK), and a pointer to `DEVELOPMENT.md` (research Decisions 1, 3, 4)
+
+**Checkpoint**: User Story 1 is fully functional — `README.md` now contains the discoverable test-command section satisfying FR-001 through FR-007 and SC-001 through SC-004.
+
+---
+
+## Phase 4: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final review confirming the change is additive and accurate.
+
+- [ ] T003 [P] [US1] Review rendered `README.md` to confirm: (a) "Running the tests" heading is scannable within 30 s (SC-001), (b) `dotnet test` command is accurate (SC-002 / FR-003), (c) no non-documentation file was modified (SC-003), (d) no pre-existing section was removed or semantically changed (SC-004 / FR-004)
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — start immediately
+- **Foundational (Phase 2)**: Empty — no blocking work
+- **User Story 1 (Phase 3)**: Depends on Setup (T001 read completes before T002 edit)
+- **Polish (Phase 4)**: Depends on Phase 3 completion
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: Self-contained; no cross-story dependencies
+
+### Within User Story 1
+
+- T001 (read) → T002 (edit) → T003 (review)
+- T003 can run in parallel with any other documentation review tasks if present
+
+### Parallel Opportunities
+
+- T003 is marked [P] — it can run in parallel with any post-implementation review task added later.
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+# Sequential — single file; no parallel opportunity within the story itself
+T001: Read README.md to find placement point
+T002: Insert "Running the tests" section
+T003: Review rendered README.md for accuracy and completeness
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: read `README.md` (T001)
+2. Complete Phase 3: insert section (T002)
+3. **STOP and VALIDATE**: review rendered output (T003)
+4. Ship — this is the entire feature
+
+### Incremental Delivery
+
+No further stories exist. The feature is complete after T003 passes.
+
+---
+
+## Notes
+
+- [P] tasks = different files or no output dependency; safe to run concurrently
+- [US1] label maps each task to User Story 1 for traceability
+- Tests are not included — the feature specification does not request automated tests (docs-only change reviewed manually)
+- No source code, configuration, build, or test behaviour is modified (FR-005, SC-003)
+- Commit after T002 with reference to feature 171

--- a/specs/171-running-tests-docs/tasks.md
+++ b/specs/171-running-tests-docs/tasks.md
@@ -17,7 +17,7 @@
 
 **Purpose**: Verify the current state of `README.md` before editing.
 
-- [ ] T001 Read `README.md` to identify the placement point adjacent to the `## Development` section
+- [X] T001 Read `README.md` to identify the placement point adjacent to the `## Development` section
 
 ---
 
@@ -39,7 +39,7 @@
 
 ### Implementation for User Story 1
 
-- [ ] T002 [US1] Insert `## Running the tests` section in `README.md` immediately before or after the existing `## Development` section (research Decision 2), containing: a one-line description, a fenced `dotnet test` command block, a prerequisite note (.NET 10 SDK), and a pointer to `DEVELOPMENT.md` (research Decisions 1, 3, 4)
+- [X] T002 [US1] Insert `## Running the tests` section in `README.md` immediately before or after the existing `## Development` section (research Decision 2), containing: a one-line description, a fenced `dotnet test` command block, a prerequisite note (.NET 10 SDK), and a pointer to `DEVELOPMENT.md` (research Decisions 1, 3, 4)
 
 **Checkpoint**: User Story 1 is fully functional — `README.md` now contains the discoverable test-command section satisfying FR-001 through FR-007 and SC-001 through SC-004.
 
@@ -49,7 +49,7 @@
 
 **Purpose**: Final review confirming the change is additive and accurate.
 
-- [ ] T003 [P] [US1] Review rendered `README.md` to confirm: (a) "Running the tests" heading is scannable within 30 s (SC-001), (b) `dotnet test` command is accurate (SC-002 / FR-003), (c) no non-documentation file was modified (SC-003), (d) no pre-existing section was removed or semantically changed (SC-004 / FR-004)
+- [X] T003 [P] [US1] Review rendered `README.md` to confirm: (a) "Running the tests" heading is scannable within 30 s (SC-001), (b) `dotnet test` command is accurate (SC-002 / FR-003), (c) no non-documentation file was modified (SC-003), (d) no pre-existing section was removed or semantically changed (SC-004 / FR-004)
 
 ---
 


### PR DESCRIPTION
## Summary
Add a short 'Running the tests' section to the repo README documenting the test command; docs-only, additive.

## Changes
- prodexec(implement): d8075672f540
- prodexec(tasks): d8075672f540
- prodexec(plan): d8075672f540
- prodexec(specify): d8075672f540

## Spec / refs
- Branch: `171-running-tests-docs`
- Spec: `specs/171-running-tests-docs/spec.md`

## Brief
Add a short 'Running the tests' section to the repo README documenting the test command; docs-only, additive.
