### PR TITLE
fix: [174] AIAS register name ≤38 + fail-fast register-name validation

### DIFF
--- a/demos/AIAS/AiasDemo.psm1
+++ b/demos/AIAS/AiasDemo.psm1
@@ -36,7 +36,7 @@ $script:AssuredLib = Join-Path $PSScriptRoot "../AssuredIdentity/lib"
 
 # --- well-known ids / constants ---------------------------------------------
 $script:PublicOrgId  = "00000000-0000-0000-0000-000000000002"
-$script:AiasName     = "Acme Identity Assurance Services (AIAS)"
+$script:AiasName     = "Acme Identity Assurance Services"
 $script:AiasSubdomain = "aias"
 
 # --- target table (single-installation; Docker-first, or n1) ----------------

--- a/demos/AIAS/AiasDemo.psm1
+++ b/demos/AIAS/AiasDemo.psm1
@@ -313,6 +313,21 @@ function Publish-AiasBlueprint {
     Remove-Item -LiteralPath $tempBp -ErrorAction SilentlyContinue
     Write-WtSuccess "blueprint: $($blueprint.BlueprintId)"
 
+    # Publishing is async: the blueprint's publish transaction must SEAL into a docket (a few seconds)
+    # before it appears in the register's /blueprints/published list. Wait for it here — otherwise the
+    # immediately-following Get-AiasDemoStatus reads before the seal and reports a false-negative
+    # 'blueprint-not-published' (NotReady) even though the publish succeeded. Mirrors the participant
+    # seal-wait; bounded so a genuinely-stuck seal still surfaces rather than hanging.
+    $bpId = $blueprint.BlueprintId
+    $sealDeadline = (Get-Date).AddSeconds(90)
+    $bpSealed = $false
+    while ((Get-Date) -lt $sealDeadline) {
+        if (@(Get-AiasPublishedBlueprintIds -Api $api -RegisterId $state.registerId) -contains $bpId) { $bpSealed = $true; break }
+        Start-Sleep -Seconds 3
+    }
+    if ($bpSealed) { Write-WtSuccess "blueprint sealed + visible in register's published list" }
+    else { Write-WtWarn "blueprint '$bpId' published but not visible in /blueprints/published after 90s — it may still be sealing" }
+
     # coherence assertion (single-source name across org/register/participant/blueprint)
     $coherence = Test-AgencyNameCoherence -AgencyName $script:AiasName -OrgName $script:AiasName -RegisterName $script:AiasName -ParticipantOrg $script:AiasName -BlueprintJson $rendered
     if (-not $coherence.Coherent) { Write-WtWarn "agency-name coherence issues: $($coherence.Mismatches -join '; ')" }

--- a/demos/AIAS/run-demo.ps1
+++ b/demos/AIAS/run-demo.ps1
@@ -20,6 +20,11 @@ param(
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
+# Import the shared walkthrough helpers directly (not just transitively via AiasDemo) so the
+# Write-Wt* presentation cmdlets are in THIS script's scope — AiasDemo imports them as a nested
+# module, which does not re-export them to the caller, so run-demo's own banner/info calls below
+# would otherwise fail with "Write-WtBanner is not recognized" once provisioning returns.
+Import-Module (Join-Path $PSScriptRoot "../../walkthroughs/modules/SorchaWalkthrough/SorchaWalkthrough.psm1") -Force -DisableNameChecking
 Import-Module (Join-Path $PSScriptRoot "AiasDemo.psm1") -Force -DisableNameChecking
 
 # One idempotent call: org -> master key -> blueprint -> agent config + launch.

--- a/demos/AIAS/run-demo.ps1
+++ b/demos/AIAS/run-demo.ps1
@@ -20,12 +20,14 @@ param(
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-# Import the shared walkthrough helpers directly (not just transitively via AiasDemo) so the
-# Write-Wt* presentation cmdlets are in THIS script's scope — AiasDemo imports them as a nested
-# module, which does not re-export them to the caller, so run-demo's own banner/info calls below
-# would otherwise fail with "Write-WtBanner is not recognized" once provisioning returns.
-Import-Module (Join-Path $PSScriptRoot "../../walkthroughs/modules/SorchaWalkthrough/SorchaWalkthrough.psm1") -Force -DisableNameChecking
 Import-Module (Join-Path $PSScriptRoot "AiasDemo.psm1") -Force -DisableNameChecking
+# Import the shared walkthrough helpers directly AFTER AiasDemo so the Write-Wt* presentation cmdlets
+# are in THIS script's scope for run-demo's own banner/info calls below. It must come last: AiasDemo
+# imports SorchaWalkthrough as a nested module with -Force, and that -Force removes+reimports the
+# module into AiasDemo's scope — evicting it from the caller's scope. Importing it here (after
+# AiasDemo has loaded) makes run-demo's the winning, script-scoped import. Otherwise the tail banner
+# calls fail with "Write-WtBanner is not recognized" once provisioning returns.
+Import-Module (Join-Path $PSScriptRoot "../../walkthroughs/modules/SorchaWalkthrough/SorchaWalkthrough.psm1") -Force -DisableNameChecking
 
 # One idempotent call: org -> master key -> blueprint -> agent config + launch.
 $result = Initialize-AiasDemo -Target $Target -StateFile $StateFile -Force:$Force.IsPresent

--- a/src/Services/Sorcha.Register.Service/Services/RegisterCreationOrchestrator.cs
+++ b/src/Services/Sorcha.Register.Service/Services/RegisterCreationOrchestrator.cs
@@ -86,6 +86,21 @@ public class RegisterCreationOrchestrator : IRegisterCreationOrchestrator
             throw new ArgumentException("At least one owner is required to create a register.");
         }
 
+        // Validate the register name at the INPUT BOUNDARY (fail-fast), not deep inside FinalizeAsync
+        // after attestations have already been signed. The same 1..38 rule is enforced again by
+        // ValidateControlRecord (finalize) and RegisterManager.CreateRegisterAsync (persist); checking
+        // it here turns a silent late failure into a clear 400 on the very first call. (F174/F175 —
+        // a 39-char name previously threw only at finalize and was masked as a partial success.)
+        if (string.IsNullOrWhiteSpace(request.Name))
+        {
+            throw new ArgumentException("Register name is required.");
+        }
+        if (request.Name.Length > 38)
+        {
+            throw new ArgumentException(
+                $"Register name must be 38 characters or less (was {request.Name.Length}: '{request.Name}').");
+        }
+
         _logger.LogInformation(
             "Initiating register creation for name '{Name}' with {OwnerCount} owner(s)",
             request.Name,

--- a/tests/Sorcha.Register.Service.IntegrationTests/Fixtures/RegisterServiceWebApplicationFactory.cs
+++ b/tests/Sorcha.Register.Service.IntegrationTests/Fixtures/RegisterServiceWebApplicationFactory.cs
@@ -37,6 +37,10 @@ public class RegisterServiceWebApplicationFactory : SorchaWebApplicationFactory<
             ["RegisterStorage:Type"] = "InMemory",
             ["ConnectionStrings:MongoDB"] = "",
             ["SystemWalletSigning:ValidatorId"] = "test-validator-id",
+            // Register-creation endpoints resolve a ValidatorServiceClient, whose ctor requires an
+            // address. A dummy is sufficient for tests that fail before any validator call (e.g.
+            // input-boundary validation at initiate).
+            ["ServiceClients:ValidatorService:Address"] = "http://localhost:9/",
         });
     }
 

--- a/tests/Sorcha.Register.Service.IntegrationTests/RegisterEndpointsTests.cs
+++ b/tests/Sorcha.Register.Service.IntegrationTests/RegisterEndpointsTests.cs
@@ -156,6 +156,25 @@ public class RegisterEndpointsTests : IAsyncLifetime
             HttpStatusCode.InternalServerError);
     }
 
+    [Fact]
+    public async Task InitiateRegisterCreation_NameOver38Chars_ReturnsBadRequest()
+    {
+        // Feature 174: the 1..38 register-name rule is validated at the initiate INPUT BOUNDARY
+        // (fail-fast), not silently deep inside finalize after attestations are signed. A 39-char
+        // name must be refused up front with a clear 400 rather than a masked partial success.
+        using var client = _factory.CreateServiceClient(); // CanManageRegisters (service token)
+        var body = new
+        {
+            name = new string('A', 39),
+            owners = new[] { new { walletId = "ws11qtestownerwallet0000000000000000000000" } }
+        };
+
+        var response = await client.PostAsJsonAsync("/api/registers/initiate", body);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest,
+            "a register name over 38 characters must fail fast at initiate");
+    }
+
     #region Internal Endpoint Auth Tests
 
     [Fact]

--- a/tests/Sorcha.Register.Service.Tests/RegisterApiTests.cs
+++ b/tests/Sorcha.Register.Service.Tests/RegisterApiTests.cs
@@ -105,9 +105,9 @@ public class RegisterApiTests : IClassFixture<RegisterServiceWebApplicationFacto
         // Act
         var response = await _client.PostAsJsonAsync("/api/registers/initiate", request);
 
-        // Assert — initiate phase generates a register ID regardless of name content;
-        // name validation occurs during finalize when the control record is verified
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        // Assert — an empty name is rejected fast at the initiate INPUT BOUNDARY (Feature 174),
+        // before any attestations are signed (initiate maps ArgumentException -> 400).
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
     }
 
     [Fact]

--- a/tests/Sorcha.Register.Service.Tests/RegisterCreationApiTests.cs
+++ b/tests/Sorcha.Register.Service.Tests/RegisterCreationApiTests.cs
@@ -92,14 +92,14 @@ public class RegisterCreationApiTests : IClassFixture<RegisterServiceWebApplicat
     }
 
     [Fact]
-    public async Task InitiateRegisterCreation_WithMissingName_ShouldAcceptForDeferredValidation()
+    public async Task InitiateRegisterCreation_WithMissingName_ShouldReturn400BadRequest()
     {
         // Arrange
         var client = _factory.CreateClient();
 
         var request = new
         {
-            // name is missing — validation deferred to finalize phase
+            // name is missing — rejected at the initiate input boundary (Feature 174)
             tenantId = "test-tenant-001",
             owners = new[]
             {
@@ -110,9 +110,9 @@ public class RegisterCreationApiTests : IClassFixture<RegisterServiceWebApplicat
         // Act
         var response = await client.PostAsJsonAsync("/api/registers/initiate", request);
 
-        // Assert — initiate phase accepts the request;
-        // name validation is enforced during the finalize phase
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        // Assert — a missing name is rejected fast at the initiate INPUT BOUNDARY (Feature 174),
+        // rather than silently deferred to finalize after attestations are signed.
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
     }
 
     [Fact]
@@ -320,9 +320,9 @@ public class RegisterCreationApiTests : IClassFixture<RegisterServiceWebApplicat
         // Act
         var response = await client.PostAsJsonAsync("/api/registers/initiate", request);
 
-        // Assert — initiate phase does not enforce name length;
-        // validation is deferred to finalize phase
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        // Assert — a 39-char name (limit 38) is rejected fast at the initiate INPUT BOUNDARY
+        // (Feature 174), matching this test's name, rather than deferred to finalize.
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
     }
 
     [Fact]


### PR DESCRIPTION
## AIAS register name ≤38 + fail-fast register-name validation

Surfaced by re-running the AIAS demo after the F175 federation unblock. The demo's register/participant/blueprint steps were **seal-timing-out**, and the root cause turned out to be trivial — a **39-char register name** — masked by weak validation.

### 1. Demo data (the actual blocker)
`$script:AiasName = "Acme Identity Assurance Services (AIAS)"` is **39 chars** and was used verbatim as the register name, exceeding the 38-char limit. `finalize` threw at `ValidateControlRecord`, so the genesis was never created/sealed and every downstream tx timed out — but the demo reported "Register created". The trailing `(AIAS)` is redundant (AIAS = the acronym of the four words), so the name becomes **"Acme Identity Assurance Services"** (32).

With this, the register **seals**: registry shows it at **Height 2** (genesis + participant sealed by the **local** validator) — confirming register-creation templates the local validator into the roster and the local node is the primary validator for its own registers.

### 2. Validation — fail fast at the input boundary
The 1..38 name rule was only enforced in `FinalizeAsync` (`ValidateControlRecord`) — **after** attestation signing — so a bad name failed silently, deep in the flow. Now validated at the **`InitiateAsync`** boundary (the initiate endpoint already maps `ArgumentException → 400`), so a bad name fails immediately with a clear message. Test added: `initiate` with a 39-char name → **400**.

### 3. Demo script fix
`run-demo.ps1` now imports `SorchaWalkthrough` directly so its own `Write-Wt*` banner calls resolve — AiasDemo imports them as a nested module which doesn't re-export to the caller, causing a `"Write-WtBanner is not recognized"` crash once provisioning returned.

### Tests
Register integration suite green except the one **pre-existing, local-only** `InitiateRegisterCreation_WithEmptyBody` 401 quirk (passes in CI). New name-validation test passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
