### PR TITLE
fix: wallet PWA showed a previous user's cached credentials after a user switch

### DIFF
--- a/src/Apps/Sorcha.Wallet.Pwa/Services/IAccessTokenStore.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Services/IAccessTokenStore.cs
@@ -35,6 +35,17 @@ public interface IAccessTokenStore
 
     /// <summary>Remove the home token (sign out, alongside <see cref="ClearAsync"/>).</summary>
     Task ClearHomeAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// The stable identity (JWT <c>sub</c>) of the user who owns the per-device cache. Written at
+    /// sign-in and used to detect a user switch. DELIBERATELY durable — unlike the access token it
+    /// is NOT cleared on expiry, only by the full sign-out/user-switch purge — so a stale cache left
+    /// by a signed-out-or-expired user is still attributable to them. Returns null on a fresh device.
+    /// </summary>
+    Task<string?> GetDataOwnerAsync(CancellationToken ct = default);
+
+    /// <summary>Records the owner of the per-device cache (the signing-in user's stable id).</summary>
+    Task SetDataOwnerAsync(string ownerId, CancellationToken ct = default);
 }
 
 /// <summary>The wallet's stored access token plus the identity context it carries.</summary>
@@ -49,8 +60,13 @@ public sealed class InMemoryAccessTokenStore : IAccessTokenStore
 {
     private AccessTokenRecord? _record;
     private AccessTokenRecord? _home;
+    private string? _dataOwner;
     /// <inheritdoc />
     public Task<AccessTokenRecord?> GetAsync(CancellationToken ct = default) => Task.FromResult(_record);
+    /// <inheritdoc />
+    public Task<string?> GetDataOwnerAsync(CancellationToken ct = default) => Task.FromResult(_dataOwner);
+    /// <inheritdoc />
+    public Task SetDataOwnerAsync(string ownerId, CancellationToken ct = default) { _dataOwner = ownerId; return Task.CompletedTask; }
     /// <inheritdoc />
     public Task SetAsync(AccessTokenRecord record, CancellationToken ct = default) { _record = record; return Task.CompletedTask; }
     /// <inheritdoc />
@@ -73,6 +89,7 @@ public sealed class IndexedDbAccessTokenStore : IAccessTokenStore
     private const string StoreName = "device";
     private const string Key = "access-token";
     private const string HomeKey = "home-access-token";
+    private const string DataOwnerKey = "data-owner";
 
     private readonly IJSRuntime _js;
 
@@ -151,5 +168,25 @@ public sealed class IndexedDbAccessTokenStore : IAccessTokenStore
     public async Task ClearHomeAsync(CancellationToken ct = default)
     {
         await _js.InvokeVoidAsync("SorchaIndexedDb.del", ct, StoreName, HomeKey);
+    }
+
+    /// <inheritdoc />
+    public async Task<string?> GetDataOwnerAsync(CancellationToken ct = default)
+    {
+        try
+        {
+            return await _js.InvokeAsync<string?>("SorchaIndexedDb.get", ct, StoreName, DataOwnerKey);
+        }
+        catch (JSException)
+        {
+            // See GetAsync — degrade to "unknown owner" when the bridge is absent.
+            return null;
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task SetDataOwnerAsync(string ownerId, CancellationToken ct = default)
+    {
+        await _js.InvokeVoidAsync("SorchaIndexedDb.put", ct, StoreName, ownerId, DataOwnerKey);
     }
 }

--- a/src/Apps/Sorcha.Wallet.Pwa/Services/IAuthService.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Services/IAuthService.cs
@@ -291,12 +291,30 @@ public sealed class AuthService : IAuthService
 
     private async Task PersistAsync(string accessToken, int expiresIn, string? email, string? refreshToken, CancellationToken ct)
     {
+        // Cross-user data-leak guard (Feature 114 — companion-first: one citizen per device). If the
+        // per-device cache belongs to a DIFFERENT user than the one now signing in, wipe every
+        // per-device store BEFORE loading the new session, so the new user never sees the previous
+        // user's credentials / personas / history. The owner marker is durable (not cleared on token
+        // expiry — only by the purge), so this also covers "previous token expired but the cached
+        // credentials lingered". Same-user re-auth (sub matches) keeps the cache.
+        var newOwner = JwtIdentity.ExtractSubject(accessToken) ?? email;
+        var priorOwner = await _store.GetDataOwnerAsync(ct);
+        if (!string.IsNullOrEmpty(priorOwner) && !string.Equals(priorOwner, newOwner, StringComparison.Ordinal))
+        {
+            await _purge.PurgeAsync(ct);
+        }
+
         var record = new AccessTokenRecord(
             accessToken,
             DateTimeOffset.UtcNow.AddSeconds(Math.Max(60, expiresIn)),
             email,
             refreshToken);
         await _store.SetAsync(record, ct);
+
+        if (!string.IsNullOrEmpty(newOwner))
+        {
+            await _store.SetDataOwnerAsync(newOwner, ct);
+        }
     }
 
     private sealed record LoginRequest(string Email, string Password, string Tier);

--- a/src/Apps/Sorcha.Wallet.Pwa/Services/JwtIdentity.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Services/JwtIdentity.cs
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Text.Json;
+
+namespace Sorcha.Wallet.Pwa.Services;
+
+/// <summary>
+/// Reads identity claims out of a JWT access token client-side. This does NOT validate the signature
+/// — it is used only to attribute the per-device cache to a user (the "who owns this data" marker),
+/// never to make an authorization decision. The server remains the sole authority on token validity.
+/// </summary>
+internal static class JwtIdentity
+{
+    /// <summary>
+    /// Extracts the <c>sub</c> (subject — the caller's stable platform user id) claim from a JWT.
+    /// Returns null if the token is missing, malformed, or carries no <c>sub</c>.
+    /// </summary>
+    public static string? ExtractSubject(string? jwt)
+    {
+        if (string.IsNullOrWhiteSpace(jwt)) return null;
+
+        var parts = jwt.Split('.');
+        if (parts.Length < 2) return null;
+
+        try
+        {
+            using var doc = JsonDocument.Parse(Base64UrlDecode(parts[1]));
+            return doc.RootElement.TryGetProperty("sub", out var sub) && sub.ValueKind == JsonValueKind.String
+                ? sub.GetString()
+                : null;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static byte[] Base64UrlDecode(string value)
+    {
+        var s = value.Replace('-', '+').Replace('_', '/');
+        s += (s.Length % 4) switch { 2 => "==", 3 => "=", _ => "" };
+        return Convert.FromBase64String(s);
+    }
+}

--- a/tests/Sorcha.Wallet.Pwa.Tests/Services/AuthServiceUserSwitchTests.cs
+++ b/tests/Sorcha.Wallet.Pwa.Tests/Services/AuthServiceUserSwitchTests.cs
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Moq;
+using Sorcha.Wallet.Pwa.Services;
+using Xunit;
+
+namespace Sorcha.Wallet.Pwa.Tests.Services;
+
+/// <summary>
+/// Guards the cross-user data-leak fix: signing in as a DIFFERENT user (different JWT <c>sub</c>) must
+/// wipe every per-device store first, while re-authenticating as the SAME user must keep the cache.
+/// </summary>
+public sealed class AuthServiceUserSwitchTests
+{
+    private static string B64Url(string s)
+        => Convert.ToBase64String(Encoding.UTF8.GetBytes(s)).TrimEnd('=').Replace('+', '-').Replace('/', '_');
+
+    private static string TokenFor(string sub)
+        => $"{B64Url("{\"alg\":\"none\"}")}.{B64Url($"{{\"sub\":\"{sub}\"}}")}.sig";
+
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        public string Body { get; set; } = "";
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+            => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(Body, Encoding.UTF8, "application/json")
+            });
+    }
+
+    private static string LoginJson(string sub)
+        => $"{{\"access_token\":\"{TokenFor(sub)}\",\"expires_in\":3600,\"requires_two_factor\":false}}";
+
+    private static (AuthService svc, StubHandler handler, Mock<ILocalDataPurge> purge, IAccessTokenStore store) Build()
+    {
+        var handler = new StubHandler();
+        var http = new HttpClient(handler) { BaseAddress = new Uri("http://localhost/") };
+        var store = new InMemoryAccessTokenStore();
+        var purge = new Mock<ILocalDataPurge>();
+        var passkey = new Mock<IPasskeyInterop>();
+        var svc = new AuthService(http, store, purge.Object, passkey.Object);
+        return (svc, handler, purge, store);
+    }
+
+    [Fact]
+    public async Task SignIn_DifferentUser_PurgesLocalDataOnce()
+    {
+        var (svc, handler, purge, store) = Build();
+
+        handler.Body = LoginJson("user-A");
+        (await svc.SignInAsync("a@x.test", "pw")).Status.Should().Be(SignInStatus.Success);
+        purge.Verify(p => p.PurgeAsync(It.IsAny<CancellationToken>()), Times.Never,
+            "first sign-in on a fresh device has no prior owner to purge");
+        (await store.GetDataOwnerAsync()).Should().Be("user-A");
+
+        handler.Body = LoginJson("user-B");
+        (await svc.SignInAsync("b@x.test", "pw")).Status.Should().Be(SignInStatus.Success);
+
+        purge.Verify(p => p.PurgeAsync(It.IsAny<CancellationToken>()), Times.Once,
+            "signing in as a different user must wipe the previous user's per-device cache");
+        (await store.GetDataOwnerAsync()).Should().Be("user-B");
+    }
+
+    [Fact]
+    public async Task SignIn_SameUserReauth_DoesNotPurge()
+    {
+        var (svc, handler, purge, _) = Build();
+
+        handler.Body = LoginJson("user-A");
+        await svc.SignInAsync("a@x.test", "pw");
+        await svc.SignInAsync("a@x.test", "pw"); // same sub — e.g. re-login after expiry
+
+        purge.Verify(p => p.PurgeAsync(It.IsAny<CancellationToken>()), Times.Never,
+            "re-authenticating as the same user must keep their cached credentials");
+    }
+}

--- a/tests/Sorcha.Wallet.Pwa.Tests/Services/JwtIdentityTests.cs
+++ b/tests/Sorcha.Wallet.Pwa.Tests/Services/JwtIdentityTests.cs
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System;
+using System.Text;
+using FluentAssertions;
+using Sorcha.Wallet.Pwa.Services;
+using Xunit;
+
+namespace Sorcha.Wallet.Pwa.Tests.Services;
+
+public sealed class JwtIdentityTests
+{
+    private static string B64Url(string s)
+        => Convert.ToBase64String(Encoding.UTF8.GetBytes(s)).TrimEnd('=').Replace('+', '-').Replace('/', '_');
+
+    private static string Jwt(string payloadJson)
+        => $"{B64Url("{\"alg\":\"none\"}")}.{B64Url(payloadJson)}.sig";
+
+    [Fact]
+    public void ExtractSubject_ReturnsSub()
+        => JwtIdentity.ExtractSubject(Jwt("{\"sub\":\"user-123\",\"aud\":\"sorcha:consumer\"}"))
+            .Should().Be("user-123");
+
+    [Fact]
+    public void ExtractSubject_NoSub_ReturnsNull()
+        => JwtIdentity.ExtractSubject(Jwt("{\"aud\":\"sorcha:consumer\"}")).Should().BeNull();
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("not-a-jwt")]
+    [InlineData("only.two")]                 // 2 segments but middle isn't valid base64url JSON
+    [InlineData("aaa.bbb.ccc")]              // garbage payload
+    public void ExtractSubject_Malformed_ReturnsNull(string? jwt)
+        => JwtIdentity.ExtractSubject(jwt).Should().BeNull();
+
+    [Fact]
+    public void ExtractSubject_SubNotAString_ReturnsNull()
+        => JwtIdentity.ExtractSubject(Jwt("{\"sub\":12345}")).Should().BeNull();
+}


### PR DESCRIPTION
The per-device IndexedDB cache (credentials, personas, history) was only wiped on explicit
sign-out. Every sign-in path funnels through PersistAsync, which never purged — so a
DIFFERENT user signing in without the previous one signing out (or after the previous
token silently expired while the cached data lingered) saw the previous user's credentials.

Fix — a data-ownership guard at sign-in (companion-first: one citizen per device):
- Stamp a durable "data owner" marker (the JWT `sub`) into the device store. Unlike the
  access token it is NOT cleared on expiry — only by the full purge — so a stale cache is
  still attributable to the user who left it.
- In PersistAsync, if the cached data belongs to a different `sub` than the one now signing
  in, wipe every per-device store BEFORE loading the new session. Same-user re-auth keeps
  the cache.
- JwtIdentity.ExtractSubject reads `sub` client-side (identity attribution only — never an
  authz decision; the server remains the token authority).

Tests: JwtIdentityTests + AuthServiceUserSwitchTests (purge once on user switch, never on
same-user re-auth). 326/326 PWA tests green.

Follow-up (in progress): per-user cache CONTENT key derived server-side from the wallet, so
lingering ciphertext is undecryptable by another user even absent a purge (defence in depth).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UDmeAycWwQ5Y8PXuz4iub6
