### PR TITLE
fix: [175] peer docket-sync read-through on empty cache + unify public read

### DIFF
--- a/specs/175-federation-public-read/research.md
+++ b/specs/175-federation-public-read/research.md
@@ -120,11 +120,27 @@ failure is **TLS/transport** on the gRPC channel. **F136 only bites the register
   (cleartext-mesh compatible); present-but-invalid/replayed ⇒ refused fail-closed.
 
 ### Phase C — anonymous read + ingest guard (COMPLETE, committed, +6 tests)
-- **T020/T022** `/api/public/registers/{id}` (+ `/dockets`, `/dockets/{n}`) — anonymous, gated
-  per-request on `Advertise`; non-public ⇒ 403; `Relaxed` (burst-tolerant) rate limit.
+- **T020/T022** anonymous public read, gated per-request on `Advertise`; non-public ⇒ 403; `Relaxed`
+  (burst-tolerant) rate limit. **Refined in follow-up:** folded into the CANONICAL register/docket read
+  endpoints (`GET /api/registers/{id}`, `/dockets`, `/dockets/{n}`) as credential-gated reads — the
+  separate `/api/public/registers` namespace was removed (a public register has one URI whether read
+  anonymously or authenticated). `CanReadTransactions`/`RequireAuthenticated` are both
+  `RequireAuthenticatedUser`, so "anonymous-or-public" is a proper superset (no authz weakening).
 - **T021 (reuse-in-place, revised)** register-identity binding on the create-on-sync genesis path
   (reject if the synced control record's `RegisterId` ≠ route). **NOT** a relocation of the full
   verification into the Register ingest — see the architectural decision below.
+
+### Follow-up (live-validation findings, 2026-07-01) — branch `175-followup-readthrough-cache`
+Two-installation live test (local `Phaethon` ↔ n1 `sorcha`) PROVED Phase B: the peer link connects
+cross-installation (was the ~60ms fast-fail) — my accept-any-cert also tolerated the corp-proxy's
+`PartialChain`-intercepted TLS. But the SSR still synced **0 dockets**. Root cause (NOT transport, NOT
+F136): the peer docket-sync serving path (`RegisterSyncGrpcService`) only read through to the Register
+Service when the cache entry was **entirely absent**; the owning node holds an **empty** cache entry
+for its own register (created by advertise/subscribe, never populated with its own dockets), which
+short-circuited the read-through and served "0 dockets". **Fix:** treat an empty/insufficient cache
+entry as a MISS and read through to the Register Service in `PullDocketChain` /
+`PullDocketTransactions` / `SubscribeToRegister`. Server-side (owner) change; the pulling node is
+unchanged. (Aligns with the OPS-011 read-through-store direction.)
 
 ### ⚑ Architectural decision (flagged for a future ADR) — Register service should own docket integrity
 **Finding:** verify-on-replicate **already runs fail-closed *before* persist**, but it lives in the

--- a/src/Services/Sorcha.Peer.Service/GrpcServices/RegisterSyncGrpcService.cs
+++ b/src/Services/Sorcha.Peer.Service/GrpcServices/RegisterSyncGrpcService.cs
@@ -68,16 +68,22 @@ public class RegisterSyncGrpcService : Protos.RegisterSync.RegisterSyncBase
             "PullDocketChain requested by peer {PeerId} for register {RegisterId} from version {FromVersion} (max {MaxDockets})",
             request.PeerId, request.RegisterId, request.FromVersion, request.MaxDockets);
 
+        // Feature 175 follow-up: read-through on cache MISS, not only on a fully-absent entry. The
+        // owning node holds an entry for its own register that is created by advertise/subscribe but
+        // never populated with its own dockets (those live in the co-located Register Service). Serving
+        // that empty entry returned "0 dockets" and short-circuited the authoritative fallback below —
+        // which is exactly why a foreign node's full-replica pull of a public register (e.g. the SSR)
+        // came back empty. Treat "entry present but no dockets in the requested range" the same as a
+        // miss and read through to the Register Service.
         var cacheEntry = _registerCache.Get(request.RegisterId);
-        if (cacheEntry != null)
+        var cachedDockets = cacheEntry?.GetDocketsFromVersion(request.FromVersion, request.MaxDockets);
+        if (cachedDockets is { Count: > 0 })
         {
-            // Serve from in-memory cache
-            var dockets = cacheEntry.GetDocketsFromVersion(request.FromVersion, request.MaxDockets);
             _logger.LogDebug(
                 "Streaming {Count} dockets from cache for register {RegisterId}",
-                dockets.Count, request.RegisterId);
+                cachedDockets.Count, request.RegisterId);
 
-            foreach (var docket in dockets)
+            foreach (var docket in cachedDockets)
             {
                 if (context.CancellationToken.IsCancellationRequested)
                     break;
@@ -98,13 +104,13 @@ public class RegisterSyncGrpcService : Protos.RegisterSync.RegisterSyncBase
 
             _logger.LogDebug(
                 "PullDocketChain completed for register {RegisterId}: streamed {Count} dockets from cache",
-                request.RegisterId, dockets.Count);
+                request.RegisterId, cachedDockets.Count);
             return;
         }
 
-        // Fall back to Register Service for registers not in cache
+        // Cache absent OR present-but-empty for the requested range → authoritative read-through.
         _logger.LogInformation(
-            "Register {RegisterId} not in cache, falling back to Register Service",
+            "Register {RegisterId} not served from cache (absent/empty) — reading through to Register Service",
             request.RegisterId);
 
         await PullDocketChainFromRegisterServiceAsync(
@@ -126,11 +132,14 @@ public class RegisterSyncGrpcService : Protos.RegisterSync.RegisterSyncBase
             "PullDocketTransactions requested by peer {PeerId} for register {RegisterId} ({Count} transaction IDs)",
             request.PeerId, request.RegisterId, request.TransactionIds.Count);
 
+        // Feature 175 follow-up: an entry that exists but holds no transactions (the owning node's own
+        // register, never replicated into the peer cache) is a cache MISS, not a hit — read through to
+        // the Register Service instead of streaming an empty result.
         var cacheEntry = _registerCache.Get(request.RegisterId);
-        if (cacheEntry == null)
+        if (cacheEntry == null || cacheEntry.GetStatistics().TransactionCount == 0)
         {
             _logger.LogInformation(
-                "Register {RegisterId} not in cache, falling back to Register Service for {Count} transaction IDs",
+                "Register {RegisterId} not served from cache (absent/empty), reading {Count} transaction IDs through to Register Service",
                 request.RegisterId, request.TransactionIds.Count);
 
             await PullDocketTransactionsFromRegisterServiceAsync(
@@ -327,11 +336,13 @@ public class RegisterSyncGrpcService : Protos.RegisterSync.RegisterSyncBase
             "SubscribeToRegister requested by peer {PeerId} for register {RegisterId} from version {FromVersion}",
             request.PeerId, request.RegisterId, request.FromVersion);
 
+        // Feature 175 follow-up: empty-but-present entry (owner's own register) is a miss — poll the
+        // authoritative Register Service rather than a cache that will never fill on this node.
         var cacheEntry = _registerCache.Get(request.RegisterId);
-        if (cacheEntry == null)
+        if (cacheEntry == null || cacheEntry.GetStatistics().TransactionCount == 0)
         {
             _logger.LogInformation(
-                "Register {RegisterId} not in cache for live subscription, polling Register Service",
+                "Register {RegisterId} not served from cache (absent/empty) for live subscription, polling Register Service",
                 request.RegisterId);
 
             await SubscribeToRegisterFromRegisterServiceAsync(

--- a/src/Services/Sorcha.Register.Service/Program.cs
+++ b/src/Services/Sorcha.Register.Service/Program.cs
@@ -700,19 +700,34 @@ registersGroup.MapGet("/", async (
 //     (control-record metadata "sandbox" == "true"). Callers exclude sandbox
 //     registers from Go-live targets and normal listings.
 // </remarks>
+// Feature 175: single register-read path, credential-gated rather than a parallel /api/public
+// namespace. Anonymous callers may read a register ONLY when it is public (Advertise==true) — the
+// credential (or its absence + the public flag) gates the read. Authenticated callers read as before.
+// A non-public register is refused 403 to an anonymous caller (never disclosed). Rate-limited
+// (burst-tolerant) since it is now anonymously reachable — a full-register federation pull must not throttle.
 registersGroup.MapGet("/{id}", async (
     RegisterManager manager,
+    HttpContext httpContext,
     string id) =>
 {
     var register = await manager.GetRegisterAsync(id);
-    return register is not null ? Results.Ok(register) : Results.NotFound();
+    if (register is null)
+        return Results.NotFound();
+
+    var isAuthenticated = httpContext.User?.Identity?.IsAuthenticated ?? false;
+    if (!isAuthenticated && !register.Advertise)
+        return Results.Json(new { error = "Register is not public" }, statusCode: StatusCodes.Status403Forbidden);
+
+    return Results.Ok(register);
 })
 .WithName("GetRegister")
 .WithSummary("Get register by ID")
-.WithDescription("Retrieves a specific register by its unique identifier. Surfaces 'advertise' (visibility) and a computed 'sandbox' flag (Feature 142) so callers can show visibility on the Go-live detail card and exclude sandbox registers from Go-live target pickers.")
+.WithDescription("Retrieves a register by id. Authenticated callers read any register they can access; anonymous callers (e.g. a foreign node bootstrapping federation) read a register only when it is public (advertised) — a non-public register is refused 403. Surfaces 'advertise' (visibility) and a computed 'sandbox' flag (Feature 142).")
+.AllowAnonymous()
+.RequireRateLimiting(RateLimitPolicies.Relaxed)
 .Produces<object>(StatusCodes.Status200OK)
-.Produces(StatusCodes.Status404NotFound)
-.Produces(StatusCodes.Status401Unauthorized);
+.Produces(StatusCodes.Status403Forbidden)
+.Produces(StatusCodes.Status404NotFound);
 
 // <summary>
 // Update register
@@ -1391,39 +1406,67 @@ var docketsGroup = app.MapGroup("/api/registers/{registerId}/dockets")
     .WithTags("Dockets")
     .RequireAuthorization("CanReadTransactions");
 
+// Feature 175: single docket-read path, credential-gated (rather than a parallel /api/public
+// namespace). Anonymous callers may read a PUBLIC (advertised) register's dockets — federation
+// bootstrap — while private-register docket reads still require authentication (CanReadTransactions
+// is RequireAuthenticatedUser, so anonymous-or-public is a proper superset, no weakening). Returns a
+// refusal IResult for a disallowed anonymous read, or null to proceed. Authenticated callers proceed.
+static async Task<IResult?> DocketAnonymousReadRefusalAsync(
+    IRegisterRepository repository, HttpContext httpContext, string registerId)
+{
+    if (httpContext.User?.Identity?.IsAuthenticated ?? false)
+        return null;
+    var register = await repository.GetRegisterAsync(registerId);
+    if (register is null)
+        return Results.NotFound(new { error = "Register not found" });
+    if (!register.Advertise)
+        return Results.Json(new { error = "Register is not public" }, statusCode: StatusCodes.Status403Forbidden);
+    return null;
+}
+
 // <summary>
 // Get all dockets for a register
 // </summary>
 docketsGroup.MapGet("/", async (
     IRegisterRepository repository,
+    HttpContext httpContext,
     string registerId) =>
 {
+    var refusal = await DocketAnonymousReadRefusalAsync(repository, httpContext, registerId);
+    if (refusal is not null) return refusal;
     var dockets = await repository.GetDocketsAsync(registerId);
     return Results.Ok(dockets);
 })
 .WithName("GetDockets")
 .WithSummary("Get all dockets")
-.WithDescription("Retrieves all dockets for a register.")
+.WithDescription("Retrieves all dockets for a register. Anonymous when the register is public (advertised); a non-public register requires authentication (403 to anonymous).")
+.AllowAnonymous()
+.RequireRateLimiting(RateLimitPolicies.Relaxed)
 .Produces<object>(StatusCodes.Status200OK)
-.Produces(StatusCodes.Status401Unauthorized);
+.Produces(StatusCodes.Status403Forbidden);
 
 // <summary>
 // Get docket by ID
 // </summary>
 docketsGroup.MapGet("/{docketId}", async (
     IRegisterRepository repository,
+    HttpContext httpContext,
     string registerId,
     ulong docketId) =>
 {
+    var refusal = await DocketAnonymousReadRefusalAsync(repository, httpContext, registerId);
+    if (refusal is not null) return refusal;
     var docket = await repository.GetDocketAsync(registerId, docketId);
     return docket is not null ? Results.Ok(docket) : Results.NotFound();
 })
 .WithName("GetDocket")
 .WithSummary("Get docket by ID")
-.WithDescription("Retrieves a specific docket by its ID (docket height).")
+.WithDescription("Retrieves a specific docket by its ID (docket height). Anonymous when the register is public (advertised); a non-public register requires authentication (403 to anonymous).")
+.AllowAnonymous()
+.RequireRateLimiting(RateLimitPolicies.Relaxed)
 .Produces<Docket>(StatusCodes.Status200OK)
-.Produces(StatusCodes.Status404NotFound)
-.Produces(StatusCodes.Status401Unauthorized);
+.Produces(StatusCodes.Status403Forbidden)
+.Produces(StatusCodes.Status404NotFound);
 
 // <summary>
 // Get transactions in a docket
@@ -1472,73 +1515,10 @@ docketsGroup.MapGet("/latest", async (
 .Produces(StatusCodes.Status404NotFound)
 .Produces(StatusCodes.Status401Unauthorized);
 
-// ===========================
-// Feature 175 — Anonymous public register read (cross-installation federation)
-// ===========================
-// A public (Advertise==true) register is open data: any node — including one from another
-// installation holding NO credential here — may read it and its sealed dockets to bootstrap trust,
-// verifying the register's own cryptography (genesis attestations + docket/validator signatures) on
-// its side. The gate is strictly the per-request Advertise flag, so a public→private flip takes
-// effect immediately (a non-advertised register is refused 403, never disclosed). Private/
-// non-advertised registers and ALL writes stay behind their existing auth. Rate-limited (burst-
-// tolerant Relaxed policy) as an abuse backstop — a full-register replication pull must not throttle.
-var publicRegistersGroup = app.MapGroup("/api/public/registers/{registerId}")
-    .WithTags("Public Federation")
-    .AllowAnonymous()
-    .RequireRateLimiting(RateLimitPolicies.Relaxed);
-
-// Resolves a register only when it is public; otherwise yields the refusal result. Returns
-// (register, null) on success or (null, result) with a 404 (unknown) / 403 (private) to return.
-static async Task<(Sorcha.Register.Models.Register? Register, IResult? Refusal)> ResolvePublicRegisterAsync(
-    IRegisterRepository repository, string registerId)
-{
-    var register = await repository.GetRegisterAsync(registerId);
-    if (register is null)
-        return (null, Results.NotFound(new { error = "Register not found" }));
-    if (!register.Advertise)
-        return (null, Results.Json(new { error = "Register is not public" }, statusCode: StatusCodes.Status403Forbidden));
-    return (register, null);
-}
-
-publicRegistersGroup.MapGet("/", async (IRegisterRepository repository, string registerId) =>
-{
-    var (register, refusal) = await ResolvePublicRegisterAsync(repository, registerId);
-    return refusal ?? Results.Ok(register);
-})
-.WithName("GetPublicRegister")
-.WithSummary("Get a public register (anonymous)")
-.WithDescription("Returns a register when it is public (advertised), for cross-installation federation. No authentication required; a non-advertised register is refused (403).")
-.Produces<object>(StatusCodes.Status200OK)
-.Produces(StatusCodes.Status403Forbidden)
-.Produces(StatusCodes.Status404NotFound);
-
-publicRegistersGroup.MapGet("/dockets", async (IRegisterRepository repository, string registerId) =>
-{
-    var (_, refusal) = await ResolvePublicRegisterAsync(repository, registerId);
-    if (refusal is not null) return refusal;
-    var dockets = await repository.GetDocketsAsync(registerId);
-    return Results.Ok(dockets);
-})
-.WithName("GetPublicRegisterDockets")
-.WithSummary("Get a public register's dockets (anonymous)")
-.WithDescription("Returns the sealed docket chain of a public register for anonymous cross-installation replication. Refused (403) when the register is not advertised.")
-.Produces<object>(StatusCodes.Status200OK)
-.Produces(StatusCodes.Status403Forbidden)
-.Produces(StatusCodes.Status404NotFound);
-
-publicRegistersGroup.MapGet("/dockets/{docketId}", async (IRegisterRepository repository, string registerId, ulong docketId) =>
-{
-    var (_, refusal) = await ResolvePublicRegisterAsync(repository, registerId);
-    if (refusal is not null) return refusal;
-    var docket = await repository.GetDocketAsync(registerId, docketId);
-    return docket is not null ? Results.Ok(docket) : Results.NotFound();
-})
-.WithName("GetPublicRegisterDocket")
-.WithSummary("Get a public register's docket by id (anonymous)")
-.WithDescription("Returns a single sealed docket of a public register. Refused (403) when the register is not advertised.")
-.Produces<Docket>(StatusCodes.Status200OK)
-.Produces(StatusCodes.Status403Forbidden)
-.Produces(StatusCodes.Status404NotFound);
+// Feature 175 follow-up: the parallel /api/public/registers namespace has been removed — anonymous
+// public read is now folded into the canonical register + docket read endpoints above (credential-
+// gated on the per-request Advertise flag), so a public register has ONE URI whether read
+// anonymously or authenticated. Writes and private registers keep their existing auth.
 
 // <summary>
 // Write a confirmed docket to the register (Validator Service only)

--- a/src/Services/Sorcha.Register.Service/README.md
+++ b/src/Services/Sorcha.Register.Service/README.md
@@ -267,23 +267,27 @@ REGISTER__EVENTPROVIDER="AspireMessaging"
 
 Cross-installation federation: a **public** (advertised) register is open data, readable by any node —
 including one from another installation holding **no credential here** — so it can bootstrap trust by
-replicating and cryptographically verifying the register on its own side. Access is gated **strictly
-per-request on the register's `Advertise` flag** (a public→private flip takes effect immediately); a
-non-advertised register is refused **403** and never disclosed. These endpoints are **anonymous** and
-**rate-limited** (burst-tolerant `Relaxed` policy — a full-register replication pull is not throttled).
-Private registers and **all writes** keep their existing auth (no cross-installation write).
+replicating and cryptographically verifying the register on its own side. There is **no separate
+public URL namespace**: the canonical register/docket **read** endpoints are **credential-gated** —
+the credential (or its absence + the register's `Advertise` flag) governs the read. An **anonymous**
+caller may read a register/docket only when the register is **public** (advertised); a private
+register requires authentication. The gate is per-request, so a public→private flip takes effect
+immediately. The read endpoints are **rate-limited** (burst-tolerant `Relaxed` policy — a full-register
+replication pull is not throttled). **All writes** keep their existing auth (no cross-installation write).
 
-| Method | Endpoint | Description |
-|--------|----------|-------------|
-| GET | `/api/public/registers/{registerId}` | Anonymous read of a public register (403 if not advertised) |
-| GET | `/api/public/registers/{registerId}/dockets` | Anonymous read of a public register's docket chain |
-| GET | `/api/public/registers/{registerId}/dockets/{docketId}` | Anonymous read of a single public docket |
+| Method | Endpoint | Anonymous access |
+|--------|----------|------------------|
+| GET | `/api/registers/{id}` | When public (advertised); else 403 to anonymous, 404 if unknown |
+| GET | `/api/registers/{registerId}/dockets` | When public; else 403 to anonymous |
+| GET | `/api/registers/{registerId}/dockets/{docketId}` | When public; else 403 to anonymous |
 
 > Peer federation authenticates by **node identity** (self-signed P-256 node cert, mTLS), not an
-> installation-scoped service token — see the Peer Service. Replicated dockets are verified fail-closed
-> before persist (`DocketFinalizationService`); a create-on-sync genesis whose control-record
-> `RegisterId` disagrees with its slot is rejected. A future ADR moves full docket verification into
-> the Register service (see `specs/175-federation-public-read/research.md`).
+> installation-scoped service token — see the Peer Service. The peer docket-sync serving path reads
+> **through to this Register Service on a cache miss** (including an empty owner-cache entry), so a
+> public register's dockets are served for replication even when the owning node's peer cache is cold.
+> Replicated dockets are verified fail-closed before persist (`DocketFinalizationService`); a
+> create-on-sync genesis whose control-record `RegisterId` disagrees with its slot is rejected. A future
+> ADR moves full docket verification into the Register service (see `specs/175-federation-public-read/research.md`).
 
 ### OData Query Endpoint
 

--- a/tests/Sorcha.Register.Service.IntegrationTests/FederationPublicReadTests.cs
+++ b/tests/Sorcha.Register.Service.IntegrationTests/FederationPublicReadTests.cs
@@ -43,7 +43,7 @@ public class FederationPublicReadTests : IAsyncLifetime
         var registerId = await SeedRegisterAsync(advertise: true);
         using var anon = _factory.CreateUnauthenticatedClient();
 
-        var response = await anon.GetAsync($"/api/public/registers/{registerId}/");
+        var response = await anon.GetAsync($"/api/registers/{registerId}");
 
         response.StatusCode.Should().Be(HttpStatusCode.OK,
             "a public register is open data readable with no credential (FR-001)");
@@ -55,7 +55,7 @@ public class FederationPublicReadTests : IAsyncLifetime
         var registerId = await SeedRegisterAsync(advertise: true);
         using var anon = _factory.CreateUnauthenticatedClient();
 
-        var response = await anon.GetAsync($"/api/public/registers/{registerId}/dockets");
+        var response = await anon.GetAsync($"/api/registers/{registerId}/dockets");
 
         response.StatusCode.Should().Be(HttpStatusCode.OK,
             "a puller replicates the public register's sealed docket chain anonymously");
@@ -69,7 +69,7 @@ public class FederationPublicReadTests : IAsyncLifetime
         var registerId = await SeedRegisterAsync(advertise: false);
         using var anon = _factory.CreateUnauthenticatedClient();
 
-        var response = await anon.GetAsync($"/api/public/registers/{registerId}/");
+        var response = await anon.GetAsync($"/api/registers/{registerId}");
 
         response.StatusCode.Should().Be(HttpStatusCode.Forbidden,
             "a non-advertised register is never exposed on the anonymous path (FR-004/FR-007, SC-004)");
@@ -81,7 +81,7 @@ public class FederationPublicReadTests : IAsyncLifetime
         var registerId = await SeedRegisterAsync(advertise: false);
         using var anon = _factory.CreateUnauthenticatedClient();
 
-        var response = await anon.GetAsync($"/api/public/registers/{registerId}/dockets");
+        var response = await anon.GetAsync($"/api/registers/{registerId}/dockets");
 
         response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
     }
@@ -91,7 +91,7 @@ public class FederationPublicReadTests : IAsyncLifetime
     {
         using var anon = _factory.CreateUnauthenticatedClient();
 
-        var response = await anon.GetAsync($"/api/public/registers/{Guid.NewGuid():N}/");
+        var response = await anon.GetAsync($"/api/registers/{Guid.NewGuid():N}");
 
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
     }

--- a/tests/Sorcha.Register.Service.IntegrationTests/RegisterEndpointsTests.cs
+++ b/tests/Sorcha.Register.Service.IntegrationTests/RegisterEndpointsTests.cs
@@ -99,16 +99,17 @@ public class RegisterEndpointsTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task GetRegisterById_RequiresAuthentication()
+    public async Task GetRegisterById_Anonymous_UnknownRegister_ReturnsNotFound()
     {
-        // Arrange
+        // Feature 175: GET /api/registers/{id} is now credential-gated rather than blanket
+        // authenticated — anonymous callers may read a PUBLIC register (see FederationPublicReadTests),
+        // so an anonymous read is no longer categorically 401. An unknown register returns 404; a known
+        // private register returns 403 (covered in FederationPublicReadTests).
         using var unauthenticatedClient = _factory.CreateUnauthenticatedClient();
 
-        // Act
         var response = await unauthenticatedClient.GetAsync("/api/registers/some-id");
 
-        // Assert
-        response.StatusCode.Should().BeOneOf(HttpStatusCode.Unauthorized, HttpStatusCode.Forbidden);
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
     }
 
     // === Register Count ===


### PR DESCRIPTION
## F175 follow-up — read-through docket-sync + unified public read

Follow-up to #1073, driven by a two-installation **live validation** (local `Phaethon` ↔ n1 `sorcha`).

### What the live test proved
Phase B's transport fix **works**: the cross-installation peer link now connects (previously a ~60ms fast-fail / "0/1 alive") — and the accept-any-cert also tolerated this machine's corporate-proxy `PartialChain`-intercepted TLS. But the SSR still synced **0 dockets**, which surfaced two things to fix.

### 1. Peer docket-sync reads through on an *empty* cache entry (the real unblock)
`RegisterSyncGrpcService` only fell back to the Register Service when the cache entry was **entirely absent**. The owning node holds an **empty** cache entry for its *own* register (created by advertise/subscribe, never populated with its own dockets — those live in the co-located Register Service), which short-circuited the read-through and served "0 dockets". Confirmed live: n1's peer cache for the SSR was `docketCount: 0` while its register-service held it at Height=5.

Fix: treat "entry present but no dockets/transactions in the requested range" as a **cache miss** → read through to the Register Service, in `PullDocketChain` / `PullDocketTransactions` / `SubscribeToRegister`. Server-side (owner) change; the pulling node is unchanged. (Aligns with the OPS-011 read-through-store direction.)

### 2. Unify anonymous public read into the canonical register path (per review)
Replaces the parallel `/api/public/registers` namespace with **credential-gated** reads on the canonical endpoints — one register resource, one URI:
- `GET /api/registers/{id}` + docket reads now `AllowAnonymous` and gate in-handler: anonymous reads a register only when **public** (advertised); private ⇒ 403, unknown ⇒ 404. Authenticated callers read as before (`CanReadTransactions`/`RequireAuthenticated` are both `RequireAuthenticatedUser`, so anonymous-or-public is a proper superset — no authz weakening). Rate-limited (`Relaxed`).
- Removed the `/api/public/registers` group; updated the obsolete `GetRegisterById_RequiresAuthentication` test and repointed `FederationPublicReadTests` at the canonical paths.

### Tests
Peer service builds clean; Register integration tests green (the one pre-existing `InitiateRegisterCreation_WithEmptyBody` failure is local-only and passes in CI). Docs updated (Register README + research.md).

### Deploy note
The read-through fix is **server-side**, so it validates by redeploying n1's peer-service; the already-running local stack re-pulls the SSR. (This machine can't build .NET Docker images — corp-proxy blocks NuGet inside the build container — so validation uses the CI-published images.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
