### PR TITLE
fix: [174] AIAS demo — make rehearse runnable + fix the reject path

### DIFF
--- a/demos/AIAS/agent/assure-id.rules.json
+++ b/demos/AIAS/agent/assure-id.rules.json
@@ -2,7 +2,7 @@
   {
     "actionName": "Verify Assured Identity Application",
     "condition": { "==": [ { "var": "checks.postcodeExists" }, false ] },
-    "decision": "reject",
+    "decision": "submit",
     "payload": {
       "decision": "rejected",
       "verificationNotes": "AIAS could not locate that address on any map. We assure real people at real places — try a postcode that exists."
@@ -11,7 +11,7 @@
   {
     "actionName": "Verify Assured Identity Application",
     "condition": { "==": [ { "var": "checks.profane" }, true ] },
-    "decision": "reject",
+    "decision": "submit",
     "payload": {
       "decision": "rejected",
       "verificationNotes": "AIAS does not assure identities described in such... colourful terms. Please reapply with your Sunday-best vocabulary."
@@ -20,7 +20,7 @@
   {
     "actionName": "Verify Assured Identity Application",
     "condition": { "==": [ { "var": "checks.emailVerified" }, false ] },
-    "decision": "reject",
+    "decision": "submit",
     "payload": {
       "decision": "rejected",
       "verificationNotes": "AIAS needs a verified email before it can assure you. Confirm your email and reapply."
@@ -29,7 +29,7 @@
   {
     "actionName": "Verify Assured Identity Application",
     "condition": { "==": [ true, true ] },
-    "decision": "approve",
+    "decision": "submit",
     "payload": {
       "decision": "approved",
       "verificationNotes": "Assured by AIAS — address found, language clean, email verified. Welcome aboard."

--- a/demos/AIAS/rehearse.ps1
+++ b/demos/AIAS/rehearse.ps1
@@ -30,8 +30,19 @@ param(
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-Import-Module (Join-Path $PSScriptRoot "../../walkthroughs/modules/SorchaWalkthrough/SorchaWalkthrough.psm1") -Force -DisableNameChecking
 Import-Module (Join-Path $PSScriptRoot "AiasDemo.psm1") -Force -DisableNameChecking
+# SorchaWalkthrough LAST: AiasDemo nested-imports it with -Force, which evicts it from the caller's
+# scope, so re-import it here to win the script-scoped copy (Write-Wt* cmdlets). Same fix as run-demo.
+Import-Module (Join-Path $PSScriptRoot "../../walkthroughs/modules/SorchaWalkthrough/SorchaWalkthrough.psm1") -Force -DisableNameChecking
+
+# The demo's generic lib helpers (Read-DemoState, Get-DemoApiBase, Import-DemoSecrets,
+# Connect-DemoNodeAdmin) are dot-sourced by AiasDemo into ITS module scope and are NOT re-exported,
+# so this script's own script-level calls to them fail with "not recognized". Dot-source them here
+# too (same units AiasDemo uses) so rehearse resolves them in its own scope.
+$script:AssuredLib = Join-Path $PSScriptRoot "../AssuredIdentity/lib"
+. (Join-Path $script:AssuredLib "Common.ps1")     # Get-DemoApiBase
+. (Join-Path $script:AssuredLib "DemoState.ps1")  # Read/Write/Merge-DemoState
+. (Join-Path $script:AssuredLib "Auth.ps1")       # Import-DemoSecrets, Connect-DemoNodeAdmin
 
 $state = Read-DemoState -Path $StateFile
 if (-not $state) { Write-WtFail "No state.json — run ./run-demo.ps1 -Target $Target first."; exit 2 }
@@ -57,7 +68,7 @@ function New-RehearsalApplicant {
     $publicOrgId = "00000000-0000-0000-0000-000000000002"
     $pu = Invoke-SorchaApi -Method GET -Uri "$api/organizations/$publicOrgId/users?includeInactive=true" -Headers $admin.Headers
     $u = $pu.users | Where-Object { $_.email -eq $email } | Select-Object -First 1
-    if ($u) { Confirm-SorchaUserEmail -TenantUrl $api -OrganizationId $publicOrgId -UserId $u.id -Headers $admin.Headers }
+    if ($u) { $null = Confirm-SorchaUserEmail -TenantUrl $api -OrganizationId $publicOrgId -UserId $u.id -Headers $admin.Headers }
 
     $session = Connect-SorchaUser -TenantUrl $api -Email $email -Password $pw -OrganizationId $publicOrgId
     $wallet = New-SorchaWallet -WalletUrl $api -Name "Rehearsal $Tag Wallet" -Headers $session.Headers -FetchPublicKey


### PR DESCRIPTION
## AIAS demo: make rehearse runnable + fix the reject path

Surfaced by live-validating the AIAS Assure-ID demo (`demos/AIAS/rehearse.ps1`) after the clean network re-genesis. Two independent problems, both fixed and validated.

### 1. `rehearse.ps1` was un-runnable (bit-rotted post-refactor)
- **dot-source the AssuredIdentity lib units** (`Read-DemoState`, `Get-DemoApiBase`, `Import-DemoSecrets`, `Connect-DemoNodeAdmin`) — AiasDemo dot-sources them into its *module* scope and doesn't re-export, so rehearse's script-level calls failed with "not recognized".
- **import `SorchaWalkthrough` after `AiasDemo`** — AiasDemo's nested `-Force` import evicts it from the caller scope (same fix as `run-demo`), so `Write-Wt*` were unresolved.
- **suppress `Confirm-SorchaUserEmail` output** in `New-RehearsalApplicant` so the applicant is returned as a single object, not an array (StrictMode: `'PublicOrgId' cannot be found`).

### 2. Reject path: submit Action 2, don't call action-level `/reject`
The reject rules used `decision="reject"`, which the agent's `ActionExecutor` routes to `/actions/{idx}/reject`. But the AIAS Action 2 is a **submit-a-decision-payload** action (enum `["approved","rejected"]`) with a `rejected-terminal` route keyed on `payload.decision=="rejected"` — not an x-review approve/reject-able action — so `/reject` fails with *"Action 2 does not allow rejection"* and the instance stalls (the agent decided reject but couldn't record it).

Fix: rules use `decision="submit"` so the agent `/execute`s Action 2 with the payload; the outcome (`approved|rejected`) stays in `payload.decision` and the blueprint routes it. **Validated live:** agent logs `Decision: submit` + `submitted successfully`, and a bad-postcode instance routes to `rejected-terminal` (`currentActionIds -> []`) with **no credential issued**.

### Context / follow-ups
- The *primary* wrongly-issued-credential cause was a **stale global `sorcha.agent 1.0.1` tool** (predates M1's external-check hook) launched via `Get-Command sorcha-agent` — being updated separately.
- **#1077** — harden agent decision to fail-closed when the external-check runner is absent (not just faulting).
- Still open: a **portrait-bearing Action 1 submission does not seal** (90s timeout; no-portrait seals in ~2s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
