### PR TITLE
fix: wire authenticated HAIP transport into verify hosts (stop 'not configured' false error)

### DIFF
--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Extensions/ServiceCollectionExtensions.cs
@@ -33,10 +33,19 @@ public static class ServiceCollectionExtensions
     /// <see cref="InvalidOperationException"/>. Server-side Aspire hosts may omit this and rely
     /// on service-discovery configuration instead.
     /// </param>
+    /// <param name="configureHaipClient">
+    /// Optional hook to extend the <see cref="IHaipVerifierClient"/> typed-client pipeline with the
+    /// host's authentication handler. The HAIP verify endpoints (<c>/api/v1/verifier/requests</c>)
+    /// require an authenticated caller (Feature 164), so a host that overrides
+    /// <see cref="IVerificationTransport"/> with <see cref="HaipVerificationTransport"/> MUST pass
+    /// its bearer/auth <see cref="System.Net.Http.DelegatingHandler"/> here — otherwise the call
+    /// goes out unauthenticated, 401s, and is mis-rendered as "Verification is not yet configured".
+    /// </param>
     public static IServiceCollection AddSorchaUserComponents(
         this IServiceCollection services,
         IConfiguration configuration,
-        string? haipBaseUrl = null)
+        string? haipBaseUrl = null,
+        Action<IHttpClientBuilder>? configureHaipClient = null)
     {
         // Feature 173: anonymous client for the three social-link step-up endpoints (F168 contract).
         services.AddScoped<IAnonymousSocialLinkClientService, AnonymousSocialLinkClientService>();
@@ -55,6 +64,10 @@ public static class ServiceCollectionExtensions
         var haipClientBuilder = services.AddHttpClient<IHaipVerifierClient, HaipVerifierClient>();
         if (!string.IsNullOrEmpty(haipBaseUrl))
             haipClientBuilder.ConfigureHttpClient(c => c.BaseAddress = new Uri(haipBaseUrl));
+
+        // Let the host attach its authentication handler to the HAIP verifier client (Feature 164).
+        // Without this the verify request is unauthenticated and the endpoint 401s.
+        configureHaipClient?.Invoke(haipClientBuilder);
 
         // Guard so a host that registered IRegisterAnchorClient before calling AddSorchaUserComponents
         // keeps its own registration rather than being shadowed by the typed HttpClient registration.

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/Verification/HaipVerificationTransport.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/Verification/HaipVerificationTransport.cs
@@ -37,6 +37,17 @@ public sealed class HaipVerificationTransport : IVerificationTransport
         CancellationToken ct = default)
     {
         var session = await StartAsync(question, ct);
+
+        // A transport/auth/server failure surfaces as an Error session with empty ids. Throw so the
+        // shared VerificationSessionQr component shows its error + retry state — returning the empty
+        // ids here would be mis-rendered as "Verification is not yet configured here." The genuine
+        // not-configured state is reserved for NotConfiguredVerificationTransport (the stub).
+        if (session.State == VerificationSessionState.Error)
+        {
+            throw new InvalidOperationException(
+                session.Error ?? "Failed to start the verification session.");
+        }
+
         return new VerificationSessionStarted(
             SessionId: session.SessionId,
             QrDeepLink: session.QrDeepLink,

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Program.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Program.cs
@@ -7,10 +7,13 @@ using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 using MudBlazor.Services;
 using Sorcha.Blueprint.Schemas.Client;
 using Sorcha.UI.Components.User.Extensions;
+using Sorcha.UI.Components.User.Services.Verification;
 using Sorcha.UI.Core.Extensions;
 using Sorcha.UI.Core.Services;
+using Sorcha.UI.Core.Services.Http;
 using Sorcha.UI.Core.Services.User.Enrolment;
 using Sorcha.UI.Web.Client;
+using Sorcha.UI.Web.Client.Services;
 
 var builder = WebAssemblyHostBuilder.CreateDefault(args);
 
@@ -30,8 +33,20 @@ builder.RootComponents.Add<HeadOutlet>("head::after");
 // Register core services (authentication, encryption, configuration) with base address
 builder.Services.AddCoreServices(builder.HostEnvironment.BaseAddress);
 
-// Feature 163: shared user-facing component library seams.
-builder.Services.AddSorchaUserComponents(builder.Configuration);
+// Feature 163/164: shared user-facing component library seams + live HAIP verify transport.
+// The web client acts as a relying-party verifier. Pass the gateway base address so the HAIP
+// verifier client can resolve relative URIs, and attach the web client's
+// AuthenticatedHttpMessageHandler so the verify request carries the signed-in user's bearer token
+// — the verify endpoints (/api/v1/verifier/requests) require an authenticated caller (Feature 164).
+builder.Services.AddSorchaUserComponents(
+    builder.Configuration,
+    haipBaseUrl: builder.HostEnvironment.BaseAddress,
+    configureHaipClient: b => b.AddHttpMessageHandler<AuthenticatedHttpMessageHandler>());
+
+// Override the NotConfigured stub transport with the live HAIP transport (Feature 164). Without
+// this override the web client always reported "Verification is not yet configured here."
+builder.Services.AddScoped<IVerifierIdentityProvider, WebVerifierIdentityProvider>();
+builder.Services.AddScoped<IVerificationTransport, HaipVerificationTransport>();
 
 // Register authorization
 builder.Services.AddAuthorizationCore();

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Services/WebVerifierIdentityProvider.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Services/WebVerifierIdentityProvider.cs
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using Microsoft.Extensions.Configuration;
+using Sorcha.UI.Components.User.Services.Verification;
+
+namespace Sorcha.UI.Web.Client.Services;
+
+/// <summary>
+/// Web-host implementation of <see cref="IVerifierIdentityProvider"/> (Feature 164). The platform
+/// web client acts as a relying-party verifier; it returns a stable <c>client_id</c> derived from
+/// configuration (<c>Verifier:OrgId</c>, defaulting to <c>"web"</c>). The HAIP endpoint derives the
+/// authoritative client_id server-side, so this value is used for request correlation / logging.
+/// Mirrors the desk verifier's stable-identity model (rather than the PWA's ephemeral identity).
+/// </summary>
+public sealed class WebVerifierIdentityProvider(IConfiguration configuration) : IVerifierIdentityProvider
+{
+    private readonly string _clientId =
+        $"did:sorcha:verifier:{configuration["Verifier:OrgId"] ?? "web"}";
+
+    /// <inheritdoc />
+    public Task<string> GetClientIdAsync(CancellationToken ct = default) => Task.FromResult(_clientId);
+}

--- a/src/Apps/Sorcha.Wallet.Pwa/Program.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Program.cs
@@ -8,6 +8,7 @@ using Sorcha.UI.Components.User.Extensions;
 using Sorcha.UI.Components.User.Services.Verification;
 using Sorcha.Wallet.Pwa;
 using Sorcha.Wallet.Pwa.Extensions;
+using Sorcha.Wallet.Pwa.Services;
 using Sorcha.Wallet.Pwa.Services.Signing;
 
 var builder = WebAssemblyHostBuilder.CreateDefault(args);
@@ -24,10 +25,18 @@ builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.
 // at the host root so we strip the /wallet/ prefix off the BaseAddress.
 var hostRoot = new Uri(builder.HostEnvironment.BaseAddress).GetLeftPart(UriPartial.Authority) + "/";
 
-// Feature 163: shared user-facing component library seams. Pass hostRoot so the
+// Feature 163/164: shared user-facing component library seams. Pass hostRoot so the
 // IHaipVerifierClient typed HttpClient gets a BaseAddress — WASM IHttpClientFactory
-// clients have no BaseAddress by default, causing relative URI calls to throw.
-builder.Services.AddSorchaUserComponents(builder.Configuration, haipBaseUrl: hostRoot);
+// clients have no BaseAddress by default, causing relative URI calls to throw — and attach the
+// PWA's BearerTokenHandler + ServerClockHandler so the verify request carries the holder's bearer
+// token. The verify endpoints (/api/v1/verifier/requests) require an authenticated caller; without
+// the handler the call 401s and is mis-rendered as "Verification is not yet configured here."
+builder.Services.AddSorchaUserComponents(
+    builder.Configuration,
+    haipBaseUrl: hostRoot,
+    configureHaipClient: b => b
+        .AddHttpMessageHandler<BearerTokenHandler>()
+        .AddHttpMessageHandler<ServerClockHandler>());
 
 builder.Services.AddCitizenWalletServices(hostRoot);
 

--- a/tests/Sorcha.UI.Components.User.Tests/Services/Verification/HaipVerificationTransportTests.cs
+++ b/tests/Sorcha.UI.Components.User.Tests/Services/Verification/HaipVerificationTransportTests.cs
@@ -88,6 +88,30 @@ public sealed class HaipVerificationTransportTests
     }
 
     [Fact]
+    public async Task StartSessionAsync_OnTransportFault_Throws()
+    {
+        // Arrange — a 401 / network / server fault must surface as a thrown error so the shared
+        // VerificationSessionQr component shows its error + retry state, NOT "Verification is not
+        // yet configured here." The not-configured state is reserved for the stub transport
+        // (Feature 164 — fixes the mis-rendered auth failure).
+        _identityMock.Setup(x => x.GetClientIdAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync("client-id");
+
+        _clientMock.Setup(x => x.CreateRequestAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException("401 Unauthorized"));
+
+        var sut = CreateSut();
+
+        // Act
+        var act = async () => await sut.StartSessionAsync(AgePreset);
+
+        // Assert
+        await act.Should().ThrowAsync<InvalidOperationException>(
+            because: "a transport fault must not be returned as an empty session that renders as not-configured");
+    }
+
+    [Fact]
     public async Task PollAsync_BeforeHolderResponds_ReturnsPendingWithNullVpToken()
     {
         // Arrange — poll result when holder has not yet responded (C3)


### PR DESCRIPTION
## Problem

Opening a verification surface showed **"Verification is not yet configured here."** on both the web client (`/app`) and the wallet PWA (`/wallet`).

## Root cause (root-solved)

The `IHaipVerifierClient` typed `HttpClient` registered in `AddSorchaUserComponents` carried **no auth handler**, so verify requests to `/api/v1/verifier/requests` (`.RequireAuthorization()`, F164) went out **unauthenticated → 401**, were **swallowed** by `HaipVerificationTransport` into an empty session, and the shared `VerificationSessionQr` component rendered that empty session as **"not configured."** Separately, the **web client never overrode** the `NotConfiguredVerificationTransport` stub at all.

## Fix

- **`AddSorchaUserComponents`** gains an optional `configureHaipClient` hook so each host attaches its own auth handler to the HAIP client.
- **Web client**: override the stub with `HaipVerificationTransport`, register a `WebVerifierIdentityProvider`, pass the gateway base address, and attach `AuthenticatedHttpMessageHandler`.
- **PWA**: attach `BearerTokenHandler` + `ServerClockHandler` to the HAIP client.
- **`HaipVerificationTransport.StartSessionAsync`** now **throws on an Error session** instead of returning empty ids, so the component shows its **error + retry** state; the not-configured state is reserved for the stub. Regression test added.

## Scope note

The standalone **`Sorcha.Verifier`** app is server-side and needs its own **service-token** outbound auth (no WASM bearer handler) — that surface is deferred to **M3** (verify across all three surfaces). This PR fixes the reported **web + PWA** breakage.

## Verification

Build clean; tests green: Components.User **25/25** (incl. new regression test), PWA **315/315**, Verifier **68/68**, UI.Core **1430/1430**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)