### PR TITLE
docs(skill): modernise prodexec skill for new orchestrator capabilities

### DIFF
--- a/.claude/skills/prodexec/SKILL.md
+++ b/.claude/skills/prodexec/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: prodexec
-description: Use when the user addresses prodexec — a message starting with "prodexec ...", or asking to have prodexec build/add/fix/run a feature, or to release/approve/answer/lock/confirm/cancel/check the status of a prodexec run. Drives the already-deployed prodexec orchestrator on the `tiny` host over SSH. Do NOT use for changing prodexec itself.
+description: Use when the user addresses prodexec — a message starting with "prodexec ...", or asking to have prodexec build/add/fix/run a feature, or to answer/confirm/review-retry/cancel/check the status of a prodexec run. Drives the already-deployed prodexec orchestrator on the `tiny` host over SSH. Do NOT use for changing prodexec itself.
 ---
 
 # prodexec — drive the deployed orchestrator
@@ -13,11 +13,12 @@ back. **Never implement or modify prodexec** (that lives in `C:\Projects\prodexe
 
 ## The one rule: FIRE AND RETURN — never block or poll
 
-Starting a run **enqueues** it via the conductor and returns **immediately** with a run id; the
-daemon executes it in the background, crash-proof (token limits / API failures / reboots resume).
-So: **submit → report the run id → tell the user how to watch → STOP.** Do **not** wait for a run
-to finish, do **not** loop polling `list`/`metrics`, do **not** tail logs. Progress surfaces in
-Slack (each project posts to `#prodexec-<project>`, e.g. `#prodexec-sorcha`) and via `prodexec list`.
+A run starts **immediately** (auto-go) and the daemon executes it in the background, crash-proof
+(token limits / API failures / reboots resume). So: **submit → report the run id → tell the user
+how to follow it → STOP.** Do **not** sit and wait for a run to finish or hand-roll a polling
+loop. Progress surfaces in Slack (each project posts to `#prodexec-<project>`, e.g.
+`#prodexec-sorcha`), via `prodexec watch <id>` (live), and via `prodexec metrics <id> --json`
+(one-shot). When you do need to react to completion, prefer `watch` over a manual poll loop.
 
 ## Transport (PowerShell tool only — never the Bash tool / Git Bash)
 
@@ -36,51 +37,114 @@ what broke** — do not fabricate run ids or behavior.
 
 | The user means… | Command (`… uv run prodexec` prefix omitted) |
 |---|---|
-| Start new work ("prodexec add a logout endpoint to sorcha", "have prodexec fix the flaky auth test") | `run <project> "<concise title>"` |
-| …and "auto" / "no gate" / "fire it off immediately" | `run <project> "<title>" --auto-lock` |
-| Release / approve a parked run at the lock gate | `lock <run_id> [--decision locked\|abandon]` |
-| Answer a run at the answer gate | `answer <run_id> "<text>"` |
-| Resolve the blast-radius gate | `confirm <run_id> [--decision proceed\|abandon]` |
+| Start new work ("prodexec add a logout endpoint to sorcha", "fix the flaky auth test") | `run <project> "<concise title>" --json` |
+| …and "wait for me before it runs" / "manual hold" | `run <project> "<title>" --require-lock --json` then `lock <run_id>` to release |
+| Answer a run parked at the answer gate | `answer <run_id> "<text>"` (empty text is rejected) |
+| Resolve a structural-change (blast-radius) gate | `confirm <run_id> [--decision proceed\|abandon]` |
 | Resolve the review gate | `review-retry <run_id> [--decision retry\|abandon]` |
-| Status ("what's prodexec doing?", "status of <id>") | `list [--limit N]` or `metrics <run_id>` |
-| Stop a run | `cancel <run_id>` |
+| Status / "did it land?" / "what's it doing?" | `metrics <run_id> --json` (one-shot) · `watch <run_id>` (live) · `list --json` (all runs) |
+| Stop / abandon a run (any stage) | `cancel <run_id>` |
 
 - **`<project>` is a registered config name (e.g. `sorcha`), NOT a path.** Infer it from the
-  request; if absent and ambiguous, run `list` (or read `~/.prodexec/config.toml`) and ask which.
+  request; if absent and ambiguous, run `list --json` (or read `~/.prodexec/config.toml`) and ask which.
 - Turn a free-form request into **one concise feature title** scoped to a **single focused fix** —
   prodexec thrashes on multi-fix bundles; split bundles into separate runs.
-- For gate commands, if the user gives no run id, look it up with `list` and confirm which run.
+- For gate commands, if the user gives no run id, look it up with `list --json` and confirm which run.
+- `--auto-lock` is a **deprecated no-op** (auto-go is the default now) — don't pass it.
 
-## Default run flow (the lock gate)
+## Default run flow — auto-go
 
-`run` **parks at the human lock gate by default** and does not execute until released. After
-submitting, tell the user: the run id, that it's **parked awaiting release**, and how to release
-(`prodexec lock <id>` here, or the one-tap button in the project's Slack channel). Only add
-`--auto-lock` when the user **explicitly** says "auto" / "no gate" / "run immediately".
+`run` **starts immediately**. Do NOT tell the user to "lock" it or that it's "parked awaiting
+release" — that's the old behaviour. The only gate a normal run can hit unprompted is the
+**blast-radius gate** on a structural/dependency change (see Gates). To stop a run, `cancel <id>`
+at any stage. Only use `--require-lock` when the user **explicitly** wants a manual hold before
+work begins; then release with `lock <id>` (or the Slack button).
 
-## Watching ≠ the truth
+## Status — use the JSON contract, never prose-parse
 
-- `list` shows the DBOS workflow status. **`SUCCESS` ≠ merged** — the workflow returns
-  `done`/`paused_error` as a normal value, so DBOS marks it SUCCESS either way. For "did it land?",
-  read `metrics <run_id>` (`terminal_status` = `done` vs `paused_error`, `first_ci_outcome`,
-  `review_fix_rounds`). A `paused_error` park (red CI / error) is terminal — relaunch, don't resume.
-- `list`/`metrics`/`run` are thin DBOSClient surfaces (no executor) and are safe to run anytime.
+`run`, `list`, and `metrics` accept **`--json`** (stable, versioned: top-level `schema_version`,
+currently `1`). JSON goes to **stdout only**; banners/logs go to stderr. **Never** grep/regex the
+human output — read the JSON.
+
+- **"Did it land?"** is exactly:
+  ```
+  ssh stuart@tiny 'cd ~/prodexec && ~/.local/bin/uv run prodexec metrics <id> --json' | <parse> .merged
+  ```
+  `merged: true` ⇔ the run reached terminal `done` (merged-on-green). Do not infer from text.
+- `metrics <id> --json` fields: `schema_version`, `workflow_status`, `terminal_status`
+  (`null | running | done | failed | paused_error | paused_rate_limited`), `first_ci_outcome`
+  (`green|red|undetermined`), `review_fix_rounds`, `pr_number`, `pr_url`, `merged` (bool),
+  `auto_recoveries` (int — human round-trips the resilience layer saved).
+- `run <project> "…" --json` → `{schema_version, run_id, state:"enqueued", lock_required}` returned
+  **immediately**. Capture `run_id` from the JSON — do **not** scrape "enqueued run …".
+- `list --json` → `{schema_version, runs:[{run_id, workflow_status}]}`.
+- `workflow_status` ≠ merged: a DBOS workflow returns `done`/`paused_error` as a normal value, so
+  the raw workflow shows success either way. Trust `merged` / `terminal_status`, not workflow state.
+
+### Live streaming — `watch`
+
+`prodexec watch <id> [--interval N] [--timeout S]` emits **newline-delimited JSON events** and
+exits at the first terminal/parked state (or after `--timeout`, default ~1 day). Event kinds:
+`phase` (phase advanced), `status` (run status changed), `ci` (first CI outcome known),
+`recovery` (a resilience auto-recovery fired), `terminal` (finished/parked — stream stops).
+Recommend `watch` for following a run; `metrics --json` for a one-shot check.
+
+## Runs self-heal — don't pre-warn about routine failures
+
+Before parking, prodexec **auto-recovers** (bounded, idempotent): transient git/CI/network errors
+retry with backoff; artifact-file merge conflicts (`CLAUDE.md`, `.specify/**`, `*FormatWhen*.razor`)
+auto-resolve to base; a behind-base branch rebases and retries the merge; a malformed PR title
+regenerates. The `auto_recoveries` metric counts the round-trips saved. **Do not pre-warn the user
+about these as likely failures** — they're handled. (Mechanism: deterministic retryable-pattern
+fast-path, else a cheap Haiku "stuck vs. silly" adjudicator restricted to a safe action set, with
+fail-safe-to-human-park on low confidence / non-allowlisted action / exhausted budget.)
+
+## Failures park cleanly — they don't crash
+
+A recoverable problem that exhausts auto-recovery lands at **`terminal_status: "paused_error"`** — a
+normal "needs attention" state with a logged rationale, **not** a crash. Causes: a genuine code
+conflict, a real CI failure, or an exhausted recovery budget. (`paused_rate_limited` is the
+rate-limit variant.) There is no crash/reconcile path to reason about. A `paused_error` is terminal
+for that attempt — diagnose + relaunch (or hand-fix the PR), don't try to "resume" it.
+
+## Gates — structural/needs-human pauses
+
+These are distinct from `paused_error`; resolve them with the matching command:
+
+| `workflow_status` | Meaning | Resolve |
+|---|---|---|
+| `AWAITING_BLAST_CONFIRM` | structural/dependency change (deterministic + cheap-model two-layer classifier) | `confirm <id>` (or `--decision abandon`) |
+| `AWAITING_REVIEW` | review wants another pass | `review-retry <id>` (or `--decision abandon`) |
+| `AWAITING_ANSWER` | the run asked a question | `answer <id> "<text>"` (empty answers rejected) |
+
+If the user has said to keep momentum, auto-resolve these to proceed (see
+[[feedback_prodexec_auto_release_locks]] / [[feedback_prodexec_gate_idle_pattern]]); merge is still
+gated by CI + review.
+
+## Per-project config (`~/.prodexec/config.toml`)
+
+Knobs are per-project / per-section (no longer hardcoded). Read them when behaviour is in question:
+- `default_branch` — base branch per `[[projects]]` (e.g. `master`; no longer hardcoded).
+- `merge_method` — `squash` | `merge` | `rebase`.
+- `[ci]` — `poll_interval_s`, `poll_max_attempts`.
+- `[resilience]` — `retryable_error_patterns`, `recovery_max_attempts`.
+- `[merge] scaffolding_allowlist` — auto-resolve-to-base conflict allowlist (default `.specify/**`,
+  `CLAUDE.md`, `*FormatWhen*.razor`).
 
 ## Output discipline
 
-Always show the **actual command you ran** and its **raw output**, then one line of plain-English
-summary (e.g. "Enqueued run `a1b2c3…`, parked at the lock gate — release with `prodexec lock a1b2c3`
-or the button in #prodexec-sorcha").
+Always show the **actual command you ran** and its **raw (JSON) output**, then one line of
+plain-English summary.
 
 ## Example
 
 > User: "prodexec fix the flaky InclusionProofEndpointTests in sorcha"
 
 ```
-ssh stuart@tiny 'cd ~/prodexec && ~/.local/bin/uv run prodexec run sorcha "Fix flaky InclusionProofEndpointTests (SystemWalletSigning:ValidatorId)"'
-# → started run a1b2c3d4e5f6
+ssh stuart@tiny 'cd ~/prodexec && ~/.local/bin/uv run prodexec run sorcha "Fix flaky InclusionProofEndpointTests (SystemWalletSigning:ValidatorId)" --json'
+# → {"schema_version":1,"run_id":"a1b2c3d4e5f6","state":"enqueued","lock_required":false}
 ```
 
-Then: "Enqueued run `a1b2c3d4e5f6` for `sorcha`, **parked at the lock gate**. Release it with
-`prodexec lock a1b2c3d4e5f6` (or tap the button in **#prodexec-sorcha**); progress streams there
-and in `prodexec list`."
+Then: "Enqueued run `a1b2c3d4e5f6` for `sorcha` — it's running now (auto-go). Follow it live with
+`prodexec watch a1b2c3d4e5f6`, check `prodexec metrics a1b2c3d4e5f6 --json` for a one-shot status,
+or watch **#prodexec-sorcha**. Cancel anytime with `prodexec cancel a1b2c3d4e5f6`."


### PR DESCRIPTION
Modernises the prodexec skill (client guide; does not touch prodexec source) for the shipped orchestrator changes on tiny (PRs #15-17): --json status contract (metrics --json | .merged), auto-go default + --require-lock opt-in (--auto-lock deprecated), prodexec watch streaming, self-heal/auto_recoveries, clean paused_error parking, AWAITING_* gates, and per-project config knobs. Skill-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)