### PR TITLE
fix: [453] re-enable Sorcha.TransactionHandler.Tests CI gate (flake resolved)

### DIFF
--- a/.github/workflows/nuget-ci.yml
+++ b/.github/workflows/nuget-ci.yml
@@ -116,8 +116,10 @@ jobs:
           # logs — but their non-zero exit does NOT gate this workflow until
           # the underlying issues are resolved. Remove from this list as each
           # project is cleaned up so regressions are caught from then on.
+          # (empty) — Sorcha.TransactionHandler.Tests removed after #453 was verified resolved:
+          # 250/250 pass on Linux, both on a host box and in the exact CI image
+          # (mcr.microsoft.com/dotnet/sdk:10.0). Add a project here only with a tracking issue.
           KNOWN_BROKEN=(
-            "Sorcha.TransactionHandler.Tests"     # 1 Linux-only flake — issue #453
           )
 
           # Test projects still on xunit v2 — direct dll invocation expects


### PR DESCRIPTION
PayloadManagerTests.GrantAccessAsync_NewRecipient_CanDecryptPayload was reported as a
Linux-only failure (deterministic on the CI SDK image) and the project was parked on
nuget-ci's KNOWN_BROKEN list so it wouldn't gate PRs.

Verified resolved on a Linux box (Ubuntu, .NET 10):
- host: 16 sequential runs, 250/250 each — 0 failures.
- exact CI image `mcr.microsoft.com/dotnet/sdk:10.0` (freshly pulled): 250/250 pass,
  including the previously-failing test.

The impl/test are unchanged since the issue was filed, so the platform crypto/OpenSSL
difference behind the original failure was resolved by a base-image/dependency update.
Remove the project from KNOWN_BROKEN so regressions are caught again (per the issue's own
"once fixed, remove from KNOWN_BROKEN" instruction). The mechanism stays for future use.

Closes #453.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UDmeAycWwQ5Y8PXuz4iub6
