### PR TITLE
fix: [326] SEC-001 configurable service-level CORS allow-list (defence-in-depth)

### DIFF
--- a/docs/audits/2026-04-01-codebase-audit.md
+++ b/docs/audits/2026-04-01-codebase-audit.md
@@ -6,7 +6,7 @@ Comprehensive audit of dead code, duplicates, constitution compliance, validatio
 
 ## CRITICAL
 
-- [ ] **SEC-001**: CORS `AllowAnyOrigin()` at service level in `src/Common/Sorcha.ServiceDefaults/CorsExtensions.cs:25-27` — any service accessed directly bypasses gateway CORS. Restrict to specific origins or remove service-level CORS entirely.
+- [x] **SEC-001**: CORS `AllowAnyOrigin()` at service level in `src/Common/Sorcha.ServiceDefaults/CorsExtensions.cs` — resolved (#326): `AddSorchaCors` now honours an optional `Cors:AllowedOrigins` allow-list (with credentials) as defence-in-depth, defaulting to the documented gateway-perimeter model when unset. Blueprint's inline duplicate converged onto the shared extension.
 - [x] **SEC-002**: Peer subscribe endpoint `POST /api/registers/{registerId}/subscribe` is `.AllowAnonymous()` in `src/Services/Sorcha.Peer.Service/Program.cs:660` — tracked as #165, must be resolved.
 - [x] **CODE-001**: ~WONTFIX~ 41 direct `new HttpClient(handler)` in Blazor WASM `ServiceCollectionExtensions.cs` — reviewed: this is idiomatic for Blazor WASM where the browser manages connection pooling. Not a socket exhaustion risk. No refactor needed.
 

--- a/src/Common/Sorcha.ServiceDefaults/CorsExtensions.cs
+++ b/src/Common/Sorcha.ServiceDefaults/CorsExtensions.cs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Sorcha Contributors
 
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.Extensions.Hosting;
@@ -11,20 +12,44 @@ namespace Microsoft.Extensions.Hosting;
 public static class CorsExtensions
 {
     /// <summary>
-    /// Registers a permissive CORS policy allowing any origin, method, and header. Suitable for development.
-    /// Production CORS restriction is handled at the API Gateway (YARP) level.
+    /// Registers the shared Sorcha CORS default policy (SEC-001).
+    /// <para>
+    /// <b>Trust boundary:</b> in the standard deployment services are not directly exposed — the API
+    /// Gateway (YARP) is the sole CORS enforcement point and each service port is reachable only
+    /// in-cluster. In that model this policy is permissive (any origin/method/header) by design.
+    /// </para>
+    /// <para>
+    /// <b>Defence-in-depth:</b> set <c>Cors:AllowedOrigins</c> (a string array in
+    /// <c>appsettings.{Environment}.json</c>) to switch the service to an explicit origin allow-list —
+    /// a second line of defence if a service port is ever exposed directly to the internet. With an
+    /// allow-list, credentials are also permitted (safe only with explicit origins; the CORS spec
+    /// forbids credentials alongside <c>AllowAnyOrigin</c>).
+    /// </para>
     /// </summary>
     /// <param name="builder">The host application builder.</param>
     /// <returns>The builder for chaining.</returns>
     public static TBuilder AddSorchaCors<TBuilder>(this TBuilder builder) where TBuilder : IHostApplicationBuilder
     {
+        var allowedOrigins = builder.Configuration
+            .GetSection("Cors:AllowedOrigins").Get<string[]>() ?? Array.Empty<string>();
+
         builder.Services.AddCors(options =>
         {
             options.AddDefaultPolicy(policy =>
             {
-                policy.AllowAnyOrigin()
-                      .AllowAnyMethod()
-                      .AllowAnyHeader();
+                if (allowedOrigins.Length > 0)
+                {
+                    policy.WithOrigins(allowedOrigins)
+                          .AllowAnyMethod()
+                          .AllowAnyHeader()
+                          .AllowCredentials();
+                }
+                else
+                {
+                    policy.AllowAnyOrigin()
+                          .AllowAnyMethod()
+                          .AllowAnyHeader();
+                }
             });
         });
 

--- a/src/Services/Sorcha.Blueprint.Service/Program.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Program.cs
@@ -657,16 +657,9 @@ builder.Services.AddSingleton<IIetfTokenStatusListSerializer, IetfTokenStatusLis
 builder.AddJwtAuthentication();
 builder.Services.AddBlueprintAuthorization();
 
-// Add CORS policy (SEC-005) - production restriction handled at API Gateway (YARP)
-builder.Services.AddCors(options =>
-{
-    options.AddDefaultPolicy(policy =>
-    {
-        policy.AllowAnyOrigin()
-              .AllowAnyMethod()
-              .AllowAnyHeader();
-    });
-});
+// Add CORS policy (SEC-001/SEC-005) — shared policy: gateway-perimeter by default, with an optional
+// Cors:AllowedOrigins service-level allow-list for defence-in-depth. See CorsExtensions.
+builder.AddSorchaCors();
 
 var app = builder.Build();
 var logger = app.Logger;

--- a/tests/Sorcha.ServiceDefaults.Tests/CorsExtensionsTests.cs
+++ b/tests/Sorcha.ServiceDefaults.Tests/CorsExtensionsTests.cs
@@ -1,8 +1,10 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Sorcha Contributors
 
+using System.Collections.Generic;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Cors.Infrastructure;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
@@ -125,5 +127,48 @@ public class CorsExtensionsTests
         defaultPolicy.Should().NotBeNull();
         defaultPolicy!.SupportsCredentials.Should().BeFalse(
             "AllowAnyOrigin and SupportsCredentials are mutually exclusive per the CORS specification");
+    }
+
+    // SEC-001 (#326) — defence-in-depth: an explicit Cors:AllowedOrigins allow-list tightens the policy.
+
+    [Fact]
+    public void AddSorchaCors_WithAllowedOrigins_RestrictsToExplicitOriginsWithCredentials()
+    {
+        // Arrange
+        var builder = WebApplication.CreateBuilder();
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["Cors:AllowedOrigins:0"] = "https://app.sorcha.dev",
+            ["Cors:AllowedOrigins:1"] = "https://n1.sorcha.dev",
+        });
+        builder.AddSorchaCors();
+        var serviceProvider = builder.Services.BuildServiceProvider();
+
+        // Act
+        var corsOptions = serviceProvider.GetRequiredService<IOptions<CorsOptions>>().Value;
+        var policy = corsOptions.GetPolicy(corsOptions.DefaultPolicyName);
+
+        // Assert
+        policy.Should().NotBeNull();
+        policy!.AllowAnyOrigin.Should().BeFalse("an allow-list must not fall back to any-origin");
+        policy.Origins.Should().BeEquivalentTo("https://app.sorcha.dev", "https://n1.sorcha.dev");
+        policy.SupportsCredentials.Should().BeTrue("credentials are safe with an explicit origin allow-list");
+    }
+
+    [Fact]
+    public void AddSorchaCors_WithoutAllowedOrigins_StaysOpen()
+    {
+        // Arrange — no Cors:AllowedOrigins configured => gateway-perimeter default.
+        var builder = WebApplication.CreateBuilder();
+        builder.AddSorchaCors();
+        var serviceProvider = builder.Services.BuildServiceProvider();
+
+        // Act
+        var corsOptions = serviceProvider.GetRequiredService<IOptions<CorsOptions>>().Value;
+        var policy = corsOptions.GetPolicy(corsOptions.DefaultPolicyName);
+
+        // Assert
+        policy!.AllowAnyOrigin.Should().BeTrue();
+        policy.SupportsCredentials.Should().BeFalse("credentials must never be combined with any-origin");
     }
 }


### PR DESCRIPTION
Every service configured CORS with AllowAnyOrigin()/AllowAnyMethod()/AllowAnyHeader().
That relies solely on the API Gateway (YARP) as the CORS enforcement point — fine in-cluster,
but no defence-in-depth if a service port is ever exposed directly.

- AddSorchaCors now reads an optional `Cors:AllowedOrigins` (string[]) from configuration. When
  set, it restricts to those origins and allows credentials (safe only with explicit origins).
  When unset it keeps the documented gateway-perimeter default (AllowAnyOrigin, no credentials),
  so nothing changes for existing deployments — the tightening is opt-in per environment.
- XML doc now states the trust boundary + the config knob explicitly.
- Converged Blueprint Service's inline AddCors duplicate onto the shared AddSorchaCors.
- Ticked the SEC-001 audit checkbox.

Tests: AddSorchaCors_WithAllowedOrigins_RestrictsToExplicitOriginsWithCredentials +
_WithoutAllowedOrigins_StaysOpen. 193/193 ServiceDefaults tests green.

Closes #326.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UDmeAycWwQ5Y8PXuz4iub6
