### PR TITLE
fix: [174] file-reference fields carry an object, not a string (portrait seal)

### DIFF
--- a/src/Core/Sorcha.Blueprint.Engine/Implementation/SchemaValidator.cs
+++ b/src/Core/Sorcha.Blueprint.Engine/Implementation/SchemaValidator.cs
@@ -128,6 +128,19 @@ public class SchemaValidator : ISchemaValidator
                 {
                     obj.Remove(key);
                 }
+
+                // Relax the "type" constraint on file-reference fields — their runtime value is
+                // a FileReference OBJECT (plus, for F107 portrait capture, a tokenImageBase64
+                // sibling), never the declared "string". Structural validation lives in
+                // FileReferenceValidator. Mirrors ValidationEngine.StripXPrefixedKeysRecursive.
+                if (obj.TryGetPropertyValue("format", out var formatNode) &&
+                    formatNode is JsonValue formatValue &&
+                    formatValue.TryGetValue<string>(out var formatStr) &&
+                    string.Equals(formatStr, "file-reference", StringComparison.Ordinal))
+                {
+                    obj.Remove("type");
+                }
+
                 foreach (var kvp in obj)
                 {
                     StripInPlace(kvp.Value);

--- a/src/Services/Sorcha.Validator.Service/Services/ValidationEngine.cs
+++ b/src/Services/Sorcha.Validator.Service/Services/ValidationEngine.cs
@@ -2157,6 +2157,25 @@ public class ValidationEngine : IValidationEngine
                 {
                     obj.Remove(key);
                 }
+
+                // Relax the "type" constraint on file-reference fields. A field declared
+                // { "type": "string", "format": "file-reference" } carries an OBJECT at
+                // runtime (the FileReference: fileName/hash/chunkTransactionIds/... plus, for
+                // F107 portrait capture, a tokenImageBase64 sibling) — never a plain string.
+                // The JSON-Schema "type" check therefore spuriously fails VAL_SCHEMA_004
+                // ("Value is object but should be string") whenever the payload is visible to
+                // the validator (DevMode / publicly-disclosed registers; encrypted registers
+                // skip schema validation entirely, which is why this stayed latent). Structural
+                // integrity of file references is enforced separately by ValidateFileReferences,
+                // so drop the "type" keyword here and let any value shape through.
+                if (obj.TryGetPropertyValue("format", out var formatNode) &&
+                    formatNode is JsonValue formatValue &&
+                    formatValue.TryGetValue<string>(out var formatStr) &&
+                    string.Equals(formatStr, "file-reference", StringComparison.Ordinal))
+                {
+                    obj.Remove("type");
+                }
+
                 foreach (var kvp in obj)
                 {
                     StripXPrefixedKeysRecursive(kvp.Value);

--- a/tests/Sorcha.Blueprint.Engine.Tests/SchemaValidatorTests.cs
+++ b/tests/Sorcha.Blueprint.Engine.Tests/SchemaValidatorTests.cs
@@ -93,6 +93,48 @@ public class SchemaValidatorTests
     }
 
     [Fact]
+    public async Task ValidateAsync_FileReferenceFieldWithObjectValue_ValidatesAsPass()
+    {
+        // A field declared { "type": "string", "format": "file-reference" } carries an OBJECT at
+        // runtime (the FileReference plus, for F107 portrait capture, a tokenImageBase64 sibling),
+        // never a plain string. The "type" constraint must be relaxed for file-reference fields or
+        // the object value spuriously fails ("Value is object but should be string"). Structural
+        // integrity is enforced separately by FileReferenceValidator. Regression for the AIAS
+        // portrait-seal bug (Feature 174): a portrait-bearing Action 1 was rejected by the validator
+        // (VAL_SCHEMA_004) and therefore never sealed.
+        var schema = JsonNode.Parse("""
+        {
+            "type": "object",
+            "properties": {
+                "name": { "type": "string" },
+                "portrait": {
+                    "type": "string",
+                    "format": "file-reference",
+                    "x-file": { "accept": ["image/jpeg"], "embedAs": "image-token-jpeg-240x320" }
+                }
+            },
+            "required": ["name"]
+        }
+        """);
+
+        var data = new Dictionary<string, object>
+        {
+            ["name"] = "Alice",
+            ["portrait"] = new Dictionary<string, object>
+            {
+                ["tokenImageBase64"] = "/9j/4AAQSkZJRg=="
+            }
+        };
+
+        var result = await _validator.ValidateAsync(data, schema!);
+
+        result.IsValid.Should().BeTrue(
+            "file-reference fields carry an object value and must validate as pass; errors: {0}",
+            string.Join(" | ", result.Errors.Select(e => $"{e.InstanceLocation}:{e.Message}")));
+        result.Errors.Should().BeEmpty();
+    }
+
+    [Fact]
     public async Task ValidateAsync_MissingRequiredField_ReturnsInvalid()
     {
         // Arrange


### PR DESCRIPTION
A blueprint field declared { "type": "string", "format": "file-reference" }
carries a FileReference OBJECT at runtime (fileName/hash/chunkTransactionIds/…
plus, for F107 portrait capture, a tokenImageBase64 sibling) — never a plain
string. When the validator can see the payload (DevMode / publicly-disclosed
registers; encrypted registers skip schema validation, which is why this stayed
latent), the JSON-Schema "type" check spuriously fails VAL_SCHEMA_004
("Value is object but should be string"), the tx is rejected, and it never seals.

This was the AIAS portrait-seal bug: a portrait-bearing Action 1 timed out at 90s
on -WaitForSeal while a no-portrait submission sealed in ~1s. The AIAS Action 1
payload is plaintext (disclosed /* to the analyst agent), so the validator ran
schema validation and rejected the portrait object.

Relax the "type" keyword on any schema node carrying "format": "file-reference"
in both schema-validation strip passes (ValidationEngine + the mirrored engine
SchemaValidator). Structural integrity of file references is still enforced by
ValidateFileReferences / FileReferenceValidator.

Verified live: the portrait-bearing Action 1 now seals (Active in ~4s).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UDmeAycWwQ5Y8PXuz4iub6
