### PR TITLE
fix: [157] WAF XSS heuristic false-positives on on*-prefixed query params

### DIFF
--- a/src/Common/Sorcha.ServiceDefaults/InputValidationMiddleware.cs
+++ b/src/Common/Sorcha.ServiceDefaults/InputValidationMiddleware.cs
@@ -254,7 +254,7 @@ public partial class InputValidationMiddleware
     private static partial Regex CreateSqlInjectionRegex();
 
     [GeneratedRegex(
-        @"<\s*script[^>]*>|<\s*/\s*script\s*>|javascript\s*:|\bon\w+\s*=|<\s*img[^>]+onerror|<\s*svg[^>]+onload|<\s*iframe|<\s*object|<\s*embed|<\s*link[^>]+href\s*=\s*['""]?javascript|expression\s*\(|vbscript\s*:",
+        @"<\s*script[^>]*>|<\s*/\s*script\s*>|javascript\s*:|[\s""'`/]on\w+\s*=|<\s*img[^>]+onerror|<\s*svg[^>]+onload|<\s*iframe|<\s*object|<\s*embed|<\s*link[^>]+href\s*=\s*['""]?javascript|expression\s*\(|vbscript\s*:",
         RegexOptions.Compiled | RegexOptions.IgnoreCase,
         matchTimeoutMilliseconds: 1000)]
     private static partial Regex CreateXssRegex();

--- a/tests/Sorcha.ServiceDefaults.Tests/InputValidationMiddlewareTests.cs
+++ b/tests/Sorcha.ServiceDefaults.Tests/InputValidationMiddlewareTests.cs
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace Sorcha.ServiceDefaults.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="InputValidationMiddleware"/> query-string XSS detection.
+/// </summary>
+public class InputValidationMiddlewareTests
+{
+    private static async Task<(bool nextCalled, int statusCode)> InvokeWithQueryAsync(string queryString)
+    {
+        var nextCalled = false;
+        var middleware = new InputValidationMiddleware(
+            next: _ => { nextCalled = true; return Task.CompletedTask; },
+            logger: NullLogger<InputValidationMiddleware>.Instance,
+            options: Options.Create(new InputValidationOptions()));
+
+        var context = new DefaultHttpContext();
+        context.Request.Path = "/";
+        context.Request.QueryString = new QueryString(queryString);
+
+        await middleware.InvokeAsync(context);
+
+        return (nextCalled, context.Response.StatusCode);
+    }
+
+    [Theory]
+    [InlineData("?onboarding=true")]   // Feature 157 wallet-wizard redirect — the reported false positive
+    [InlineData("?online=1")]
+    [InlineData("?once=abc")]
+    [InlineData("?returnUrl=/app/wallets")]
+    public async Task InvokeAsync_LegitimateOnPrefixedQueryParam_IsAllowed(string queryString)
+    {
+        // The XSS event-handler heuristic must not flag ordinary query params that merely start
+        // with "on" (onboarding, online, once, …). A real event-handler injection always has a
+        // preceding attribute separator (whitespace / quote / slash); a bare query param does not.
+        var (nextCalled, statusCode) = await InvokeWithQueryAsync(queryString);
+
+        nextCalled.Should().BeTrue("'{0}' is a benign query string and must pass the WAF", queryString);
+        statusCode.Should().Be(StatusCodes.Status200OK);
+    }
+
+    [Theory]
+    [InlineData("?q=<img src=x onerror=alert(1)>")]   // event handler with a leading space
+    [InlineData("?q=\"><svg onload=alert(1)>")]
+    [InlineData("?q=<script>alert(1)</script>")]
+    [InlineData("?q=javascript:alert(1)")]
+    public async Task InvokeAsync_ActualXssPayload_IsBlocked(string queryString)
+    {
+        var (nextCalled, statusCode) = await InvokeWithQueryAsync(queryString);
+
+        nextCalled.Should().BeFalse("'{0}' is an XSS payload and must be blocked", queryString);
+        statusCode.Should().Be(StatusCodes.Status400BadRequest);
+    }
+}


### PR DESCRIPTION
The InputValidationMiddleware XSS detector used `\bon\w+\s*=` to catch inline
event-handler injection (onerror=, onload=, …). That word-boundary form also
matches any ordinary query param that merely starts with "on" — so the Feature
157 wallet-wizard completion redirect `GET /?onboarding=true` was rejected with
400 {"error":"Invalid characters in query string"} at the end of first-time
wallet creation.

A genuine event-handler XSS payload always has a preceding attribute separator
(whitespace, quote, backtick, or slash) — `<img src=x onerror=…>`, `" onload=…`.
A bare query param (`?onboarding=`, `?online=`) does not. Require one of those
separators before the `on\w+=` sub-pattern; the tag-anchored `<img[^>]+onerror`
/ `<svg[^>]+onload` alternatives are unchanged, so real vectors stay blocked.

Adds InputValidationMiddlewareTests covering both directions: benign on*-prefixed
params pass, actual XSS payloads (event handlers, <script>, javascript:) still 400.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UDmeAycWwQ5Y8PXuz4iub6
