### PR TITLE
test: [450] migrate Sorcha.Wallet.Providers.Azure.Tests to xunit.v3 + re-enable in CI

### DIFF
--- a/.github/workflows/nuget-ci.yml
+++ b/.github/workflows/nuget-ci.yml
@@ -122,13 +122,13 @@ jobs:
           KNOWN_BROKEN=(
           )
 
-          # Test projects still on xunit v2 — direct dll invocation expects
-          # xunit.v3's Microsoft.Testing.Platform CLI flags, which v2 doesn't
-          # recognise (fails with FormatException on --report-xunit-trx-*).
-          # Skip until migrated to xunit.v3.
+          # Projects skipped by the direct-dll test runner, which expects xunit.v3's
+          # Microsoft.Testing.Platform CLI flags. Sorcha.Wallet.Providers.Azure.Tests was
+          # migrated to xunit.v3 (#450) and removed. Sorcha.Performance.Tests is an NBomber
+          # load-test EXE (not a xunit unit-test project), so it stays skipped here — it is
+          # not a xunit-v3 migration target.
           XUNIT_V2_PENDING_MIGRATION=(
             "Sorcha.Performance.Tests"
-            "Sorcha.Wallet.Providers.Azure.Tests"
           )
 
           is_in() {

--- a/tests/Sorcha.Wallet.Providers.Azure.Tests/Sorcha.Wallet.Providers.Azure.Tests.csproj
+++ b/tests/Sorcha.Wallet.Providers.Azure.Tests/Sorcha.Wallet.Providers.Azure.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
+    <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
@@ -11,8 +12,11 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="xunit" />
-    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Moq" />
     <PackageReference Include="Azure.Security.KeyVault.Keys" />


### PR DESCRIPTION
The project was on xunit v2, so nuget-ci's direct-dll test runner (which uses xunit.v3's
Microsoft.Testing.Platform CLI flags) couldn't invoke it — it was parked on
XUNIT_V2_PENDING_MIGRATION and never gated PRs.

- Migrate the csproj to xunit.v3 (OutputType=Exe + xunit.v3 + MTP-native runner assets),
  mirroring the other ~40 v3 test projects. The 3 test files use only Fact/Theory/InlineData/
  Assert + Moq + FluentAssertions — no v2-only APIs — so no source changes were needed.
- Remove it from XUNIT_V2_PENDING_MIGRATION so it runs and gates again.
- Clarify Sorcha.Performance.Tests on that list: it's an NBomber load-test EXE, not a xunit
  unit-test project, so it stays skipped for the right reason (not a v3 migration target).

Verified: 25 test cases pass locally and via the exact CI path
(`dotnet <dll> --report-xunit-trx`), including the direct-DLL MTP invocation that v2 broke on.

Closes #450.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UDmeAycWwQ5Y8PXuz4iub6
