### PR TITLE
fix: [150] Security settings won't load — same client JSON enum mismatch

### DIFF
--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/Shared/AuthMethodsClientService.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/Shared/AuthMethodsClientService.cs
@@ -4,6 +4,7 @@
 using System.Net.Http.Json;
 using System.Text.Json;
 using Microsoft.Extensions.Logging;
+using Sorcha.UI.Core.Extensions;
 using Sorcha.UI.Core.Models;
 
 namespace Sorcha.UI.Core.Services;
@@ -260,7 +261,7 @@ public sealed class AuthMethodsClientService : IAuthMethodsClientService
         try
         {
             return await _httpClient.GetFromJsonAsync<AuthMethodsResponse>(
-                "/api/me/auth-methods", cancellationToken);
+                "/api/me/auth-methods", JsonDefaults.Api, cancellationToken);
         }
         catch (Exception ex)
         {
@@ -288,7 +289,7 @@ public sealed class AuthMethodsClientService : IAuthMethodsClientService
             }
 
             var payload = await response.Content.ReadFromJsonAsync<SocialLinkInitiateResponse>(
-                cancellationToken: cancellationToken);
+                JsonDefaults.Api, cancellationToken);
             return payload?.AuthorizationUrl;
         }
         catch (Exception ex)
@@ -349,7 +350,7 @@ public sealed class AuthMethodsClientService : IAuthMethodsClientService
             }
 
             return await response.Content.ReadFromJsonAsync<ChallengeInitiateResult>(
-                cancellationToken: cancellationToken);
+                JsonDefaults.Api, cancellationToken);
         }
         catch (Exception ex)
         {
@@ -376,7 +377,7 @@ public sealed class AuthMethodsClientService : IAuthMethodsClientService
             if (response.IsSuccessStatusCode)
             {
                 var body = await response.Content.ReadFromJsonAsync<ChallengeVerifyBodyResponse>(
-                    cancellationToken: cancellationToken);
+                    JsonDefaults.Api, cancellationToken);
                 return body is null || string.IsNullOrEmpty(body.Token)
                     ? new ChallengeVerifyResult(false, null, ChallengeVerifyError.Failed)
                     : new ChallengeVerifyResult(true, body.Token, ChallengeVerifyError.None);
@@ -417,7 +418,7 @@ public sealed class AuthMethodsClientService : IAuthMethodsClientService
             }
 
             var body = await response.Content.ReadFromJsonAsync<PasskeyRegisterOptionsResponseBody>(
-                cancellationToken: cancellationToken);
+                JsonDefaults.Api, cancellationToken);
             return body is null
                 ? null
                 : new PasskeyAddBegunResult(body.TransactionId, body.Options);


### PR DESCRIPTION
"We couldn't load your security settings" was the same root cause as the persona
read-back: GET /api/me/auth-methods returns 200 with kebab-case string enums
("assuranceTier":"basic", "requiredProofTier":"basic"), but AuthMethodsClientService
deserialised with default JSON options (no string-enum converter) → threw → the page
showed the load-failed state.

Use JsonDefaults.Api (now carrying the KebabCaseLower JsonStringEnumConverter) for
every deserialisation in AuthMethodsClientService (auth-methods, social-initiate,
challenge initiate/verify, passkey register options).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UDmeAycWwQ5Y8PXuz4iub6
