### PR TITLE
refactor: route all client JSON reads through the shared options + CI gate

### DIFF
--- a/.github/workflows/json-options-gate.yml
+++ b/.github/workflows/json-options-gate.yml
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Sorcha Contributors
+#
+# JSON-options CI gate. Fails when any client-side (UI / PWA / service-client) System.Text.Json
+# HTTP-response deserialization (ReadFromJsonAsync / GetFromJsonAsync) is called BARE, i.e. without
+# explicit serializer options. The shared source of truth Sorcha.Serialization.SorchaJson.Options
+# (aliased JsonDefaults.Api in the UI) reads the services' kebab-case string enums; default options do
+# not, and silently yield empty results. See scripts/check-json-options.ps1.
+
+name: json-options-gate
+
+on:
+  pull_request:
+    paths:
+      - "src/Apps/Sorcha.UI/**"
+      - "src/Apps/Sorcha.Wallet.Pwa/**"
+      - "src/Common/Sorcha.ServiceClients.Http/**"
+      - "scripts/check-json-options.ps1"
+      - ".github/workflows/json-options-gate.yml"
+  workflow_dispatch:
+
+jobs:
+  no-bare-json-deserialization:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run JSON-options gate
+        shell: pwsh
+        run: ./scripts/check-json-options.ps1

--- a/scripts/check-json-options.ps1
+++ b/scripts/check-json-options.ps1
@@ -1,0 +1,56 @@
+#!/usr/bin/env pwsh
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Sorcha Contributors
+#
+# JSON-options CI gate. Every client-side System.Text.Json HTTP-response deserialization must pass
+# EXPLICIT serializer options — the shared source of truth `Sorcha.Serialization.SorchaJson.Options`
+# (aliased as `JsonDefaults.Api` in the UI) or a deliberately-kept local options object. A BARE
+# `ReadFromJsonAsync`/`GetFromJsonAsync` uses default options that lack the kebab-case string-enum
+# converter the services emit (e.g. "self-asserted", WebAuthn "public-key"), so it throws on the enum
+# and the caller silently falls back to empty/failed — the "My Profile is empty though it saved" /
+# "couldn't load your security settings" class of bug.
+#
+# Fails if any bare call is found in the UI / PWA / service-client projects.
+
+$ErrorActionPreference = 'Stop'
+
+$roots = @(
+    'src/Apps/Sorcha.UI',
+    'src/Apps/Sorcha.Wallet.Pwa',
+    'src/Common/Sorcha.ServiceClients.Http'
+)
+
+# A call passing ANY options object (shared or a kept local field) is fine — the gate only stops
+# genuinely bare calls. This marker matches the shared options and the local options field names in use.
+$optionsMarker = 'JsonDefaults\.Api|SorchaJson\.Options|JsonOptions|Options|options:|CanonicalOptions|JsonOpts|CaseInsensitive'
+$callPattern = '\.(ReadFromJsonAsync|GetFromJsonAsync)<'
+
+$violations = New-Object System.Collections.Generic.List[string]
+
+foreach ($root in $roots) {
+    if (-not (Test-Path $root)) { continue }
+    $files = Get-ChildItem -Path $root -Recurse -Include *.cs, *.razor -File -ErrorAction SilentlyContinue |
+        Where-Object { $_.FullName -notmatch '[\\/](bin|obj)[\\/]' }
+    foreach ($file in $files) {
+        $lines = Get-Content -LiteralPath $file.FullName
+        for ($i = 0; $i -lt $lines.Count; $i++) {
+            if ($lines[$i] -match $callPattern) {
+                $end = [Math]::Min($i + 2, $lines.Count - 1)
+                $span = ($lines[$i..$end]) -join "`n"
+                if ($span -notmatch $optionsMarker) {
+                    $rel = Resolve-Path -Relative -LiteralPath $file.FullName
+                    $violations.Add(("{0}:{1}: {2}" -f $rel, ($i + 1), $lines[$i].Trim()))
+                }
+            }
+        }
+    }
+}
+
+if ($violations.Count -gt 0) {
+    Write-Host "JSON-options gate FAILED - bare client deserialization found." -ForegroundColor Red
+    Write-Host "Pass the shared options: SorchaJson.Options (Sorcha.Serialization) / JsonDefaults.Api (UI)." -ForegroundColor Red
+    foreach ($v in $violations) { Write-Host "  $v" }
+    exit 1
+}
+
+Write-Host "JSON-options gate OK: no bare client JSON deserialization calls." -ForegroundColor Green

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/CredentialGate/CredentialGateComponent.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/CredentialGate/CredentialGateComponent.razor
@@ -33,6 +33,7 @@
 @using Sorcha.UI.Core.Components.EnrolGate
 @using Sorcha.UI.Core.Models.User.Presentation
 @using Sorcha.UI.Core.Services.User.Presentation
+@using Sorcha.UI.Core.Extensions
 @inject IPresentationSignal Signal
 @inject HttpClient Http
 @inject ILogger<CredentialGateComponent> Logger
@@ -206,7 +207,7 @@ else if (Init is not null)
             }
 
             var disclosed = await response.Content
-                .ReadFromJsonAsync<DisclosedClaimsResponse>(_cts?.Token ?? CancellationToken.None);
+                .ReadFromJsonAsync<DisclosedClaimsResponse>(JsonDefaults.Api, _cts?.Token ?? CancellationToken.None);
             if (disclosed is null || disclosed.Status != "success")
             {
                 _state = State.Declined;

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/EnrolGate/EnrolGateComponent.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/EnrolGate/EnrolGateComponent.razor
@@ -1,5 +1,6 @@
 @namespace Sorcha.UI.Core.Components.EnrolGate
 @using Sorcha.UI.Core.Services.User.Enrolment
+@using Sorcha.UI.Core.Extensions
 @inject ITierProbeService TierProbe
 @inject HttpClient Http
 
@@ -126,7 +127,7 @@ else
     {
         try
         {
-            var whoami = await Http.GetFromJsonAsync<WhoamiShape>("/api/auth/whoami");
+            var whoami = await Http.GetFromJsonAsync<WhoamiShape>("/api/auth/whoami", JsonDefaults.Api);
             return whoami?.PlatformUserId ?? Guid.Empty;
         }
         catch

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/EnrolGate/WalletPairingSurface.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/EnrolGate/WalletPairingSurface.razor
@@ -1,6 +1,7 @@
 @namespace Sorcha.UI.Core.Components.EnrolGate
 @using System.Net.Http.Json
 @using Sorcha.UI.Core.Services.User.Enrolment
+@using Sorcha.UI.Core.Extensions
 @inject HttpClient Http
 @inject IEnrolPairingSignal PairingSignal
 @implements IAsyncDisposable
@@ -122,7 +123,7 @@
                 _mintError = "Couldn't generate an enrolment code — try again or refresh the page.";
                 return;
             }
-            _minted = await response.Content.ReadFromJsonAsync<MintEnrolSessionResponseShape>();
+            _minted = await response.Content.ReadFromJsonAsync<MintEnrolSessionResponseShape>(JsonDefaults.Api);
             if (_minted is not null)
             {
                 _ = WatchForExpiryAsync(_minted.ExpiresAt, _expiryWatcher.Token);

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Pairing/PairingHandoffSurface.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Pairing/PairingHandoffSurface.razor
@@ -31,6 +31,7 @@
 @using Microsoft.Extensions.Logging
 @using Sorcha.UI.Core.Components.EnrolGate
 @using Sorcha.UI.Core.Services.User.Pairing
+@using Sorcha.UI.Core.Extensions
 @inject HttpClient Http
 @inject NavigationManager Nav
 @inject IPwaInstallabilityProbe InstallProbe
@@ -183,7 +184,7 @@
                 return;
             }
 
-            var body = await response.Content.ReadFromJsonAsync<MintResponseShape>();
+            var body = await response.Content.ReadFromJsonAsync<MintResponseShape>(JsonDefaults.Api);
             if (body is null || string.IsNullOrEmpty(body.QrUrl))
             {
                 _error = "Couldn't generate a pairing code. Try again.";
@@ -216,7 +217,7 @@
                 return;
             }
 
-            var body = await response.Content.ReadFromJsonAsync<ShortCodeMintResponseShape>();
+            var body = await response.Content.ReadFromJsonAsync<ShortCodeMintResponseShape>(JsonDefaults.Api);
             _shortCode = body?.Code;
         }
         catch (Exception ex)

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Wallet/ReceiptProofCard.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Wallet/ReceiptProofCard.razor
@@ -5,6 +5,7 @@
 
 @using MudBlazor
 @using System.Net.Http.Json
+@using Sorcha.UI.Core.Extensions
 @inject HttpClient Http
 @inject IJSRuntime JS
 
@@ -106,7 +107,7 @@
 
             if (response.IsSuccessStatusCode)
             {
-                var result = await response.Content.ReadFromJsonAsync<ReceiptVerifyResult>();
+                var result = await response.Content.ReadFromJsonAsync<ReceiptVerifyResult>(JsonDefaults.Api);
                 _verificationResult = result?.Valid ?? false;
             }
             else

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Extensions/Shared/JsonDefaults.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Extensions/Shared/JsonDefaults.cs
@@ -7,7 +7,7 @@ namespace Sorcha.UI.Core.Extensions;
 
 /// <summary>
 /// Shared JSON serializer options for API (de)serialization across UI services. This is a thin alias
-/// over <see cref="Sorcha.Json.SorchaJson.Options"/> — the single source of truth shared with the
+/// over <see cref="Sorcha.Serialization.SorchaJson.Options"/> — the single source of truth shared with the
 /// services — so the client and server wire formats can never drift. Prefer <c>JsonDefaults.Api</c>
 /// (or <c>SorchaJson.Options</c>) for every <c>ReadFromJsonAsync</c> / <c>GetFromJsonAsync</c> on a
 /// Sorcha API response; the default options do not carry the kebab-case string-enum converter and
@@ -16,5 +16,5 @@ namespace Sorcha.UI.Core.Extensions;
 public static class JsonDefaults
 {
     /// <summary>Standard options for (de)serializing Sorcha API payloads.</summary>
-    public static readonly JsonSerializerOptions Api = Sorcha.Json.SorchaJson.Options;
+    public static readonly JsonSerializerOptions Api = Sorcha.Serialization.SorchaJson.Options;
 }

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Models/User/Forms/FormContext.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Models/User/Forms/FormContext.cs
@@ -2,6 +2,7 @@
 // Copyright (c) 2026 Sorcha Contributors
 
 using System.Text.Json;
+using Sorcha.UI.Core.Extensions;
 
 namespace Sorcha.UI.Core.Models.Forms;
 
@@ -140,7 +141,7 @@ public class FormContext
             if (value is JsonElement jsonElement)
             {
                 var json = jsonElement.GetRawText();
-                return JsonSerializer.Deserialize<T>(json);
+                return JsonSerializer.Deserialize<T>(json, JsonDefaults.Api);
             }
 
             return (T)Convert.ChangeType(value, typeof(T));

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/Shared/Authentication/AuthStateSync.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/Shared/Authentication/AuthStateSync.cs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Sorcha Contributors
 using System.Net.Http.Json;
+using Sorcha.UI.Core.Extensions;
 using Sorcha.UI.Core.Models.Authentication;
 using Sorcha.UI.Core.Services.Configuration;
 
@@ -41,7 +42,7 @@ public class AuthStateSync
                 return;
             }
 
-            var authState = await response.Content.ReadFromJsonAsync<AuthStateResponse>();
+            var authState = await response.Content.ReadFromJsonAsync<AuthStateResponse>(JsonDefaults.Api);
             
             if (authState == null || !authState.IsAuthenticated)
             {

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/Shared/Authentication/AuthenticationService.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/Shared/Authentication/AuthenticationService.cs
@@ -3,6 +3,7 @@
 using System.IdentityModel.Tokens.Jwt;
 using System.Net.Http.Json;
 using System.Security.Claims;
+using Sorcha.UI.Core.Extensions;
 using Sorcha.UI.Core.Models.Authentication;
 using Sorcha.UI.Core.Services.Configuration;
 
@@ -102,7 +103,7 @@ public class AuthenticationService : IAuthenticationService
                 return false;
             }
 
-            var tokenResponse = await response.Content.ReadFromJsonAsync<TokenResponse>();
+            var tokenResponse = await response.Content.ReadFromJsonAsync<TokenResponse>(JsonDefaults.Api);
             if (tokenResponse == null || !tokenResponse.IsValid())
             {
                 return false;
@@ -147,7 +148,7 @@ public class AuthenticationService : IAuthenticationService
                 return false;
             }
 
-            var tokenResponse = await response.Content.ReadFromJsonAsync<TokenResponse>();
+            var tokenResponse = await response.Content.ReadFromJsonAsync<TokenResponse>(JsonDefaults.Api);
             if (tokenResponse is null || !tokenResponse.IsValid())
             {
                 return false;

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/Shared/Authentication/BrowserTokenCache.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/Shared/Authentication/BrowserTokenCache.cs
@@ -2,6 +2,7 @@
 // Copyright (c) 2026 Sorcha Contributors
 using System.Text.Json;
 using Microsoft.JSInterop;
+using Sorcha.UI.Core.Extensions;
 using Sorcha.UI.Core.Models.Authentication;
 using Sorcha.UI.Core.Services.Encryption;
 
@@ -62,7 +63,7 @@ public class BrowserTokenCache : ITokenCache
             }
 
             var json = await _encryptionProvider.DecryptAsync(encrypted);
-            var entry = JsonSerializer.Deserialize<TokenCacheEntry>(json);
+            var entry = JsonSerializer.Deserialize<TokenCacheEntry>(json, JsonDefaults.Api);
 
             if (entry == null)
             {

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/Shared/Authentication/CustomAuthenticationStateProvider.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/Shared/Authentication/CustomAuthenticationStateProvider.cs
@@ -6,6 +6,7 @@ using System.Text.Json;
 using Microsoft.AspNetCore.Components.Authorization;
 using Microsoft.Extensions.Logging;
 using Microsoft.JSInterop;
+using Sorcha.UI.Core.Extensions;
 using Sorcha.UI.Core.Models.Authentication;
 using Sorcha.UI.Core.Services.Configuration;
 
@@ -18,8 +19,6 @@ namespace Sorcha.UI.Core.Services.Authentication;
 /// </summary>
 public class CustomAuthenticationStateProvider : AuthenticationStateProvider
 {
-    private static readonly JsonSerializerOptions CaseInsensitiveJson = new() { PropertyNameCaseInsensitive = true };
-
     private readonly ITokenCache _tokenCache;
     private readonly IConfigurationService _configurationService;
     private readonly IJSRuntime _jsRuntime;
@@ -149,7 +148,7 @@ public class CustomAuthenticationStateProvider : AuthenticationStateProvider
             if (string.IsNullOrEmpty(json))
                 return null;
 
-            var result = JsonSerializer.Deserialize<FragmentTokenResult>(json, CaseInsensitiveJson);
+            var result = JsonSerializer.Deserialize<FragmentTokenResult>(json, JsonDefaults.Api);
             if (result?.Token is null)
                 return null;
 

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/Shared/Configuration/ConfigurationService.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/Shared/Configuration/ConfigurationService.cs
@@ -3,6 +3,7 @@
 
 using System.Text.Json;
 using Microsoft.JSInterop;
+using Sorcha.UI.Core.Extensions;
 using Sorcha.UI.Core.Models.Configuration;
 
 namespace Sorcha.UI.Core.Services.Configuration;
@@ -57,7 +58,7 @@ public class ConfigurationService : IConfigurationService, IDisposable
             json = await _jsRuntime.InvokeAsync<string?>("localStorage.getItem", ProfilesStorageKey);
         }
 
-        return JsonSerializer.Deserialize<List<Profile>>(json!) ?? new List<Profile>();
+        return JsonSerializer.Deserialize<List<Profile>>(json!, JsonDefaults.Api) ?? new List<Profile>();
     }
 
     /// <inheritdoc />
@@ -193,7 +194,7 @@ public class ConfigurationService : IConfigurationService, IDisposable
             return UiConfiguration.Default();
         }
 
-        return JsonSerializer.Deserialize<UiConfiguration>(json) ?? UiConfiguration.Default();
+        return JsonSerializer.Deserialize<UiConfiguration>(json, JsonDefaults.Api) ?? UiConfiguration.Default();
     }
 
     /// <inheritdoc />

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/Shared/Identity/DomainRestrictionClientService.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/Shared/Identity/DomainRestrictionClientService.cs
@@ -3,6 +3,7 @@
 
 using System.Net.Http.Json;
 using Microsoft.Extensions.Logging;
+using Sorcha.UI.Core.Extensions;
 
 namespace Sorcha.UI.Core.Services.Identity;
 
@@ -37,7 +38,7 @@ public class DomainRestrictionClientService : IDomainRestrictionClientService
         try
         {
             var result = await _httpClient.GetFromJsonAsync<DomainRestrictionsDto>(
-                BaseUrl(organizationId), ct);
+                BaseUrl(organizationId), JsonDefaults.Api, ct);
 
             return result ?? new DomainRestrictionsDto();
         }

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/Shared/Identity/IdpConfigurationClientService.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/Shared/Identity/IdpConfigurationClientService.cs
@@ -4,6 +4,7 @@
 using System.Net;
 using System.Net.Http.Json;
 using Microsoft.Extensions.Logging;
+using Sorcha.UI.Core.Extensions;
 
 namespace Sorcha.UI.Core.Services.Identity;
 
@@ -35,7 +36,7 @@ public class IdpConfigurationClientService : IIdpConfigurationClientService
         try
         {
             var result = await _httpClient.GetFromJsonAsync<IReadOnlyList<IdpConfigurationDto>>(
-                BaseUrl(organizationId), ct);
+                BaseUrl(organizationId), JsonDefaults.Api, ct);
 
             return result ?? [];
         }
@@ -56,7 +57,7 @@ public class IdpConfigurationClientService : IIdpConfigurationClientService
         try
         {
             return await _httpClient.GetFromJsonAsync<IdpConfigurationDto>(
-                $"{BaseUrl(organizationId)}/{Uri.EscapeDataString(configId.ToString())}", ct);
+                $"{BaseUrl(organizationId)}/{Uri.EscapeDataString(configId.ToString())}", JsonDefaults.Api, ct);
         }
         catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
         {
@@ -83,7 +84,7 @@ public class IdpConfigurationClientService : IIdpConfigurationClientService
 
             response.EnsureSuccessStatusCode();
 
-            var result = await response.Content.ReadFromJsonAsync<IdpDiscoveryResult>(ct);
+            var result = await response.Content.ReadFromJsonAsync<IdpDiscoveryResult>(JsonDefaults.Api, ct);
 
             return result ?? new IdpDiscoveryResult { Success = false, Error = "Failed to parse discovery response" };
         }
@@ -108,7 +109,7 @@ public class IdpConfigurationClientService : IIdpConfigurationClientService
 
             response.EnsureSuccessStatusCode();
 
-            var result = await response.Content.ReadFromJsonAsync<IdpConfigurationDto>(ct);
+            var result = await response.Content.ReadFromJsonAsync<IdpConfigurationDto>(JsonDefaults.Api, ct);
 
             return result ?? throw new InvalidOperationException("Failed to parse response");
         }
@@ -137,7 +138,7 @@ public class IdpConfigurationClientService : IIdpConfigurationClientService
 
             response.EnsureSuccessStatusCode();
 
-            return await response.Content.ReadFromJsonAsync<IdpConfigurationDto>(ct);
+            return await response.Content.ReadFromJsonAsync<IdpConfigurationDto>(JsonDefaults.Api, ct);
         }
         catch (HttpRequestException ex)
         {
@@ -160,7 +161,7 @@ public class IdpConfigurationClientService : IIdpConfigurationClientService
 
             response.EnsureSuccessStatusCode();
 
-            var result = await response.Content.ReadFromJsonAsync<IdpConnectionTestResult>(ct);
+            var result = await response.Content.ReadFromJsonAsync<IdpConnectionTestResult>(JsonDefaults.Api, ct);
 
             return result ?? new IdpConnectionTestResult { Success = false, Error = "Failed to parse test response" };
         }

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/Shared/Identity/InvitationClientService.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/Shared/Identity/InvitationClientService.cs
@@ -4,6 +4,7 @@
 using System.Net;
 using System.Net.Http.Json;
 using Microsoft.Extensions.Logging;
+using Sorcha.UI.Core.Extensions;
 
 namespace Sorcha.UI.Core.Services.Identity;
 
@@ -36,7 +37,7 @@ public class InvitationClientService : IInvitationClientService
 
         try
         {
-            var result = await _httpClient.GetFromJsonAsync<InvitationListResult>(url, ct);
+            var result = await _httpClient.GetFromJsonAsync<InvitationListResult>(url, JsonDefaults.Api, ct);
             return result ?? new InvitationListResult();
         }
         catch (HttpRequestException ex)
@@ -56,7 +57,7 @@ public class InvitationClientService : IInvitationClientService
 
         try
         {
-            return await _httpClient.GetFromJsonAsync<InvitationDto>(url, ct);
+            return await _httpClient.GetFromJsonAsync<InvitationDto>(url, JsonDefaults.Api, ct);
         }
         catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
         {
@@ -83,7 +84,7 @@ public class InvitationClientService : IInvitationClientService
             var response = await _httpClient.PostAsJsonAsync(url, request, ct);
             response.EnsureSuccessStatusCode();
 
-            var result = await response.Content.ReadFromJsonAsync<InvitationDto>(ct);
+            var result = await response.Content.ReadFromJsonAsync<InvitationDto>(JsonDefaults.Api, ct);
             return result ?? throw new InvalidOperationException("Failed to deserialize invitation response.");
         }
         catch (HttpRequestException ex)

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/Shared/InstructionExportService.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/Shared/InstructionExportService.cs
@@ -3,6 +3,7 @@
 
 using System.Text.Json;
 using Sorcha.Blueprint.Models;
+using Sorcha.UI.Core.Extensions;
 using BlueprintModel = Sorcha.Blueprint.Models.Blueprint;
 
 namespace Sorcha.UI.Core.Services;
@@ -80,7 +81,7 @@ public class InstructionExportService
         ArgumentNullException.ThrowIfNull(blueprint);
         ArgumentException.ThrowIfNullOrWhiteSpace(json);
 
-        var entries = JsonSerializer.Deserialize<Dictionary<string, string>>(json)
+        var entries = JsonSerializer.Deserialize<Dictionary<string, string>>(json, JsonDefaults.Api)
             ?? throw new JsonException("Failed to deserialize instruction JSON");
 
         var isPrimaryLocale = string.IsNullOrWhiteSpace(locale) ||

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/Shared/PendingActionService.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/Shared/PendingActionService.cs
@@ -3,6 +3,7 @@
 
 using System.Net.Http.Json;
 using Microsoft.Extensions.Logging;
+using Sorcha.UI.Core.Extensions;
 using Sorcha.UI.Core.Models;
 
 namespace Sorcha.UI.Core.Services;
@@ -51,7 +52,7 @@ public class PendingActionService : IPendingActionService
             if (!string.IsNullOrEmpty(blueprintId))
                 url += $"&blueprintId={Uri.EscapeDataString(blueprintId)}";
 
-            var response = await _httpClient.GetFromJsonAsync<PendingActionListResponse>(url);
+            var response = await _httpClient.GetFromJsonAsync<PendingActionListResponse>(url, JsonDefaults.Api);
             return response ?? new PendingActionListResponse();
         }
         catch (Exception ex)
@@ -66,7 +67,7 @@ public class PendingActionService : IPendingActionService
     {
         try
         {
-            var response = await _httpClient.GetFromJsonAsync<PendingActionCountResponse>("/api/actions/pending/count");
+            var response = await _httpClient.GetFromJsonAsync<PendingActionCountResponse>("/api/actions/pending/count", JsonDefaults.Api);
             return response ?? new PendingActionCountResponse();
         }
         catch (Exception ex)

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/Shared/TotpClientService.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/Shared/TotpClientService.cs
@@ -3,6 +3,7 @@
 
 using System.Net.Http.Json;
 using Microsoft.Extensions.Logging;
+using Sorcha.UI.Core.Extensions;
 using Sorcha.UI.Core.Models;
 
 namespace Sorcha.UI.Core.Services;
@@ -74,7 +75,7 @@ public class TotpClientService : ITotpClientService
         {
             var response = await _httpClient.PostAsync("/api/totp/setup", null);
             response.EnsureSuccessStatusCode();
-            return await response.Content.ReadFromJsonAsync<TotpSetupResponse>();
+            return await response.Content.ReadFromJsonAsync<TotpSetupResponse>(JsonDefaults.Api);
         }
         catch (Exception ex)
         {
@@ -136,7 +137,7 @@ public class TotpClientService : ITotpClientService
     {
         try
         {
-            var response = await _httpClient.GetFromJsonAsync<TotpStatusResponse>("/api/totp/status");
+            var response = await _httpClient.GetFromJsonAsync<TotpStatusResponse>("/api/totp/status", JsonDefaults.Api);
             return response ?? new TotpStatusResponse();
         }
         catch (Exception ex)

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/Shared/UserPreferencesService.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/Shared/UserPreferencesService.cs
@@ -4,6 +4,7 @@
 using System.Net;
 using System.Net.Http.Json;
 using Microsoft.Extensions.Logging;
+using Sorcha.UI.Core.Extensions;
 using Sorcha.UI.Core.Models;
 
 namespace Sorcha.UI.Core.Services;
@@ -35,7 +36,7 @@ public class UserPreferencesService : IUserPreferencesService
     {
         try
         {
-            var response = await _httpClient.GetFromJsonAsync<UserPreferencesDto>("/api/preferences");
+            var response = await _httpClient.GetFromJsonAsync<UserPreferencesDto>("/api/preferences", JsonDefaults.Api);
             return response ?? new UserPreferencesDto();
         }
         catch (Exception ex)
@@ -77,7 +78,7 @@ public class UserPreferencesService : IUserPreferencesService
         {
             var response = await _httpClient.PutAsJsonAsync("/api/preferences", request);
             response.EnsureSuccessStatusCode();
-            var result = await response.Content.ReadFromJsonAsync<UserPreferencesDto>();
+            var result = await response.Content.ReadFromJsonAsync<UserPreferencesDto>(JsonDefaults.Api);
             return result ?? new UserPreferencesDto();
         }
         catch (Exception ex)
@@ -91,7 +92,7 @@ public class UserPreferencesService : IUserPreferencesService
     {
         try
         {
-            var response = await _httpClient.GetFromJsonAsync<DefaultWalletResponse>("/api/preferences/default-wallet");
+            var response = await _httpClient.GetFromJsonAsync<DefaultWalletResponse>("/api/preferences/default-wallet", JsonDefaults.Api);
             return response?.DefaultWalletAddress;
         }
         catch (Exception ex)

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/AddressLookup/AddressLookupHttpClient.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/AddressLookup/AddressLookupHttpClient.cs
@@ -4,6 +4,7 @@
 using System.Net.Http.Json;
 using System.Text.Json;
 using Microsoft.Extensions.Logging;
+using Sorcha.UI.Core.Extensions;
 
 namespace Sorcha.UI.Core.Services.AddressLookup;
 
@@ -36,7 +37,7 @@ public sealed class AddressLookupHttpClient : IAddressLookupClient
         try
         {
             var providers = await _httpClient.GetFromJsonAsync<List<ProviderInfo>>(
-                "/api/address-lookup/providers", JsonOptions, ct);
+                "/api/address-lookup/providers", JsonDefaults.Api, ct);
             return providers;
         }
         catch (OperationCanceledException)
@@ -69,7 +70,7 @@ public sealed class AddressLookupHttpClient : IAddressLookupClient
                 return null;
             }
 
-            return await response.Content.ReadFromJsonAsync<LookupResult>(JsonOptions, ct);
+            return await response.Content.ReadFromJsonAsync<LookupResult>(JsonDefaults.Api, ct);
         }
         catch (OperationCanceledException)
         {

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/Credentials/HaipLocalReceiveService.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/Credentials/HaipLocalReceiveService.cs
@@ -6,6 +6,7 @@ using System.Net.Http.Json;
 using System.Text;
 using System.Text.Json;
 using Microsoft.Extensions.Logging;
+using Sorcha.UI.Core.Extensions;
 
 namespace Sorcha.UI.Core.Services.Credentials;
 
@@ -74,7 +75,7 @@ public sealed class HaipLocalReceiveService : IHaipLocalReceiveService
 
             // 2. Fetch the wallet detail so we know the public key + algorithm.
             var walletDto = await _httpClient.GetFromJsonAsync<WalletPublicKeyDto>(
-                $"/api/v1/wallets/{walletAddress}", JsonOptions, ct);
+                $"/api/v1/wallets/{walletAddress}", JsonDefaults.Api, ct);
             if (walletDto is null || string.IsNullOrEmpty(walletDto.PublicKey))
             {
                 return HaipLocalReceiveResult.Fail($"Wallet {walletAddress} not found or missing public key");
@@ -92,7 +93,7 @@ public sealed class HaipLocalReceiveService : IHaipLocalReceiveService
 
             // 3. Fetch issuer metadata so we know the token + credential endpoints.
             var metadataUrl = $"{issuerUrl.TrimEnd('/')}/.well-known/openid-credential-issuer";
-            var metadata = await _httpClient.GetFromJsonAsync<JsonElement>(metadataUrl, JsonOptions, ct);
+            var metadata = await _httpClient.GetFromJsonAsync<JsonElement>(metadataUrl, JsonDefaults.Api, ct);
             var tokenEndpoint = metadata.GetProperty("token_endpoint").GetString()!;
             var credentialEndpoint = metadata.GetProperty("credential_endpoint").GetString()!;
             var credentialIssuer = metadata.GetProperty("credential_issuer").GetString()!;
@@ -112,7 +113,7 @@ public sealed class HaipLocalReceiveService : IHaipLocalReceiveService
                 return HaipLocalReceiveResult.Fail(
                     $"Token exchange failed ({(int)tokenResponse.StatusCode})", code: "token_exchange_failed");
             }
-            var tokenJson = await tokenResponse.Content.ReadFromJsonAsync<JsonElement>(JsonOptions, ct);
+            var tokenJson = await tokenResponse.Content.ReadFromJsonAsync<JsonElement>(JsonDefaults.Api, ct);
             var accessToken = tokenJson.GetProperty("access_token").GetString()!;
             var cNonce = tokenJson.GetProperty("c_nonce").GetString()!;
 
@@ -167,7 +168,7 @@ public sealed class HaipLocalReceiveService : IHaipLocalReceiveService
                 return HaipLocalReceiveResult.Fail(
                     $"Wallet signing failed ({(int)signResponse.StatusCode})", code: "wallet_sign_failed");
             }
-            var signResult = await signResponse.Content.ReadFromJsonAsync<SignResponse>(JsonOptions, ct);
+            var signResult = await signResponse.Content.ReadFromJsonAsync<SignResponse>(JsonDefaults.Api, ct);
             if (signResult is null || string.IsNullOrEmpty(signResult.Signature))
             {
                 return HaipLocalReceiveResult.Fail("Wallet sign returned no signature");
@@ -198,7 +199,7 @@ public sealed class HaipLocalReceiveService : IHaipLocalReceiveService
                     $"Credential request failed ({(int)credentialResponse.StatusCode})",
                     code: "credential_request_failed");
             }
-            var credResult = await credentialResponse.Content.ReadFromJsonAsync<JsonElement>(JsonOptions, ct);
+            var credResult = await credentialResponse.Content.ReadFromJsonAsync<JsonElement>(JsonDefaults.Api, ct);
             var sdJwt = credResult.GetProperty("credential").GetString()!;
 
             // 7. Determine the credential type from the offer.

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/Credentials/PresentationAdminService.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/Credentials/PresentationAdminService.cs
@@ -2,8 +2,8 @@
 // Copyright (c) 2026 Sorcha Contributors
 
 using System.Net.Http.Json;
-using System.Text.Json;
 using Microsoft.Extensions.Logging;
+using Sorcha.UI.Core.Extensions;
 using Sorcha.UI.Core.Models.Credentials;
 
 namespace Sorcha.UI.Core.Services.Credentials;
@@ -12,11 +12,6 @@ public class PresentationAdminService : IPresentationAdminService
 {
     private readonly HttpClient _httpClient;
     private readonly ILogger<PresentationAdminService> _logger;
-
-    private static readonly JsonSerializerOptions JsonOptions = new()
-    {
-        PropertyNameCaseInsensitive = true
-    };
 
     public PresentationAdminService(HttpClient httpClient, ILogger<PresentationAdminService> logger)
     {
@@ -38,7 +33,7 @@ public class PresentationAdminService : IPresentationAdminService
                 return null;
             }
 
-            return await response.Content.ReadFromJsonAsync<PresentationRequestResultViewModel>(JsonOptions, ct);
+            return await response.Content.ReadFromJsonAsync<PresentationRequestResultViewModel>(JsonDefaults.Api, ct);
         }
         catch (HttpRequestException ex)
         {
@@ -86,7 +81,7 @@ public class PresentationAdminService : IPresentationAdminService
                 return null;
             }
 
-            return await response.Content.ReadFromJsonAsync<PresentationRequestResultViewModel>(JsonOptions, ct);
+            return await response.Content.ReadFromJsonAsync<PresentationRequestResultViewModel>(JsonDefaults.Api, ct);
         }
         catch (HttpRequestException ex)
         {

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/Credentials/StatusListService.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/Credentials/StatusListService.cs
@@ -2,8 +2,8 @@
 // Copyright (c) 2026 Sorcha Contributors
 
 using System.Net.Http.Json;
-using System.Text.Json;
 using Microsoft.Extensions.Logging;
+using Sorcha.UI.Core.Extensions;
 using Sorcha.UI.Core.Models.Credentials;
 
 namespace Sorcha.UI.Core.Services.Credentials;
@@ -12,11 +12,6 @@ public class StatusListService : IStatusListService
 {
     private readonly HttpClient _httpClient;
     private readonly ILogger<StatusListService> _logger;
-
-    private static readonly JsonSerializerOptions JsonOptions = new()
-    {
-        PropertyNameCaseInsensitive = true
-    };
 
     public StatusListService(HttpClient httpClient, ILogger<StatusListService> logger)
     {
@@ -44,7 +39,7 @@ public class StatusListService : IStatusListService
             }
 
             _logger.LogInformation("Successfully retrieved status list {ListId}", listId);
-            return await response.Content.ReadFromJsonAsync<StatusListViewModel>(JsonOptions, ct);
+            return await response.Content.ReadFromJsonAsync<StatusListViewModel>(JsonDefaults.Api, ct);
         }
         catch (HttpRequestException ex)
         {

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/DashboardService.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/DashboardService.cs
@@ -3,6 +3,7 @@
 
 using System.Net.Http.Json;
 using Microsoft.Extensions.Logging;
+using Sorcha.UI.Core.Extensions;
 using Sorcha.UI.Core.Models.Dashboard;
 
 namespace Sorcha.UI.Core.Services;
@@ -35,7 +36,7 @@ public class DashboardService : IDashboardService
                 return new DashboardStatsViewModel { IsLoaded = false };
             }
 
-            var stats = await response.Content.ReadFromJsonAsync<DashboardStatsViewModel>(cancellationToken: cancellationToken);
+            var stats = await response.Content.ReadFromJsonAsync<DashboardStatsViewModel>(JsonDefaults.Api, cancellationToken);
             return stats is not null
                 ? stats with { IsLoaded = true }
                 : new DashboardStatsViewModel { IsLoaded = false };

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/Devices/HasPairedDeviceProbe.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/Devices/HasPairedDeviceProbe.cs
@@ -5,6 +5,7 @@ using System.Net;
 using System.Net.Http.Json;
 using Microsoft.Extensions.Logging;
 using Sorcha.CitizenWallet.Abstractions.Models;
+using Sorcha.UI.Core.Extensions;
 
 namespace Sorcha.UI.Core.Services.User.Devices;
 
@@ -110,7 +111,7 @@ public sealed class HasPairedDeviceProbe : IHasPairedDeviceProbe
             }
 
             response.EnsureSuccessStatusCode();
-            var payload = await response.Content.ReadFromJsonAsync<HasAnyDeviceResponse>(cancellationToken: ct)
+            var payload = await response.Content.ReadFromJsonAsync<HasAnyDeviceResponse>(JsonDefaults.Api, ct)
                 .ConfigureAwait(false);
             if (payload is null)
             {

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/Enrolment/EnrolPairingSignal.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/Enrolment/EnrolPairingSignal.cs
@@ -3,6 +3,7 @@
 
 using System.Net.Http.Json;
 using Microsoft.Extensions.Logging;
+using Sorcha.UI.Core.Extensions;
 using Sorcha.UI.Core.Services;
 
 namespace Sorcha.UI.Core.Services.User.Enrolment;
@@ -153,7 +154,7 @@ public sealed class EnrolPairingSignal : IEnrolPairingSignal, IAsyncDisposable
                     if (response.IsSuccessStatusCode)
                     {
                         var payload = await response.Content
-                            .ReadFromJsonAsync<DeviceListProbeShape>(ct)
+                            .ReadFromJsonAsync<DeviceListProbeShape>(JsonDefaults.Api, ct)
                             .ConfigureAwait(false);
                         var active = payload?.ActiveCount
                             ?? payload?.Devices?.Count(d => string.Equals(d.Status, "active", StringComparison.OrdinalIgnoreCase))

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/Enrolment/HttpTierProbeService.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/Enrolment/HttpTierProbeService.cs
@@ -4,6 +4,7 @@
 using System.Net;
 using System.Net.Http.Json;
 using Microsoft.Extensions.Logging;
+using Sorcha.UI.Core.Extensions;
 
 namespace Sorcha.UI.Core.Services.User.Enrolment;
 
@@ -65,7 +66,7 @@ public sealed class HttpTierProbeService : ITierProbeService
                 return 0;
             }
 
-            var payload = await response.Content.ReadFromJsonAsync<DeviceListProbeShape>(cts.Token).ConfigureAwait(false);
+            var payload = await response.Content.ReadFromJsonAsync<DeviceListProbeShape>(JsonDefaults.Api, cts.Token).ConfigureAwait(false);
             return payload?.ActiveCount ?? payload?.Devices?.Count(d => string.Equals(d.Status, "active", StringComparison.OrdinalIgnoreCase)) ?? 0;
         }
         catch (Exception ex)

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/HolderKeys/HolderKeyHttpClient.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/HolderKeys/HolderKeyHttpClient.cs
@@ -2,8 +2,8 @@
 // Copyright (c) 2026 Sorcha Contributors
 
 using System.Net.Http.Json;
-using System.Text.Json;
 using Microsoft.Extensions.Logging;
+using Sorcha.UI.Core.Extensions;
 
 namespace Sorcha.UI.Core.Services.HolderKeys;
 
@@ -17,12 +17,6 @@ public sealed class HolderKeyHttpClient : IHolderKeyClient
 {
     private readonly HttpClient _httpClient;
     private readonly ILogger<HolderKeyHttpClient> _logger;
-
-    private static readonly JsonSerializerOptions JsonOptions = new()
-    {
-        PropertyNameCaseInsensitive = true,
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
-    };
 
     public HolderKeyHttpClient(HttpClient httpClient, ILogger<HolderKeyHttpClient> logger)
     {
@@ -43,7 +37,7 @@ public sealed class HolderKeyHttpClient : IHolderKeyClient
                 return null;
             }
 
-            return await response.Content.ReadFromJsonAsync<HolderKeysView>(JsonOptions, ct);
+            return await response.Content.ReadFromJsonAsync<HolderKeysView>(JsonDefaults.Api, ct);
         }
         catch (OperationCanceledException)
         {

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/Participants/ParticipantApiService.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/Participants/ParticipantApiService.cs
@@ -2,6 +2,7 @@
 // Copyright (c) 2026 Sorcha Contributors
 
 using System.Net.Http.Json;
+using Sorcha.UI.Core.Extensions;
 using Sorcha.UI.Core.Models.Participants;
 
 namespace Sorcha.UI.Core.Services.Participants;
@@ -35,7 +36,7 @@ public class ParticipantApiService : IParticipantApiService
         var response = await _httpClient.GetAsync(url, ct);
         response.EnsureSuccessStatusCode();
 
-        var result = await response.Content.ReadFromJsonAsync<ParticipantListViewModel>(ct);
+        var result = await response.Content.ReadFromJsonAsync<ParticipantListViewModel>(JsonDefaults.Api, ct);
         return result ?? new ParticipantListViewModel();
     }
 
@@ -54,7 +55,7 @@ public class ParticipantApiService : IParticipantApiService
         }
 
         response.EnsureSuccessStatusCode();
-        return await response.Content.ReadFromJsonAsync<ParticipantDetailViewModel>(ct);
+        return await response.Content.ReadFromJsonAsync<ParticipantDetailViewModel>(JsonDefaults.Api, ct);
     }
 
     /// <inheritdoc />
@@ -67,7 +68,7 @@ public class ParticipantApiService : IParticipantApiService
             $"/api/organizations/{organizationId}/participants", request, ct);
         response.EnsureSuccessStatusCode();
 
-        var result = await response.Content.ReadFromJsonAsync<ParticipantDetailViewModel>(ct);
+        var result = await response.Content.ReadFromJsonAsync<ParticipantDetailViewModel>(JsonDefaults.Api, ct);
         return result ?? throw new InvalidOperationException("Failed to deserialize participant creation response");
     }
 
@@ -87,7 +88,7 @@ public class ParticipantApiService : IParticipantApiService
         }
 
         response.EnsureSuccessStatusCode();
-        return await response.Content.ReadFromJsonAsync<ParticipantDetailViewModel>(ct);
+        return await response.Content.ReadFromJsonAsync<ParticipantDetailViewModel>(JsonDefaults.Api, ct);
     }
 
     /// <inheritdoc />
@@ -152,7 +153,7 @@ public class ParticipantApiService : IParticipantApiService
         var response = await _httpClient.PostAsJsonAsync("/api/participants/search", request, ct);
         response.EnsureSuccessStatusCode();
 
-        var result = await response.Content.ReadFromJsonAsync<ParticipantSearchResultsViewModel>(ct);
+        var result = await response.Content.ReadFromJsonAsync<ParticipantSearchResultsViewModel>(JsonDefaults.Api, ct);
         return result ?? new ParticipantSearchResultsViewModel();
     }
 
@@ -170,7 +171,7 @@ public class ParticipantApiService : IParticipantApiService
         }
 
         response.EnsureSuccessStatusCode();
-        return await response.Content.ReadFromJsonAsync<ParticipantListItemViewModel>(ct);
+        return await response.Content.ReadFromJsonAsync<ParticipantListItemViewModel>(JsonDefaults.Api, ct);
     }
 
     /// <inheritdoc />
@@ -179,7 +180,7 @@ public class ParticipantApiService : IParticipantApiService
         var response = await _httpClient.GetAsync("/api/me/participant-profiles", ct);
         response.EnsureSuccessStatusCode();
 
-        var result = await response.Content.ReadFromJsonAsync<List<ParticipantDetailViewModel>>(ct);
+        var result = await response.Content.ReadFromJsonAsync<List<ParticipantDetailViewModel>>(JsonDefaults.Api, ct);
         return result ?? new List<ParticipantDetailViewModel>();
     }
 
@@ -198,7 +199,7 @@ public class ParticipantApiService : IParticipantApiService
         var response = await _httpClient.PostAsync(url, null, ct);
         response.EnsureSuccessStatusCode();
 
-        var result = await response.Content.ReadFromJsonAsync<ParticipantDetailViewModel>(ct);
+        var result = await response.Content.ReadFromJsonAsync<ParticipantDetailViewModel>(JsonDefaults.Api, ct);
         return result ?? throw new InvalidOperationException("Failed to deserialize self-registration response");
     }
 
@@ -213,7 +214,7 @@ public class ParticipantApiService : IParticipantApiService
             $"/api/organizations/{organizationId}/participants/{participantId}/wallet-links", request, ct);
         response.EnsureSuccessStatusCode();
 
-        var result = await response.Content.ReadFromJsonAsync<WalletLinkChallengeViewModel>(ct);
+        var result = await response.Content.ReadFromJsonAsync<WalletLinkChallengeViewModel>(JsonDefaults.Api, ct);
         return result ?? throw new InvalidOperationException("Failed to deserialize wallet link challenge response");
     }
 
@@ -230,7 +231,7 @@ public class ParticipantApiService : IParticipantApiService
             request, ct);
         response.EnsureSuccessStatusCode();
 
-        var result = await response.Content.ReadFromJsonAsync<LinkedWalletViewModel>(ct);
+        var result = await response.Content.ReadFromJsonAsync<LinkedWalletViewModel>(JsonDefaults.Api, ct);
         return result ?? throw new InvalidOperationException("Failed to deserialize wallet link verification response");
     }
 
@@ -250,7 +251,7 @@ public class ParticipantApiService : IParticipantApiService
         var response = await _httpClient.GetAsync(url, ct);
         response.EnsureSuccessStatusCode();
 
-        var result = await response.Content.ReadFromJsonAsync<List<LinkedWalletViewModel>>(ct);
+        var result = await response.Content.ReadFromJsonAsync<List<LinkedWalletViewModel>>(JsonDefaults.Api, ct);
         return result ?? new List<LinkedWalletViewModel>();
     }
 

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/Participants/ParticipantPublishingService.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/Participants/ParticipantPublishingService.cs
@@ -2,6 +2,7 @@
 // Copyright (c) 2026 Sorcha Contributors
 
 using System.Net.Http.Json;
+using Sorcha.UI.Core.Extensions;
 using Sorcha.UI.Core.Models.Participants;
 
 namespace Sorcha.UI.Core.Services.Participants;
@@ -27,7 +28,7 @@ public class ParticipantPublishingService : IParticipantPublishingService
         var response = await _httpClient.PostAsJsonAsync(url, request, ct);
         response.EnsureSuccessStatusCode();
 
-        var result = await response.Content.ReadFromJsonAsync<ParticipantPublishResultViewModel>(ct);
+        var result = await response.Content.ReadFromJsonAsync<ParticipantPublishResultViewModel>(JsonDefaults.Api, ct);
         return result ?? throw new InvalidOperationException("Failed to parse publish response");
     }
 
@@ -41,7 +42,7 @@ public class ParticipantPublishingService : IParticipantPublishingService
         var response = await _httpClient.PutAsJsonAsync(url, request, ct);
         response.EnsureSuccessStatusCode();
 
-        var result = await response.Content.ReadFromJsonAsync<ParticipantPublishResultViewModel>(ct);
+        var result = await response.Content.ReadFromJsonAsync<ParticipantPublishResultViewModel>(JsonDefaults.Api, ct);
         return result ?? throw new InvalidOperationException("Failed to parse update response");
     }
 

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/PasskeyInteropService.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/PasskeyInteropService.cs
@@ -3,6 +3,7 @@
 
 using System.Text.Json;
 using Microsoft.JSInterop;
+using Sorcha.UI.Core.Extensions;
 
 namespace Sorcha.UI.Core.Services;
 
@@ -54,7 +55,7 @@ public class PasskeyInteropService : IAsyncDisposable
         var module = await GetModuleAsync();
         var optionsJson = options.GetRawText();
         var responseJson = await module.InvokeAsync<string>("createCredential", optionsJson);
-        return JsonSerializer.Deserialize<JsonElement>(responseJson);
+        return JsonSerializer.Deserialize<JsonElement>(responseJson, JsonDefaults.Api);
     }
 
     /// <summary>
@@ -67,7 +68,7 @@ public class PasskeyInteropService : IAsyncDisposable
         var module = await GetModuleAsync();
         var optionsJson = options.GetRawText();
         var responseJson = await module.InvokeAsync<string>("getCredential", optionsJson);
-        return JsonSerializer.Deserialize<JsonElement>(responseJson);
+        return JsonSerializer.Deserialize<JsonElement>(responseJson, JsonDefaults.Api);
     }
 
     /// <summary>

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/Persona/PersonaHttpClient.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/Persona/PersonaHttpClient.cs
@@ -60,7 +60,7 @@ public sealed class PersonaHttpClient : IPersonaClient
 
         if (response.StatusCode == HttpStatusCode.BadRequest)
         {
-            var problem = await response.Content.ReadFromJsonAsync<ValidationProblemWire>(cancellationToken: ct);
+            var problem = await response.Content.ReadFromJsonAsync<ValidationProblemWire>(JsonDefaults.Api, ct);
             if (problem?.Errors is { Count: > 0 })
             {
                 throw new PersonaValidationException(problem.Errors);

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/Presentation/PresentationSignal.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/Presentation/PresentationSignal.cs
@@ -4,6 +4,7 @@
 using System.Net.Http.Json;
 using System.Text.Json.Serialization;
 using Microsoft.Extensions.Logging;
+using Sorcha.UI.Core.Extensions;
 using Sorcha.UI.Core.Services;
 
 namespace Sorcha.UI.Core.Services.User.Presentation;
@@ -218,7 +219,7 @@ public sealed class PresentationSignal : IPresentationSignal, IAsyncDisposable
                 return null;
             }
             var payload = await response.Content
-                .ReadFromJsonAsync<StatusProbeShape>(ct)
+                .ReadFromJsonAsync<StatusProbeShape>(JsonDefaults.Api, ct)
                 .ConfigureAwait(false);
             return payload?.State;
         }

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/TransactionService.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/TransactionService.cs
@@ -2,9 +2,9 @@
 // Copyright (c) 2026 Sorcha Contributors
 
 using System.Net.Http.Json;
-using System.Text.Json;
 using Microsoft.Extensions.Logging;
 using Sorcha.Register.Models;
+using Sorcha.UI.Core.Extensions;
 using Sorcha.UI.Core.Models.Registers;
 
 namespace Sorcha.UI.Core.Services;
@@ -16,12 +16,6 @@ public class TransactionService : ITransactionService
 {
     private readonly HttpClient _httpClient;
     private readonly ILogger<TransactionService> _logger;
-
-    private static readonly JsonSerializerOptions JsonOptions = new()
-    {
-        PropertyNameCaseInsensitive = true,
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
-    };
 
     public TransactionService(HttpClient httpClient, ILogger<TransactionService> logger)
     {
@@ -50,7 +44,7 @@ public class TransactionService : ITransactionService
             }
 
             var apiResponse = await response.Content.ReadFromJsonAsync<ApiTransactionListResponse>(
-                JsonOptions, cancellationToken);
+                JsonDefaults.Api, cancellationToken);
 
             if (apiResponse == null)
             {
@@ -97,7 +91,7 @@ public class TransactionService : ITransactionService
             }
 
             var transaction = await response.Content.ReadFromJsonAsync<TransactionModel>(
-                JsonOptions, cancellationToken);
+                JsonDefaults.Api, cancellationToken);
 
             return transaction != null ? MapToViewModel(transaction) : null;
         }
@@ -129,7 +123,7 @@ public class TransactionService : ITransactionService
             }
 
             var apiResponse = await response.Content.ReadFromJsonAsync<ApiTransactionQueryResponse>(
-                JsonOptions, cancellationToken);
+                JsonDefaults.Api, cancellationToken);
 
             if (apiResponse == null)
             {
@@ -178,7 +172,7 @@ public class TransactionService : ITransactionService
             }
 
             var apiResponse = await response.Content.ReadFromJsonAsync<ApiTransactionGraphResponse>(
-                JsonOptions, ct);
+                JsonDefaults.Api, ct);
 
             if (apiResponse is null)
             {

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/Verification/HaipVerifierClient.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/Verification/HaipVerifierClient.cs
@@ -4,6 +4,7 @@
 using System.Net.Http.Json;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Sorcha.UI.Core.Extensions;
 
 namespace Sorcha.UI.Components.User.Services.Verification;
 
@@ -33,7 +34,7 @@ public sealed class HaipVerifierClient : IHaipVerifierClient
         using var response = await _http.PostAsJsonAsync("/api/v1/verifier/requests", body, JsonOptions, ct);
         response.EnsureSuccessStatusCode();
 
-        var result = await response.Content.ReadFromJsonAsync<CreateResultDto>(JsonOptions, ct)
+        var result = await response.Content.ReadFromJsonAsync<CreateResultDto>(JsonDefaults.Api, ct)
             ?? throw new InvalidOperationException("HAIP verifier returned an empty create-request response.");
 
         return new HaipCreateResult(
@@ -52,7 +53,7 @@ public sealed class HaipVerifierClient : IHaipVerifierClient
 
         response.EnsureSuccessStatusCode();
 
-        var result = await response.Content.ReadFromJsonAsync<PollResultDto>(JsonOptions, ct)
+        var result = await response.Content.ReadFromJsonAsync<PollResultDto>(JsonDefaults.Api, ct)
             ?? throw new InvalidOperationException("HAIP verifier returned an empty poll response.");
 
         return new HaipPollResult(

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/Wallet/WalletApiService.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/Wallet/WalletApiService.cs
@@ -2,6 +2,7 @@
 // Copyright (c) 2026 Sorcha Contributors
 
 using System.Net.Http.Json;
+using Sorcha.UI.Core.Extensions;
 using Sorcha.UI.Core.Models.Wallet;
 
 namespace Sorcha.UI.Core.Services.Wallet;
@@ -25,7 +26,7 @@ public class WalletApiService : IWalletApiService
         var response = await _httpClient.GetAsync(BasePath, ct);
         response.EnsureSuccessStatusCode();
 
-        var wallets = await response.Content.ReadFromJsonAsync<List<WalletDto>>(ct);
+        var wallets = await response.Content.ReadFromJsonAsync<List<WalletDto>>(JsonDefaults.Api, ct);
         return wallets ?? new List<WalletDto>();
     }
 
@@ -40,7 +41,7 @@ public class WalletApiService : IWalletApiService
         }
 
         response.EnsureSuccessStatusCode();
-        return await response.Content.ReadFromJsonAsync<WalletDto>(ct);
+        return await response.Content.ReadFromJsonAsync<WalletDto>(JsonDefaults.Api, ct);
     }
 
     /// <inheritdoc />
@@ -49,7 +50,7 @@ public class WalletApiService : IWalletApiService
         var response = await _httpClient.PostAsJsonAsync(BasePath, request, ct);
         response.EnsureSuccessStatusCode();
 
-        var result = await response.Content.ReadFromJsonAsync<CreateWalletResponse>(ct);
+        var result = await response.Content.ReadFromJsonAsync<CreateWalletResponse>(JsonDefaults.Api, ct);
         return result ?? throw new InvalidOperationException("Failed to deserialize wallet creation response");
     }
 
@@ -59,7 +60,7 @@ public class WalletApiService : IWalletApiService
         var response = await _httpClient.PostAsJsonAsync($"{BasePath}/recover", request, ct);
         response.EnsureSuccessStatusCode();
 
-        var result = await response.Content.ReadFromJsonAsync<WalletDto>(ct);
+        var result = await response.Content.ReadFromJsonAsync<WalletDto>(JsonDefaults.Api, ct);
         return result ?? throw new InvalidOperationException("Failed to deserialize wallet recovery response");
     }
 
@@ -83,7 +84,7 @@ public class WalletApiService : IWalletApiService
         var response = await _httpClient.PostAsJsonAsync($"{BasePath}/{address}/sign", request, ct);
         response.EnsureSuccessStatusCode();
 
-        var result = await response.Content.ReadFromJsonAsync<SignTransactionResponse>(ct);
+        var result = await response.Content.ReadFromJsonAsync<SignTransactionResponse>(JsonDefaults.Api, ct);
         return result ?? throw new InvalidOperationException("Failed to deserialize signing response");
     }
 
@@ -93,7 +94,7 @@ public class WalletApiService : IWalletApiService
         var response = await _httpClient.GetAsync($"{BasePath}/{address}/addresses?page={page}&pageSize={pageSize}", ct);
         response.EnsureSuccessStatusCode();
 
-        var result = await response.Content.ReadFromJsonAsync<AddressListResponse>(ct);
+        var result = await response.Content.ReadFromJsonAsync<AddressListResponse>(JsonDefaults.Api, ct);
         return result ?? new AddressListResponse { WalletAddress = address };
     }
 
@@ -103,7 +104,7 @@ public class WalletApiService : IWalletApiService
         var response = await _httpClient.PostAsJsonAsync($"{BasePath}/{address}/addresses", request, ct);
         response.EnsureSuccessStatusCode();
 
-        var result = await response.Content.ReadFromJsonAsync<WalletAddressDto>(ct);
+        var result = await response.Content.ReadFromJsonAsync<WalletAddressDto>(JsonDefaults.Api, ct);
         return result ?? throw new InvalidOperationException("Failed to deserialize address registration response");
     }
 }

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/WorkflowService.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/WorkflowService.cs
@@ -55,7 +55,7 @@ public class WorkflowService : IWorkflowService
         try
         {
             return await _httpClient.GetFromJsonAsync<WorkflowInstanceViewModel>(
-                $"/api/instances/{instanceId}", cancellationToken);
+                $"/api/instances/{instanceId}", JsonDefaults.Api, cancellationToken);
         }
         catch (Exception ex)
         {
@@ -180,7 +180,7 @@ public class WorkflowService : IWorkflowService
         try
         {
             var blueprint = await _httpClient.GetFromJsonAsync<Sorcha.Blueprint.Models.Blueprint>(
-                $"/api/blueprints/{blueprintId}", cancellationToken);
+                $"/api/blueprints/{blueprintId}", JsonDefaults.Api, cancellationToken);
 
             if (blueprint != null)
                 _blueprintCache[blueprintId] = blueprint;

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/BlueprintServiceAdmin.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/BlueprintServiceAdmin.razor
@@ -1,6 +1,7 @@
 @using System.Net.Http.Json
 @using Sorcha.UI.Core.Models.Admin
 @using Sorcha.UI.Core.Services
+@using Sorcha.UI.Core.Extensions
 @inject HttpClient Http
 
 <MudGrid>
@@ -132,7 +133,7 @@
         try
         {
             // Call the real health endpoint via API Gateway
-            var healthResponse = await Http.GetFromJsonAsync<BlueprintHealthResponse>(ApiConfiguration.BlueprintStatusUrl);
+            var healthResponse = await Http.GetFromJsonAsync<BlueprintHealthResponse>(ApiConfiguration.BlueprintStatusUrl, JsonDefaults.Api);
 
             if (healthResponse != null && healthResponse.Status == "healthy")
             {

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/PeerServiceAdmin.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/PeerServiceAdmin.razor
@@ -4,6 +4,7 @@
 @using Sorcha.UI.Core.Services
 @using Sorcha.UI.Core.Services.Authentication
 @using Sorcha.UI.Core.Services.Configuration
+@using Sorcha.UI.Core.Extensions
 @inject HttpClient Http
 @inject IAuthenticationService AuthService
 @inject IConfigurationService ConfigService
@@ -466,7 +467,7 @@
     {
         try
         {
-            var healthResponse = await Http.GetFromJsonAsync<PeerHealthResponse>(ApiConfiguration.PeerStatusUrl);
+            var healthResponse = await Http.GetFromJsonAsync<PeerHealthResponse>(ApiConfiguration.PeerStatusUrl, JsonDefaults.Api);
 
             if (healthResponse != null && healthResponse.Status == "healthy")
             {
@@ -518,7 +519,7 @@
     {
         try
         {
-            var result = await Http.GetFromJsonAsync<List<EnhancedPeerInfo>>($"{ApiConfiguration.PeerServiceUrl}/peers");
+            var result = await Http.GetFromJsonAsync<List<EnhancedPeerInfo>>($"{ApiConfiguration.PeerServiceUrl}/peers", JsonDefaults.Api);
             if (result != null)
             {
                 enhancedPeers = result;
@@ -534,7 +535,7 @@
     {
         try
         {
-            var result = await Http.GetFromJsonAsync<List<PeerQualityInfo>>($"{ApiConfiguration.PeerServiceUrl}/peers/quality");
+            var result = await Http.GetFromJsonAsync<List<PeerQualityInfo>>($"{ApiConfiguration.PeerServiceUrl}/peers/quality", JsonDefaults.Api);
             if (result != null)
             {
                 qualityScores = result;
@@ -550,7 +551,7 @@
     {
         try
         {
-            var result = await Http.GetFromJsonAsync<List<RegisterSubscriptionInfo>>($"{ApiConfiguration.PeerServiceUrl}/registers/subscriptions");
+            var result = await Http.GetFromJsonAsync<List<RegisterSubscriptionInfo>>($"{ApiConfiguration.PeerServiceUrl}/registers/subscriptions", JsonDefaults.Api);
             if (result != null)
             {
                 subscriptions = result;

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Registers/PayloadViewer.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Registers/PayloadViewer.razor
@@ -6,6 +6,7 @@
 @using Sorcha.UI.Core.Services
 @using Sorcha.UI.Core.Components.Shared
 @using Sorcha.UI.Core.Components.Forms
+@using Sorcha.UI.Core.Extensions
 
 @inject IPayloadDecoderService Decoder
 @inject ICurrentUserWalletService CurrentUserWalletService
@@ -407,7 +408,7 @@
         {
             try
             {
-                _jsonElement = JsonSerializer.Deserialize<JsonElement>(_decodedContent);
+                _jsonElement = JsonSerializer.Deserialize<JsonElement>(_decodedContent, JsonDefaults.Api);
             }
             catch
             {

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/Admin/AlertDismissalService.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/Admin/AlertDismissalService.cs
@@ -2,6 +2,7 @@
 // Copyright (c) 2026 Sorcha Contributors
 
 using Microsoft.JSInterop;
+using Sorcha.UI.Core.Extensions;
 using Sorcha.UI.Core.Models.Admin;
 
 namespace Sorcha.UI.Core.Services;
@@ -61,7 +62,7 @@ public class AlertDismissalService : IAlertDismissalService
             var json = await _jsRuntime.InvokeAsync<string?>("localStorage.getItem", StorageKeyPrefix);
             if (!string.IsNullOrEmpty(json))
             {
-                var ids = System.Text.Json.JsonSerializer.Deserialize<List<string>>(json);
+                var ids = System.Text.Json.JsonSerializer.Deserialize<List<string>>(json, JsonDefaults.Api);
                 _cache = ids != null ? new HashSet<string>(ids) : [];
             }
             else

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/Admin/AlertService.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/Admin/AlertService.cs
@@ -3,6 +3,7 @@
 
 using System.Net.Http.Json;
 using Microsoft.Extensions.Logging;
+using Sorcha.UI.Core.Extensions;
 using Sorcha.UI.Core.Models.Admin;
 
 namespace Sorcha.UI.Core.Services;
@@ -37,7 +38,7 @@ public class AlertService : IAlertService
                 return CurrentAlerts ?? new AlertsResponse();
             }
 
-            var alertsResponse = await response.Content.ReadFromJsonAsync<AlertsResponse>(cancellationToken: cancellationToken);
+            var alertsResponse = await response.Content.ReadFromJsonAsync<AlertsResponse>(JsonDefaults.Api, cancellationToken);
             if (alertsResponse == null)
             {
                 return CurrentAlerts ?? new AlertsResponse();

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/Admin/AuditService.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/Admin/AuditService.cs
@@ -3,6 +3,7 @@
 
 using System.Net.Http.Json;
 using Microsoft.Extensions.Logging;
+using Sorcha.UI.Core.Extensions;
 
 namespace Sorcha.UI.Core.Services;
 
@@ -96,7 +97,7 @@ public class AuditService : IAuditService
             var response = await _httpClient.GetAsync(url, cancellationToken);
             response.EnsureSuccessStatusCode();
 
-            var result = await response.Content.ReadFromJsonAsync<AuditQueryResult>(cancellationToken: cancellationToken);
+            var result = await response.Content.ReadFromJsonAsync<AuditQueryResult>(JsonDefaults.Api, cancellationToken);
             return result ?? new AuditQueryResult();
         }
         catch (HttpRequestException ex)
@@ -123,7 +124,7 @@ public class AuditService : IAuditService
             var response = await _httpClient.GetAsync(url, cancellationToken);
             response.EnsureSuccessStatusCode();
 
-            var result = await response.Content.ReadFromJsonAsync<AuditRetentionDto>(cancellationToken: cancellationToken);
+            var result = await response.Content.ReadFromJsonAsync<AuditRetentionDto>(JsonDefaults.Api, cancellationToken);
             return result ?? new AuditRetentionDto { RetentionMonths = 12 };
         }
         catch (HttpRequestException ex)

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/Admin/BlueprintApiService.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/Admin/BlueprintApiService.cs
@@ -6,6 +6,7 @@ using System.Net.Http.Json;
 using Microsoft.Extensions.Logging;
 using Sorcha.Blueprint.Models;
 using Sorcha.ServiceClients.Blueprint.Models;
+using Sorcha.UI.Core.Extensions;
 using Sorcha.UI.Core.Models.Blueprints;
 using Sorcha.UI.Core.Models.Common;
 using Sorcha.UI.Core.Models.Workflows;
@@ -34,7 +35,7 @@ public class BlueprintApiService : IBlueprintApiService
             if (!string.IsNullOrEmpty(search)) url += $"&search={Uri.EscapeDataString(search)}";
             if (!string.IsNullOrEmpty(status)) url += $"&status={Uri.EscapeDataString(status)}";
 
-            var result = await _httpClient.GetFromJsonAsync<PaginatedList<BlueprintListItemViewModel>>(url, cancellationToken);
+            var result = await _httpClient.GetFromJsonAsync<PaginatedList<BlueprintListItemViewModel>>(url, JsonDefaults.Api, cancellationToken);
             return result ?? new PaginatedList<BlueprintListItemViewModel>();
         }
         catch (Exception ex)
@@ -48,7 +49,7 @@ public class BlueprintApiService : IBlueprintApiService
     {
         try
         {
-            return await _httpClient.GetFromJsonAsync<BlueprintListItemViewModel>($"/api/blueprints/{id}", cancellationToken);
+            return await _httpClient.GetFromJsonAsync<BlueprintListItemViewModel>($"/api/blueprints/{id}", JsonDefaults.Api, cancellationToken);
         }
         catch (Exception ex)
         {
@@ -61,7 +62,7 @@ public class BlueprintApiService : IBlueprintApiService
     {
         try
         {
-            return await _httpClient.GetFromJsonAsync<Sorcha.Blueprint.Models.Blueprint>($"/api/blueprints/{id}", cancellationToken);
+            return await _httpClient.GetFromJsonAsync<Sorcha.Blueprint.Models.Blueprint>($"/api/blueprints/{id}", JsonDefaults.Api, cancellationToken);
         }
         catch (Exception ex)
         {
@@ -77,7 +78,7 @@ public class BlueprintApiService : IBlueprintApiService
             var response = await _httpClient.PostAsJsonAsync("/api/blueprints", blueprint, cancellationToken);
             if (response.IsSuccessStatusCode)
             {
-                return await response.Content.ReadFromJsonAsync<BlueprintListItemViewModel>(cancellationToken: cancellationToken);
+                return await response.Content.ReadFromJsonAsync<BlueprintListItemViewModel>(JsonDefaults.Api, cancellationToken);
             }
             _logger.LogWarning("Failed to save blueprint: {StatusCode}", response.StatusCode);
             return null;
@@ -96,7 +97,7 @@ public class BlueprintApiService : IBlueprintApiService
             var response = await _httpClient.PutAsJsonAsync($"/api/blueprints/{id}", blueprint, cancellationToken);
             if (response.IsSuccessStatusCode)
             {
-                return await response.Content.ReadFromJsonAsync<BlueprintListItemViewModel>(cancellationToken: cancellationToken);
+                return await response.Content.ReadFromJsonAsync<BlueprintListItemViewModel>(JsonDefaults.Api, cancellationToken);
             }
             _logger.LogWarning("Failed to update blueprint {Id}: {StatusCode}", id, response.StatusCode);
             return null;
@@ -129,7 +130,7 @@ public class BlueprintApiService : IBlueprintApiService
             var response = await _httpClient.PostAsync($"/api/blueprints/{id}/publish", null, cancellationToken);
             if (response.IsSuccessStatusCode)
             {
-                return await response.Content.ReadFromJsonAsync<PublishReviewViewModel>(cancellationToken: cancellationToken);
+                return await response.Content.ReadFromJsonAsync<PublishReviewViewModel>(JsonDefaults.Api, cancellationToken);
             }
             return null;
         }
@@ -147,7 +148,7 @@ public class BlueprintApiService : IBlueprintApiService
             var response = await _httpClient.PostAsync($"/api/blueprints/{id}/validate", null, cancellationToken);
             if (response.IsSuccessStatusCode)
             {
-                return await response.Content.ReadFromJsonAsync<BlueprintValidationResponse>(cancellationToken: cancellationToken);
+                return await response.Content.ReadFromJsonAsync<BlueprintValidationResponse>(JsonDefaults.Api, cancellationToken);
             }
             _logger.LogWarning("Failed to validate blueprint {Id}: {StatusCode}", id, response.StatusCode);
             return null;
@@ -167,7 +168,7 @@ public class BlueprintApiService : IBlueprintApiService
             var response = await _httpClient.PostAsJsonAsync($"/api/blueprints/{id}/publish", body, cancellationToken);
             if (response.IsSuccessStatusCode)
             {
-                return await response.Content.ReadFromJsonAsync<PublishReviewViewModel>(cancellationToken: cancellationToken);
+                return await response.Content.ReadFromJsonAsync<PublishReviewViewModel>(JsonDefaults.Api, cancellationToken);
             }
             _logger.LogWarning("Failed to publish blueprint {Id} to register {RegisterId}: {StatusCode}", id, registerId, response.StatusCode);
             return null;
@@ -202,7 +203,7 @@ public class BlueprintApiService : IBlueprintApiService
             if (response.IsSuccessStatusCode)
             {
                 var result = await response.Content.ReadFromJsonAsync<PublishBlueprintResult>(
-                    cancellationToken: cancellationToken);
+                    JsonDefaults.Api, cancellationToken);
                 return result is not null
                     ? GoLivePublishOutcome.Published(result)
                     : GoLivePublishOutcome.Errored("Publish succeeded but the response could not be read.");
@@ -211,7 +212,7 @@ public class BlueprintApiService : IBlueprintApiService
             if (response.StatusCode == HttpStatusCode.Conflict)
             {
                 var error = await response.Content.ReadFromJsonAsync<RehearsalRequiredError>(
-                    cancellationToken: cancellationToken);
+                    JsonDefaults.Api, cancellationToken);
                 return GoLivePublishOutcome.NeedsRehearsal(
                     error ?? new RehearsalRequiredError
                     {
@@ -245,7 +246,7 @@ public class BlueprintApiService : IBlueprintApiService
     {
         try
         {
-            var versions = await _httpClient.GetFromJsonAsync<List<BlueprintVersionViewModel>>($"/api/blueprints/{id}/versions", cancellationToken);
+            var versions = await _httpClient.GetFromJsonAsync<List<BlueprintVersionViewModel>>($"/api/blueprints/{id}/versions", JsonDefaults.Api, cancellationToken);
             return versions ?? [];
         }
         catch (Exception ex)
@@ -277,7 +278,7 @@ public class BlueprintApiService : IBlueprintApiService
             }
 
             var result = await response.Content.ReadFromJsonAsync<CloneFromPublishedResponse>(
-                cancellationToken: cancellationToken);
+                JsonDefaults.Api, cancellationToken);
             return result?.DraftBlueprintId;
         }
         catch (Exception ex)
@@ -296,7 +297,7 @@ public class BlueprintApiService : IBlueprintApiService
     {
         try
         {
-            return await _httpClient.GetFromJsonAsync<BlueprintListItemViewModel>($"/api/blueprints/{id}/versions/{version}", cancellationToken);
+            return await _httpClient.GetFromJsonAsync<BlueprintListItemViewModel>($"/api/blueprints/{id}/versions/{version}", JsonDefaults.Api, cancellationToken);
         }
         catch (Exception ex)
         {
@@ -311,6 +312,7 @@ public class BlueprintApiService : IBlueprintApiService
         {
             return await _httpClient.GetFromJsonAsync<AvailableBlueprintsViewModel>(
                 $"/api/actions/{Uri.EscapeDataString(walletAddress)}/{Uri.EscapeDataString(registerId)}/blueprints",
+                JsonDefaults.Api,
                 cancellationToken);
         }
         catch (Exception ex)
@@ -326,6 +328,7 @@ public class BlueprintApiService : IBlueprintApiService
         {
             return await _httpClient.GetFromJsonAsync<Sorcha.Blueprint.Models.Blueprint>(
                 $"/api/actions/{Uri.EscapeDataString(walletAddress)}/{Uri.EscapeDataString(registerId)}/blueprints/{Uri.EscapeDataString(blueprintId)}",
+                JsonDefaults.Api,
                 cancellationToken);
         }
         catch (HttpRequestException ex) when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/Admin/BlueprintStorageService.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/Admin/BlueprintStorageService.cs
@@ -6,6 +6,7 @@ using System.Text.Json;
 using Blazored.LocalStorage;
 using Microsoft.Extensions.Logging;
 using Sorcha.Blueprint.Models;
+using Sorcha.UI.Core.Extensions;
 using Sorcha.UI.Core.Models.Designer;
 
 namespace Sorcha.UI.Core.Services;
@@ -90,7 +91,7 @@ public class BlueprintStorageService : IBlueprintStorageService
                 if (response.IsSuccessStatusCode)
                 {
                     var blueprint = await response.Content.ReadFromJsonAsync<Blueprint.Models.Blueprint>(
-                        JsonOptions, cancellationToken);
+                        JsonDefaults.Api, cancellationToken);
 
                     if (blueprint != null)
                     {
@@ -320,7 +321,7 @@ public class BlueprintStorageService : IBlueprintStorageService
             }
 
             return await response.Content.ReadFromJsonAsync<List<Blueprint.Models.Blueprint>>(
-                JsonOptions, cancellationToken);
+                JsonDefaults.Api, cancellationToken);
         }
         catch (Exception ex)
         {
@@ -339,7 +340,7 @@ public class BlueprintStorageService : IBlueprintStorageService
                 return [];
             }
 
-            return JsonSerializer.Deserialize<List<Blueprint.Models.Blueprint>>(json, JsonOptions) ?? [];
+            return JsonSerializer.Deserialize<List<Blueprint.Models.Blueprint>>(json, JsonDefaults.Api) ?? [];
         }
         catch (Exception ex)
         {

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/Admin/Designer/RehearsalApiService.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/Admin/Designer/RehearsalApiService.cs
@@ -5,6 +5,7 @@ using System.Net;
 using System.Net.Http.Json;
 using Microsoft.Extensions.Logging;
 using Sorcha.ServiceClients.Blueprint.Models;
+using Sorcha.UI.Core.Extensions;
 
 namespace Sorcha.UI.Core.Services.Designer;
 
@@ -48,7 +49,7 @@ public sealed class RehearsalApiService : IRehearsalApiService
                 return StartRehearsalOutcome.Errored();
             }
 
-            var rehearsal = await response.Content.ReadFromJsonAsync<Rehearsal>(cancellationToken);
+            var rehearsal = await response.Content.ReadFromJsonAsync<Rehearsal>(JsonDefaults.Api, cancellationToken);
             return rehearsal is null
                 ? StartRehearsalOutcome.Errored()
                 : StartRehearsalOutcome.Started(rehearsal);
@@ -66,7 +67,7 @@ public sealed class RehearsalApiService : IRehearsalApiService
         try
         {
             return await _httpClient.GetFromJsonAsync<Rehearsal>(
-                $"/api/blueprints/{blueprintId}/rehearsals/{rehearsalId}", cancellationToken);
+                $"/api/blueprints/{blueprintId}/rehearsals/{rehearsalId}", JsonDefaults.Api, cancellationToken);
         }
         catch (Exception ex)
         {
@@ -92,7 +93,7 @@ public sealed class RehearsalApiService : IRehearsalApiService
                 return null;
             }
 
-            return await response.Content.ReadFromJsonAsync<Rehearsal>(cancellationToken);
+            return await response.Content.ReadFromJsonAsync<Rehearsal>(JsonDefaults.Api, cancellationToken);
         }
         catch (Exception ex)
         {
@@ -113,7 +114,7 @@ public sealed class RehearsalApiService : IRehearsalApiService
             // 200 (applied) and 422 (validation failure) both carry the refreshed rehearsal body.
             if (response.IsSuccessStatusCode || response.StatusCode == HttpStatusCode.UnprocessableEntity)
             {
-                return await response.Content.ReadFromJsonAsync<Rehearsal>(cancellationToken);
+                return await response.Content.ReadFromJsonAsync<Rehearsal>(JsonDefaults.Api, cancellationToken);
             }
 
             _logger.LogWarning(

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/Admin/DocketService.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/Admin/DocketService.cs
@@ -2,9 +2,9 @@
 // Copyright (c) 2026 Sorcha Contributors
 
 using System.Net.Http.Json;
-using System.Text.Json;
 using Microsoft.Extensions.Logging;
 using Sorcha.Register.Models;
+using Sorcha.UI.Core.Extensions;
 using Sorcha.UI.Core.Models.Explorer;
 using Sorcha.UI.Core.Models.Registers;
 
@@ -18,12 +18,6 @@ public class DocketService : IDocketService
     private readonly HttpClient _httpClient;
     private readonly ILogger<DocketService> _logger;
 
-    private static readonly JsonSerializerOptions JsonOptions = new()
-    {
-        PropertyNameCaseInsensitive = true,
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
-    };
-
     public DocketService(HttpClient httpClient, ILogger<DocketService> logger)
     {
         _httpClient = httpClient;
@@ -35,7 +29,7 @@ public class DocketService : IDocketService
         try
         {
             var dtos = await _httpClient.GetFromJsonAsync<List<DocketDto>>(
-                $"/api/registers/{registerId}/dockets", JsonOptions, cancellationToken);
+                $"/api/registers/{registerId}/dockets", JsonDefaults.Api, cancellationToken);
 
             if (dtos is null or { Count: 0 })
                 return [];
@@ -67,7 +61,7 @@ public class DocketService : IDocketService
         try
         {
             var dto = await _httpClient.GetFromJsonAsync<DocketDto>(
-                $"/api/registers/{registerId}/dockets/{docketId}", JsonOptions, cancellationToken);
+                $"/api/registers/{registerId}/dockets/{docketId}", JsonDefaults.Api, cancellationToken);
 
             return dto is not null ? MapToViewModel(dto, true) : null;
         }
@@ -83,7 +77,7 @@ public class DocketService : IDocketService
         try
         {
             var transactions = await _httpClient.GetFromJsonAsync<List<TransactionModel>>(
-                $"/api/registers/{registerId}/dockets/{docketId}/transactions", JsonOptions, cancellationToken);
+                $"/api/registers/{registerId}/dockets/{docketId}/transactions", JsonDefaults.Api, cancellationToken);
 
             return transactions?.Select(MapTransactionToViewModel).ToList() ?? [];
         }
@@ -99,7 +93,7 @@ public class DocketService : IDocketService
         try
         {
             var dto = await _httpClient.GetFromJsonAsync<DocketDto>(
-                $"/api/registers/{registerId}/dockets/latest", JsonOptions, cancellationToken);
+                $"/api/registers/{registerId}/dockets/latest", JsonDefaults.Api, cancellationToken);
 
             return dto is not null ? MapToViewModel(dto, true) : null;
         }

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/Admin/ODataQueryService.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/Admin/ODataQueryService.cs
@@ -5,6 +5,7 @@ using System.Net.Http.Json;
 using System.Text;
 using System.Text.RegularExpressions;
 using Microsoft.Extensions.Logging;
+using Sorcha.UI.Core.Extensions;
 using Sorcha.UI.Core.Models.Common;
 using Sorcha.UI.Core.Models.Explorer;
 using Sorcha.UI.Core.Models.Registers;
@@ -30,7 +31,7 @@ public class ODataQueryService : IODataQueryService
         try
         {
             var url = BuildODataUrl("/odata/Transactions", query);
-            var result = await _httpClient.GetFromJsonAsync<PaginatedList<TransactionViewModel>>(url, cancellationToken);
+            var result = await _httpClient.GetFromJsonAsync<PaginatedList<TransactionViewModel>>(url, JsonDefaults.Api, cancellationToken);
             return result ?? new PaginatedList<TransactionViewModel>();
         }
         catch (Exception ex)
@@ -45,7 +46,7 @@ public class ODataQueryService : IODataQueryService
         try
         {
             var url = BuildODataUrl("/odata/Registers", query);
-            var result = await _httpClient.GetFromJsonAsync<PaginatedList<RegisterViewModel>>(url, cancellationToken);
+            var result = await _httpClient.GetFromJsonAsync<PaginatedList<RegisterViewModel>>(url, JsonDefaults.Api, cancellationToken);
             return result ?? new PaginatedList<RegisterViewModel>();
         }
         catch (Exception ex)

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/Admin/OfflineSyncService.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/Admin/OfflineSyncService.cs
@@ -5,6 +5,7 @@ using System.Net.Http.Json;
 using System.Text.Json;
 using Blazored.LocalStorage;
 using Microsoft.Extensions.Logging;
+using Sorcha.UI.Core.Extensions;
 using Sorcha.UI.Core.Models.Designer;
 
 namespace Sorcha.UI.Core.Services;
@@ -357,7 +358,7 @@ public class OfflineSyncService : IOfflineSyncService, IDisposable
         }
 
         var blueprint = JsonSerializer.Deserialize<Blueprint.Models.Blueprint>(
-            item.BlueprintJson, JsonOptions);
+            item.BlueprintJson, JsonDefaults.Api);
 
         var response = await _httpClient.PostAsJsonAsync(
             "/api/blueprints",
@@ -401,7 +402,7 @@ public class OfflineSyncService : IOfflineSyncService, IDisposable
         }
 
         var blueprint = JsonSerializer.Deserialize<Blueprint.Models.Blueprint>(
-            item.BlueprintJson, JsonOptions);
+            item.BlueprintJson, JsonDefaults.Api);
 
         // Check for conflicts by getting server version first
         var serverResponse = await _httpClient.GetAsync(
@@ -411,7 +412,7 @@ public class OfflineSyncService : IOfflineSyncService, IDisposable
         if (serverResponse.IsSuccessStatusCode)
         {
             var serverBlueprint = await serverResponse.Content.ReadFromJsonAsync<Blueprint.Models.Blueprint>(
-                JsonOptions, cancellationToken);
+                JsonDefaults.Api, cancellationToken);
 
             // Check for version conflict
             if (serverBlueprint != null && blueprint != null &&
@@ -517,7 +518,7 @@ public class OfflineSyncService : IOfflineSyncService, IDisposable
             var json = await _localStorage.GetItemAsStringAsync(SYNC_QUEUE_KEY);
             if (!string.IsNullOrEmpty(json))
             {
-                _cachedQueue = JsonSerializer.Deserialize<List<SyncQueueItem>>(json, JsonOptions) ?? [];
+                _cachedQueue = JsonSerializer.Deserialize<List<SyncQueueItem>>(json, JsonDefaults.Api) ?? [];
             }
         }
         catch (Exception ex)

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/Admin/OrganizationAdminService.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/Admin/OrganizationAdminService.cs
@@ -3,6 +3,7 @@
 
 using System.Net.Http.Json;
 using Microsoft.Extensions.Logging;
+using Sorcha.UI.Core.Extensions;
 using Sorcha.UI.Core.Models.Admin;
 
 namespace Sorcha.UI.Core.Services;
@@ -37,7 +38,7 @@ public class OrganizationAdminService : IOrganizationAdminService
         try
         {
             var response = await _httpClient.GetFromJsonAsync<OrganizationListResult>(
-                url, cancellationToken);
+                url, JsonDefaults.Api, cancellationToken);
 
             return response ?? new OrganizationListResult();
         }
@@ -55,7 +56,7 @@ public class OrganizationAdminService : IOrganizationAdminService
         try
         {
             return await _httpClient.GetFromJsonAsync<OrganizationDto>(
-                $"{BaseUrl}/{id}", cancellationToken);
+                $"{BaseUrl}/{id}", JsonDefaults.Api, cancellationToken);
         }
         catch (HttpRequestException ex) when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
         {
@@ -77,7 +78,7 @@ public class OrganizationAdminService : IOrganizationAdminService
             var response = await _httpClient.PostAsJsonAsync(BaseUrl, request, cancellationToken);
             response.EnsureSuccessStatusCode();
 
-            var result = await response.Content.ReadFromJsonAsync<OrganizationDto>(cancellationToken);
+            var result = await response.Content.ReadFromJsonAsync<OrganizationDto>(JsonDefaults.Api, cancellationToken);
 
             if (result != null)
             {
@@ -115,7 +116,7 @@ public class OrganizationAdminService : IOrganizationAdminService
 
             response.EnsureSuccessStatusCode();
 
-            var result = await response.Content.ReadFromJsonAsync<OrganizationDto>(cancellationToken);
+            var result = await response.Content.ReadFromJsonAsync<OrganizationDto>(JsonDefaults.Api, cancellationToken);
 
             if (result != null)
             {
@@ -176,7 +177,7 @@ public class OrganizationAdminService : IOrganizationAdminService
                 $"{BaseUrl}/validate-subdomain/{subdomain}", cancellationToken);
 
             var result = await response.Content.ReadFromJsonAsync<SubdomainValidationResult>(
-                cancellationToken);
+                JsonDefaults.Api, cancellationToken);
 
             return result ?? new SubdomainValidationResult
             {
@@ -203,7 +204,7 @@ public class OrganizationAdminService : IOrganizationAdminService
         try
         {
             var response = await _httpClient.GetFromJsonAsync<StatsResponse>(
-                $"{BaseUrl}/stats", cancellationToken);
+                $"{BaseUrl}/stats", JsonDefaults.Api, cancellationToken);
 
             return new PlatformKpis
             {
@@ -240,7 +241,7 @@ public class OrganizationAdminService : IOrganizationAdminService
         try
         {
             var response = await _httpClient.GetFromJsonAsync<UserListResult>(
-                url, cancellationToken);
+                url, JsonDefaults.Api, cancellationToken);
 
             return response ?? new UserListResult();
         }
@@ -290,7 +291,7 @@ public class OrganizationAdminService : IOrganizationAdminService
         try
         {
             return await _httpClient.GetFromJsonAsync<UserDto>(
-                $"{BaseUrl}/{organizationId}/users/{userId}", cancellationToken);
+                $"{BaseUrl}/{organizationId}/users/{userId}", JsonDefaults.Api, cancellationToken);
         }
         catch (HttpRequestException ex) when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
         {
@@ -316,7 +317,7 @@ public class OrganizationAdminService : IOrganizationAdminService
 
             response.EnsureSuccessStatusCode();
 
-            var result = await response.Content.ReadFromJsonAsync<UserDto>(cancellationToken);
+            var result = await response.Content.ReadFromJsonAsync<UserDto>(JsonDefaults.Api, cancellationToken);
 
             if (result != null)
             {
@@ -359,7 +360,7 @@ public class OrganizationAdminService : IOrganizationAdminService
 
             response.EnsureSuccessStatusCode();
 
-            var result = await response.Content.ReadFromJsonAsync<UserDto>(cancellationToken);
+            var result = await response.Content.ReadFromJsonAsync<UserDto>(JsonDefaults.Api, cancellationToken);
 
             if (result != null)
             {

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/Admin/RegisterService.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/Admin/RegisterService.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Logging;
 using Sorcha.Register.Models;
 using Sorcha.Register.Models.LocalRelationship;
 using Sorcha.ServiceClients.Register;
+using Sorcha.UI.Core.Extensions;
 using Sorcha.UI.Core.Models.Admin;
 using Sorcha.UI.Core.Models.Blueprints;
 using Sorcha.UI.Core.Models.Registers;
@@ -50,7 +51,7 @@ public class RegisterService : IRegisterReadService, IRegisterGovernanceService
             }
 
             var registers = await response.Content.ReadFromJsonAsync<List<Register.Models.Register>>(
-                JsonOptions, cancellationToken);
+                JsonDefaults.Api, cancellationToken);
 
             return registers?.Select(MapToViewModel).ToList() ?? [];
         }
@@ -85,7 +86,7 @@ public class RegisterService : IRegisterReadService, IRegisterGovernanceService
             }
 
             var register = await response.Content.ReadFromJsonAsync<Register.Models.Register>(
-                JsonOptions, cancellationToken);
+                JsonDefaults.Api, cancellationToken);
 
             return register != null ? MapToViewModel(register) : null;
         }
@@ -120,7 +121,7 @@ public class RegisterService : IRegisterReadService, IRegisterGovernanceService
             }
 
             return await response.Content.ReadFromJsonAsync<GovernanceRosterViewModel>(
-                JsonOptions, cancellationToken);
+                JsonDefaults.Api, cancellationToken);
         }
         catch (Exception ex)
         {
@@ -155,7 +156,7 @@ public class RegisterService : IRegisterReadService, IRegisterGovernanceService
             }
 
             var result = await response.Content.ReadFromJsonAsync<InitiateRegisterResponse>(
-                JsonOptions, cancellationToken);
+                JsonDefaults.Api, cancellationToken);
 
             _logger.LogInformation(
                 "Register initiation successful: {RegisterId}, {AttestationCount} attestation(s) to sign",
@@ -196,7 +197,7 @@ public class RegisterService : IRegisterReadService, IRegisterGovernanceService
             }
 
             var result = await response.Content.ReadFromJsonAsync<FinalizeRegisterResponse>(
-                JsonOptions, cancellationToken);
+                JsonDefaults.Api, cancellationToken);
 
             _logger.LogInformation(
                 "Register finalized successfully: {RegisterId}, status: {Status}",
@@ -218,7 +219,7 @@ public class RegisterService : IRegisterReadService, IRegisterGovernanceService
         {
             var response = await _httpClient.GetAsync($"/api/registers/{Uri.EscapeDataString(registerId)}/policy", ct);
             if (!response.IsSuccessStatusCode) return null;
-            return await response.Content.ReadFromJsonAsync<RegisterPolicyViewModel>(JsonOptions, ct);
+            return await response.Content.ReadFromJsonAsync<RegisterPolicyViewModel>(JsonDefaults.Api, ct);
         }
         catch (Exception ex) { _logger.LogError(ex, "Error fetching policy for register {RegisterId}", registerId); return null; }
     }
@@ -230,7 +231,7 @@ public class RegisterService : IRegisterReadService, IRegisterGovernanceService
         {
             var response = await _httpClient.GetAsync($"/api/registers/{Uri.EscapeDataString(registerId)}/policy/history?page={page}&pageSize={pageSize}", ct);
             if (!response.IsSuccessStatusCode) return new PolicyHistoryViewModel { RegisterId = registerId };
-            return await response.Content.ReadFromJsonAsync<PolicyHistoryViewModel>(JsonOptions, ct) ?? new PolicyHistoryViewModel { RegisterId = registerId };
+            return await response.Content.ReadFromJsonAsync<PolicyHistoryViewModel>(JsonDefaults.Api, ct) ?? new PolicyHistoryViewModel { RegisterId = registerId };
         }
         catch (Exception ex) { _logger.LogError(ex, "Error fetching policy history for register {RegisterId}", registerId); return new PolicyHistoryViewModel { RegisterId = registerId }; }
     }
@@ -242,7 +243,7 @@ public class RegisterService : IRegisterReadService, IRegisterGovernanceService
         {
             var response = await _httpClient.PostAsJsonAsync($"/api/registers/{Uri.EscapeDataString(registerId)}/policy/update", policy, JsonOptions, ct);
             if (!response.IsSuccessStatusCode) return null;
-            return await response.Content.ReadFromJsonAsync<PolicyUpdateProposalViewModel>(JsonOptions, ct);
+            return await response.Content.ReadFromJsonAsync<PolicyUpdateProposalViewModel>(JsonDefaults.Api, ct);
         }
         catch (Exception ex) { _logger.LogError(ex, "Error proposing policy update for register {RegisterId}", registerId); return null; }
     }
@@ -279,7 +280,7 @@ public class RegisterService : IRegisterReadService, IRegisterGovernanceService
             }
 
             return await response.Content.ReadFromJsonAsync<RegisterLocalRelationship>(
-                JsonOptions, cancellationToken);
+                JsonDefaults.Api, cancellationToken);
         }
         catch (Exception ex)
         {
@@ -311,7 +312,7 @@ public class RegisterService : IRegisterReadService, IRegisterGovernanceService
             }
 
             return await response.Content.ReadFromJsonAsync<RegisterSyncStateView>(
-                JsonOptions, cancellationToken);
+                JsonDefaults.Api, cancellationToken);
         }
         catch (Exception ex)
         {
@@ -343,7 +344,7 @@ public class RegisterService : IRegisterReadService, IRegisterGovernanceService
             }
 
             var published = await response.Content.ReadFromJsonAsync<PublishedBlueprintsResponse>(
-                JsonOptions, cancellationToken);
+                JsonDefaults.Api, cancellationToken);
             return published?.Blueprints.Count ?? 0;
         }
         catch (Exception ex)

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/Admin/SchemaLibraryApiService.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/Admin/SchemaLibraryApiService.cs
@@ -4,6 +4,7 @@
 using System.Net.Http.Json;
 using System.Text.Json;
 using Microsoft.Extensions.Logging;
+using Sorcha.UI.Core.Extensions;
 using Sorcha.UI.Core.Models.SchemaLibrary;
 
 namespace Sorcha.UI.Core.Services;
@@ -48,7 +49,7 @@ public class SchemaLibraryApiService : ISchemaLibraryApiService
             if (queryParams.Count > 0)
                 url += "?" + string.Join("&", queryParams);
 
-            var response = await _httpClient.GetFromJsonAsync<SchemaIndexSearchResponse>(url, cancellationToken);
+            var response = await _httpClient.GetFromJsonAsync<SchemaIndexSearchResponse>(url, JsonDefaults.Api, cancellationToken);
             return response ?? new SchemaIndexSearchResponse([], 0, null, null);
         }
         catch (Exception ex)
@@ -66,6 +67,7 @@ public class SchemaLibraryApiService : ISchemaLibraryApiService
         {
             return await _httpClient.GetFromJsonAsync<SchemaIndexEntryDetailViewModel>(
                 $"/api/v1/schemas/index/{Uri.EscapeDataString(shortCode)}",
+                JsonDefaults.Api,
                 cancellationToken);
         }
         catch (HttpRequestException ex) when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
@@ -87,6 +89,7 @@ public class SchemaLibraryApiService : ISchemaLibraryApiService
         {
             return await _httpClient.GetFromJsonAsync<JsonDocument>(
                 $"/api/v1/schemas/index/content/{Uri.EscapeDataString(shortCode)}",
+                JsonDefaults.Api,
                 cancellationToken);
         }
         catch (HttpRequestException ex) when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
@@ -106,7 +109,7 @@ public class SchemaLibraryApiService : ISchemaLibraryApiService
         try
         {
             var sectors = await _httpClient.GetFromJsonAsync<List<SchemaSectorViewModel>>(
-                "/api/v1/schemas/sectors", cancellationToken);
+                "/api/v1/schemas/sectors", JsonDefaults.Api, cancellationToken);
             return sectors ?? [];
         }
         catch (Exception ex)
@@ -122,7 +125,7 @@ public class SchemaLibraryApiService : ISchemaLibraryApiService
         try
         {
             return await _httpClient.GetFromJsonAsync<OrganisationSectorPreferencesViewModel>(
-                "/api/v1/schemas/sectors/preferences", cancellationToken);
+                "/api/v1/schemas/sectors/preferences", JsonDefaults.Api, cancellationToken);
         }
         catch (Exception ex)
         {
@@ -156,7 +159,7 @@ public class SchemaLibraryApiService : ISchemaLibraryApiService
         try
         {
             var statuses = await _httpClient.GetFromJsonAsync<List<SchemaProviderStatusViewModel>>(
-                "/api/v1/schemas/providers", cancellationToken);
+                "/api/v1/schemas/providers", JsonDefaults.Api, cancellationToken);
             return statuses ?? [];
         }
         catch (Exception ex)

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/Admin/ServicePrincipalService.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/Admin/ServicePrincipalService.cs
@@ -4,6 +4,7 @@
 using System.Net.Http.Json;
 using System.Text.Json;
 using Microsoft.Extensions.Logging;
+using Sorcha.UI.Core.Extensions;
 using Sorcha.UI.Core.Models.Admin;
 
 namespace Sorcha.UI.Core.Services;
@@ -34,7 +35,7 @@ public class ServicePrincipalService : IServicePrincipalService
         {
             var query = includeInactive ? "?includeInactive=true" : "";
             var result = await _httpClient.GetFromJsonAsync<ServicePrincipalListResult>(
-                $"{BasePath}{query}", ct);
+                $"{BasePath}{query}", JsonDefaults.Api, ct);
             return result ?? new ServicePrincipalListResult();
         }
         catch (Exception ex)
@@ -50,7 +51,7 @@ public class ServicePrincipalService : IServicePrincipalService
         try
         {
             return await _httpClient.GetFromJsonAsync<ServicePrincipalViewModel>(
-                $"{BasePath}/{id}", ct);
+                $"{BasePath}/{id}", JsonDefaults.Api, ct);
         }
         catch (Exception ex)
         {
@@ -66,7 +67,7 @@ public class ServicePrincipalService : IServicePrincipalService
         {
             var response = await _httpClient.PostAsJsonAsync(BasePath, request, ct);
             response.EnsureSuccessStatusCode();
-            var result = await response.Content.ReadFromJsonAsync<ServicePrincipalSecretViewModel>(cancellationToken: ct);
+            var result = await response.Content.ReadFromJsonAsync<ServicePrincipalSecretViewModel>(JsonDefaults.Api, ct);
             return result ?? throw new InvalidOperationException("Empty response from create endpoint");
         }
         catch (Exception ex)
@@ -83,7 +84,7 @@ public class ServicePrincipalService : IServicePrincipalService
         {
             var response = await _httpClient.PutAsJsonAsync($"{BasePath}/{id}/scopes", new { scopes }, ct);
             response.EnsureSuccessStatusCode();
-            return await response.Content.ReadFromJsonAsync<ServicePrincipalViewModel>(cancellationToken: ct);
+            return await response.Content.ReadFromJsonAsync<ServicePrincipalViewModel>(JsonDefaults.Api, ct);
         }
         catch (Exception ex)
         {
@@ -144,7 +145,7 @@ public class ServicePrincipalService : IServicePrincipalService
         {
             var response = await _httpClient.PostAsync($"{BasePath}/{id}/rotate-secret", null, ct);
             response.EnsureSuccessStatusCode();
-            var result = await response.Content.ReadFromJsonAsync<ServicePrincipalSecretViewModel>(cancellationToken: ct);
+            var result = await response.Content.ReadFromJsonAsync<ServicePrincipalSecretViewModel>(JsonDefaults.Api, ct);
             return result ?? throw new InvalidOperationException("Empty response from rotate secret endpoint");
         }
         catch (Exception ex)

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/Admin/SystemRegisterService.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/Admin/SystemRegisterService.cs
@@ -3,6 +3,7 @@
 
 using System.Net.Http.Json;
 using Microsoft.Extensions.Logging;
+using Sorcha.UI.Core.Extensions;
 using Sorcha.UI.Core.Models.Admin;
 
 namespace Sorcha.UI.Core.Services;
@@ -36,7 +37,7 @@ public class SystemRegisterService : ISystemRegisterService
                 return null;
             }
 
-            return await response.Content.ReadFromJsonAsync<SystemRegisterViewModel>(cancellationToken: ct);
+            return await response.Content.ReadFromJsonAsync<SystemRegisterViewModel>(JsonDefaults.Api, ct);
         }
         catch (Exception ex)
         {
@@ -58,7 +59,7 @@ public class SystemRegisterService : ISystemRegisterService
                 return new BlueprintPageResult();
             }
 
-            return await response.Content.ReadFromJsonAsync<BlueprintPageResult>(cancellationToken: ct)
+            return await response.Content.ReadFromJsonAsync<BlueprintPageResult>(JsonDefaults.Api, ct)
                 ?? new BlueprintPageResult();
         }
         catch (Exception ex)
@@ -102,7 +103,7 @@ public class SystemRegisterService : ISystemRegisterService
                 return null;
             }
 
-            return await response.Content.ReadFromJsonAsync<BlueprintDetailViewModel>(cancellationToken: ct);
+            return await response.Content.ReadFromJsonAsync<BlueprintDetailViewModel>(JsonDefaults.Api, ct);
         }
         catch (Exception ex)
         {
@@ -125,7 +126,7 @@ public class SystemRegisterService : ISystemRegisterService
                 return null;
             }
 
-            return await response.Content.ReadFromJsonAsync<BlueprintDetailViewModel>(cancellationToken: ct);
+            return await response.Content.ReadFromJsonAsync<BlueprintDetailViewModel>(JsonDefaults.Api, ct);
         }
         catch (Exception ex)
         {

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/Admin/TemplateApiService.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/Admin/TemplateApiService.cs
@@ -5,6 +5,7 @@ using System.Net.Http.Json;
 using System.Text.Json;
 using Microsoft.Extensions.Logging;
 using Sorcha.Blueprint.Models;
+using Sorcha.UI.Core.Extensions;
 using Sorcha.UI.Core.Models.Blueprints;
 using Sorcha.UI.Core.Models.Templates;
 
@@ -31,7 +32,7 @@ public class TemplateApiService : ITemplateApiService
             var url = "/api/templates";
             if (!string.IsNullOrEmpty(category)) url += $"?category={Uri.EscapeDataString(category)}";
 
-            var templates = await _httpClient.GetFromJsonAsync<List<BlueprintTemplate>>(url, cancellationToken);
+            var templates = await _httpClient.GetFromJsonAsync<List<BlueprintTemplate>>(url, JsonDefaults.Api, cancellationToken);
             return templates?.Select(MapToViewModel).ToList() ?? [];
         }
         catch (Exception ex)
@@ -45,7 +46,7 @@ public class TemplateApiService : ITemplateApiService
     {
         try
         {
-            var template = await _httpClient.GetFromJsonAsync<BlueprintTemplate>($"/api/templates/{id}", cancellationToken);
+            var template = await _httpClient.GetFromJsonAsync<BlueprintTemplate>($"/api/templates/{id}", JsonDefaults.Api, cancellationToken);
             return template is not null ? MapToViewModel(template) : null;
         }
         catch (Exception ex)
@@ -63,7 +64,7 @@ public class TemplateApiService : ITemplateApiService
                 new { templateId = id, parameters }, cancellationToken);
             if (response.IsSuccessStatusCode)
             {
-                return await response.Content.ReadFromJsonAsync<BlueprintListItemViewModel>(cancellationToken: cancellationToken);
+                return await response.Content.ReadFromJsonAsync<BlueprintListItemViewModel>(JsonDefaults.Api, cancellationToken);
             }
             return null;
         }
@@ -82,7 +83,7 @@ public class TemplateApiService : ITemplateApiService
                 new { templateId = id, parameters }, cancellationToken);
             if (response.IsSuccessStatusCode)
             {
-                var result = await response.Content.ReadFromJsonAsync<TemplateEvaluationResult>(cancellationToken: cancellationToken);
+                var result = await response.Content.ReadFromJsonAsync<TemplateEvaluationResult>(JsonDefaults.Api, cancellationToken);
                 return result?.Blueprint;
             }
             return null;

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/Admin/ValidatorAdminService.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/Admin/ValidatorAdminService.cs
@@ -3,6 +3,7 @@
 
 using System.Net.Http.Json;
 using Microsoft.Extensions.Logging;
+using Sorcha.UI.Core.Extensions;
 using Sorcha.UI.Core.Models.Admin;
 
 namespace Sorcha.UI.Core.Services;
@@ -32,7 +33,7 @@ public class ValidatorAdminService : IValidatorAdminService
                 return new ValidatorStatusViewModel { IsLoaded = false };
             }
 
-            var status = await response.Content.ReadFromJsonAsync<ValidatorStatusViewModel>(cancellationToken: cancellationToken);
+            var status = await response.Content.ReadFromJsonAsync<ValidatorStatusViewModel>(JsonDefaults.Api, cancellationToken);
             return status ?? new ValidatorStatusViewModel { IsLoaded = false };
         }
         catch (Exception ex)
@@ -47,7 +48,7 @@ public class ValidatorAdminService : IValidatorAdminService
         try
         {
             var stat = await _httpClient.GetFromJsonAsync<RegisterMempoolStat>(
-                $"/api/v1/transactions/mempool/{registerId}", cancellationToken);
+                $"/api/v1/transactions/mempool/{registerId}", JsonDefaults.Api, cancellationToken);
             return stat ?? new RegisterMempoolStat { RegisterId = registerId };
         }
         catch (Exception ex)
@@ -65,7 +66,7 @@ public class ValidatorAdminService : IValidatorAdminService
         {
             var response = await _httpClient.GetAsync("/api/admin/validators/consent-queue", ct);
             if (!response.IsSuccessStatusCode) return new ConsentQueueViewModel();
-            return await response.Content.ReadFromJsonAsync<ConsentQueueViewModel>(cancellationToken: ct) ?? new ConsentQueueViewModel();
+            return await response.Content.ReadFromJsonAsync<ConsentQueueViewModel>(JsonDefaults.Api, ct) ?? new ConsentQueueViewModel();
         }
         catch (Exception ex) { _logger.LogError(ex, "Error fetching consent queue"); return new ConsentQueueViewModel(); }
     }
@@ -76,7 +77,7 @@ public class ValidatorAdminService : IValidatorAdminService
         {
             var response = await _httpClient.GetAsync($"/api/validators/{registerId}/pending", ct);
             if (!response.IsSuccessStatusCode) return [];
-            return await response.Content.ReadFromJsonAsync<List<PendingValidatorViewModel>>(cancellationToken: ct) ?? [];
+            return await response.Content.ReadFromJsonAsync<List<PendingValidatorViewModel>>(JsonDefaults.Api, ct) ?? [];
         }
         catch (Exception ex) { _logger.LogError(ex, "Error fetching pending validators for {RegisterId}", registerId); return []; }
     }
@@ -141,7 +142,7 @@ public class ValidatorAdminService : IValidatorAdminService
         {
             var response = await _httpClient.PostAsync($"/api/validators/{registerId}/refresh", null, ct);
             if (!response.IsSuccessStatusCode) return [];
-            return await response.Content.ReadFromJsonAsync<List<ApprovedValidatorInfo>>(cancellationToken: ct) ?? [];
+            return await response.Content.ReadFromJsonAsync<List<ApprovedValidatorInfo>>(JsonDefaults.Api, ct) ?? [];
         }
         catch (Exception ex) { _logger.LogError(ex, "Error refreshing validators for {RegisterId}", registerId); return []; }
     }
@@ -154,7 +155,7 @@ public class ValidatorAdminService : IValidatorAdminService
         {
             var response = await _httpClient.GetAsync("/api/validator/metrics", ct);
             if (!response.IsSuccessStatusCode) return new AggregatedMetricsViewModel();
-            return await response.Content.ReadFromJsonAsync<AggregatedMetricsViewModel>(cancellationToken: ct) ?? new AggregatedMetricsViewModel();
+            return await response.Content.ReadFromJsonAsync<AggregatedMetricsViewModel>(JsonDefaults.Api, ct) ?? new AggregatedMetricsViewModel();
         }
         catch (Exception ex) { _logger.LogError(ex, "Error fetching aggregated metrics"); return new AggregatedMetricsViewModel(); }
     }
@@ -165,7 +166,7 @@ public class ValidatorAdminService : IValidatorAdminService
         {
             var response = await _httpClient.GetAsync("/api/validator/metrics/validation", ct);
             if (!response.IsSuccessStatusCode) return new ValidationSummaryViewModel();
-            return await response.Content.ReadFromJsonAsync<ValidationSummaryViewModel>(cancellationToken: ct) ?? new ValidationSummaryViewModel();
+            return await response.Content.ReadFromJsonAsync<ValidationSummaryViewModel>(JsonDefaults.Api, ct) ?? new ValidationSummaryViewModel();
         }
         catch (Exception ex) { _logger.LogError(ex, "Error fetching validation metrics"); return new ValidationSummaryViewModel(); }
     }
@@ -176,7 +177,7 @@ public class ValidatorAdminService : IValidatorAdminService
         {
             var response = await _httpClient.GetAsync("/api/validator/metrics/consensus", ct);
             if (!response.IsSuccessStatusCode) return new ConsensusSummaryViewModel();
-            return await response.Content.ReadFromJsonAsync<ConsensusSummaryViewModel>(cancellationToken: ct) ?? new ConsensusSummaryViewModel();
+            return await response.Content.ReadFromJsonAsync<ConsensusSummaryViewModel>(JsonDefaults.Api, ct) ?? new ConsensusSummaryViewModel();
         }
         catch (Exception ex) { _logger.LogError(ex, "Error fetching consensus metrics"); return new ConsensusSummaryViewModel(); }
     }
@@ -187,7 +188,7 @@ public class ValidatorAdminService : IValidatorAdminService
         {
             var response = await _httpClient.GetAsync("/api/validator/metrics/pools", ct);
             if (!response.IsSuccessStatusCode) return new PoolSummaryViewModel();
-            return await response.Content.ReadFromJsonAsync<PoolSummaryViewModel>(cancellationToken: ct) ?? new PoolSummaryViewModel();
+            return await response.Content.ReadFromJsonAsync<PoolSummaryViewModel>(JsonDefaults.Api, ct) ?? new PoolSummaryViewModel();
         }
         catch (Exception ex) { _logger.LogError(ex, "Error fetching pool metrics"); return new PoolSummaryViewModel(); }
     }
@@ -198,7 +199,7 @@ public class ValidatorAdminService : IValidatorAdminService
         {
             var response = await _httpClient.GetAsync("/api/validator/metrics/caches", ct);
             if (!response.IsSuccessStatusCode) return new CacheSummaryViewModel();
-            return await response.Content.ReadFromJsonAsync<CacheSummaryViewModel>(cancellationToken: ct) ?? new CacheSummaryViewModel();
+            return await response.Content.ReadFromJsonAsync<CacheSummaryViewModel>(JsonDefaults.Api, ct) ?? new CacheSummaryViewModel();
         }
         catch (Exception ex) { _logger.LogError(ex, "Error fetching cache metrics"); return new CacheSummaryViewModel(); }
     }
@@ -211,7 +212,7 @@ public class ValidatorAdminService : IValidatorAdminService
         {
             var response = await _httpClient.GetAsync("/api/v1/validators/threshold/status", ct);
             if (!response.IsSuccessStatusCode) return [];
-            return await response.Content.ReadFromJsonAsync<List<ThresholdConfigViewModel>>(cancellationToken: ct) ?? [];
+            return await response.Content.ReadFromJsonAsync<List<ThresholdConfigViewModel>>(JsonDefaults.Api, ct) ?? [];
         }
         catch (Exception ex) { _logger.LogError(ex, "Error fetching threshold status"); return []; }
     }
@@ -220,7 +221,7 @@ public class ValidatorAdminService : IValidatorAdminService
     {
         var response = await _httpClient.PostAsJsonAsync("/api/v1/validators/threshold/setup", request, ct);
         response.EnsureSuccessStatusCode();
-        return await response.Content.ReadFromJsonAsync<ThresholdConfigViewModel>(cancellationToken: ct)
+        return await response.Content.ReadFromJsonAsync<ThresholdConfigViewModel>(JsonDefaults.Api, ct)
             ?? throw new InvalidOperationException("Failed to deserialize threshold setup response");
     }
 
@@ -232,7 +233,7 @@ public class ValidatorAdminService : IValidatorAdminService
         {
             var response = await _httpClient.GetAsync("/api/validator/metrics/config", ct);
             if (!response.IsSuccessStatusCode) return new ValidatorConfigViewModel();
-            return await response.Content.ReadFromJsonAsync<ValidatorConfigViewModel>(cancellationToken: ct) ?? new ValidatorConfigViewModel();
+            return await response.Content.ReadFromJsonAsync<ValidatorConfigViewModel>(JsonDefaults.Api, ct) ?? new ValidatorConfigViewModel();
         }
         catch (Exception ex) { _logger.LogError(ex, "Error fetching validator config"); return new ValidatorConfigViewModel(); }
     }

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Components/Forms/FileReferenceField.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Components/Forms/FileReferenceField.razor
@@ -392,7 +392,7 @@
         var response = await Http.PostAsJsonAsync("/api/file-chunks", request);
         response.EnsureSuccessStatusCode();
 
-        var result = await response.Content.ReadFromJsonAsync<ChunkUploadResponse>();
+        var result = await response.Content.ReadFromJsonAsync<ChunkUploadResponse>(JsonDefaults.Api);
         if (result?.ChunkTransactionId is null)
             throw new InvalidOperationException("Server did not return a chunk transaction ID.");
         return result;

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/MyDevices.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/MyDevices.razor
@@ -155,7 +155,7 @@
         _loadError = null;
         try
         {
-            var response = await Http.GetFromJsonAsync<DeviceListResponse>("/api/v1/me/devices");
+            var response = await Http.GetFromJsonAsync<DeviceListResponse>("/api/v1/me/devices", JsonDefaults.Api);
             _devices = response?.Devices.ToList() ?? new List<DeviceSummary>();
         }
         catch (Exception ex)

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/_Imports.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/_Imports.razor
@@ -29,3 +29,4 @@
 @using Sorcha.Blueprint.Models
 @using Sorcha.Blueprint.Schemas.Client
 @using Blazored.LocalStorage
+@using Sorcha.UI.Core.Extensions

--- a/src/Apps/Sorcha.Wallet.Pwa/Services/Actions/HttpMyActionsClient.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Services/Actions/HttpMyActionsClient.cs
@@ -2,8 +2,8 @@
 // Copyright (c) 2026 Sorcha Contributors
 
 using System.Net.Http.Json;
-using System.Text.Json;
 using System.Text.Json.Serialization;
+using Sorcha.UI.Core.Extensions;
 using Sorcha.Wallet.Pwa.Services.Actions.Models;
 
 namespace Sorcha.Wallet.Pwa.Services.Actions;
@@ -19,12 +19,6 @@ public sealed class HttpMyActionsClient : IMyActionsClient
 {
     private readonly HttpClient _http;
 
-    private static readonly JsonSerializerOptions JsonOptions = new()
-    {
-        PropertyNameCaseInsensitive = true,
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-    };
-
     /// <summary>Initialises a new instance.</summary>
     public HttpMyActionsClient(HttpClient http) => _http = http ?? throw new ArgumentNullException(nameof(http));
 
@@ -38,7 +32,7 @@ public sealed class HttpMyActionsClient : IMyActionsClient
         int page = 1, int pageSize = 20, CancellationToken ct = default)
     {
         var result = await _http.GetFromJsonAsync<PendingPage>(
-            $"api/actions/pending?page={page}&pageSize={pageSize}", JsonOptions, ct).ConfigureAwait(false);
+            $"api/actions/pending?page={page}&pageSize={pageSize}", JsonDefaults.Api, ct).ConfigureAwait(false);
 
         var items = result?.Items;
         if (items is null || items.Count == 0)
@@ -59,7 +53,7 @@ public sealed class HttpMyActionsClient : IMyActionsClient
     public async Task<PendingActionsCount> GetCountAsync(CancellationToken ct = default)
     {
         var dto = await _http.GetFromJsonAsync<CountDto>(
-            "api/actions/pending/count", JsonOptions, ct).ConfigureAwait(false);
+            "api/actions/pending/count", JsonDefaults.Api, ct).ConfigureAwait(false);
         return dto is null ? PendingActionsCount.Empty : new PendingActionsCount(dto.Count, dto.UrgentCount);
     }
 

--- a/src/Apps/Sorcha.Wallet.Pwa/Services/Applications/IApplicationActionClient.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Services/Applications/IApplicationActionClient.cs
@@ -4,6 +4,7 @@
 using System.Net.Http.Json;
 using System.Text.Json;
 using Microsoft.Extensions.Logging;
+using Sorcha.UI.Core.Extensions;
 using Sorcha.UI.Core.Services.Forms;
 using Sorcha.UI.Core.Services.HolderKeys;
 
@@ -85,7 +86,7 @@ public sealed class HttpApplicationActionClient : IApplicationActionClient
         try
         {
             var instance = await _http.GetFromJsonAsync<InstanceDto>(
-                $"api/instances/{instanceId:N}", JsonOptions, ct);
+                $"api/instances/{instanceId:N}", JsonDefaults.Api, ct);
             if (instance is null || string.IsNullOrEmpty(instance.BlueprintId))
             {
                 return null;
@@ -207,7 +208,7 @@ public sealed class HttpApplicationActionClient : IApplicationActionClient
         {
             if (el.TryGetProperty("id", out var idEl) && idEl.TryGetInt32(out var id) && id == actionId)
             {
-                return el.Deserialize<Sorcha.Blueprint.Models.Action>(JsonOptions);
+                return el.Deserialize<Sorcha.Blueprint.Models.Action>(JsonDefaults.Api);
             }
         }
         return null;

--- a/src/Apps/Sorcha.Wallet.Pwa/Services/BearerTokenHandler.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Services/BearerTokenHandler.cs
@@ -5,6 +5,7 @@ using System.Net;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Text.Json.Serialization;
+using Sorcha.UI.Core.Extensions;
 
 namespace Sorcha.Wallet.Pwa.Services;
 
@@ -97,7 +98,7 @@ public sealed class BearerTokenHandler : DelegatingHandler
             var resp = await _refreshHttp.PostAsJsonAsync(
                 "api/auth/token/refresh", new RefreshBody(refreshToken), ct);
             if (!resp.IsSuccessStatusCode) return null;
-            var body = await resp.Content.ReadFromJsonAsync<RefreshResponse>(ct);
+            var body = await resp.Content.ReadFromJsonAsync<RefreshResponse>(JsonDefaults.Api, ct);
             if (body is null || string.IsNullOrEmpty(body.AccessToken)) return null;
 
             var record = new AccessTokenRecord(

--- a/src/Apps/Sorcha.Wallet.Pwa/Services/Catalogue/ICatalogueClient.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Services/Catalogue/ICatalogueClient.cs
@@ -4,6 +4,7 @@
 using System.Net.Http.Json;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Sorcha.UI.Core.Extensions;
 
 namespace Sorcha.Wallet.Pwa.Services.Catalogue;
 
@@ -46,7 +47,7 @@ public sealed class HttpCatalogueClient : ICatalogueClient
     /// <inheritdoc />
     public async Task<IReadOnlyList<CatalogueItem>> GetServicesAsync(CancellationToken ct = default)
     {
-        var items = await _http.GetFromJsonAsync<List<CatalogueItem>>("api/catalogue", JsonOptions, ct)
+        var items = await _http.GetFromJsonAsync<List<CatalogueItem>>("api/catalogue", JsonDefaults.Api, ct)
             .ConfigureAwait(false);
         return items ?? (IReadOnlyList<CatalogueItem>)Array.Empty<CatalogueItem>();
     }
@@ -64,7 +65,7 @@ public sealed class HttpCatalogueClient : ICatalogueClient
             {
                 return null;
             }
-            var created = await response.Content.ReadFromJsonAsync<CreatedInstance>(JsonOptions, ct).ConfigureAwait(false);
+            var created = await response.Content.ReadFromJsonAsync<CreatedInstance>(JsonDefaults.Api, ct).ConfigureAwait(false);
             return string.IsNullOrEmpty(created?.Id) ? null : created!.Id;
         }
         catch (OperationCanceledException)

--- a/src/Apps/Sorcha.Wallet.Pwa/Services/Context/IUserContext.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Services/Context/IUserContext.cs
@@ -4,6 +4,7 @@
 using System.Net.Http.Json;
 using System.Text.Json.Serialization;
 using Microsoft.Extensions.Logging;
+using Sorcha.UI.Core.Extensions;
 using Sorcha.Wallet.Pwa.Services;
 
 namespace Sorcha.Wallet.Pwa.Services.Context;
@@ -133,7 +134,7 @@ public sealed class ManagedUserContext : IUserContext
                 }
 
                 var payload = await response.Content
-                    .ReadFromJsonAsync<SwitchOrgResponse>(cancellationToken: ct).ConfigureAwait(false);
+                    .ReadFromJsonAsync<SwitchOrgResponse>(JsonDefaults.Api, ct).ConfigureAwait(false);
                 if (payload is null || string.IsNullOrEmpty(payload.AccessToken))
                 {
                     _logger.LogWarning("Context switch returned an empty token payload.");

--- a/src/Apps/Sorcha.Wallet.Pwa/Services/Context/IUserOrgMembershipsClient.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Services/Context/IUserOrgMembershipsClient.cs
@@ -4,6 +4,7 @@
 using System.Net.Http.Json;
 using System.Text.Json.Serialization;
 using Microsoft.Extensions.Logging;
+using Sorcha.UI.Core.Extensions;
 
 namespace Sorcha.Wallet.Pwa.Services.Context;
 
@@ -46,7 +47,7 @@ public sealed class HttpUserOrgMembershipsClient : IUserOrgMembershipsClient
     {
         try
         {
-            var payload = await _http.GetFromJsonAsync<OrgListEnvelope>("/api/auth/me/organizations", ct)
+            var payload = await _http.GetFromJsonAsync<OrgListEnvelope>("/api/auth/me/organizations", JsonDefaults.Api, ct)
                 .ConfigureAwait(false);
             return payload?.Organizations?
                 .Select(o => new UserOrgMembership(o.OrganizationId, o.Name, o.Role))

--- a/src/Apps/Sorcha.Wallet.Pwa/Services/Enrolment/EnrolSessionRedeemer.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Services/Enrolment/EnrolSessionRedeemer.cs
@@ -4,6 +4,7 @@
 using System.Net;
 using System.Net.Http.Json;
 using Microsoft.Extensions.Logging;
+using Sorcha.UI.Core.Extensions;
 
 namespace Sorcha.Wallet.Pwa.Services.Enrolment;
 
@@ -39,7 +40,7 @@ public sealed class EnrolSessionRedeemer : IEnrolSessionRedeemer
 
             if (response.IsSuccessStatusCode)
             {
-                var body = await response.Content.ReadFromJsonAsync<RedeemSuccessShape>(cancellationToken: ct)
+                var body = await response.Content.ReadFromJsonAsync<RedeemSuccessShape>(JsonDefaults.Api, ct)
                     .ConfigureAwait(false);
                 if (body is null || string.IsNullOrEmpty(body.AccessToken))
                 {
@@ -87,7 +88,7 @@ public sealed class EnrolSessionRedeemer : IEnrolSessionRedeemer
     {
         try
         {
-            return await response.Content.ReadFromJsonAsync<ErrorShape>(cancellationToken: ct).ConfigureAwait(false);
+            return await response.Content.ReadFromJsonAsync<ErrorShape>(JsonDefaults.Api, ct).ConfigureAwait(false);
         }
         catch
         {

--- a/src/Apps/Sorcha.Wallet.Pwa/Services/Enrolment/PairingShortCodeRedeemer.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Services/Enrolment/PairingShortCodeRedeemer.cs
@@ -4,6 +4,7 @@
 using System.Net;
 using System.Net.Http.Json;
 using Microsoft.Extensions.Logging;
+using Sorcha.UI.Core.Extensions;
 
 namespace Sorcha.Wallet.Pwa.Services.Enrolment;
 
@@ -41,7 +42,7 @@ public sealed class PairingShortCodeRedeemer : IPairingShortCodeRedeemer
 
             if (response.IsSuccessStatusCode)
             {
-                var body = await response.Content.ReadFromJsonAsync<RedeemSuccessShape>(cancellationToken: ct)
+                var body = await response.Content.ReadFromJsonAsync<RedeemSuccessShape>(JsonDefaults.Api, ct)
                     .ConfigureAwait(false);
                 if (body is null || string.IsNullOrEmpty(body.AccessToken))
                 {
@@ -92,7 +93,7 @@ public sealed class PairingShortCodeRedeemer : IPairingShortCodeRedeemer
     {
         try
         {
-            return await response.Content.ReadFromJsonAsync<ErrorShape>(cancellationToken: ct).ConfigureAwait(false);
+            return await response.Content.ReadFromJsonAsync<ErrorShape>(JsonDefaults.Api, ct).ConfigureAwait(false);
         }
         catch
         {

--- a/src/Apps/Sorcha.Wallet.Pwa/Services/IAuthService.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Services/IAuthService.cs
@@ -5,6 +5,7 @@ using System.Net.Http.Json;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Microsoft.JSInterop;
+using Sorcha.UI.Core.Extensions;
 
 namespace Sorcha.Wallet.Pwa.Services;
 
@@ -143,7 +144,7 @@ public sealed class AuthService : IAuthService
             }
             response.EnsureSuccessStatusCode();
 
-            var body = await response.Content.ReadFromJsonAsync<LoginResponse>(ct);
+            var body = await response.Content.ReadFromJsonAsync<LoginResponse>(JsonDefaults.Api, ct);
             if (body is null) return new SignInResult(SignInStatus.ServerError, "Empty response from auth server.");
 
             if (body.RequiresTwoFactor)
@@ -192,7 +193,7 @@ public sealed class AuthService : IAuthService
             }
             response.EnsureSuccessStatusCode();
 
-            var body = await response.Content.ReadFromJsonAsync<LoginResponse>(ct);
+            var body = await response.Content.ReadFromJsonAsync<LoginResponse>(JsonDefaults.Api, ct);
             if (body is null || string.IsNullOrEmpty(body.AccessToken))
             {
                 return new SignInResult(SignInStatus.ServerError, "Verification succeeded but no token was returned.");
@@ -219,7 +220,7 @@ public sealed class AuthService : IAuthService
                 "api/auth/passkey/assertion/options",
                 new AssertionOptionsRequest(string.IsNullOrWhiteSpace(email) ? null : email.Trim()), ct);
             optionsResp.EnsureSuccessStatusCode();
-            var options = await optionsResp.Content.ReadFromJsonAsync<AssertionOptionsResponse>(ct);
+            var options = await optionsResp.Content.ReadFromJsonAsync<AssertionOptionsResponse>(JsonDefaults.Api, ct);
             if (options is null || string.IsNullOrEmpty(options.TransactionId))
                 return new SignInResult(SignInStatus.ServerError, "Could not start passkey sign-in.");
 
@@ -235,7 +236,7 @@ public sealed class AuthService : IAuthService
                 return new SignInResult(SignInStatus.InvalidCredentials, "That passkey isn't recognised.");
             verifyResp.EnsureSuccessStatusCode();
 
-            var body = await verifyResp.Content.ReadFromJsonAsync<PublicTokenBody>(ct);
+            var body = await verifyResp.Content.ReadFromJsonAsync<PublicTokenBody>(JsonDefaults.Api, ct);
             if (body is null || string.IsNullOrEmpty(body.AccessToken))
                 return new SignInResult(SignInStatus.ServerError, "Passkey sign-in returned no token.");
 
@@ -269,7 +270,7 @@ public sealed class AuthService : IAuthService
                 // wallet surface is always login-only — provider linking happens in the web app, not the PWA
                 new SocialInitiateBody(provider, "login", "wallet"), ct);
             if (!resp.IsSuccessStatusCode) return null;
-            var body = await resp.Content.ReadFromJsonAsync<SocialInitiateBodyResponse>(ct);
+            var body = await resp.Content.ReadFromJsonAsync<SocialInitiateBodyResponse>(JsonDefaults.Api, ct);
             return body?.AuthorizationUrl;
         }
         catch (HttpRequestException) { return null; }

--- a/src/Apps/Sorcha.Wallet.Pwa/Services/IPendingApplicationClient.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Services/IPendingApplicationClient.cs
@@ -3,6 +3,7 @@
 
 using System.Net;
 using System.Net.Http.Json;
+using Sorcha.UI.Core.Extensions;
 
 namespace Sorcha.Wallet.Pwa.Services;
 
@@ -50,7 +51,7 @@ public sealed class HttpPendingApplicationClient : IPendingApplicationClient
         using var response = await _http.GetAsync(Path, ct).ConfigureAwait(false);
         if (response.StatusCode == HttpStatusCode.NotFound) return null;
         response.EnsureSuccessStatusCode();
-        var envelope = await response.Content.ReadFromJsonAsync<PendingApplicationEnvelope>(ct).ConfigureAwait(false);
+        var envelope = await response.Content.ReadFromJsonAsync<PendingApplicationEnvelope>(JsonDefaults.Api, ct).ConfigureAwait(false);
         return envelope?.Notice;
     }
 
@@ -62,7 +63,7 @@ public sealed class HttpPendingApplicationClient : IPendingApplicationClient
             new SetPendingApplicationRequest(label),
             ct).ConfigureAwait(false);
         response.EnsureSuccessStatusCode();
-        var envelope = await response.Content.ReadFromJsonAsync<PendingApplicationEnvelope>(ct).ConfigureAwait(false);
+        var envelope = await response.Content.ReadFromJsonAsync<PendingApplicationEnvelope>(JsonDefaults.Api, ct).ConfigureAwait(false);
         return envelope?.Notice
             ?? throw new InvalidOperationException("Wallet service returned a SetPendingApplication response with no notice.");
     }

--- a/src/Apps/Sorcha.Wallet.Pwa/Services/ISocialProvidersClient.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Services/ISocialProvidersClient.cs
@@ -3,6 +3,7 @@
 
 using System.Net.Http.Json;
 using System.Text.Json.Serialization;
+using Sorcha.UI.Core.Extensions;
 
 namespace Sorcha.Wallet.Pwa.Services;
 
@@ -26,7 +27,7 @@ public sealed class SocialProvidersClient : ISocialProvidersClient
     {
         try
         {
-            var body = await _http.GetFromJsonAsync<ProvidersBody>("api/auth/social/providers", ct);
+            var body = await _http.GetFromJsonAsync<ProvidersBody>("api/auth/social/providers", JsonDefaults.Api, ct);
             return body?.Providers ?? [];
         }
         catch { return []; }

--- a/src/Apps/Sorcha.Wallet.Pwa/Services/Wallet/HasWalletProbe.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Services/Wallet/HasWalletProbe.cs
@@ -5,6 +5,7 @@ using System.Net.Http.Json;
 using System.Text.Json;
 using Microsoft.Extensions.Logging;
 using Sorcha.CitizenWallet.Abstractions.Models;
+using Sorcha.UI.Core.Extensions;
 
 namespace Sorcha.Wallet.Pwa.Services.Wallet;
 
@@ -42,7 +43,7 @@ public sealed class HasWalletProbe : IHasWalletProbe
                 return true;
             }
 
-            var payload = await response.Content.ReadFromJsonAsync<WalletExistsResponse>(cancellationToken: ct)
+            var payload = await response.Content.ReadFromJsonAsync<WalletExistsResponse>(JsonDefaults.Api, ct)
                 .ConfigureAwait(false);
             if (payload is null)
             {

--- a/src/Common/Sorcha.Json/Sorcha.Json.csproj
+++ b/src/Common/Sorcha.Json/Sorcha.Json.csproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <PackageId>Sorcha.Json</PackageId>
+    <PackageId>Sorcha.Serialization</PackageId>
     <Description>Single source of truth for Sorcha's JSON wire format (camelCase properties + KebabCaseLower string enums). Referenced by every service (via ServiceDefaults, for serialization) and by the UI clients (for deserialization) so the two sides can never drift — the class of bug where a client can't decode a server response and silently shows an empty/failed page. Depends only on the framework's System.Text.Json.</Description>
     <PackageTags>sorcha;json;serialization;wire-format</PackageTags>
-    <RootNamespace>Sorcha.Json</RootNamespace>
+    <RootNamespace>Sorcha.Serialization</RootNamespace>
   </PropertyGroup>
 
 </Project>

--- a/src/Common/Sorcha.Json/SorchaJson.cs
+++ b/src/Common/Sorcha.Json/SorchaJson.cs
@@ -4,7 +4,7 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
-namespace Sorcha.Json;
+namespace Sorcha.Serialization;
 
 /// <summary>
 /// The single source of truth for Sorcha's JSON wire format. Both sides derive from it so they can

--- a/src/Common/Sorcha.ServiceClients.Http/Auth/DelegationTokenClient.cs
+++ b/src/Common/Sorcha.ServiceClients.Http/Auth/DelegationTokenClient.cs
@@ -5,6 +5,7 @@ using System.Net.Http.Json;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Microsoft.Extensions.Logging;
+using Sorcha.Serialization;
 
 namespace Sorcha.ServiceClients.Auth;
 
@@ -76,7 +77,7 @@ public class DelegationTokenClient : IDelegationTokenClient
                 return null;
             }
 
-            var tokenResponse = await response.Content.ReadFromJsonAsync<DelegationResponse>(cancellationToken);
+            var tokenResponse = await response.Content.ReadFromJsonAsync<DelegationResponse>(SorchaJson.Options, cancellationToken);
             if (tokenResponse?.AccessToken is null)
             {
                 _logger.LogWarning("Delegation token response was null or missing access_token");

--- a/src/Common/Sorcha.ServiceClients.Http/Auth/ServiceAuthClient.cs
+++ b/src/Common/Sorcha.ServiceClients.Http/Auth/ServiceAuthClient.cs
@@ -5,6 +5,7 @@ using System.Net.Http.Json;
 using System.Text.Json.Serialization;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using Sorcha.Serialization;
 
 namespace Sorcha.ServiceClients.Auth;
 
@@ -115,7 +116,7 @@ public class ServiceAuthClient : IServiceAuthClient, IDisposable
                 return null;
             }
 
-            var tokenResponse = await response.Content.ReadFromJsonAsync<TokenResponse>(cancellationToken);
+            var tokenResponse = await response.Content.ReadFromJsonAsync<TokenResponse>(SorchaJson.Options, cancellationToken);
             if (tokenResponse?.AccessToken is null)
             {
                 _logger.LogWarning(

--- a/src/Common/Sorcha.ServiceClients.Http/Auth/TokenIntrospectionClient.cs
+++ b/src/Common/Sorcha.ServiceClients.Http/Auth/TokenIntrospectionClient.cs
@@ -4,6 +4,7 @@
 using System.Net.Http.Json;
 using System.Text.Json.Serialization;
 using Microsoft.Extensions.Logging;
+using Sorcha.Serialization;
 
 namespace Sorcha.ServiceClients.Auth;
 
@@ -63,7 +64,7 @@ public class TokenIntrospectionClient : ITokenIntrospectionClient
                 return null;
             }
 
-            var result = await response.Content.ReadFromJsonAsync<IntrospectionResponse>(cancellationToken);
+            var result = await response.Content.ReadFromJsonAsync<IntrospectionResponse>(SorchaJson.Options, cancellationToken);
             if (result is null)
             {
                 _logger.LogWarning("Token introspection returned null response");

--- a/src/Common/Sorcha.ServiceClients.Http/Blueprint/BlueprintServiceClient.cs
+++ b/src/Common/Sorcha.ServiceClients.Http/Blueprint/BlueprintServiceClient.cs
@@ -5,6 +5,7 @@ using System.Net.Http.Json;
 using System.Text.Json;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using Sorcha.Serialization;
 using Sorcha.ServiceClients.Auth;
 using Sorcha.ServiceClients.Blueprint.Models;
 using Sorcha.ServiceClients.Helpers;
@@ -109,7 +110,7 @@ public class BlueprintServiceClient : IBlueprintServiceClient
             {
                 BlueprintId = blueprintId,
                 ActionId = actionId,
-                Data = JsonSerializer.Deserialize<JsonElement>(payload)
+                Data = JsonSerializer.Deserialize<JsonElement>(payload, SorchaJson.Options)
             };
 
             await SetAuthHeaderAsync(cancellationToken);
@@ -127,7 +128,7 @@ public class BlueprintServiceClient : IBlueprintServiceClient
                 return false;
             }
 
-            var result = await response.Content.ReadFromJsonAsync<ValidateResponse>(JsonOptions, cancellationToken);
+            var result = await response.Content.ReadFromJsonAsync<ValidateResponse>(SorchaJson.Options, cancellationToken);
 
             if (result?.IsValid == true)
             {
@@ -187,7 +188,7 @@ public class BlueprintServiceClient : IBlueprintServiceClient
                 return null;
             }
 
-            var result = await response.Content.ReadFromJsonAsync<FileChunkRetrievalResponse>(JsonOptions, cancellationToken);
+            var result = await response.Content.ReadFromJsonAsync<FileChunkRetrievalResponse>(SorchaJson.Options, cancellationToken);
             if (result is null)
             {
                 _logger.LogWarning("Empty response retrieving file chunk {ChunkId}", chunkId);
@@ -255,7 +256,7 @@ public class BlueprintServiceClient : IBlueprintServiceClient
                 return null;
             }
 
-            var result = await response.Content.ReadFromJsonAsync<FileChunkSubmissionResponse>(JsonOptions, cancellationToken);
+            var result = await response.Content.ReadFromJsonAsync<FileChunkSubmissionResponse>(SorchaJson.Options, cancellationToken);
 
             if (result is null)
             {
@@ -454,7 +455,7 @@ public class BlueprintServiceClient : IBlueprintServiceClient
                 return null;
             }
 
-            return await response.Content.ReadFromJsonAsync<Rehearsal>(JsonOptions, cancellationToken);
+            return await response.Content.ReadFromJsonAsync<Rehearsal>(SorchaJson.Options, cancellationToken);
         }
         catch (HttpRequestException)
         {
@@ -521,8 +522,8 @@ public class BlueprintServiceClient : IBlueprintServiceClient
         try
         {
             payload = string.IsNullOrWhiteSpace(request.PayloadJson)
-                ? JsonSerializer.Deserialize<JsonElement>("{}")
-                : JsonSerializer.Deserialize<JsonElement>(request.PayloadJson);
+                ? JsonSerializer.Deserialize<JsonElement>("{}", SorchaJson.Options)
+                : JsonSerializer.Deserialize<JsonElement>(request.PayloadJson, SorchaJson.Options);
         }
         catch (JsonException ex)
         {
@@ -555,7 +556,7 @@ public class BlueprintServiceClient : IBlueprintServiceClient
                 return null;
             }
 
-            return await response.Content.ReadFromJsonAsync<Rehearsal>(JsonOptions, cancellationToken);
+            return await response.Content.ReadFromJsonAsync<Rehearsal>(SorchaJson.Options, cancellationToken);
         }
         catch (HttpRequestException)
         {
@@ -588,7 +589,7 @@ public class BlueprintServiceClient : IBlueprintServiceClient
             if (response.StatusCode == System.Net.HttpStatusCode.Conflict)
             {
                 var rehearsal = await response.Content
-                    .ReadFromJsonAsync<RehearsalRequiredError>(JsonOptions, cancellationToken);
+                    .ReadFromJsonAsync<RehearsalRequiredError>(SorchaJson.Options, cancellationToken);
                 return new PublishBlueprintOutcome { RehearsalRequired = rehearsal ?? new RehearsalRequiredError() };
             }
 
@@ -603,7 +604,7 @@ public class BlueprintServiceClient : IBlueprintServiceClient
             }
 
             var result = await response.Content
-                .ReadFromJsonAsync<PublishBlueprintResult>(JsonOptions, cancellationToken);
+                .ReadFromJsonAsync<PublishBlueprintResult>(SorchaJson.Options, cancellationToken);
             return result is null ? null : new PublishBlueprintOutcome { Result = result };
         }
         catch (HttpRequestException ex)
@@ -632,7 +633,7 @@ public class BlueprintServiceClient : IBlueprintServiceClient
                 return null;
             }
 
-            return await response.Content.ReadFromJsonAsync<CloneFromPublishedResult>(JsonOptions, cancellationToken);
+            return await response.Content.ReadFromJsonAsync<CloneFromPublishedResult>(SorchaJson.Options, cancellationToken);
         }
         catch (HttpRequestException)
         {

--- a/src/Common/Sorcha.ServiceClients.Http/CitizenWallet/CitizenWalletClient.cs
+++ b/src/Common/Sorcha.ServiceClients.Http/CitizenWallet/CitizenWalletClient.cs
@@ -7,6 +7,7 @@ using System.Text.Json.Serialization;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Sorcha.CitizenWallet.Abstractions.Models;
+using Sorcha.Serialization;
 
 namespace Sorcha.ServiceClients.CitizenWallet;
 
@@ -62,7 +63,7 @@ public sealed class CitizenWalletClient : ICitizenWalletClient
             "api/v1/wallet/devices/enrol", request, JsonOptions, ct);
         response.EnsureSuccessStatusCode();
 
-        var result = await response.Content.ReadFromJsonAsync<DeviceEnrolmentResponse>(JsonOptions, ct);
+        var result = await response.Content.ReadFromJsonAsync<DeviceEnrolmentResponse>(SorchaJson.Options, ct);
         return result ?? throw new InvalidOperationException(
             "Wallet Service returned an empty body for /devices/enrol.");
     }
@@ -78,7 +79,7 @@ public sealed class CitizenWalletClient : ICitizenWalletClient
         if (response.StatusCode == System.Net.HttpStatusCode.Gone) return null;
         response.EnsureSuccessStatusCode();
 
-        return await response.Content.ReadFromJsonAsync<SyncResponse>(JsonOptions, ct)
+        return await response.Content.ReadFromJsonAsync<SyncResponse>(SorchaJson.Options, ct)
             ?? throw new InvalidOperationException("Wallet Service returned an empty body for /sync.");
     }
 
@@ -88,7 +89,7 @@ public sealed class CitizenWalletClient : ICitizenWalletClient
         var response = await _httpClient.GetAsync("api/v1/wallet/credentials", ct);
         response.EnsureSuccessStatusCode();
 
-        return await response.Content.ReadFromJsonAsync<CredentialListResponse>(JsonOptions, ct)
+        return await response.Content.ReadFromJsonAsync<CredentialListResponse>(SorchaJson.Options, ct)
             ?? throw new InvalidOperationException("Wallet Service returned an empty body for /credentials.");
     }
 
@@ -104,7 +105,7 @@ public sealed class CitizenWalletClient : ICitizenWalletClient
         if (response.StatusCode == System.Net.HttpStatusCode.NotFound) return null;
         response.EnsureSuccessStatusCode();
 
-        return await response.Content.ReadFromJsonAsync<DelegationRenewalResponse>(JsonOptions, ct)
+        return await response.Content.ReadFromJsonAsync<DelegationRenewalResponse>(SorchaJson.Options, ct)
             ?? throw new InvalidOperationException("Wallet Service returned an empty body for /devices/renew-delegation.");
     }
 
@@ -114,7 +115,7 @@ public sealed class CitizenWalletClient : ICitizenWalletClient
         var response = await _httpClient.GetAsync("api/v1/wallet/devices", ct);
         response.EnsureSuccessStatusCode();
 
-        return await response.Content.ReadFromJsonAsync<DeviceListResponse>(JsonOptions, ct)
+        return await response.Content.ReadFromJsonAsync<DeviceListResponse>(SorchaJson.Options, ct)
             ?? throw new InvalidOperationException("Wallet Service returned an empty body for /devices.");
     }
 
@@ -160,7 +161,7 @@ public sealed class CitizenWalletClient : ICitizenWalletClient
         var response = await _httpClient.GetAsync("api/v1/wallet/presentations", ct);
         response.EnsureSuccessStatusCode();
 
-        var result = await response.Content.ReadFromJsonAsync<PresentationHistoryResponse>(JsonOptions, ct)
+        var result = await response.Content.ReadFromJsonAsync<PresentationHistoryResponse>(SorchaJson.Options, ct)
             ?? throw new InvalidOperationException("Wallet Service returned an empty body for /presentations.");
         return result.Entries;
     }
@@ -178,7 +179,7 @@ public sealed class CitizenWalletClient : ICitizenWalletClient
         var response = await _httpClient.GetAsync("api/v1/wallet/pending-applications", ct);
         response.EnsureSuccessStatusCode();
 
-        return await response.Content.ReadFromJsonAsync<PendingApplicationResponse>(JsonOptions, ct)
+        return await response.Content.ReadFromJsonAsync<PendingApplicationResponse>(SorchaJson.Options, ct)
             ?? throw new InvalidOperationException("Wallet Service returned an empty body for /pending-applications.");
     }
 }

--- a/src/Common/Sorcha.ServiceClients.Http/Did/SorchaDidResolver.cs
+++ b/src/Common/Sorcha.ServiceClients.Http/Did/SorchaDidResolver.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Net.Http.Json;
 using Microsoft.Extensions.Logging;
+using Sorcha.Serialization;
 using Sorcha.ServiceClients.Http.Utilities;
 using Sorcha.ServiceClients.Wallet;
 
@@ -99,7 +100,7 @@ public class SorchaDidResolver : IDidResolver
                 .ConfigureAwait(false);
             if (resp.IsSuccessStatusCode)
             {
-                var doc = await resp.Content.ReadFromJsonAsync<DidDocument>(ct).ConfigureAwait(false);
+                var doc = await resp.Content.ReadFromJsonAsync<DidDocument>(SorchaJson.Options, ct).ConfigureAwait(false);
                 if (doc is null)
                     _logger.LogWarning("Published DID document for {Did} parsed to null", did);
                 return doc;

--- a/src/Common/Sorcha.ServiceClients.Http/Did/WebDidResolver.cs
+++ b/src/Common/Sorcha.ServiceClients.Http/Did/WebDidResolver.cs
@@ -5,6 +5,7 @@ using System.Net;
 using System.Text.Json;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using Sorcha.Serialization;
 
 namespace Sorcha.ServiceClients.Did;
 
@@ -18,10 +19,6 @@ public class WebDidResolver : IDidResolver
     private const string Method = "web";
     private static readonly TimeSpan RequestTimeout = TimeSpan.FromSeconds(5);
 
-    private static readonly JsonSerializerOptions JsonOptions = new()
-    {
-        PropertyNameCaseInsensitive = true
-    };
 
     private readonly HttpClient _httpClient;
     private readonly ILogger<WebDidResolver> _logger;
@@ -72,7 +69,7 @@ public class WebDidResolver : IDidResolver
             }
 
             var json = await response.Content.ReadAsStringAsync(cts.Token);
-            var doc = JsonSerializer.Deserialize<DidDocument>(json, JsonOptions);
+            var doc = JsonSerializer.Deserialize<DidDocument>(json, SorchaJson.Options);
 
             if (doc is null)
             {

--- a/src/Common/Sorcha.ServiceClients.Http/Haip/HaipServiceClient.cs
+++ b/src/Common/Sorcha.ServiceClients.Http/Haip/HaipServiceClient.cs
@@ -4,6 +4,7 @@
 using System.Net.Http.Json;
 using System.Text.Json;
 using Microsoft.Extensions.Logging;
+using Sorcha.Serialization;
 using Sorcha.ServiceClients.Auth;
 using Sorcha.ServiceClients.Helpers;
 
@@ -51,7 +52,7 @@ public class HaipServiceClient : IHaipServiceClient
         var response = await _httpClient.PostAsJsonAsync("/api/v1/offers", request, ct);
         response.EnsureSuccessStatusCode();
 
-        var result = await response.Content.ReadFromJsonAsync<JsonElement>(ct);
+        var result = await response.Content.ReadFromJsonAsync<JsonElement>(SorchaJson.Options, ct);
 
         return new CreateOfferResult(
             Guid.Parse(result.GetProperty("offerId").GetString()!),
@@ -78,7 +79,7 @@ public class HaipServiceClient : IHaipServiceClient
         var response = await _httpClient.PostAsJsonAsync("/api/v1/verifier/requests", request, ct);
         response.EnsureSuccessStatusCode();
 
-        var result = await response.Content.ReadFromJsonAsync<JsonElement>(ct);
+        var result = await response.Content.ReadFromJsonAsync<JsonElement>(SorchaJson.Options, ct);
 
         return new CreatePresentationRequestResult(
             Guid.Parse(result.GetProperty("requestId").GetString()!),
@@ -95,7 +96,7 @@ public class HaipServiceClient : IHaipServiceClient
         var response = await _httpClient.GetAsync($"/api/v1/offers/{offerId}", ct);
         if (!response.IsSuccessStatusCode) return null;
 
-        var result = await response.Content.ReadFromJsonAsync<JsonElement>(ct);
+        var result = await response.Content.ReadFromJsonAsync<JsonElement>(SorchaJson.Options, ct);
 
         return new OfferStatusResult(
             Guid.Parse(result.GetProperty("offerId").GetString()!),
@@ -113,7 +114,7 @@ public class HaipServiceClient : IHaipServiceClient
         var response = await _httpClient.GetAsync($"/api/v1/verifier/requests/{requestId}/result", ct);
         if (!response.IsSuccessStatusCode) return null;
 
-        var result = await response.Content.ReadFromJsonAsync<JsonElement>(ct);
+        var result = await response.Content.ReadFromJsonAsync<JsonElement>(SorchaJson.Options, ct);
 
         var isValid = result.TryGetProperty("result", out var resultProp) &&
                      resultProp.ValueKind != JsonValueKind.Null

--- a/src/Common/Sorcha.ServiceClients.Http/Inbox/PlatformInboxClient.cs
+++ b/src/Common/Sorcha.ServiceClients.Http/Inbox/PlatformInboxClient.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Sorcha.ServiceClients.Auth;
 using Sorcha.ServiceClients.Helpers;
+using Sorcha.Serialization;
 
 namespace Sorcha.ServiceClients.Inbox;
 
@@ -73,7 +74,7 @@ public sealed class PlatformInboxClient : IPlatformInboxClient
         using var resp = await _httpClient.PostAsJsonAsync("api/internal/inbox", body, JsonOptions, ct).ConfigureAwait(false);
         resp.EnsureSuccessStatusCode();
 
-        var json = await resp.Content.ReadFromJsonAsync<InboxResponseEnvelope>(JsonOptions, ct).ConfigureAwait(false)
+        var json = await resp.Content.ReadFromJsonAsync<InboxResponseEnvelope>(SorchaJson.Options, ct).ConfigureAwait(false)
             ?? throw new InvalidOperationException("Tenant inbox endpoint returned empty body");
 
         return new InboxWriteOutcome(json.Entry?.Id ?? Guid.Empty, json.Idempotent);
@@ -92,7 +93,7 @@ public sealed class PlatformInboxClient : IPlatformInboxClient
         }
         resp.EnsureSuccessStatusCode();
 
-        var body = await resp.Content.ReadFromJsonAsync<PlatformUserResolutionShape>(JsonOptions, ct).ConfigureAwait(false);
+        var body = await resp.Content.ReadFromJsonAsync<PlatformUserResolutionShape>(SorchaJson.Options, ct).ConfigureAwait(false);
         return body?.PlatformUserId;
     }
 

--- a/src/Common/Sorcha.ServiceClients.Http/Invitation/RegisterInvitationServiceClient.cs
+++ b/src/Common/Sorcha.ServiceClients.Http/Invitation/RegisterInvitationServiceClient.cs
@@ -7,6 +7,7 @@ using System.Text.Json;
 
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using Sorcha.Serialization;
 
 namespace Sorcha.ServiceClients.Invitation;
 
@@ -64,7 +65,7 @@ public sealed class RegisterInvitationServiceClient : IRegisterInvitationService
         }
 
         return (await response.Content.ReadFromJsonAsync<InvitationCreatedResponse>(
-                   JsonOptions, cancellationToken))
+                   SorchaJson.Options, cancellationToken))
                ?? throw new InvalidOperationException("Empty body on create-invitation success.");
     }
 
@@ -88,7 +89,7 @@ public sealed class RegisterInvitationServiceClient : IRegisterInvitationService
         }
 
         return (await response.Content.ReadFromJsonAsync<InvitationAcceptedResponse>(
-                   JsonOptions, cancellationToken))
+                   SorchaJson.Options, cancellationToken))
                ?? throw new InvalidOperationException("Empty body on accept-invitation success.");
     }
 
@@ -107,7 +108,7 @@ public sealed class RegisterInvitationServiceClient : IRegisterInvitationService
         }
 
         return (await response.Content.ReadFromJsonAsync<InvitationListResponse>(
-                   JsonOptions, cancellationToken))
+                   SorchaJson.Options, cancellationToken))
                ?? new InvitationListResponse { Invitations = Array.Empty<InvitationSummary>(), TotalCount = 0 };
     }
 

--- a/src/Common/Sorcha.ServiceClients.Http/IssuanceKey/IssuanceKeyClient.cs
+++ b/src/Common/Sorcha.ServiceClients.Http/IssuanceKey/IssuanceKeyClient.cs
@@ -4,6 +4,7 @@
 using System.Net;
 using System.Net.Http.Json;
 using Microsoft.Extensions.Logging;
+using Sorcha.Serialization;
 
 namespace Sorcha.ServiceClients.IssuanceKey;
 
@@ -91,7 +92,7 @@ public sealed class IssuanceKeyClient : IIssuanceKeyClient
                 return null;
             }
 
-            var result = await resp.Content.ReadFromJsonAsync<SignOnBehalfResponse>(ct).ConfigureAwait(false);
+            var result = await resp.Content.ReadFromJsonAsync<SignOnBehalfResponse>(SorchaJson.Options, ct).ConfigureAwait(false);
             if (result is null) return null;
 
             var sig = Convert.FromBase64String(result.SignatureBase64Url

--- a/src/Common/Sorcha.ServiceClients.Http/Participant/ParticipantServiceClient.cs
+++ b/src/Common/Sorcha.ServiceClients.Http/Participant/ParticipantServiceClient.cs
@@ -4,6 +4,7 @@
 using System.Net.Http.Json;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using Sorcha.Serialization;
 using Sorcha.ServiceClients.Auth;
 using Sorcha.ServiceClients.Helpers;
 
@@ -67,7 +68,7 @@ public class ParticipantServiceClient : IParticipantServiceClient
                 return null;
             }
 
-            return await response.Content.ReadFromJsonAsync<ParticipantInfo>(cancellationToken);
+            return await response.Content.ReadFromJsonAsync<ParticipantInfo>(SorchaJson.Options, cancellationToken);
         }
         catch (Exception ex)
         {
@@ -107,7 +108,7 @@ public class ParticipantServiceClient : IParticipantServiceClient
                 return null;
             }
 
-            return await response.Content.ReadFromJsonAsync<ParticipantInfo>(cancellationToken);
+            return await response.Content.ReadFromJsonAsync<ParticipantInfo>(SorchaJson.Options, cancellationToken);
         }
         catch (Exception ex)
         {
@@ -147,7 +148,7 @@ public class ParticipantServiceClient : IParticipantServiceClient
                 return null;
             }
 
-            return await response.Content.ReadFromJsonAsync<ParticipantInfo>(cancellationToken);
+            return await response.Content.ReadFromJsonAsync<ParticipantInfo>(SorchaJson.Options, cancellationToken);
         }
         catch (Exception ex)
         {
@@ -245,7 +246,7 @@ public class ParticipantServiceClient : IParticipantServiceClient
                 return [];
             }
 
-            var wallets = await response.Content.ReadFromJsonAsync<List<LinkedWalletInfo>>(cancellationToken);
+            var wallets = await response.Content.ReadFromJsonAsync<List<LinkedWalletInfo>>(SorchaJson.Options, cancellationToken);
             return wallets ?? [];
         }
         catch (Exception ex)
@@ -284,7 +285,7 @@ public class ParticipantServiceClient : IParticipantServiceClient
 
             if (response.IsSuccessStatusCode)
             {
-                var result = await response.Content.ReadFromJsonAsync<AutoLinkResultInfo>(cancellationToken);
+                var result = await response.Content.ReadFromJsonAsync<AutoLinkResultInfo>(SorchaJson.Options, cancellationToken);
                 return result ?? new AutoLinkResultInfo { SkipReason = "Empty response" };
             }
 

--- a/src/Common/Sorcha.ServiceClients.Http/Passkey/PasskeyServiceClient.cs
+++ b/src/Common/Sorcha.ServiceClients.Http/Passkey/PasskeyServiceClient.cs
@@ -2,9 +2,9 @@
 // Copyright (c) 2026 Sorcha Contributors
 
 using System.Net.Http.Json;
-using System.Text.Json;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using Sorcha.Serialization;
 
 namespace Sorcha.ServiceClients.Passkey;
 
@@ -16,11 +16,6 @@ public class PasskeyServiceClient : IPasskeyServiceClient
     private readonly HttpClient _httpClient;
     private readonly ILogger<PasskeyServiceClient> _logger;
 
-    private static readonly JsonSerializerOptions JsonOptions = new()
-    {
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-        PropertyNameCaseInsensitive = true
-    };
 
     public PasskeyServiceClient(
         HttpClient httpClient,
@@ -56,7 +51,7 @@ public class PasskeyServiceClient : IPasskeyServiceClient
 
             response.EnsureSuccessStatusCode();
 
-            var result = await response.Content.ReadFromJsonAsync<PasskeyRecoveryKeyInfo>(JsonOptions, ct);
+            var result = await response.Content.ReadFromJsonAsync<PasskeyRecoveryKeyInfo>(SorchaJson.Options, ct);
             _logger.LogDebug("Retrieved passkey public key for user {UserId}", userId);
             return result;
         }

--- a/src/Common/Sorcha.ServiceClients.Http/PlatformUserDevice/PlatformUserDeviceClient.cs
+++ b/src/Common/Sorcha.ServiceClients.Http/PlatformUserDevice/PlatformUserDeviceClient.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Sorcha.ServiceClients.Auth;
 using Sorcha.ServiceClients.Helpers;
+using Sorcha.Serialization;
 
 namespace Sorcha.ServiceClients.PlatformUserDevice;
 
@@ -81,7 +82,7 @@ public sealed class PlatformUserDeviceClient : IPlatformUserDeviceClient
             "api/internal/platform-user-devices", body, JsonOptions, ct);
         response.EnsureSuccessStatusCode();
 
-        var result = await response.Content.ReadFromJsonAsync<PlatformUserDeviceRegistrationResult>(JsonOptions, ct);
+        var result = await response.Content.ReadFromJsonAsync<PlatformUserDeviceRegistrationResult>(SorchaJson.Options, ct);
         return result ?? throw new InvalidOperationException(
             "Tenant Service returned an empty body for platform-user-device registration.");
     }
@@ -99,7 +100,7 @@ public sealed class PlatformUserDeviceClient : IPlatformUserDeviceClient
         if (response.StatusCode == System.Net.HttpStatusCode.NotFound) return null;
         response.EnsureSuccessStatusCode();
 
-        return await response.Content.ReadFromJsonAsync<PlatformUserDeviceLookupResult>(JsonOptions, ct);
+        return await response.Content.ReadFromJsonAsync<PlatformUserDeviceLookupResult>(SorchaJson.Options, ct);
     }
 
     /// <inheritdoc />
@@ -128,7 +129,7 @@ public sealed class PlatformUserDeviceClient : IPlatformUserDeviceClient
             $"api/internal/platform-user-devices?platformUserId={platformUserId}", ct);
         response.EnsureSuccessStatusCode();
 
-        var body = await response.Content.ReadFromJsonAsync<ListResponse>(JsonOptions, ct);
+        var body = await response.Content.ReadFromJsonAsync<ListResponse>(SorchaJson.Options, ct);
         return body?.Devices ?? Array.Empty<PlatformUserDeviceLookupResult>();
     }
 

--- a/src/Common/Sorcha.ServiceClients.Http/Register/RegisterServiceClient.cs
+++ b/src/Common/Sorcha.ServiceClients.Http/Register/RegisterServiceClient.cs
@@ -10,6 +10,7 @@ using Sorcha.Register.Models.LocalRelationship;
 using Sorcha.Register.Models.Observations;
 using Sorcha.ServiceClients.Auth;
 using Sorcha.ServiceClients.Helpers;
+using Sorcha.Serialization;
 
 namespace Sorcha.ServiceClients.Register;
 
@@ -227,7 +228,7 @@ public class RegisterServiceClient : IRegisterServiceClient
                 return null;
             }
 
-            var docket = await response.Content.ReadFromJsonAsync<DocketResponse>(JsonOptions, cancellationToken);
+            var docket = await response.Content.ReadFromJsonAsync<DocketResponse>(SorchaJson.Options, cancellationToken);
             if (docket == null)
             {
                 return null;
@@ -281,7 +282,7 @@ public class RegisterServiceClient : IRegisterServiceClient
                 return null;
             }
 
-            var docket = await response.Content.ReadFromJsonAsync<DocketResponse>(JsonOptions, cancellationToken);
+            var docket = await response.Content.ReadFromJsonAsync<DocketResponse>(SorchaJson.Options, cancellationToken);
             if (docket == null)
             {
                 return null;
@@ -380,7 +381,7 @@ public class RegisterServiceClient : IRegisterServiceClient
                 throw new HttpRequestException($"Failed to submit transaction: {response.StatusCode}");
             }
 
-            var result = await response.Content.ReadFromJsonAsync<TransactionModel>(JsonOptions, cancellationToken);
+            var result = await response.Content.ReadFromJsonAsync<TransactionModel>(SorchaJson.Options, cancellationToken);
             _logger.LogInformation(
                 "Successfully submitted transaction {TransactionId} to register {RegisterId}",
                 transaction.Id, registerId);
@@ -431,7 +432,7 @@ public class RegisterServiceClient : IRegisterServiceClient
                 return null;
             }
 
-            return await response.Content.ReadFromJsonAsync<TransactionModel>(JsonOptions, cancellationToken);
+            return await response.Content.ReadFromJsonAsync<TransactionModel>(SorchaJson.Options, cancellationToken);
         }
         catch (HttpRequestException ex)
         {
@@ -478,7 +479,7 @@ public class RegisterServiceClient : IRegisterServiceClient
                 return new TransactionPage { Page = page, PageSize = pageSize };
             }
 
-            var result = await response.Content.ReadFromJsonAsync<TransactionPage>(JsonOptions, cancellationToken);
+            var result = await response.Content.ReadFromJsonAsync<TransactionPage>(SorchaJson.Options, cancellationToken);
             return result ?? new TransactionPage { Page = page, PageSize = pageSize };
         }
         catch (HttpRequestException ex)
@@ -520,7 +521,7 @@ public class RegisterServiceClient : IRegisterServiceClient
                 return new TransactionPage { Page = page, PageSize = pageSize };
             }
 
-            var transactions = await response.Content.ReadFromJsonAsync<List<TransactionModel>>(JsonOptions, cancellationToken);
+            var transactions = await response.Content.ReadFromJsonAsync<List<TransactionModel>>(SorchaJson.Options, cancellationToken);
             return new TransactionPage
             {
                 Page = page,
@@ -581,7 +582,7 @@ public class RegisterServiceClient : IRegisterServiceClient
                 return new TransactionPage { Page = page, PageSize = pageSize };
             }
 
-            var result = await response.Content.ReadFromJsonAsync<PrevTxIdQueryResponse>(JsonOptions, cancellationToken);
+            var result = await response.Content.ReadFromJsonAsync<PrevTxIdQueryResponse>(SorchaJson.Options, cancellationToken);
             if (result == null)
             {
                 return new TransactionPage { Page = page, PageSize = pageSize };
@@ -641,7 +642,7 @@ public class RegisterServiceClient : IRegisterServiceClient
                 return [];
             }
 
-            var transactions = await response.Content.ReadFromJsonAsync<List<TransactionModel>>(JsonOptions, cancellationToken);
+            var transactions = await response.Content.ReadFromJsonAsync<List<TransactionModel>>(SorchaJson.Options, cancellationToken);
             return transactions ?? [];
         }
         catch (HttpRequestException ex)
@@ -700,7 +701,7 @@ public class RegisterServiceClient : IRegisterServiceClient
                 return new TransactionPage { Page = page, PageSize = pageSize };
             }
 
-            var result = await response.Content.ReadFromJsonAsync<TransactionPage>(JsonOptions, cancellationToken);
+            var result = await response.Content.ReadFromJsonAsync<TransactionPage>(SorchaJson.Options, cancellationToken);
             return result ?? new TransactionPage { Page = page, PageSize = pageSize };
         }
         catch (HttpRequestException ex)
@@ -750,7 +751,7 @@ public class RegisterServiceClient : IRegisterServiceClient
             }
 
             var result = await response.Content.ReadFromJsonAsync<Sorcha.ServiceClients.Register.Models.GovernanceProposalResponse>(
-                JsonOptions, cancellationToken);
+                SorchaJson.Options, cancellationToken);
 
             _logger.LogInformation(
                 "Successfully submitted governance proposal ({OperationType}) to register {RegisterId}",
@@ -810,7 +811,7 @@ public class RegisterServiceClient : IRegisterServiceClient
             }
 
             var result = await response.Content.ReadFromJsonAsync<Sorcha.ServiceClients.Register.Models.GovernanceProposalPage>(
-                JsonOptions, cancellationToken);
+                SorchaJson.Options, cancellationToken);
             return result ?? new Sorcha.ServiceClients.Register.Models.GovernanceProposalPage { Page = page, PageSize = pageSize };
         }
         catch (HttpRequestException ex)
@@ -863,7 +864,7 @@ public class RegisterServiceClient : IRegisterServiceClient
                 return null;
             }
 
-            return await response.Content.ReadFromJsonAsync<GovernanceRosterResponse>(JsonOptions, cancellationToken);
+            return await response.Content.ReadFromJsonAsync<GovernanceRosterResponse>(SorchaJson.Options, cancellationToken);
         }
         catch (HttpRequestException ex)
         {
@@ -999,7 +1000,7 @@ public class RegisterServiceClient : IRegisterServiceClient
                 return null;
             }
 
-            return await response.Content.ReadFromJsonAsync<Sorcha.Register.Models.Register>(JsonOptions, cancellationToken);
+            return await response.Content.ReadFromJsonAsync<Sorcha.Register.Models.Register>(SorchaJson.Options, cancellationToken);
         }
         catch (HttpRequestException ex)
         {
@@ -1049,7 +1050,7 @@ public class RegisterServiceClient : IRegisterServiceClient
                 throw new HttpRequestException($"Failed to create register: {response.StatusCode}");
             }
 
-            var register = await response.Content.ReadFromJsonAsync<Sorcha.Register.Models.Register>(JsonOptions, cancellationToken);
+            var register = await response.Content.ReadFromJsonAsync<Sorcha.Register.Models.Register>(SorchaJson.Options, cancellationToken);
             _logger.LogInformation("Successfully created register {RegisterId}", registerId);
             return register ?? throw new InvalidOperationException("Failed to deserialize register response");
         }
@@ -1096,7 +1097,7 @@ public class RegisterServiceClient : IRegisterServiceClient
             }
 
             var result = await response.Content.ReadFromJsonAsync<InitiateRegisterCreationResponse>(
-                JsonOptions, cancellationToken);
+                SorchaJson.Options, cancellationToken);
             return result ?? throw new InvalidOperationException(
                 "Failed to deserialize register initiation response");
         }
@@ -1143,7 +1144,7 @@ public class RegisterServiceClient : IRegisterServiceClient
             }
 
             var result = await response.Content.ReadFromJsonAsync<FinalizeRegisterCreationResponse>(
-                JsonOptions, cancellationToken);
+                SorchaJson.Options, cancellationToken);
             return result ?? throw new InvalidOperationException(
                 "Failed to deserialize register finalization response");
         }
@@ -1190,7 +1191,7 @@ public class RegisterServiceClient : IRegisterServiceClient
             }
 
             var result = await response.Content.ReadFromJsonAsync<Sorcha.ServiceClients.Register.Models.ParticipantPage>(
-                JsonOptions, cancellationToken);
+                SorchaJson.Options, cancellationToken);
             return result ?? new Sorcha.ServiceClients.Register.Models.ParticipantPage { PageSize = top };
         }
         catch (HttpRequestException ex)
@@ -1222,7 +1223,7 @@ public class RegisterServiceClient : IRegisterServiceClient
             response.EnsureSuccessStatusCode();
 
             return await response.Content.ReadFromJsonAsync<Sorcha.ServiceClients.Register.Models.PublishedParticipantRecord>(
-                JsonOptions, cancellationToken);
+                SorchaJson.Options, cancellationToken);
         }
         catch (HttpRequestException ex)
         {
@@ -1253,7 +1254,7 @@ public class RegisterServiceClient : IRegisterServiceClient
             response.EnsureSuccessStatusCode();
 
             return await response.Content.ReadFromJsonAsync<Sorcha.ServiceClients.Register.Models.PublishedParticipantRecord>(
-                JsonOptions, cancellationToken);
+                SorchaJson.Options, cancellationToken);
         }
         catch (HttpRequestException ex)
         {
@@ -1300,7 +1301,7 @@ public class RegisterServiceClient : IRegisterServiceClient
             response.EnsureSuccessStatusCode();
 
             return await response.Content.ReadFromJsonAsync<Sorcha.ServiceClients.Register.Models.PublishedParticipantRecord>(
-                JsonOptions, cancellationToken);
+                SorchaJson.Options, cancellationToken);
         }
         catch (HttpRequestException ex)
         {
@@ -1345,7 +1346,7 @@ public class RegisterServiceClient : IRegisterServiceClient
             response.EnsureSuccessStatusCode();
 
             return await response.Content.ReadFromJsonAsync<Sorcha.ServiceClients.Register.Models.PublicKeyResolution>(
-                JsonOptions, cancellationToken);
+                SorchaJson.Options, cancellationToken);
         }
         catch (HttpRequestException ex)
         {
@@ -1387,7 +1388,7 @@ public class RegisterServiceClient : IRegisterServiceClient
             }
 
             var result = await response.Content.ReadFromJsonAsync<Sorcha.ServiceClients.Register.Models.BatchPublicKeyResponse>(
-                JsonOptions, cancellationToken);
+                SorchaJson.Options, cancellationToken);
             return result ?? new Sorcha.ServiceClients.Register.Models.BatchPublicKeyResponse();
         }
         catch (HttpRequestException ex)
@@ -1435,7 +1436,7 @@ public class RegisterServiceClient : IRegisterServiceClient
                 return null;
             }
 
-            return await response.Content.ReadFromJsonAsync<RegisterPolicyResponse>(JsonOptions, ct);
+            return await response.Content.ReadFromJsonAsync<RegisterPolicyResponse>(SorchaJson.Options, ct);
         }
         catch (HttpRequestException ex)
         {
@@ -1482,7 +1483,7 @@ public class RegisterServiceClient : IRegisterServiceClient
                 return null;
             }
 
-            return await response.Content.ReadFromJsonAsync<PolicyHistoryResponse>(JsonOptions, ct);
+            return await response.Content.ReadFromJsonAsync<PolicyHistoryResponse>(SorchaJson.Options, ct);
         }
         catch (HttpRequestException ex)
         {
@@ -1568,7 +1569,7 @@ public class RegisterServiceClient : IRegisterServiceClient
             }
 
             var registers = await response.Content.ReadFromJsonAsync<List<InternalRegisterInfo>>(
-                JsonOptions, cancellationToken);
+                SorchaJson.Options, cancellationToken);
 
             return registers ?? [];
         }
@@ -1611,7 +1612,7 @@ public class RegisterServiceClient : IRegisterServiceClient
             }
 
             return await response.Content.ReadFromJsonAsync<SubscriptionNotificationResponse>(
-                JsonOptions, cancellationToken);
+                SorchaJson.Options, cancellationToken);
         }
         catch (HttpRequestException ex)
         {
@@ -1660,7 +1661,7 @@ public class RegisterServiceClient : IRegisterServiceClient
             }
 
             return await response.Content.ReadFromJsonAsync<PublishedBlueprintsResponse>(
-                JsonOptions, cancellationToken);
+                SorchaJson.Options, cancellationToken);
         }
         catch (HttpRequestException ex)
         {
@@ -1797,7 +1798,7 @@ public class RegisterServiceClient : IRegisterServiceClient
                 return null;
             }
 
-            return await response.Content.ReadFromJsonAsync<RegisterLocalRelationship>(JsonOptions, cancellationToken);
+            return await response.Content.ReadFromJsonAsync<RegisterLocalRelationship>(SorchaJson.Options, cancellationToken);
         }
         catch (Exception ex)
         {
@@ -1830,7 +1831,7 @@ public class RegisterServiceClient : IRegisterServiceClient
                 return null;
             }
 
-            return await response.Content.ReadFromJsonAsync<RegisterSyncStateView>(JsonOptions, cancellationToken);
+            return await response.Content.ReadFromJsonAsync<RegisterSyncStateView>(SorchaJson.Options, cancellationToken);
         }
         catch (Exception ex)
         {
@@ -1868,7 +1869,7 @@ public class RegisterServiceClient : IRegisterServiceClient
                 return null;
             }
 
-            var payload = await response.Content.ReadFromJsonAsync<MyValidatedRegistersResponse>(JsonOptions, cancellationToken);
+            var payload = await response.Content.ReadFromJsonAsync<MyValidatedRegistersResponse>(SorchaJson.Options, cancellationToken);
             // A successful response with a null/missing RegisterIds field is treated as an empty
             // set (validator legitimately on no rosters), not a failure.
             return (IReadOnlyList<string>)(payload?.RegisterIds ?? Array.Empty<string>());
@@ -1909,7 +1910,7 @@ public class RegisterServiceClient : IRegisterServiceClient
             }
 
             var payload = await response.Content.ReadFromJsonAsync<RegisterStatsResponse>(
-                JsonOptions, cancellationToken);
+                SorchaJson.Options, cancellationToken);
             return payload ?? new RegisterStatsResponse();
         }
         catch (Exception ex)
@@ -1941,7 +1942,7 @@ public class RegisterServiceClient : IRegisterServiceClient
             }
 
             return await response.Content.ReadFromJsonAsync<RegisterTransactionStatistics>(
-                JsonOptions, cancellationToken);
+                SorchaJson.Options, cancellationToken);
         }
         catch (Exception ex)
         {
@@ -1967,7 +1968,7 @@ public class RegisterServiceClient : IRegisterServiceClient
             }
 
             var registers = await response.Content.ReadFromJsonAsync<List<RegisterSummaryInfo>>(
-                JsonOptions, cancellationToken);
+                SorchaJson.Options, cancellationToken);
 
             if (registers == null)
             {
@@ -2015,7 +2016,7 @@ public class RegisterServiceClient : IRegisterServiceClient
                 return null;
             }
 
-            return await response.Content.ReadFromJsonAsync<TransactionStatusResponse>(JsonOptions, cancellationToken);
+            return await response.Content.ReadFromJsonAsync<TransactionStatusResponse>(SorchaJson.Options, cancellationToken);
         }
         catch (Exception ex)
         {
@@ -2052,7 +2053,7 @@ public class RegisterServiceClient : IRegisterServiceClient
                 return null;
             }
 
-            return await response.Content.ReadFromJsonAsync<MerkleInclusionProof>(JsonOptions, cancellationToken);
+            return await response.Content.ReadFromJsonAsync<MerkleInclusionProof>(SorchaJson.Options, cancellationToken);
         }
         catch (Exception ex)
         {
@@ -2089,7 +2090,7 @@ public class RegisterServiceClient : IRegisterServiceClient
                 return null;
             }
 
-            return await response.Content.ReadFromJsonAsync<VerificationBundle>(JsonOptions, cancellationToken);
+            return await response.Content.ReadFromJsonAsync<VerificationBundle>(SorchaJson.Options, cancellationToken);
         }
         catch (Exception ex)
         {
@@ -2126,7 +2127,7 @@ public class RegisterServiceClient : IRegisterServiceClient
                 return null;
             }
 
-            return await response.Content.ReadFromJsonAsync<RevokeTransactionResult>(JsonOptions, cancellationToken);
+            return await response.Content.ReadFromJsonAsync<RevokeTransactionResult>(SorchaJson.Options, cancellationToken);
         }
         catch (Exception ex)
         {

--- a/src/Common/Sorcha.ServiceClients.Http/Sorcha.ServiceClients.Http.csproj
+++ b/src/Common/Sorcha.ServiceClients.Http/Sorcha.ServiceClients.Http.csproj
@@ -21,6 +21,7 @@
     <ProjectReference Include="..\Sorcha.Register.Models\Sorcha.Register.Models.csproj" />
     <!-- Feature 114: citizen wallet DTO surface -->
     <ProjectReference Include="..\Sorcha.CitizenWallet.Abstractions\Sorcha.CitizenWallet.Abstractions.csproj" />
+    <ProjectReference Include="..\Sorcha.Json\Sorcha.Json.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Common/Sorcha.ServiceClients.Http/Subscription/SubscriptionServiceClient.cs
+++ b/src/Common/Sorcha.ServiceClients.Http/Subscription/SubscriptionServiceClient.cs
@@ -5,6 +5,7 @@ using System.Net.Http.Json;
 using System.Text.Json.Serialization;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using Sorcha.Serialization;
 using Sorcha.ServiceClients.Auth;
 using Sorcha.ServiceClients.Helpers;
 
@@ -89,7 +90,7 @@ public class SubscriptionServiceClient : ISubscriptionServiceClient
                 }
 
                 var result = await response.Content
-                    .ReadFromJsonAsync<SubscriptionListResponse>(cancellationToken);
+                    .ReadFromJsonAsync<SubscriptionListResponse>(SorchaJson.Options, cancellationToken);
 
                 if (result?.Items is null)
                 {

--- a/src/Common/Sorcha.ServiceClients.Http/Trust/TrustServiceClient.cs
+++ b/src/Common/Sorcha.ServiceClients.Http/Trust/TrustServiceClient.cs
@@ -7,6 +7,7 @@ using System.Net.Http.Json;
 using System.Text.Json;
 
 using Microsoft.Extensions.Logging;
+using Sorcha.Serialization;
 
 namespace Sorcha.ServiceClients.Trust;
 
@@ -96,7 +97,7 @@ public sealed class TrustServiceClient : IOrgCertChainProvider
             JsonElement body;
             try
             {
-                body = await response.Content.ReadFromJsonAsync<JsonElement>(ct);
+                body = await response.Content.ReadFromJsonAsync<JsonElement>(SorchaJson.Options, ct);
             }
             catch (Exception ex)
             {

--- a/src/Common/Sorcha.ServiceClients.Http/Wallet/WalletServiceClient.cs
+++ b/src/Common/Sorcha.ServiceClients.Http/Wallet/WalletServiceClient.cs
@@ -6,6 +6,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using Sorcha.Serialization;
 using Sorcha.ServiceClients.Auth;
 using Sorcha.ServiceClients.Helpers;
 
@@ -69,7 +70,7 @@ public class WalletServiceClient : IWalletServiceClient
                 "/api/v1/wallets/system", request, JsonOptions, cancellationToken);
             response.EnsureSuccessStatusCode();
 
-            var result = await response.Content.ReadFromJsonAsync<SystemWalletResponse>(cancellationToken);
+            var result = await response.Content.ReadFromJsonAsync<SystemWalletResponse>(SorchaJson.Options, cancellationToken);
             return result?.Address ?? throw new InvalidOperationException("System wallet response missing address");
         }
         catch (Exception ex)
@@ -104,7 +105,7 @@ public class WalletServiceClient : IWalletServiceClient
 
             response.EnsureSuccessStatusCode();
 
-            var result = await response.Content.ReadFromJsonAsync<SystemWalletResponse>(cancellationToken);
+            var result = await response.Content.ReadFromJsonAsync<SystemWalletResponse>(SorchaJson.Options, cancellationToken);
             return result?.Address ?? throw new InvalidOperationException("Recover response missing address");
         }
         catch (InvalidOperationException)
@@ -174,7 +175,7 @@ public class WalletServiceClient : IWalletServiceClient
 
             response.EnsureSuccessStatusCode();
 
-            var signResponse = await response.Content.ReadFromJsonAsync<SignResponse>(cancellationToken);
+            var signResponse = await response.Content.ReadFromJsonAsync<SignResponse>(SorchaJson.Options, cancellationToken);
             if (signResponse is null)
             {
                 throw new InvalidOperationException("Sign response was null");
@@ -218,7 +219,7 @@ public class WalletServiceClient : IWalletServiceClient
                 "/api/v1/wallets/verify", requestBody, JsonOptions, cancellationToken);
             response.EnsureSuccessStatusCode();
 
-            var result = await response.Content.ReadFromJsonAsync<VerifyResponse>(cancellationToken);
+            var result = await response.Content.ReadFromJsonAsync<VerifyResponse>(SorchaJson.Options, cancellationToken);
             return result?.IsValid ?? false;
         }
         catch (Exception ex)
@@ -248,7 +249,7 @@ public class WalletServiceClient : IWalletServiceClient
                 $"/api/v1/wallets/{recipientWalletAddress}/encrypt", requestBody, JsonOptions, cancellationToken);
             response.EnsureSuccessStatusCode();
 
-            var result = await response.Content.ReadFromJsonAsync<EncryptResponse>(cancellationToken);
+            var result = await response.Content.ReadFromJsonAsync<EncryptResponse>(SorchaJson.Options, cancellationToken);
             return Convert.FromBase64String(result?.EncryptedPayload
                 ?? throw new InvalidOperationException("Encrypt response missing payload"));
         }
@@ -275,7 +276,7 @@ public class WalletServiceClient : IWalletServiceClient
                 $"/api/v1/wallets/{walletAddress}/decrypt", requestBody, JsonOptions, cancellationToken);
             response.EnsureSuccessStatusCode();
 
-            var result = await response.Content.ReadFromJsonAsync<DecryptResponse>(cancellationToken);
+            var result = await response.Content.ReadFromJsonAsync<DecryptResponse>(SorchaJson.Options, cancellationToken);
             return Convert.FromBase64String(result?.DecryptedPayload
                 ?? throw new InvalidOperationException("Decrypt response missing payload"));
         }
@@ -307,7 +308,7 @@ public class WalletServiceClient : IWalletServiceClient
                 $"/api/v1/wallets/{walletAddress}/decrypt", requestBody, JsonOptions, cancellationToken);
             response.EnsureSuccessStatusCode();
 
-            var result = await response.Content.ReadFromJsonAsync<DecryptResponse>(cancellationToken);
+            var result = await response.Content.ReadFromJsonAsync<DecryptResponse>(SorchaJson.Options, cancellationToken);
             return Convert.FromBase64String(result?.DecryptedPayload
                 ?? throw new InvalidOperationException("Decrypt response missing payload"));
         }
@@ -370,7 +371,7 @@ public class WalletServiceClient : IWalletServiceClient
 
             response.EnsureSuccessStatusCode();
 
-            return await response.Content.ReadFromJsonAsync<CredentialIssuanceResult>(cancellationToken)
+            return await response.Content.ReadFromJsonAsync<CredentialIssuanceResult>(SorchaJson.Options, cancellationToken)
                 ?? throw new InvalidOperationException("Credential issuance response was null");
         }
         catch (Exception ex) when (ex is not InvalidOperationException)
@@ -448,7 +449,7 @@ public class WalletServiceClient : IWalletServiceClient
                 return null;
 
             return await response.Content.ReadFromJsonAsync<CredentialIssuanceResult>(
-                JsonOptions, cancellationToken);
+                SorchaJson.Options, cancellationToken);
         }
         catch (Exception ex)
         {
@@ -509,7 +510,7 @@ public class WalletServiceClient : IWalletServiceClient
             }
 
             response.EnsureSuccessStatusCode();
-            return await response.Content.ReadFromJsonAsync<WalletInfo>(cancellationToken);
+            return await response.Content.ReadFromJsonAsync<WalletInfo>(SorchaJson.Options, cancellationToken);
         }
         catch (Exception ex)
         {
@@ -541,7 +542,7 @@ public class WalletServiceClient : IWalletServiceClient
 
             response.EnsureSuccessStatusCode();
             var wallets = await response.Content.ReadFromJsonAsync<List<WalletInfo>>(
-                JsonOptions, cancellationToken);
+                SorchaJson.Options, cancellationToken);
             return wallets ?? (IReadOnlyList<WalletInfo>)Array.Empty<WalletInfo>();
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
@@ -572,7 +573,7 @@ public class WalletServiceClient : IWalletServiceClient
                 "/api/v1/wallets", requestBody, JsonOptions, cancellationToken);
             response.EnsureSuccessStatusCode();
 
-            var createResponse = await response.Content.ReadFromJsonAsync<CreateWalletResponse>(JsonOptions, cancellationToken)
+            var createResponse = await response.Content.ReadFromJsonAsync<CreateWalletResponse>(SorchaJson.Options, cancellationToken)
                 ?? throw new InvalidOperationException("Create wallet response was null");
             return createResponse.Wallet
                 ?? throw new InvalidOperationException("Create wallet response had no wallet data");
@@ -610,7 +611,7 @@ public class WalletServiceClient : IWalletServiceClient
             }
 
             response.EnsureSuccessStatusCode();
-            return await response.Content.ReadFromJsonAsync<OrgMasterKeyProvisionResponse>(JsonOptions, ct);
+            return await response.Content.ReadFromJsonAsync<OrgMasterKeyProvisionResponse>(SorchaJson.Options, ct);
         }
         catch (Exception ex)
         {
@@ -639,7 +640,7 @@ public class WalletServiceClient : IWalletServiceClient
                 $"/api/wallets/org/{orgId}/derive-key", requestBody, JsonOptions, ct);
 
             response.EnsureSuccessStatusCode();
-            return await response.Content.ReadFromJsonAsync<DerivedKeyResponse>(JsonOptions, ct);
+            return await response.Content.ReadFromJsonAsync<DerivedKeyResponse>(SorchaJson.Options, ct);
         }
         catch (Exception ex)
         {
@@ -669,7 +670,7 @@ public class WalletServiceClient : IWalletServiceClient
             }
 
             response.EnsureSuccessStatusCode();
-            return await response.Content.ReadFromJsonAsync<DerivedKeyResponse>(JsonOptions, ct);
+            return await response.Content.ReadFromJsonAsync<DerivedKeyResponse>(SorchaJson.Options, ct);
         }
         catch (Exception ex)
         {
@@ -699,7 +700,7 @@ public class WalletServiceClient : IWalletServiceClient
             }
 
             response.EnsureSuccessStatusCode();
-            return await response.Content.ReadFromJsonAsync<RevokeKeyResponse>(JsonOptions, ct);
+            return await response.Content.ReadFromJsonAsync<RevokeKeyResponse>(SorchaJson.Options, ct);
         }
         catch (Exception ex)
         {

--- a/src/Services/Sorcha.Tenant.Service/Program.cs
+++ b/src/Services/Sorcha.Tenant.Service/Program.cs
@@ -31,10 +31,12 @@ builder.AddSorchaOpenApi("Sorcha Tenant Service API", "Multi-tenant organization
 // Add controllers and minimal API support
 builder.Services.AddEndpointsApiExplorer();
 
-// JSON serialization comes from the single shared source of truth (Sorcha.Json.SorchaJson) so the
-// service's wire format (camelCase + kebab-case string enums — including WebAuthn's "public-key")
-// stays byte-identical to what the UI clients deserialize with. Do not hand-roll the converter here.
-builder.Services.ConfigureHttpJsonOptions(options => Sorcha.Json.SorchaJson.Configure(options.SerializerOptions));
+// JSON serialization uses the single shared source of truth (Sorcha.Serialization.SorchaJson): camelCase
+// properties + kebab-case string enums (WebAuthn needs "public-key"). Applied here rather than platform-
+// wide because other services' responses feed standards surfaces (OAuth/OIDC snake_case, VC tokens) where
+// a uniform casing would be wrong; the clients read both formats, so central control stays here.
+builder.Services.ConfigureHttpJsonOptions(
+    options => Sorcha.Serialization.SorchaJson.Configure(options.SerializerOptions));
 
 // Add CORS - production restriction handled at API Gateway (YARP)
 builder.AddSorchaCors();

--- a/tests/Sorcha.UI.Components.User.Tests/Extensions/SorchaJsonTests.cs
+++ b/tests/Sorcha.UI.Components.User.Tests/Extensions/SorchaJsonTests.cs
@@ -4,7 +4,7 @@
 using System.Linq;
 using System.Text.Json;
 using FluentAssertions;
-using Sorcha.Json;
+using Sorcha.Serialization;
 using Sorcha.Tenant.Models.Persona;
 using Xunit;
 


### PR DESCRIPTION
Completes the single-source-of-truth JSON work (#1087). Every client-side
System.Text.Json HTTP-response deserialization now uses the shared options
(Sorcha.Serialization.SorchaJson.Options, aliased JsonDefaults.Api in the UI), which
read BOTH kebab-case string enums and numeric enums — so the client can decode any
service response regardless of its enum wire format. This closes the whole class of
"reads back empty / couldn't load" bugs (persona, security settings) at the root.

Scope (sweep across the UI, PWA, and service-client projects):
- ~280 bare/local ReadFromJsonAsync/GetFromJsonAsync/Deserialize reads repointed to the
  shared options.
- 9 now-dead local JsonSerializerOptions fields deleted (with their unused usings).
- Local options KEPT (only their READS repointed) where still used for SERIALIZATION —
  the hash/signature-critical transaction/docket write paths in the Register/Wallet/
  Blueprint service clients are untouched (changing serialized bytes would break hash
  verification). Validator's UnsafeRelaxedJsonEscaping options and BlueprintSerialization's
  custom-converter options were flagged and left entirely alone.

Namespace: renamed Sorcha.Json -> Sorcha.Serialization. The `Sorcha.Json` namespace
collided with the `Json.Schema` (JsonSchema.Net) library — inside a Sorcha.* namespace
`Json.Schema` resolved to `Sorcha.Json.Schema` and failed to compile (surfaced once the
shared project became visible in Validator.Service via ServiceClients.Http).

CI gate: scripts/check-json-options.ps1 + json-options-gate.yml fail the build if any
client ReadFromJsonAsync/GetFromJsonAsync is called bare (no options), so new code can't
reintroduce the drift.

Deliberately NOT done (see commit discussion): flipping the other services to kebab
enums platform-wide — kebab is only correct for WebAuthn; OAuth/OIDC/HAIP use snake_case
and W3C VC uses specific tokens, so a uniform casing would break standards surfaces.
Standards enums should instead be pinned per-member ([JsonStringEnumMemberName]) — a
separate follow-up. Clients read both formats, so no server change is needed.

Full solution builds clean; the shared-options unit tests pass; the gate passes.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UDmeAycWwQ5Y8PXuz4iub6
