### PR TITLE
fix: [157] apply phone E.164 conversion + friendly errors on My Profile too

### DIFF
--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Onboarding/CompleteProfileStep.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Onboarding/CompleteProfileStep.razor
@@ -194,7 +194,7 @@ else
             emails.Add(new PersonaEmail(_email.Trim(), IsDefault: true));
 
         var phones = new List<PersonaPhone>();
-        var normalisedPhone = NormalisePhone(_phone);
+        var normalisedPhone = PhoneNormalizer.ToE164(_phone);
         if (!string.IsNullOrWhiteSpace(normalisedPhone))
             phones.Add(new PersonaPhone(normalisedPhone, IsDefault: true));
 
@@ -226,7 +226,9 @@ else
             // actual reason — most commonly a phone number that isn't in E.164 form — rather than a
             // generic "unexpected error".
             Logger.LogWarning("Profile save rejected (validation): {Fields}", string.Join(", ", ex.Errors.Keys));
-            Feedback.ShowError(DescribeValidationError(ex.Errors), autoDismissMs: 0);
+            var first = ex.Errors.First();
+            Feedback.ShowError(PhoneNormalizer.DescribeError(first.Key, first.Value.FirstOrDefault() ?? string.Empty),
+                autoDismissMs: 0);
         }
         catch (PersonaWalletNotProvisionedException ex)
         {
@@ -250,64 +252,4 @@ else
             await OnSkip.InvokeAsync();
     }
 
-    /// <summary>
-    /// Best-effort conversion of a typed phone number to E.164. Strips spaces/dashes/brackets, maps a
-    /// leading international access code ("00…" → "+…"), and — for the browser's own region — promotes
-    /// a national trunk-prefixed number ("07700 900123" in GB → "+447700900123"). If the region can't
-    /// be resolved to a known calling code the national number is left as-is, so a wrong country code
-    /// is never invented; validation then prompts the user for the international format.
-    /// </summary>
-    private static string? NormalisePhone(string? raw)
-    {
-        if (string.IsNullOrWhiteSpace(raw)) return null;
-
-        var cleaned = new string(raw.Where(c => char.IsDigit(c) || c == '+').ToArray());
-        if (string.IsNullOrEmpty(cleaned)) return null;
-
-        if (cleaned.StartsWith('+')) return cleaned;
-        if (cleaned.StartsWith("00")) return "+" + cleaned[2..];
-        if (cleaned.StartsWith('0'))
-        {
-            var callingCode = LocalCallingCode();
-            if (callingCode is not null) return "+" + callingCode + cleaned[1..];
-        }
-
-        return cleaned;
-    }
-
-    /// <summary>
-    /// The calling code for the browser's current region, or null when it can't be resolved to a
-    /// known code (so callers leave the number untouched rather than guess).
-    /// </summary>
-    private static string? LocalCallingCode()
-    {
-        try
-        {
-            return CallingCodesByRegion.GetValueOrDefault(
-                System.Globalization.RegionInfo.CurrentRegion.TwoLetterISORegionName);
-        }
-        catch
-        {
-            return null;
-        }
-    }
-
-    // Common regions only — an unmapped region falls through to "leave the number as typed" rather
-    // than risk prepending the wrong country code.
-    private static readonly Dictionary<string, string> CallingCodesByRegion = new(StringComparer.OrdinalIgnoreCase)
-    {
-        ["GB"] = "44",  ["IE"] = "353", ["AU"] = "61", ["NZ"] = "64", ["FR"] = "33", ["DE"] = "49",
-        ["ES"] = "34",  ["IT"] = "39",  ["NL"] = "31", ["BE"] = "32", ["PT"] = "351", ["SE"] = "46",
-        ["NO"] = "47",  ["DK"] = "45",  ["FI"] = "358", ["CH"] = "41", ["AT"] = "43", ["PL"] = "48",
-        ["IN"] = "91",  ["ZA"] = "27",
-    };
-
-    private static string DescribeValidationError(IReadOnlyDictionary<string, string[]> errors)
-    {
-        if (errors.Keys.Any(k => k.Contains("phone", StringComparison.OrdinalIgnoreCase)))
-            return "Please enter your phone number in international format, e.g. +447700900123 — or leave it blank.";
-        if (errors.Keys.Any(k => k.Contains("email", StringComparison.OrdinalIgnoreCase)))
-            return "That email address doesn't look valid. Please check it and try again.";
-        return "Some of the details you entered are invalid. Please check and try again.";
-    }
 }

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Persona/PersonaEditor.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Persona/PersonaEditor.razor
@@ -474,7 +474,10 @@
                 FullName = NullIfBlank(_fullName),
                 DateOfBirth = _dateOfBirth is { } dob ? DateOnly.FromDateTime(dob) : null,
                 Emails = _emails.Where(e => !string.IsNullOrWhiteSpace(e.Value)).ToList(),
-                Phones = _phones.Where(p => !string.IsNullOrWhiteSpace(p.Value)).ToList(),
+                Phones = _phones
+                    .Where(p => !string.IsNullOrWhiteSpace(p.Value))
+                    .Select(p => p with { Value = PhoneNormalizer.ToE164(p.Value) ?? p.Value })
+                    .ToList(),
                 Addresses = _addresses.Where(a => !string.IsNullOrWhiteSpace(a.Line1)).ToList(),
                 Nationalities = nationalities,
             };
@@ -490,7 +493,7 @@
             {
                 foreach (var err in errors)
                 {
-                    Feedback.ShowError($"{field}: {err}", autoDismissMs: 0);
+                    Feedback.ShowError(PhoneNormalizer.DescribeError(field, err), autoDismissMs: 0);
                 }
             }
         }

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/Persona/PhoneNormalizer.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/Persona/PhoneNormalizer.cs
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Globalization;
+
+namespace Sorcha.UI.Core.Services.Persona;
+
+/// <summary>
+/// Best-effort conversion of a user-typed phone number to E.164, shared by every persona surface
+/// (onboarding profile step and the My Profile editor) so they behave identically. Strips
+/// spaces/dashes/brackets, maps a leading international access code ("00…" → "+…"), and promotes a
+/// national trunk-prefixed number ("07966 242717" in GB → "+447966242717") using the browser's own
+/// region. If the region can't be resolved to a known calling code the national number is left as
+/// typed — a wrong country code is never invented; validation then prompts for the international form.
+/// </summary>
+public static class PhoneNormalizer
+{
+    /// <summary>Returns the E.164 form of <paramref name="raw"/>, or null when it is blank.</summary>
+    public static string? ToE164(string? raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw)) return null;
+
+        var cleaned = new string(raw.Where(c => char.IsDigit(c) || c == '+').ToArray());
+        if (string.IsNullOrEmpty(cleaned)) return null;
+
+        if (cleaned.StartsWith('+')) return cleaned;
+        if (cleaned.StartsWith("00")) return "+" + cleaned[2..];
+        if (cleaned.StartsWith('0'))
+        {
+            var callingCode = LocalCallingCode();
+            if (callingCode is not null) return "+" + callingCode + cleaned[1..];
+        }
+
+        return cleaned;
+    }
+
+    private static string? LocalCallingCode()
+    {
+        try
+        {
+            // Derive the region from the current culture (Blazor WASM sets it from navigator.language,
+            // e.g. "en-GB") rather than RegionInfo.CurrentRegion, which reads the OS region. A
+            // region-less culture (e.g. "en") makes RegionInfo throw → null → leave the number as typed.
+            var region = new RegionInfo(CultureInfo.CurrentCulture.Name);
+            return CallingCodesByRegion.GetValueOrDefault(region.TwoLetterISORegionName);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    // Common trunk-"0" regions only — an unmapped region falls through to "leave the number as typed"
+    // rather than risk prepending the wrong country code. US/CA (+1) have no trunk 0, so their
+    // national numbers never start with 0 and don't need an entry.
+    private static readonly Dictionary<string, string> CallingCodesByRegion = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["GB"] = "44",  ["IE"] = "353", ["AU"] = "61", ["NZ"] = "64", ["FR"] = "33", ["DE"] = "49",
+        ["ES"] = "34",  ["IT"] = "39",  ["NL"] = "31", ["BE"] = "32", ["PT"] = "351", ["SE"] = "46",
+        ["NO"] = "47",  ["DK"] = "45",  ["FI"] = "358", ["CH"] = "41", ["AT"] = "43", ["PL"] = "48",
+        ["IN"] = "91",  ["ZA"] = "27",
+    };
+
+    /// <summary>
+    /// Maps a persona validation error (field pointer + code) to a human-readable message, so surfaces
+    /// show "Phone number: use international format…" rather than the raw "phones[0].value: invalid_phone".
+    /// </summary>
+    public static string DescribeError(string field, string code) => code switch
+    {
+        "invalid_phone" => "Phone number: enter it in international format, e.g. +447700900123 — or leave it blank.",
+        "invalid_email" => "That email address doesn't look valid. Please check it.",
+        "invalid_country_code" => $"{PrettyField(field)}: use a 2-letter country code (e.g. GB).",
+        "required" => $"{PrettyField(field)} is required.",
+        "list_cap_exceeded" => $"{PrettyField(field)}: too many entries (maximum 5).",
+        "multiple_defaults" => $"{PrettyField(field)}: only one entry can be the default.",
+        _ => $"{PrettyField(field)}: {code}",
+    };
+
+    private static string PrettyField(string field)
+    {
+        if (field.StartsWith("phone", StringComparison.OrdinalIgnoreCase)) return "Phone number";
+        if (field.StartsWith("email", StringComparison.OrdinalIgnoreCase)) return "Email address";
+        if (field.StartsWith("address", StringComparison.OrdinalIgnoreCase)) return "Address";
+        if (field.StartsWith("nationalit", StringComparison.OrdinalIgnoreCase)) return "Nationality";
+        return "One of the details you entered";
+    }
+}

--- a/tests/Sorcha.UI.Components.User.Tests/Services/Persona/PhoneNormalizerTests.cs
+++ b/tests/Sorcha.UI.Components.User.Tests/Services/Persona/PhoneNormalizerTests.cs
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System;
+using System.Globalization;
+using FluentAssertions;
+using Sorcha.UI.Core.Services.Persona;
+using Xunit;
+
+namespace Sorcha.UI.Components.User.Tests.Services.Persona;
+
+/// <summary>
+/// Unit tests for <see cref="PhoneNormalizer"/> — the shared national → E.164 conversion used by the
+/// onboarding profile step and the My Profile editor. Regression for a GB national number
+/// ("07966242717") being rejected as invalid_phone instead of saved as "+447966242717".
+/// </summary>
+public sealed class PhoneNormalizerTests
+{
+    private static T WithRegion<T>(string culture, Func<T> body)
+    {
+        var original = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = new CultureInfo(culture);
+            return body();
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = original;
+        }
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void ToE164_Blank_ReturnsNull(string? input) =>
+        PhoneNormalizer.ToE164(input).Should().BeNull();
+
+    [Theory]
+    [InlineData("+447700900123", "+447700900123")]
+    [InlineData("+44 7700 900123", "+447700900123")]   // spaces stripped
+    [InlineData("+44 (7700) 900-123", "+447700900123")] // punctuation stripped
+    [InlineData("00447700900123", "+447700900123")]     // international access code
+    public void ToE164_AlreadyInternational_IsCleanedRegionIndependent(string input, string expected) =>
+        PhoneNormalizer.ToE164(input).Should().Be(expected);
+
+    [Fact]
+    public void ToE164_GbNationalNumber_PromotedToPlus44()
+    {
+        // The reported case: a GB national number typed on a GB browser.
+        WithRegion("en-GB", () => PhoneNormalizer.ToE164("07966242717"))
+            .Should().Be("+447966242717");
+    }
+
+    [Fact]
+    public void ToE164_GbNationalWithSpaces_PromotedToPlus44()
+    {
+        WithRegion("en-GB", () => PhoneNormalizer.ToE164("07966 242717"))
+            .Should().Be("+447966242717");
+    }
+
+    [Fact]
+    public void ToE164_FrenchNationalOnFrenchBrowser_PromotedToPlus33()
+    {
+        WithRegion("fr-FR", () => PhoneNormalizer.ToE164("0612345678"))
+            .Should().Be("+33612345678");
+    }
+
+    [Fact]
+    public void ToE164_UnmappedRegion_LeavesNationalNumberUntouched()
+    {
+        // Japan isn't in the common-region map: never invent a country code.
+        WithRegion("ja-JP", () => PhoneNormalizer.ToE164("09012345678"))
+            .Should().Be("09012345678");
+    }
+
+    [Theory]
+    [InlineData("phones[0].value", "invalid_phone")]
+    public void DescribeError_InvalidPhone_IsHumanReadable(string field, string code)
+    {
+        var message = PhoneNormalizer.DescribeError(field, code);
+        message.Should().Contain("international format");
+        message.Should().NotContain("phones[0]");
+    }
+}


### PR DESCRIPTION
The national -> E.164 phone conversion added for the onboarding step lived only in
CompleteProfileStep, so editing the phone on the My Profile page (PersonaEditor) still
rejected a national number — e.g. GB "07966242717" surfaced the raw validation key
"phones[0].value: invalid_phone".

Extract the conversion into a shared PhoneNormalizer (keyed off CultureInfo.CurrentCulture
so it follows the browser locale in WASM and is unit-testable), and use it in BOTH
surfaces. PersonaEditor now normalises phones before submit and renders friendly
messages (PhoneNormalizer.DescribeError) instead of raw "field: code" strings.

GB "07966242717" -> "+447966242717"; fr-FR "06…" -> "+33…"; unmapped regions and
already-international numbers are handled per the onboarding step. 8 unit tests.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UDmeAycWwQ5Y8PXuz4iub6
