### PR TITLE
docs(spec): [174] AIAS Assured Identity (M1) spec + plan

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/170-activity-timeline-tidy"
+  "feature_directory": "specs/174-aias-assured-identity"
 }

--- a/specs/174-aias-assured-identity/checklists/requirements.md
+++ b/specs/174-aias-assured-identity/checklists/requirements.md
@@ -1,0 +1,38 @@
+# Specification Quality Checklist: AIAS Assured Identity with photo + autonomous Assure-ID agent
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-06-29
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Items marked incomplete require spec updates before `/speckit.clarify` or `/speckit.plan`.
+- Validation run 2026-06-29: all items pass. The spec deliberately keeps the settled technical
+  decisions (single-credential verify, present-and-map deferral, agent reuse, postcodes.io) in the
+  north-star and Assumptions rather than in requirements, so the requirements stay WHAT-focused and
+  testable. No [NEEDS CLARIFICATION] markers — the design was root-solved during brainstorming.

--- a/specs/174-aias-assured-identity/contracts/external-checks.md
+++ b/specs/174-aias-assured-identity/contracts/external-checks.md
@@ -1,0 +1,74 @@
+# Contract: Rules-engine external-check hook (Sorcha.Agent)
+
+The one new code surface in M1. Lives under `src/Apps/Sorcha.Agent/Decision/Checks/`. Keeps the
+decision declarative: checks produce **facts**, JSON-Logic rules decide.
+
+## `IExternalCheck`
+
+```csharp
+/// <summary>
+/// A single pre-decision check that inspects the action payload and produces one or more named
+/// boolean facts (optionally with a human detail string) for the rules context.
+/// </summary>
+public interface IExternalCheck
+{
+    /// <summary>Stable fact key (e.g. "postcodeExists", "profane").</summary>
+    string Name { get; }
+
+    /// <summary>
+    /// Evaluate against the action payload. MUST NOT throw on a normal "false" outcome; network
+    /// faults degrade per the check's own fallback policy (see PostcodeExistsCheck offline mode).
+    /// </summary>
+    Task<ExternalCheckResult> EvaluateAsync(IReadOnlyDictionary<string, object?> payload, CancellationToken ct);
+}
+
+/// <param name="Name">Fact key.</param>
+/// <param name="Value">Boolean result merged at /checks/{Name}.</param>
+/// <param name="Detail">Optional human string merged at /checks/{Name}Detail (for rejection copy).</param>
+public sealed record ExternalCheckResult(string Name, bool Value, string? Detail = null);
+```
+
+## `ExternalCheckRunner`
+
+```csharp
+/// <summary>
+/// Runs the configured checks and merges their results into a "checks" sub-object on the rules
+/// context BEFORE RulesDecisionEngine evaluates JSON Logic. Checks run concurrently; an individual
+/// check that faults unexpectedly resolves to a safe default (its Value=false) and is logged — it
+/// never crashes the decision.
+/// </summary>
+public sealed class ExternalCheckRunner
+{
+    Task<IReadOnlyDictionary<string, object?>> RunAsync(
+        IReadOnlyDictionary<string, object?> payload, CancellationToken ct);
+    // returns { "postcodeExists": true, "postcodeExistsDetail": "...", "profane": false, ... }
+}
+```
+
+## Integration point
+
+`RulesDecisionEngine` (`src/Apps/Sorcha.Agent/Decision/RulesDecisionEngine.cs`) gains a pre-step:
+before building the JSON-Logic data context for the matching action, it calls
+`ExternalCheckRunner.RunAsync(payload)` and adds the result under the `checks` key. The existing
+first-match-wins rule evaluation is unchanged — rules reference `{ "var": "checks.postcodeExists" }`
+etc. The runner + checks are only invoked for actions that have checks configured (config-driven),
+so non-AIAS agents are unaffected.
+
+## Concrete checks
+
+| Check | Type | Behaviour |
+|-------|------|-----------|
+| `EmailVerifiedCheck` | email-verified | Reads the applicant's verified-email signal from the payload/context. |
+| `field-present` (generic) | field-present | True iff the configured JSON-Pointer field is present & non-empty (used for `photoPresent`). |
+| `PostcodeExistsCheck` | uk-postcode | Calls **postcodes.io**; on a network fault (or `offlineMode: "always"`) resolves against the bundled fixture. `Detail` carries the queried postcode for the rejection reason. |
+| `ProfanityCheck` | profanity | Scans the configured free-text fields against the bundled wordlist; `Value=true` if any match. |
+
+## Test contract (xUnit, `tests/Sorcha.Agent.Tests/Decision/Checks/`)
+
+- Each check: true/false cases against representative payloads.
+- `PostcodeExistsCheck`: live-shape (mocked HTTP) returns true for a known postcode, false for a
+  nonsense one; **offline fallback** returns the fixture result when the HTTP call throws.
+- `ExternalCheckRunner`: merges multiple checks into the `checks` object; a faulting check resolves
+  to `false` and does not throw.
+- `RulesDecisionEngine` (extended): given facts, the AIAS rules approve the clean case and reject
+  each dodgy case with the expected reason — exercising the data-model rule table.

--- a/specs/174-aias-assured-identity/data-model.md
+++ b/specs/174-aias-assured-identity/data-model.md
@@ -1,0 +1,93 @@
+# Phase 1 Data Model: AIAS Assured Identity (M1)
+
+No new persistent storage is introduced. The entities below are either existing domain objects
+(reused) or in-memory/config shapes for the new external-check hook.
+
+## Entities
+
+### AIAS Organisation *(existing — Tenant Service)*
+The fictional assurance provider; issuer of the Assured Identity credential and owner of the
+application blueprint.
+- `Name`: "Acme Identity Assurance Services (AIAS)"
+- `Subdomain`: e.g. `aias`
+- Branding (name/theme) is carried in the blueprint template, not org storage (R7).
+- Provisioned idempotently by `AiasDemo.psm1`.
+
+### Assured Identity Application *(existing — register workflow instance)*
+The submitted application as workflow payload.
+- Identity details: given/family name, date of birth, **address incl. postcode**, email.
+- `portrait` (optional): `/portrait/tokenImageBase64` (F107 embedAs token).
+- State: submitted → approved → rejected (workflow routing).
+
+### External Check Result *(NEW — in-memory, agent)*
+The output of one external check, merged into the rules context as a fact.
+- `Name`: stable fact key, e.g. `postcodeExists`, `profane`, `emailVerified`, `photoPresent`.
+- `Value`: boolean.
+- `Detail` (optional): human string for the rejection reason (e.g. the unfound postcode).
+- Exposed to JSON Logic under `/checks/{Name}` (value) and `/checks/{Name}Detail` (detail).
+
+### Assurance Decision *(existing — agent action result)*
+The agent's recorded outcome.
+- `Decision`: `approved` | `rejected`.
+- `Reason` / `verificationNotes`: human-readable, on-brand (humorous) for rejections.
+- Recorded on the immutable register and surfaced to the applicant.
+
+### Assured Identity Credential *(existing — SD-JWT VC via HAIP)*
+Issued on approval.
+- `credentialType`: AIAS Assured Identity.
+- Claims from `claimMappings`: name, DOB, email, address, `portrait` (when present), all `disclosable`
+  as configured.
+- Issuer: AIAS org (per the VC issuer-signing model — the org needs a master key set, see quickstart).
+
+## Configuration shapes (NEW — `demos/AIAS/agent/`)
+
+### `assure-id.checks.json`
+Declares which external checks run and their settings.
+```json
+{
+  "checks": [
+    { "name": "emailVerified", "type": "email-verified" },
+    { "name": "photoPresent",  "type": "field-present", "field": "/portrait/tokenImageBase64" },
+    { "name": "postcodeExists", "type": "uk-postcode",
+      "addressField": "/address", "offlineFixture": "fixtures/postcodes.offline.json",
+      "offlineMode": "auto" },
+    { "name": "profane", "type": "profanity",
+      "fields": ["/givenName", "/familyName", "/address"], "wordlistInline": ["..."] }
+  ]
+}
+```
+
+### `assure-id.rules.json` *(JSON Logic over the merged facts)*
+```json
+[
+  {
+    "actionName": "Verify Assured Identity Application",
+    "condition": { "==": [ { "var": "checks.postcodeExists" }, false ] },
+    "decision": "reject",
+    "payload": { "decision": "rejected",
+      "verificationNotes": "AIAS could not locate that address on any map." }
+  },
+  {
+    "actionName": "Verify Assured Identity Application",
+    "condition": { "==": [ { "var": "checks.profane" }, true ] },
+    "decision": "reject",
+    "payload": { "decision": "rejected",
+      "verificationNotes": "AIAS does not assure identities described in such... colourful terms." }
+  },
+  {
+    "actionName": "Verify Assured Identity Application",
+    "condition": { "==": [ { "var": "checks.emailVerified" }, false ] },
+    "decision": "reject",
+    "payload": { "decision": "rejected",
+      "verificationNotes": "AIAS needs a verified email before it can assure you." }
+  },
+  {
+    "actionName": "Verify Assured Identity Application",
+    "condition": { "==": [ true, true ] },
+    "decision": "approve",
+    "payload": { "decision": "approved", "verificationNotes": "Assured by AIAS." }
+  }
+]
+```
+> Rule order matters — first match wins (existing `RulesDecisionEngine` semantics). Rejections are
+> evaluated before the catch-all approve.

--- a/specs/174-aias-assured-identity/plan.md
+++ b/specs/174-aias-assured-identity/plan.md
@@ -1,0 +1,117 @@
+# Implementation Plan: AIAS Assured Identity with photo + autonomous Assure-ID agent
+
+**Branch**: `174-aias-assured-identity` | **Date**: 2026-06-29 | **Spec**: [spec.md](./spec.md)
+
+**Input**: Feature specification from `/specs/174-aias-assured-identity/spec.md`
+
+> Program north-star: `docs/superpowers/specs/2026-06-29-aias-conference-demo-design.md` (M1 of M0–M5).
+
+## Summary
+
+Stand up a fictional assurance provider **Acme Identity Assurance Services (AIAS)** and deliver the
+anonymous→assured journey end to end, issuing an **Assured Identity** credential that carries the
+applicant's photo. The work is **~80% assembly of proven parts** (the `demos/AssuredIdentity`
+blueprint + `Sorcha.Agent` + F107 portrait capture/embed + HAIP issuance) plus **one genuine code
+addition**: an **external-check hook** on the agent's rules engine so the autonomous Assure-ID agent
+can evaluate real signals (email-verified, photo-present, **postcode existence**, **profanity**) and
+**reject** with an on-brand reason. Everything is reproduced from a clean network by a single
+idempotent provisioning module under `demos/AIAS/`.
+
+## Technical Context
+
+**Language/Version**: C# 14 / .NET 10 (services + agent); PowerShell 7 (provisioning + rehearsal).
+
+**Primary Dependencies (all existing, reused)**:
+- `Sorcha.Agent` CLI — `RulesDecisionEngine` (JSON Logic), `AiDecisionEngine`, dual SignalR+polling listeners.
+- Blueprint Service `ActionExecutionService` — `credentialIssuanceConfig` + `claimMappings` + routing.
+- HAIP Service `/api/v1/offers` — OpenID4VCI credential issuance.
+- Tenant Service — organisation create; existing anonymous signup + email verification.
+- `Sorcha.UI.Components.User` `FileRenderer` + `PhotoTokenResizer` (F107) — portrait capture (camera/upload) + embed.
+- **New external dependency**: UK **postcodes.io** (public, read-only) for the address-existence check, with a bundled offline fixture fallback.
+
+**Storage**: No new storage. Reuses existing register (Mongo) for the workflow/decision record and Tenant (Postgres) for the org. No persona portrait persistence (out of scope per the settled model).
+
+**Testing**: xUnit v3 for the agent external-check unit tests; a PowerShell **rehearsal hook** under `demos/AIAS/` exercising one approval + one rejection end to end.
+
+**Target Platform**: Docker-first (`docker-compose`), then n1. Agent runs as a CLI process; UI is Blazor WASM behind the gateway.
+
+**Project Type**: Web (Blazor WASM front + microservices back) plus a long-running CLI agent.
+
+**Performance Goals**: Agent reaches + records a decision within **30 s** of submission (SC-003); applicant completes application incl. photo in **< 2 min** (SC-002).
+
+**Constraints**: **Offline-capable** assurance — the postcode check must fall back to a bundled fixture when postcodes.io is unreachable (SC-007). Idempotent, reboot-proof provisioning (SC-001/SC-006).
+
+**Scale/Scope**: Demo scale (single org, handfuls of applications); not a load-bearing production path.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Assessment |
+|-----------|------------|
+| Microservices-first; no new service | ✅ No new service. The external-check hook lives in the existing `Sorcha.Agent` CLI; issuance/org/signup reuse existing services. |
+| Internal comms gRPC / external REST via gateway | ✅ Unchanged. The agent uses existing client paths; the only new outbound call is postcodes.io (external, read-only, over HTTPS). |
+| Security / no new secrets | ✅ postcodes.io needs no key; profanity check is local; email-verified reuses existing signup state. No secrets added. |
+| Blueprint as JSON/YAML (not Fluent) | ✅ The AIAS blueprint is a JSON template (reuses the `demos/AssuredIdentity` template + adds a reject route). |
+| Testing (xUnit, integration/e2e) | ✅ xUnit unit tests for the checks + a PowerShell rehearsal hook (approval + rejection). |
+| Docs (READMEs, specs, XML) | ✅ `demos/AIAS/README.md`, XML docs on new agent types, north-star + this spec/plan. |
+| License headers, .NET 10 | ✅ Followed. |
+
+**Result: PASS — no violations, Complexity Tracking not required.**
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/174-aias-assured-identity/
+├── plan.md              # This file
+├── research.md          # Phase 0 — reuse map + resolved decisions
+├── data-model.md        # Phase 1 — entities (org, application, decision, agent config, credential)
+├── quickstart.md        # Phase 1 — provision + run the AIAS demo (Docker then n1)
+├── contracts/
+│   ├── external-checks.md       # the rules-engine external-check hook contract
+│   └── aias-rules.md            # the AIAS Assure-ID rules config shape (JSON Logic facts)
+└── tasks.md             # Phase 2 — created by /speckit.tasks (NOT here)
+```
+
+### Source Code (repository root)
+
+```text
+src/Apps/Sorcha.Agent/
+├── Decision/
+│   ├── RulesDecisionEngine.cs        # EXTEND: invoke external checks, surface results as JSON-Logic facts
+│   └── Checks/                       # NEW — the external-check hook
+│       ├── IExternalCheck.cs         # one check = (application payload) -> named boolean fact(s)
+│       ├── ExternalCheckRunner.cs    # runs configured checks, merges facts into the rules context
+│       ├── PostcodeExistsCheck.cs    # postcodes.io + bundled-fixture offline fallback (config toggle)
+│       ├── ProfanityCheck.cs         # local wordlist scan of submitted details
+│       └── EmailVerifiedCheck.cs     # asserts the applicant's email-verified signal
+└── (existing Inbox/Execution/Auth unchanged)
+
+demos/AIAS/                            # NEW — the reboot-proof provisioning slice
+├── AiasDemo.psm1                      # idempotent: org + branding + blueprint + agent config
+├── blueprints/
+│   └── aias-assured-identity.template.json   # base AssuredIdentity template + AIAS branding + reject route
+├── agent/
+│   ├── assure-id.rules.json          # AIAS Assure-ID rules (approve/reject on the check facts)
+│   └── assure-id.checks.json         # which external checks to run + postcode offline fixture path
+├── fixtures/
+│   └── postcodes.offline.json        # bundled fallback dataset for offline venues
+├── run-demo.ps1                      # provision (Docker-first / n1) + launch the agent
+├── rehearse.ps1                      # test hook: one approval + one rejection end to end
+└── README.md
+
+tests/Sorcha.Agent.Tests/             # NEW or extend
+└── Decision/Checks/                   # unit tests per check + the runner (fact merging, offline fallback)
+```
+
+**Structure Decision**: Single new code surface — the **external-check hook** under
+`Sorcha.Agent/Decision/Checks/` — keeps the one genuine addition isolated and unit-testable. All
+demo wiring (org, branding, blueprint, agent config, fixtures, rehearsal) lives under `demos/AIAS/`,
+mirroring the proven `demos/AssuredIdentity` layout so provisioning is one idempotent module. No
+service, storage, or schema changes.
+
+## Complexity Tracking
+
+> Not required — Constitution Check passed with no violations.

--- a/specs/174-aias-assured-identity/quickstart.md
+++ b/specs/174-aias-assured-identity/quickstart.md
@@ -1,0 +1,61 @@
+# Quickstart: Provision & run the AIAS demo (M1)
+
+Docker-first; the same module targets n1. Everything is one idempotent script — re-runnable after a
+network wipe.
+
+## Prerequisites
+- A running Sorcha stack: `docker-compose up -d` (or n1). Platform auto-seeds (System Admin + Public
+  org) — do **not** run `sorcha bootstrap`.
+- PowerShell 7.
+
+## 1. Provision AIAS (idempotent)
+
+```powershell
+# Docker (default)
+./demos/AIAS/run-demo.ps1
+
+# n1
+./demos/AIAS/run-demo.ps1 -Target n1
+```
+
+`run-demo.ps1` calls `AiasDemo.psm1` to, idempotently:
+1. Create org **"Acme Identity Assurance Services (AIAS)"** (skips if present).
+2. **Set the org VC-issuance master key** (`Set-SorchaOrgMasterKey`). ⚠ **Required** — an org that
+   issues native `SorchaLocalWallet` VCs without a master key signs with its bare wallet key and
+   emits an unresolvable `iss` (no `kid`/`jwk`), so verification later fails closed. The
+   AssuredIdentity demo historically skipped this (HAIP-enrolment only); AIAS MUST do it.
+3. Publish the AIAS Assured Identity blueprint (template with `{{issuerName}}` + AIAS theme + the
+   reject route) to the register.
+4. Launch the **Assure-ID agent**: `sorcha-agent run --config demos/AIAS/agent/assure-id.config.json
+   --state <state.json>` (rules mode; reads `assure-id.rules.json` + `assure-id.checks.json`).
+
+## 2. Walk the happy path
+1. Sign up an anonymous user (verify email).
+2. Open the AIAS Assured Identity application; fill name + an **existing UK postcode**; capture a
+   **photo** (camera or upload).
+3. Submit. Within ~30 s the Assure-ID agent approves and HAIP issues the Assured Identity credential.
+4. Claim it into the wallet — the credential shows AIAS branding and the photo.
+
+## 3. Walk the rejection paths (the on-stage theatre)
+- **Bad postcode**: enter `ZZ99 9ZZ` / "Hogwarts" → rejected: *"AIAS could not locate that address on
+  any map."*
+- **Sweary details**: include profanity in a detail field → rejected with an on-brand reason.
+- **Unverified email**: skip email verification → rejected/held with the email reason.
+
+## 4. Offline behaviour
+Set the postcode check to offline (`assure-id.checks.json` → `"offlineMode": "always"`, or simply
+pull the venue's internet): the check resolves against `demos/AIAS/fixtures/postcodes.offline.json`,
+so approvals/rejections still flow. Verify the demo completes with no internet.
+
+## 5. Rehearsal / test hook
+
+```powershell
+./demos/AIAS/rehearse.ps1            # Docker
+./demos/AIAS/rehearse.ps1 -Target n1
+```
+Runs one **approval** and one **rejection** end to end against the provisioned environment and
+asserts: approved → credential issued with portrait; rejected → reason recorded, no credential.
+
+## 6. Re-run safety
+Re-running `run-demo.ps1` against an already-provisioned environment completes without creating
+duplicate orgs/blueprints/agents (idempotent — the gate for SC-001).

--- a/specs/174-aias-assured-identity/research.md
+++ b/specs/174-aias-assured-identity/research.md
@@ -1,0 +1,103 @@
+# Phase 0 Research: AIAS Assured Identity (M1)
+
+The unknowns for this milestone were resolved during the north-star brainstorming via three codebase
+investigations (assurance/agent infra, photo path, and the credential-model root-solve). This file
+consolidates the decisions; there were no open `NEEDS CLARIFICATION` items left for planning.
+
+## R1 — Assurance workflow & issuance
+
+**Decision**: Reuse the `demos/AssuredIdentity` 3-action blueprint (submit → verify/decide → claim)
+and its `credentialIssuanceConfig` (HAIP `/api/v1/offers` → OpenID4VCI), adding a **reject route**.
+
+**Rationale**: The full submit→decide→issue→claim path is proven end to end (`ActionExecutionService`
++ HAIP `CredentialOfferService` + `HaipCredentialMinter`). The only gap vs. the demo is that the
+demo rule is always-approve with no reject branch.
+
+**Alternatives considered**: Build a new AIAS-specific blueprint from scratch — rejected (duplicates
+proven structure, more surface to test).
+
+## R2 — Autonomous agent
+
+**Decision**: Reuse the `Sorcha.Agent` CLI in **rules mode** (`RulesDecisionEngine`, JSON Logic),
+run with an AIAS config. "Two agents" (Assure-ID / Cyber) = two configs of the same binary, not new
+code.
+
+**Rationale**: The agent already does autonomous decisioning over pending actions with dual
+SignalR+polling listeners and records decisions back via `ActionExecutor`. No agent-runtime changes
+needed.
+
+**Alternatives considered**: `AiDecisionEngine` (Claude) for the decision — rejected for M1 (the
+checks are deterministic; an LLM adds nondeterminism and cost to a step that doesn't need it). May
+revisit for richer rejection copy.
+
+## R3 — The one new capability: external-check hook
+
+**Decision**: Add an **external-check hook** to the rules engine. Before evaluating JSON Logic, run a
+configured set of checks (email-verified, photo-present, postcode-exists, profanity) and merge their
+boolean results into the rules context as facts (e.g. `/checks/postcodeExists`,
+`/checks/profane`, `/checks/emailVerified`, `/checks/photoPresent`). The existing JSON-Logic rules
+then approve/reject on those facts.
+
+**Rationale**: The rules engine today only evaluates JSON Logic over the submitted payload — it can't
+call out to a postcode service or scan for profanity. A thin, testable pre-decision hook is the
+minimal extension that keeps the decision itself declarative (rules stay JSON).
+
+**Alternatives considered**: (a) a server-side pre-action validator endpoint stamping the payload —
+rejected for M1 (more moving parts, a new endpoint, more to provision; chosen "checks run in the
+agent" per the design decision). (b) hard-coding the checks in the agent decision — rejected (not
+configurable, not unit-testable in isolation).
+
+## R4 — Address / postcode existence
+
+**Decision**: Use UK **postcodes.io** (public, no key) for the postcode-existence check, with a
+**bundled offline fixture** fallback toggled by config (`assure-id.checks.json`). When postcodes.io
+is unreachable, the check resolves against the fixture so the demo never breaks offline (SC-007).
+
+**Rationale**: postcodes.io is free, keyless, and authoritative for UK postcodes — and gives the
+on-brand humour hook ("could not locate that address"). The offline fixture satisfies the
+reboot-proof / no-internet-venue constraint.
+
+**Alternatives considered**: a paid address API (needs a key/secret — rejected); no real lookup
+(loses the genuine check + the funny rejection — rejected).
+
+## R5 — Profanity check
+
+**Decision**: A **local wordlist scan** of the submitted free-text details, bundled with the agent
+config. Deterministic, offline, no dependency.
+
+**Rationale**: Keeps the check offline and dependency-free; the wordlist is editable for the demo.
+
+**Alternatives considered**: an online moderation API — rejected (network dependency + key for a
+trivial check).
+
+## R6 — Photo path
+
+**Decision**: Reuse F107 **as-is** — `FileRenderer` (camera `capture="user"` + upload) →
+`PhotoTokenResizer` (240×320 JPEG ≤20KB) → `embedAs` → `portrait` claim on the Assured Identity VC.
+The verdict-render path (`VerdictTrailPanel`) already paints the portrait. **No new photo code.**
+
+**Rationale**: The capture→embed→render path exists and is tested. Photo is **optional** at the
+Assured Identity stage (it becomes mandatory only for cyber in M2).
+
+**Alternatives considered**: persona portrait persistence — rejected (not needed under the
+single-credential / present-and-map model; avoids storing a biometric at rest).
+
+## R7 — Branding
+
+**Decision**: Bake AIAS branding into the **blueprint template** (`{{issuerName}}` token + an AIAS
+theme / `x-review` header), as the AssuredIdentity demo does. Do **not** block on the unimplemented
+admin-dashboard org-branding feature.
+
+**Rationale**: Demo-level branding via the template is proven and sufficient for the conference;
+per-org branding admin UI is out of scope and unfinished.
+
+## R8 — Provisioning & repeatability
+
+**Decision**: A single idempotent PowerShell module `demos/AIAS/AiasDemo.psm1` (mirroring
+`demos/AssuredIdentity/AssuredIdentityDemo.psm1`) that creates org + branding + blueprint + agent
+config from a clean network, Docker-first then n1, plus a `rehearse.ps1` test hook (one approval +
+one rejection). Provisioning is built **in this milestone**, not deferred to M5 (M5 only
+consolidates).
+
+**Rationale**: The network will be wiped repeatedly; "re-run one script" is a hard constraint
+(SC-001/SC-006). The AssuredIdentity module is a proven, idempotent template to follow.

--- a/specs/174-aias-assured-identity/spec.md
+++ b/specs/174-aias-assured-identity/spec.md
@@ -1,0 +1,151 @@
+# Feature Specification: AIAS Assured Identity with photo + autonomous Assure-ID agent
+
+**Feature Branch**: `174-aias-assured-identity`
+
+**Created**: 2026-06-29
+
+**Status**: Draft
+
+**Input**: User description: "M1 — AIAS Assured Identity with photo + autonomous Assure-ID agent. First build milestone of the AIAS conference demo."
+
+> Program context: this is milestone **M1** of the AIAS conference demo. The program north-star —
+> narrative, two-credential model, agent role, and M0–M5 decomposition — is
+> `docs/superpowers/specs/2026-06-29-aias-conference-demo-design.md`. Read it first.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - An anonymous person becomes assured, with their face on the credential (Priority: P1)
+
+An anonymous attendee signs up, applies to **Acme Identity Assurance Services (AIAS)** for an
+Assured Identity, includes a photo of themselves, and — once AIAS approves — receives an **Assured
+Identity** credential carrying that photo into their wallet. This is the spine of the whole demo:
+without a held, photo-bearing Assured Identity, nothing downstream (the cyber credential, the verify
+moments) has anything to stand on.
+
+**Why this priority**: It is the minimum viable slice — a person going from "nobody" to "holds a
+real, AIAS-branded, photo-bearing credential." If only this ships, the demo already tells a
+complete, compelling story on its own.
+
+**Independent Test**: From a clean environment, sign up as a new person, complete the AIAS
+application including a photo, and confirm an Assured Identity credential bearing that photo arrives
+in the applicant's wallet and can be opened.
+
+**Acceptance Scenarios**:
+
+1. **Given** a freshly provisioned AIAS and a new anonymous user with a verified email, **When** they submit a complete application (real-looking name, an existing postcode, clean wording) and include a photo, **Then** AIAS approves it automatically and the applicant receives an Assured Identity credential whose portrait matches the photo they submitted.
+2. **Given** an approved application, **When** the applicant opens the issued credential in their wallet, **Then** the credential is attributed to AIAS (AIAS branding/issuer) and displays the applicant's photo.
+3. **Given** an applicant who chooses to skip the photo, **When** they submit an otherwise-valid application, **Then** the application may still be approved and a credential issued without a portrait (photo is optional at this stage).
+
+---
+
+### User Story 2 - AIAS turns down dodgy applications, with personality (Priority: P2)
+
+The AIAS assurance decision is made **autonomously by an agent**, live, with no human in the loop.
+When an application is implausible — a postcode that doesn't exist, profane/abusive details — the
+agent **rejects** it and gives a humorous, on-brand reason. This is the demo's live-decisioning
+theatre: the audience sees AIAS say "no" for honest, funny reasons.
+
+**Why this priority**: The rejections are what make the autonomy *visible and entertaining* on
+stage. The happy path alone looks like a rubber stamp; the rejections prove there's a real decision
+being made.
+
+**Independent Test**: Submit applications designed to fail each check (non-existent postcode; profane
+details) and confirm each is rejected automatically with a distinct, human-readable, on-brand reason,
+and that no credential is issued.
+
+**Acceptance Scenarios**:
+
+1. **Given** an application whose address/postcode cannot be found in a real lookup, **When** the agent evaluates it, **Then** it is rejected with a reason that names the unfound location (e.g. *"AIAS could not locate that address on any map"*) and no credential is issued.
+2. **Given** an application containing profane or abusive details, **When** the agent evaluates it, **Then** it is rejected with an on-brand reason and no credential is issued.
+3. **Given** an application whose email is not verified, **When** the agent evaluates it, **Then** it is rejected (or held) with a reason indicating email verification is required.
+4. **Given** any decision (approve or reject), **When** the agent records it, **Then** the outcome and its reason are visible to the applicant and on the immutable record.
+
+---
+
+### User Story 3 - The whole of AIAS rebuilds from a clean network with one script (Priority: P2)
+
+A demo operator can stand up AIAS — org, branding, the application workflow, and the running
+assurance agent — on a **freshly wiped network** by running a **single, idempotent script**,
+Docker-first and then on n1, and can re-run it after every network reboot without manual steps or
+duplicate-state errors.
+
+**Why this priority**: The network *will* be wiped repeatedly. If setup is a manual ceremony, the
+demo is fragile and unrepeatable — which defeats the purpose. Repeatability is a stated,
+non-negotiable constraint of the program.
+
+**Independent Test**: On a clean Docker stack, run the provisioning script; confirm AIAS exists,
+branded, with a live assurance agent, and that a test application flows through to a decision.
+Re-run the script and confirm it succeeds without creating duplicates or erroring.
+
+**Acceptance Scenarios**:
+
+1. **Given** a clean network, **When** the operator runs the provisioning script, **Then** AIAS is created with its branding, the application workflow is published, and the assurance agent is running and reachable.
+2. **Given** an already-provisioned AIAS, **When** the operator re-runs the script, **Then** it completes successfully without creating duplicate orgs/workflows/agents.
+3. **Given** the provisioning succeeded on Docker, **When** the same script is pointed at n1, **Then** it provisions AIAS there using the same steps.
+
+---
+
+### Edge Cases
+
+- **Offline / unavailable address lookup**: when the real postcode lookup cannot be reached (no
+  internet at the venue, or the upstream service is down), the postcode check **falls back to a
+  bundled fixture / allow-list** (configurable) so the assurance step still functions; it does not
+  hard-fail the demo.
+- **Photo present but unusable** (too large / wrong format): the existing capture control already
+  resizes/validates; an unusable photo results in no portrait on the credential rather than a failed
+  application (photo is optional at this stage).
+- **Profanity false positive**: a legitimate but unusual name flagged as profane — the rejection
+  reason must be clear enough that the operator can recognise and explain it on stage.
+- **Agent not running**: if the assurance agent is down, applications sit undecided (no silent
+  auto-approval); the operator can see they are pending.
+- **Duplicate application** from the same person: handled without crashing; the latest application is
+  the one decided.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST provision an organisation **"Acme Identity Assurance Services (AIAS)"** with recognisable AIAS branding presented to applicants and on the issued credential, without depending on any unfinished org-branding administration feature.
+- **FR-002**: An anonymous person MUST be able to sign up and submit an AIAS Assured Identity application that captures their identity details (including name and address/postcode) and **optionally** a photo of themselves.
+- **FR-003**: The application MUST allow the applicant to capture their photo by camera or by uploading a file, and MUST allow them to skip the photo.
+- **FR-004**: The assurance decision MUST be made **autonomously by an agent** with no human approval step in the demo path.
+- **FR-005**: Before approving, the agent MUST evaluate, at minimum: (a) the applicant's **email is verified**; (b) whether a **photo is present** (recorded as a signal; not required for approval at this stage); (c) the **address/postcode exists** per a real lookup; (d) the submitted details **contain no profanity/abuse**.
+- **FR-006**: The address/postcode check MUST use a real external lookup when available, and MUST **degrade gracefully to a bundled offline fallback** (configurable) when the lookup is unreachable, so the assurance step keeps working without internet.
+- **FR-007**: On approval, the system MUST issue an **Assured Identity credential** attributed to AIAS that carries the applicant's submitted photo as its portrait (when a usable photo was provided), and the credential MUST be delivered to and claimable by the applicant's wallet.
+- **FR-008**: On rejection, the system MUST record a **decision with a human-readable, on-brand (humorous) reason**, MUST NOT issue a credential, and MUST surface the reason to the applicant.
+- **FR-009**: Every assurance decision (approve or reject) and its reason MUST be recorded on the immutable record and be attributable to AIAS.
+- **FR-010**: The entire AIAS setup — organisation, branding, application workflow, and the running assurance agent — MUST be reproducible from a clean network by a **single idempotent provisioning script**, runnable Docker-first and then against n1, with no manual steps and safe to re-run.
+- **FR-011**: The milestone MUST include an automated **test/rehearsal hook** that exercises at least one approval and one rejection end to end against the provisioned environment.
+- **FR-012**: The feature MUST NOT regress existing assured-identity / agent behaviour relied upon by other walkthroughs (the existing always-approve demo remains available; the AIAS variant adds the real checks and the reject route).
+
+### Key Entities
+
+- **AIAS Organisation**: the fictional assurance provider; issuer of the Assured Identity credential and owner of the application workflow; carries demo branding.
+- **Applicant**: an anonymous person who signs up and applies; becomes the holder of the issued credential.
+- **Assured Identity Application**: the submitted application — identity details, address/postcode, optional photo — and its state (submitted / approved / rejected).
+- **Assurance Decision**: the agent's outcome (approve/reject) plus the reason; recorded immutably.
+- **Assure-ID Agent**: the autonomous decision-maker that applies the assurance checks and records decisions; runs continuously.
+- **Assured Identity Credential**: the issued credential attributed to AIAS, optionally carrying the applicant's portrait.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: From a clean network, a single script makes AIAS demo-ready (org + branding + workflow + running agent) in **one run with no manual steps**, and re-running it produces no duplicates or errors.
+- **SC-002**: An applicant can complete the application (including capturing a photo) in **under 2 minutes**.
+- **SC-003**: After an application is submitted, the autonomous agent reaches and records a decision within **30 seconds**, with no human intervention.
+- **SC-004**: A non-existent postcode and profane details are each **rejected 100% of the time**, each with a distinct, human-readable, on-brand reason, and **no credential is issued** in those cases.
+- **SC-005**: On approval with a photo, the issued credential carries a portrait that visibly **matches the submitted photo**, and arrives in the applicant's wallet ready to open.
+- **SC-006**: The complete approve-and-reject flow runs **identically on Docker and on n1** from the same script.
+- **SC-007**: With no internet available, the application + decision flow still completes (postcode check uses the offline fallback) — the demo does not break offline.
+
+## Assumptions
+
+- **Anonymous signup with email verification already exists** and is reused; "email verified" is a state the agent can rely on at application time.
+- **Photo capture, resize, and embedding into a credential already exist** (the shared file-capture control with camera/upload and the credential portrait-embed path); this milestone reuses them rather than building new capture/embed infrastructure.
+- **An autonomous agent runtime already exists** (rules-based decisioning over pending actions); this milestone reuses it and adds AIAS-specific rules plus an external-check capability (email/postcode/profanity), not a new agent.
+- **The existing assured-identity application workflow is the starting point**; this milestone adds a real reject route and the real checks (the prior demo auto-approved everything).
+- **Branding is delivered at the demo level** (e.g. baked into the workflow / issuer presentation), not via the unfinished organisation-branding administration feature.
+- **Address lookup targets UK postcodes** via a public lookup, with a bundled offline fallback dataset for venues without reliable internet.
+- **Persona-level photo persistence is explicitly out of scope** (the settled model does not need it); the photo lives on the application/credential, not on a stored persona record.
+- **Downstream milestones depend on this**: the cyber questionnaire (M2) consumes the Assured Identity credential; this spec stops at a held, photo-bearing Assured Identity.


### PR DESCRIPTION
M1 of the AIAS conference demo (north-star: `docs/superpowers/specs/2026-06-29-aias-conference-demo-design.md`).

Spec + implementation plan + design artifacts for the anonymous→assured journey:
- `spec.md` — 3 user stories, 12 FRs, 7 success criteria
- `plan.md` — ~80% assembly of proven parts + one new code surface (the rules-engine external-check hook)
- `research.md`, `data-model.md`, `contracts/external-checks.md`, `quickstart.md`

Doc-only (specs/ + the active-feature pin). No source changes. Implementation lands separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)