### PR TITLE
fix: [787] bound unverified-pool transaction retries + evict with operator alert

### DIFF
--- a/src/Services/Sorcha.Validator.Service/Configuration/TransactionPoolPollerConfiguration.cs
+++ b/src/Services/Sorcha.Validator.Service/Configuration/TransactionPoolPollerConfiguration.cs
@@ -44,6 +44,17 @@ public class TransactionPoolPollerConfiguration
     public int MaxRetries { get; set; } = 3;
 
     /// <summary>
+    /// Maximum number of times a transaction may be returned to the unverified pool before it is
+    /// evicted (dropped, not re-submitted) and an operator alert is raised (<c>LogCritical</c> +
+    /// the <c>sorcha_validator_pool_transaction_evicted_total</c> counter). Distinct from
+    /// <see cref="MaxRetries"/> (transient Redis-operation retries): this bounds a transaction's
+    /// *lifetime* in the pool so one that can never be sealed cannot re-submit at ~1 Hz forever
+    /// (issue #787). Set high enough to clear legitimately-delayed transactions given your docket
+    /// cadence; <c>0</c> disables the bound (legacy unbounded behaviour).
+    /// </summary>
+    public int MaxTransactionRetries { get; set; } = 50;
+
+    /// <summary>
     /// Delay between retry attempts
     /// </summary>
     public TimeSpan RetryDelay { get; set; } = TimeSpan.FromMilliseconds(500);

--- a/src/Services/Sorcha.Validator.Service/Services/FederationValidatorMetrics.cs
+++ b/src/Services/Sorcha.Validator.Service/Services/FederationValidatorMetrics.cs
@@ -29,6 +29,18 @@ public sealed class FederationValidatorMetrics
         unit: "{ejection}",
         description: "Validators automatically ejected via a sealed control transaction (US3), by reason.");
 
+    private static readonly Counter<long> _poolTxEvicted = _meter.CreateCounter<long>(
+        "sorcha_validator_pool_transaction_evicted_total",
+        unit: "{transaction}",
+        description: "Transactions evicted from the unverified pool after exceeding the max retry bound (#787) — could not be sealed and were dropped rather than re-submitted forever.");
+
+    /// <summary>
+    /// Record a transaction evicted from the unverified pool after exceeding
+    /// <c>TransactionPoolPollerConfiguration.MaxTransactionRetries</c> (#787). Static so the poller
+    /// can record it without taking a dependency on this instance.
+    /// </summary>
+    public static void PoolTransactionEvicted() => _poolTxEvicted.Add(1);
+
     /// <summary>
     /// Record a rejected vote. <paramref name="reason"/> is one of
     /// <c>not_in_sealed_roster</c>, <c>bad_signature</c>, <c>double_vote</c>.

--- a/src/Services/Sorcha.Validator.Service/Services/TransactionPoolPoller.cs
+++ b/src/Services/Sorcha.Validator.Service/Services/TransactionPoolPoller.cs
@@ -287,15 +287,37 @@ public class TransactionPoolPoller : ITransactionPoolPoller
             transactions.Count, registerId);
 
         var returned = 0;
+        var evicted = 0;
         foreach (var transaction in transactions)
         {
             // Increment retry count
             transaction.RetryCount++;
 
+            // #787 — bound the pool lifetime. A transaction that can never be sealed would otherwise
+            // re-submit at the poll cadence forever with no operator signal. Once it exceeds the
+            // configured bound, evict it (do NOT re-submit) and raise a LogCritical + metric so the
+            // stuck transaction is actionable rather than silently churning.
+            if (_config.MaxTransactionRetries > 0 && transaction.RetryCount > _config.MaxTransactionRetries)
+            {
+                _logger.LogCritical(
+                    "Evicting transaction {TransactionId} from register {RegisterId}'s unverified pool: it could not be sealed after {RetryCount} attempts (limit {MaxTransactionRetries}). It will NOT be retried further and requires operator attention.",
+                    transaction.TransactionId, registerId, transaction.RetryCount, _config.MaxTransactionRetries);
+                FederationValidatorMetrics.PoolTransactionEvicted();
+                evicted++;
+                continue;
+            }
+
             if (await SubmitTransactionAsync(registerId, transaction, ct))
             {
                 returned++;
             }
+        }
+
+        if (evicted > 0)
+        {
+            _logger.LogWarning(
+                "Evicted {Evicted} unsealable transaction(s) from register {RegisterId}'s unverified pool (exceeded {MaxTransactionRetries} retries)",
+                evicted, registerId, _config.MaxTransactionRetries);
         }
 
         Interlocked.Add(ref _totalReturned, returned);

--- a/tests/Sorcha.Validator.Service.Tests/Services/TransactionPoolPollerTests.cs
+++ b/tests/Sorcha.Validator.Service.Tests/Services/TransactionPoolPollerTests.cs
@@ -1198,4 +1198,62 @@ public class TransactionPoolPollerTests
     }
 
     #endregion
+
+    #region ReturnTransactionsAsync retry-bound (#787)
+
+    [Fact]
+    public async Task ReturnTransactionsAsync_ExceedsMaxTransactionRetries_EvictsAndLogsCritical()
+    {
+        // Arrange — a transaction already at the bound; the increment tips it over.
+        _config.MaxTransactionRetries = 2;
+        var poller = new TransactionPoolPoller(_mockRedis.Object, _options, _mockLogger.Object);
+        var stuck = CreateValidTransaction("tx-stuck");
+        stuck.RetryCount = 2; // ++ -> 3 > 2
+
+        // Act
+        await poller.ReturnTransactionsAsync("register-1", new[] { stuck });
+
+        // Assert — evicted (never re-submitted) and flagged for operators.
+        _mockDatabase.Verify(x => x.CreateTransaction(It.IsAny<object>()), Times.Never,
+            "an over-limit transaction must be evicted, not re-submitted to the pool");
+        _mockLogger.Verify(
+            x => x.Log(
+                LogLevel.Critical,
+                It.IsAny<EventId>(),
+                It.IsAny<It.IsAnyType>(),
+                It.IsAny<Exception?>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once,
+            "eviction must raise a LogCritical operator signal");
+    }
+
+    [Fact]
+    public async Task ReturnTransactionsAsync_UnderMaxTransactionRetries_ResubmitsNotEvicted()
+    {
+        // Arrange — comfortably under the bound; must be returned to the pool as before.
+        _config.MaxTransactionRetries = 50;
+        var poller = new TransactionPoolPoller(_mockRedis.Object, _options, _mockLogger.Object);
+        var mockTransaction = new Mock<ITransaction>();
+        _mockDatabase.Setup(x => x.CreateTransaction(It.IsAny<object>())).Returns(mockTransaction.Object);
+        _mockDatabase.Setup(x => x.KeyExistsAsync(It.IsAny<RedisKey>(), It.IsAny<CommandFlags>())).ReturnsAsync(false);
+        mockTransaction.Setup(x => x.ExecuteAsync(It.IsAny<CommandFlags>())).ReturnsAsync(true);
+        var ok = CreateValidTransaction("tx-ok"); // RetryCount 0 -> 1
+
+        // Act
+        await poller.ReturnTransactionsAsync("register-1", new[] { ok });
+
+        // Assert — re-submitted, no eviction alert.
+        _mockDatabase.Verify(x => x.CreateTransaction(It.IsAny<object>()), Times.AtLeastOnce,
+            "an under-limit transaction must be re-submitted to the pool");
+        _mockLogger.Verify(
+            x => x.Log(
+                LogLevel.Critical,
+                It.IsAny<EventId>(),
+                It.IsAny<It.IsAnyType>(),
+                It.IsAny<Exception?>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Never);
+    }
+
+    #endregion
 }


### PR DESCRIPTION
Gap B from #787: `Transaction.RetryCount` was incremented each time a transaction was
returned to the unverified pool (TransactionPoolPoller.ReturnTransactionsAsync) but never
compared against any limit. A transaction that can never be sealed re-submitted at the poll
cadence (~1 Hz) forever, with no LogCritical and no eviction — operators got no actionable
signal (the only bound in the codebase was the genesis-docket-write 3-strike).

- Add TransactionPoolPollerConfiguration.MaxTransactionRetries (default 50; 0 = unbounded /
  legacy). Distinct from MaxRetries, which bounds transient Redis-op retries — this bounds a
  transaction's lifetime in the pool.
- ReturnTransactionsAsync now evicts a transaction once RetryCount exceeds the bound (does NOT
  re-submit) and raises LogCritical + the new sorcha_validator_pool_transaction_evicted_total
  counter (on the existing Sorcha.Validator meter), so a stuck transaction is actionable
  rather than silently churning.

Scoped to Gap B (the highest-value, lowest-risk standalone per the issue triage). Gap A
(pool-drain guard at the roster-change / genesis-failure UnregisterFromMonitoring sites)
remains open on #787. The consensus-failure increment site (ValidatorOrchestrator) is
backstopped: those transactions cycle back through the poller and hit this same bound.

Tests: ReturnTransactionsAsync_ExceedsMaxTransactionRetries_EvictsAndLogsCritical +
_UnderMaxTransactionRetries_ResubmitsNotEvicted. 989/989 validator-service tests green.

Addresses #787 (Gap B).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UDmeAycWwQ5Y8PXuz4iub6
