### PR TITLE
fix: [157] show the real persona-save error (not a generic one) + tolerate phone spacing

### DIFF
--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Onboarding/CompleteProfileStep.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Onboarding/CompleteProfileStep.razor
@@ -3,6 +3,7 @@
 
 @namespace Sorcha.UI.Components.User.Components.Onboarding
 
+@using System.Linq
 @using Microsoft.AspNetCore.Components.Authorization
 @using Microsoft.Extensions.Logging
 @using Sorcha.Tenant.Models.Persona
@@ -193,8 +194,9 @@ else
             emails.Add(new PersonaEmail(_email.Trim(), IsDefault: true));
 
         var phones = new List<PersonaPhone>();
-        if (!string.IsNullOrWhiteSpace(_phone))
-            phones.Add(new PersonaPhone(_phone.Trim(), IsDefault: true));
+        var normalisedPhone = NormalisePhone(_phone);
+        if (!string.IsNullOrWhiteSpace(normalisedPhone))
+            phones.Add(new PersonaPhone(normalisedPhone, IsDefault: true));
 
         return new PersonaAttributesV1
         {
@@ -218,15 +220,18 @@ else
             if (OnContinue.HasDelegate)
                 await OnContinue.InvokeAsync();
         }
-        catch (HttpRequestException ex) when (ex.StatusCode == System.Net.HttpStatusCode.BadRequest)
+        catch (PersonaValidationException ex)
         {
-            Logger.LogWarning(ex, "Profile save rejected (400)");
-            Feedback.ShowError("Some of the values you entered are invalid. Please check and try again.", autoDismissMs: 0);
+            // The client throws typed persona exceptions (not HttpRequestException), so surface the
+            // actual reason — most commonly a phone number that isn't in E.164 form — rather than a
+            // generic "unexpected error".
+            Logger.LogWarning("Profile save rejected (validation): {Fields}", string.Join(", ", ex.Errors.Keys));
+            Feedback.ShowError(DescribeValidationError(ex.Errors), autoDismissMs: 0);
         }
-        catch (HttpRequestException ex) when (ex.StatusCode == System.Net.HttpStatusCode.Conflict)
+        catch (PersonaWalletNotProvisionedException ex)
         {
-            Logger.LogWarning(ex, "Profile save rejected (409) — wallet not yet provisioned");
-            Feedback.ShowError("Your wallet has not been created yet. Please create a wallet first and then retry.", autoDismissMs: 0);
+            Logger.LogWarning(ex, "Profile save rejected — wallet not provisioned");
+            Feedback.ShowError("Your wallet isn't ready yet. Please wait a moment and try again.", autoDismissMs: 0);
         }
         catch (Exception ex)
         {
@@ -243,5 +248,27 @@ else
     {
         if (OnSkip.HasDelegate)
             await OnSkip.InvokeAsync();
+    }
+
+    /// <summary>
+    /// Strips spaces, dashes, and brackets from a typed phone number so natural input like
+    /// "+44 7700 900123" becomes the E.164 "+447700900123". Keeps only digits and a leading "+";
+    /// it does not invent a country code, so a bare national number still fails validation (and the
+    /// user is told to use the international format).
+    /// </summary>
+    private static string? NormalisePhone(string? raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw)) return null;
+        var cleaned = new string(raw.Where(c => char.IsDigit(c) || c == '+').ToArray());
+        return string.IsNullOrEmpty(cleaned) ? null : cleaned;
+    }
+
+    private static string DescribeValidationError(IReadOnlyDictionary<string, string[]> errors)
+    {
+        if (errors.Keys.Any(k => k.Contains("phone", StringComparison.OrdinalIgnoreCase)))
+            return "Please enter your phone number in international format, e.g. +447700900123 — or leave it blank.";
+        if (errors.Keys.Any(k => k.Contains("email", StringComparison.OrdinalIgnoreCase)))
+            return "That email address doesn't look valid. Please check it and try again.";
+        return "Some of the details you entered are invalid. Please check and try again.";
     }
 }


### PR DESCRIPTION
CompleteProfileStep.SaveAsync caught HttpRequestException by status code, but the
persona client throws typed PersonaValidationException / PersonaWalletNotProvisioned
exceptions — so a 400 validation failure fell through to the catch-all "An unexpected
error occurred saving your profile" instead of telling the user what was wrong.

Symptom (n1): a fresh signup's name + email auto-seeded fine (PUT 200), but pressing
"Save and continue" after typing a phone number returned 400 (phone not E.164) and the
UI showed the generic error. Now:
- catch the typed exceptions and surface a specific message (phone → "use international
  format, e.g. +447700900123, or leave it blank"; email → "doesn't look valid"), and
- normalise the phone input (strip spaces/dashes/brackets) so "+44 7700 900123" becomes
  the valid E.164 "+447700900123" before submission.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UDmeAycWwQ5Y8PXuz4iub6
