### PR TITLE
fix: wallet PWA top content sits under the iPhone status bar (safe-area insets)

### DIFF
--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Wallet/WalletHero.razor.css
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Wallet/WalletHero.razor.css
@@ -34,7 +34,12 @@
 .wallet-hero__content {
     position: relative;
     z-index: 1;
-    padding: 8px 16px 26px;
+    /* Push the hero content (greeting row + headline) below the device status bar /
+       notch on installed iOS/Android — Capacitor renders the WebView edge-to-edge
+       (viewport-fit=cover). The gradient background (.wallet-hero__bg, inset:0) stays
+       full-bleed to the top edge; only the content is inset. env() is 0 on non-notched
+       screens (web/desktop), so this is a no-op there. */
+    padding: calc(8px + env(safe-area-inset-top, 0px)) 16px 26px;
 }
 
 .wallet-hero__header {

--- a/src/Apps/Sorcha.Wallet.Pwa/wwwroot/css/app.css
+++ b/src/Apps/Sorcha.Wallet.Pwa/wwwroot/css/app.css
@@ -32,6 +32,21 @@ html, body {
     padding-bottom: calc(116px + env(safe-area-inset-bottom, 0px));
 }
 
+/* Feature 141 — device safe-area (status bar / notch) on installed iOS/Android. The
+   WebView is edge-to-edge (viewport-fit=cover), so the fixed top app bar (shown on every
+   non-Home page — Home's gradient hero handles its own top inset in WalletHero.razor.css)
+   must grow by the top inset and pad its content down, and the content region below it
+   must clear the taller bar. env() is 0 on non-notched screens, so all of this is a no-op
+   on the web/desktop host. */
+.mud-appbar.mud-appbar-fixed-top {
+    padding-top: env(safe-area-inset-top, 0px);
+    height: calc(var(--mud-appbar-height, 64px) + env(safe-area-inset-top, 0px));
+}
+
+.wallet-content:not(.wallet-content--home) {
+    padding-top: calc(var(--mud-appbar-height, 64px) + env(safe-area-inset-top, 0px));
+}
+
 /* Build-version badge — fixed bottom-right corner on every screen so the running
    build is verifiable after a deploy. Tiny, muted, non-interactive; sits in the
    corner clear of the centred floating tab bar. */

--- a/src/Apps/Sorcha.Wallet.Pwa/wwwroot/index.html
+++ b/src/Apps/Sorcha.Wallet.Pwa/wwwroot/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>Sorcha Wallet</title>
     <base href="/wallet/" />
     <link rel="manifest" href="manifest.webmanifest" />


### PR DESCRIPTION
On installed iOS/Android the Capacitor WebView renders edge-to-edge, but the app never
declared viewport-fit=cover and never applied env(safe-area-inset-top), so the Home hero
greeting row ("WELCOME / Your wallet is empty") and the top app bar on other pages render
UP under the device status bar / notch.

- index.html: add viewport-fit=cover so iOS exposes the safe-area-inset-* env() values.
- WalletHero.razor.css: inset the hero CONTENT by env(safe-area-inset-top) while the
  gradient background (inset:0) stays full-bleed to the top edge — preserves the
  edge-to-edge look, just moves the text below the status bar.
- app.css: grow the fixed top app bar by the top inset (+ pad its content) and clear the
  content region below it on non-Home pages.

env(safe-area-inset-*, 0px) evaluates to 0 on non-notched screens, so this is a no-op on
the web/desktop host and only adds spacing on notched devices. The native apps load the PWA
from n1 (server.url), so this reaches them via the n1 redeploy — no store rebuild needed.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UDmeAycWwQ5Y8PXuz4iub6
