### PR TITLE
fix: [157] My Profile read-back — client couldn't deserialise the persona response

### DIFF
--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Persona/PersonaEditor.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Persona/PersonaEditor.razor
@@ -117,6 +117,7 @@
                 <MudText Typo="Typo.h6">Phone numbers</MudText>
                 <MudButton StartIcon="@Icons.Material.Filled.Add" Variant="Variant.Outlined"
                            Color="Color.Primary" Disabled="@(_phones.Count >= MaxListEntries)"
+                           data-testid="persona-add-phone"
                            OnClick="AddPhone">Add phone</MudButton>
             </MudStack>
             @for (var i = 0; i < _phones.Count; i++)
@@ -127,6 +128,7 @@
                     <MudItem xs="12" sm="5">
                         <MudTextField Value="row.Value" Label="Phone (E.164, e.g. +441234567890)"
                                       Variant="Variant.Outlined"
+                                      data-testid="@($"persona-phone-{idx}")"
                                       ValueChanged="@((string v) => _phones[idx] = row with { Value = v })" />
                     </MudItem>
                     <MudItem xs="6" sm="2">
@@ -259,6 +261,7 @@
             </MudButton>
             <MudButton Variant="Variant.Filled" Color="Color.Primary"
                        StartIcon="@Icons.Material.Filled.Save"
+                       data-testid="persona-save-button"
                        OnClick="HandleSave" Disabled="@_saving">
                 @(_saving ? "Saving…" : "Save profile")
             </MudButton>

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Extensions/Shared/JsonDefaults.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Extensions/Shared/JsonDefaults.cs
@@ -2,6 +2,7 @@
 // Copyright (c) 2026 Sorcha Contributors
 
 using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Sorcha.UI.Core.Extensions;
 
@@ -18,6 +19,12 @@ public static class JsonDefaults
     private static JsonSerializerOptions CreateApiOptions()
     {
         var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+        // The services serialize enums as kebab-case strings (JsonStringEnumConverter with
+        // KebabCaseLower — e.g. PersonaAttributeSource -> "self-asserted"). Without a matching
+        // converter here, deserialising such a response throws and the caller silently gets an empty
+        // result (the "My Profile is empty even though it saved" class of bug). The converter also
+        // reads numeric enum values, so it is safe for any endpoint that emits numbers.
+        options.Converters.Add(new JsonStringEnumConverter(JsonNamingPolicy.KebabCaseLower));
         options.MakeReadOnly(populateMissingResolver: true);
         return options;
     }

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/Persona/PersonaHttpClient.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/Persona/PersonaHttpClient.cs
@@ -5,6 +5,7 @@ using System.Net;
 using System.Net.Http.Json;
 using Microsoft.Extensions.Logging;
 using Sorcha.Tenant.Models.Persona;
+using Sorcha.UI.Core.Extensions;
 
 namespace Sorcha.UI.Core.Services.Persona;
 
@@ -43,7 +44,7 @@ public sealed class PersonaHttpClient : IPersonaClient
                 return null;
             }
 
-            return await response.Content.ReadFromJsonAsync<PersonaReadModelV1>(cancellationToken: ct);
+            return await response.Content.ReadFromJsonAsync<PersonaReadModelV1>(JsonDefaults.Api, ct);
         }
         catch (Exception ex)
         {
@@ -74,7 +75,7 @@ public sealed class PersonaHttpClient : IPersonaClient
 
         response.EnsureSuccessStatusCode();
 
-        var result = await response.Content.ReadFromJsonAsync<PersonaReadModelV1>(cancellationToken: ct);
+        var result = await response.Content.ReadFromJsonAsync<PersonaReadModelV1>(JsonDefaults.Api, ct);
         return result ?? new PersonaReadModelV1();
     }
 

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/Persona/PersonaService.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/Persona/PersonaService.cs
@@ -136,14 +136,17 @@ public sealed class PersonaService : IPersonaService
     /// <inheritdoc />
     public async Task SetAutofillEnabledAsync(bool enabled)
     {
+        // Best-effort: this is a per-device convenience preference in localStorage, NOT part of the
+        // (server-side, already-persisted) profile. On some mobile browsers a localStorage write can
+        // throw (private mode / storage partitioning); that must not surface as "couldn't save
+        // profile" after the persona itself saved successfully. Mirrors GetAutofillEnabledAsync.
         try
         {
             await _localStorage.SetItemAsync(AutofillPreferenceKey, enabled);
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to write autofill preference.");
-            throw;
+            _logger.LogWarning(ex, "Failed to write autofill preference; continuing (local convenience setting).");
         }
     }
 

--- a/tests/Sorcha.UI.Components.User.Tests/Extensions/JsonDefaultsPersonaTests.cs
+++ b/tests/Sorcha.UI.Components.User.Tests/Extensions/JsonDefaultsPersonaTests.cs
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Text.Json;
+using FluentAssertions;
+using Sorcha.Tenant.Models.Persona;
+using Sorcha.UI.Core.Extensions;
+using Xunit;
+
+namespace Sorcha.UI.Components.User.Tests.Extensions;
+
+/// <summary>
+/// Regression for the "My Profile is empty even though it saved" bug: the services serialize enums
+/// as kebab-case strings (JsonStringEnumConverter with KebabCaseLower — PersonaAttributeSource
+/// becomes "self-asserted"), so the client's read options MUST carry the same converter or the whole
+/// persona response fails to deserialize and the caller silently gets a blank form.
+/// </summary>
+public sealed class JsonDefaultsPersonaTests
+{
+    // Exactly the shape the Tenant Service returns from GET /api/me/persona.
+    private const string ServerPersonaJson = """
+    {
+      "givenName": { "value": "Stuart", "source": "self-asserted", "verifiedBy": null, "lastUpdated": "2026-07-02T10:01:44.21+00:00" },
+      "familyName": { "value": "Fraser", "source": "self-asserted", "verifiedBy": null, "lastUpdated": "2026-07-02T10:01:44.21+00:00" },
+      "defaultEmail": { "value": { "value": "stuart@example.test", "isDefault": true, "label": null }, "source": "self-asserted", "verifiedBy": null, "lastUpdated": "2026-07-02T10:01:44.21+00:00" },
+      "allEmails": [ { "value": "stuart@example.test", "isDefault": true, "label": null } ],
+      "defaultPhone": { "value": { "value": "+447966242717", "isDefault": true, "label": null, "kind": null }, "source": "self-asserted", "verifiedBy": null, "lastUpdated": "2026-07-02T10:01:44.21+00:00" },
+      "allPhones": [ { "value": "+447966242717", "isDefault": true, "label": null, "kind": null } ]
+    }
+    """;
+
+    [Fact]
+    public void ApiOptions_DeserialisesServerPersona_WithKebabCaseEnumStrings()
+    {
+        var model = JsonSerializer.Deserialize<PersonaReadModelV1>(ServerPersonaJson, JsonDefaults.Api);
+
+        model.Should().NotBeNull();
+        model!.GivenName.Should().NotBeNull("the kebab-case enum string must not break deserialization");
+        model.GivenName!.Value.Should().Be("Stuart");
+        model.GivenName.Source.Should().Be(PersonaAttributeSource.SelfAsserted);
+        model.FamilyName!.Value.Should().Be("Fraser");
+        model.DefaultEmail!.Value.Value.Should().Be("stuart@example.test");
+        model.DefaultPhone!.Value.Value.Should().Be("+447966242717");
+    }
+}

--- a/tests/Sorcha.UI.E2E.Tests/Tests/Onboarding/CompleteProfileStepTests.cs
+++ b/tests/Sorcha.UI.E2E.Tests/Tests/Onboarding/CompleteProfileStepTests.cs
@@ -26,6 +26,11 @@ public class CompleteProfileStepTests : DockerTestBase
     protected override bool AssertNoConsoleErrors => false;
     protected override bool AssertNoNetworkFailures => false;
 
+    // Pin the browser locale so navigator.language → Blazor CurrentCulture → phone-region resolution
+    // is deterministic (GB → +44). Without this, headless Chromium defaults to en-US and the GB
+    // national-number conversion (correctly) doesn't fire.
+    public override BrowserNewContextOptions ContextOptions() => new() { Locale = "en-GB" };
+
     private const string Password = "Onboard_Pass_2026!";
 
     /// <summary>
@@ -62,11 +67,6 @@ public class CompleteProfileStepTests : DockerTestBase
     /// verified by opening My Profile (which reads the persona, not the login claims).
     /// </summary>
     [Test]
-    [Ignore("Auto-seed persistence is proven server-side (persona PUT → 200, 'Persona saved', decrypt " +
-        "200), but asserting it purely through the My Profile read-back is timing-sensitive in the " +
-        "Docker E2E (the best-effort seed vs. the immediate skip + reload). Carry-across is covered " +
-        "green by Onboarding_CarriesSignupNameAndEmailIntoProfileStep; auto-seed logic is unit-covered " +
-        "by ProfilePrefillTests. Follow-up: stabilise the read-back assertion.")]
     public async Task Onboarding_AutoSeedsPersona_SoSkippingStillPopulatesProfile()
     {
         var email = $"onboard-seed-{Guid.NewGuid():N}@example.test";
@@ -100,6 +100,36 @@ public class CompleteProfileStepTests : DockerTestBase
             Assert.That(emailValue, Is.EqualTo(email),
                 "Persona should have been auto-seeded with the login email.");
         });
+    }
+
+    /// <summary>
+    /// The reported bug: the profile saves but "when I go back in, the form is empty". My Profile must
+    /// re-fetch and re-populate the stored persona across a full page reload — not show a blank form.
+    /// </summary>
+    [Test]
+    public async Task MyProfile_PersistsAcrossReload()
+    {
+        var email = $"myprofile-{Guid.NewGuid():N}@example.test";
+        await SignUpVerifyAndSignInAsync(email, "Reload Tester");
+        await CompleteWalletWizardAsync();
+        await WaitForProfileStepAsync();
+        await Page.Locator("[data-testid='profile-skip-button']").ClickAsync();
+
+        // My Profile shows the auto-seeded identity.
+        await NavigateAndWaitForBlazorAsync(TestConstants.AuthenticatedRoutes.Profile);
+        await Expect(Field("persona-given-name"))
+            .ToHaveValueAsync("Reload", new() { Timeout = TestConstants.PageLoadTimeout });
+
+        // Edit + save, then reload: the value must survive (the "empty on reload" regression).
+        var given = Field("persona-given-name");
+        await given.FillAsync("Reloaded");
+        await Page.Locator("[data-testid='persona-save-button']").ClickAsync();
+        await Page.WaitForTimeoutAsync(1500);
+
+        // Full reload (fresh navigation to the same route) — the persona must be re-fetched.
+        await NavigateAndWaitForBlazorAsync(TestConstants.AuthenticatedRoutes.Profile);
+        await Expect(Field("persona-given-name"))
+            .ToHaveValueAsync("Reloaded", new() { Timeout = TestConstants.PageLoadTimeout });
     }
 
     // ---------------------------------------------------------------------------------------------


### PR DESCRIPTION
Root cause of "the profile saves but the form is empty when I go back in": the
services serialise enums as kebab-case strings (JsonStringEnumConverter with
KebabCaseLower — PersonaAttributeSource -> "self-asserted"), but the client's
PersonaHttpClient deserialised GET/PUT responses with default JSON options that
have NO string-enum converter. So every persona read threw on the enum and the
caller silently fell back to an empty PersonaReadModelV1 — a blank form, even
though the server had the data (verified: GET returns the full persona, 86ms
decrypt). The write always worked; only the read-back was broken.

- Add the matching JsonStringEnumConverter(KebabCaseLower) to JsonDefaults.Api
  (also reads numeric enums, so safe for every consumer), and use JsonDefaults.Api
  for all PersonaHttpClient (de)serialisation.
- Make SetAutofillEnabledAsync best-effort (localStorage write can throw on mobile
  Safari private mode; that must not surface as "couldn't save profile" after the
  persona itself saved).
- data-testids on the PersonaEditor phone/save controls for E2E.

Tests: unit guard deserialising a real server persona payload via JsonDefaults.Api;
E2E MyProfile_PersistsAcrossReload (edit -> save -> full reload -> value survives);
the previously-[Ignore]'d auto-seed read-back E2E now passes and is re-enabled.
Full onboarding+profile fixture green (3/3) on Docker.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UDmeAycWwQ5Y8PXuz4iub6
