### PR TITLE
feat: [327] request-DTO validation seam + both VAL-001 audit-named DTOs (Tenant + Blueprint)

### DIFF
--- a/src/Common/Sorcha.ServiceDefaults/RequestValidationExtensions.cs
+++ b/src/Common/Sorcha.ServiceDefaults/RequestValidationExtensions.cs
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Collections;
+using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace Microsoft.AspNetCore.Builder;
+
+/// <summary>
+/// Minimal-API request-DTO validation (VAL-001, #327). Runs <c>System.ComponentModel.DataAnnotations</c>
+/// attributes (<c>[Required]</c>, <c>[StringLength]</c>, <c>[RegularExpression]</c>, <c>[Range]</c>, …) on
+/// the bound request object and returns RFC 7807 <c>400 ValidationProblem</c> before the handler runs, so
+/// endpoints no longer fall back to ad-hoc null/empty checks (or none at all) deep in the handler.
+/// <para>
+/// The <c>AddInputValidation</c> middleware guards the attack surface (oversized bodies, malformed JSON);
+/// this covers business-logic validation. Apply per endpoint or group with <see cref="WithRequestValidation"/>.
+/// </para>
+/// </summary>
+public static class RequestValidationExtensions
+{
+    /// <summary>Validates bound request DTOs against their DataAnnotations before the handler runs.</summary>
+    public static RouteHandlerBuilder WithRequestValidation(this RouteHandlerBuilder builder)
+        => builder.AddEndpointFilter<RequestValidationFilter>().ProducesValidationProblem();
+
+    /// <summary>Applies request-DTO validation to every endpoint in the group.</summary>
+    public static RouteGroupBuilder WithRequestValidation(this RouteGroupBuilder builder)
+        => builder.AddEndpointFilter<RequestValidationFilter>();
+}
+
+/// <summary>
+/// Endpoint filter that validates each bound request DTO argument (and its nested request DTOs) with
+/// DataAnnotations, short-circuiting to <c>400 ValidationProblem</c> on the first invalid argument.
+/// Only types that actually declare a DataAnnotations attribute on a property are inspected — framework
+/// types, primitives, and injected services are skipped.
+/// </summary>
+public sealed class RequestValidationFilter : IEndpointFilter
+{
+    /// <inheritdoc />
+    public async ValueTask<object?> InvokeAsync(EndpointFilterInvocationContext context, EndpointFilterDelegate next)
+    {
+        foreach (var argument in context.Arguments)
+        {
+            if (argument is null || !ShouldValidate(argument.GetType())) continue;
+
+            var errors = new Dictionary<string, List<string>>(StringComparer.Ordinal);
+            Validate(argument, prefix: string.Empty, errors, new HashSet<object>(ReferenceEqualityComparer.Instance));
+
+            if (errors.Count > 0)
+            {
+                return Results.ValidationProblem(errors.ToDictionary(kvp => kvp.Key, kvp => kvp.Value.ToArray()));
+            }
+        }
+
+        return await next(context);
+    }
+
+    private static void Validate(object instance, string prefix, Dictionary<string, List<string>> errors, HashSet<object> visited)
+    {
+        if (!visited.Add(instance)) return; // cycle guard
+
+        var results = new List<ValidationResult>();
+        Validator.TryValidateObject(instance, new ValidationContext(instance), results, validateAllProperties: true);
+
+        foreach (var result in results)
+        {
+            var members = result.MemberNames.Any() ? result.MemberNames : new[] { string.Empty };
+            foreach (var member in members)
+            {
+                var key = Combine(prefix, member);
+                if (!errors.TryGetValue(key, out var list)) errors[key] = list = new List<string>();
+                list.Add(result.ErrorMessage ?? "Invalid value.");
+            }
+        }
+
+        // Recurse into nested request DTOs so their attributes are enforced too (e.g. Branding on
+        // CreateOrganizationRequest). Collections of DTOs are validated element-by-element.
+        foreach (var property in instance.GetType().GetProperties())
+        {
+            if (property.GetIndexParameters().Length > 0) continue;
+
+            object? value;
+            try { value = property.GetValue(instance); }
+            catch { continue; }
+            if (value is null) continue;
+
+            if (ShouldValidate(value.GetType()))
+            {
+                Validate(value, Combine(prefix, property.Name), errors, visited);
+            }
+            else if (value is IEnumerable enumerable and not string)
+            {
+                foreach (var item in enumerable)
+                {
+                    if (item is not null && ShouldValidate(item.GetType()))
+                    {
+                        Validate(item, Combine(prefix, property.Name), errors, visited);
+                    }
+                }
+            }
+        }
+    }
+
+    private static string Combine(string prefix, string member)
+        => string.IsNullOrEmpty(prefix) ? member : string.IsNullOrEmpty(member) ? prefix : $"{prefix}.{member}";
+
+    private static readonly System.Collections.Concurrent.ConcurrentDictionary<Type, bool> Validatable = new();
+
+    // A type is validated iff it declares at least one DataAnnotations attribute on a property. Precise
+    // (injected services, framework types, and primitives are skipped) and needs no namespace convention
+    // or marker interface. Cached per type.
+    private static bool ShouldValidate(Type type)
+    {
+        if (!type.IsClass || type == typeof(string)) return false;
+        if (type.Namespace is { } ns &&
+            (ns.StartsWith("System", StringComparison.Ordinal) || ns.StartsWith("Microsoft", StringComparison.Ordinal)))
+        {
+            return false;
+        }
+        return Validatable.GetOrAdd(type, static t =>
+            t.GetProperties().Any(p => p.GetCustomAttributes(typeof(ValidationAttribute), inherit: true).Length > 0));
+    }
+}

--- a/src/Services/Sorcha.Blueprint.Service/Models/Requests/ActionSubmissionRequest.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Models/Requests/ActionSubmissionRequest.cs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Sorcha Contributors
 
+using System.ComponentModel.DataAnnotations;
 using Sorcha.Blueprint.Models.Credentials;
 using Sorcha.ServiceClients.Register.Models;
 
@@ -14,36 +15,47 @@ public record ActionSubmissionRequest
     /// <summary>
     /// The blueprint ID
     /// </summary>
+    [Required(AllowEmptyStrings = false)]
+    [StringLength(256)]
     public required string BlueprintId { get; init; }
 
     /// <summary>
     /// The action ID within the blueprint
     /// </summary>
+    [Required(AllowEmptyStrings = false)]
+    [StringLength(128)]
     public required string ActionId { get; init; }
 
     /// <summary>
     /// The workflow instance ID (optional, will be generated if not provided for first action)
     /// </summary>
+    [StringLength(128)]
     public string? InstanceId { get; init; }
 
     /// <summary>
     /// Hash of the previous transaction in the workflow (optional, for action chaining)
     /// </summary>
+    [StringLength(256)]
     public string? PreviousTransactionHash { get; init; }
 
     /// <summary>
     /// The wallet address of the submitter
     /// </summary>
+    [Required(AllowEmptyStrings = false)]
+    [StringLength(256)]
     public required string SenderWallet { get; init; }
 
     /// <summary>
     /// The register address where the transaction will be submitted
     /// </summary>
+    [Required(AllowEmptyStrings = false)]
+    [StringLength(256)]
     public required string RegisterAddress { get; init; }
 
     /// <summary>
     /// The action payload data
     /// </summary>
+    [Required]
     public required Dictionary<string, object> PayloadData { get; init; }
 
     /// <summary>
@@ -74,15 +86,20 @@ public record FileAttachment
     /// <summary>
     /// The file name
     /// </summary>
+    [Required(AllowEmptyStrings = false)]
+    [StringLength(260)]
     public required string FileName { get; init; }
 
     /// <summary>
     /// The content type (MIME type)
     /// </summary>
+    [Required(AllowEmptyStrings = false)]
+    [StringLength(200)]
     public required string ContentType { get; init; }
 
     /// <summary>
     /// Base64-encoded file content
     /// </summary>
+    [Required(AllowEmptyStrings = false)]
     public required string ContentBase64 { get; init; }
 }

--- a/src/Services/Sorcha.Blueprint.Service/Program.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Program.cs
@@ -1658,6 +1658,7 @@ actionsGroup.MapPost("/", async (
         return Results.Problem("An error occurred processing the request.", statusCode: 400);
     }
 })
+.WithRequestValidation()
 .WithName("SubmitAction")
 .WithSummary("Submit an action")
 .WithDescription("Submit a new action for execution in a blueprint workflow");
@@ -2429,6 +2430,7 @@ instancesGroup.MapPost("/{instanceId}/actions/{actionId}/execute", async (
         return Results.Problem("An error occurred processing the request.", statusCode: 400);
     }
 })
+.WithRequestValidation()
 .WithName("ExecuteAction")
 .WithSummary("Execute action with orchestration")
 .WithDescription("Execute an action in a workflow instance with full orchestration: state reconstruction, validation, routing, transaction building, and notification. Requires X-Delegation-Token header.");

--- a/src/Services/Sorcha.Tenant.Service/Endpoints/OrganizationEndpoints.cs
+++ b/src/Services/Sorcha.Tenant.Service/Endpoints/OrganizationEndpoints.cs
@@ -32,6 +32,7 @@ public static class OrganizationEndpoints
 
         // Organization CRUD
         group.MapPost("/", CreateOrganization)
+            .WithRequestValidation()
             .WithName("CreateOrganization")
             .WithSummary("Create a new organization")
             .WithDescription("Creates a new organization. The authenticated user becomes the organization administrator.")
@@ -100,6 +101,7 @@ public static class OrganizationEndpoints
             .Produces<OrganizationStatsResponse>();
 
         group.MapPut("/{id:guid}", UpdateOrganization)
+            .WithRequestValidation()
             .WithName("UpdateOrganization")
             .WithSummary("Update an organization")
             .WithDescription("Updates an existing organization. Requires administrator role.")

--- a/src/Services/Sorcha.Tenant.Service/Endpoints/PlatformOrgEndpoints.cs
+++ b/src/Services/Sorcha.Tenant.Service/Endpoints/PlatformOrgEndpoints.cs
@@ -25,6 +25,7 @@ public static class PlatformOrgEndpoints
             .WithTags("Platform Organisations");
 
         group.MapPost("/", CreateOrganization)
+            .WithRequestValidation()
             .WithName("AdminCreateOrganization")
             .WithSummary("Admin-initiated organisation creation with invite")
             .WithDescription("Creates a private org and invites the specified admin by email. " +

--- a/src/Services/Sorcha.Tenant.Service/Models/Dtos/OrganizationDtos.cs
+++ b/src/Services/Sorcha.Tenant.Service/Models/Dtos/OrganizationDtos.cs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Sorcha Contributors
 
+using System.ComponentModel.DataAnnotations;
+
 namespace Sorcha.Tenant.Service.Models.Dtos;
 
 /// <summary>
@@ -11,11 +13,16 @@ public record CreateOrganizationRequest
     /// <summary>
     /// Organization display name.
     /// </summary>
+    [Required(AllowEmptyStrings = false)]
+    [StringLength(100, MinimumLength = 1)]
     public required string Name { get; init; }
 
     /// <summary>
-    /// Unique subdomain (3-50 alphanumeric characters with hyphens).
+    /// Unique subdomain (3-50 lowercase letters, digits, or hyphens).
     /// </summary>
+    [Required(AllowEmptyStrings = false)]
+    [StringLength(50, MinimumLength = 3)]
+    [RegularExpression("^[a-z0-9-]+$", ErrorMessage = "Subdomain must contain only lowercase letters, digits, and hyphens.")]
     public required string Subdomain { get; init; }
 
     /// <summary>
@@ -32,6 +39,7 @@ public record UpdateOrganizationRequest
     /// <summary>
     /// Updated organization name.
     /// </summary>
+    [StringLength(100, MinimumLength = 1)]
     public string? Name { get; init; }
 
     /// <summary>
@@ -53,21 +61,26 @@ public record BrandingConfigurationDto
     /// <summary>
     /// URL to organization logo (HTTPS required).
     /// </summary>
+    [StringLength(2048)]
+    [RegularExpression(@"^https://.+", ErrorMessage = "LogoUrl must be an https:// URL.")]
     public string? LogoUrl { get; init; }
 
     /// <summary>
-    /// Primary brand color (hex format).
+    /// Primary brand color (hex format, e.g. #1A2B3C).
     /// </summary>
+    [RegularExpression("^#[0-9a-fA-F]{6}$", ErrorMessage = "PrimaryColor must be a 6-digit hex colour, e.g. #1A2B3C.")]
     public string? PrimaryColor { get; init; }
 
     /// <summary>
-    /// Secondary brand color (hex format).
+    /// Secondary brand color (hex format, e.g. #1A2B3C).
     /// </summary>
+    [RegularExpression("^#[0-9a-fA-F]{6}$", ErrorMessage = "SecondaryColor must be a 6-digit hex colour, e.g. #1A2B3C.")]
     public string? SecondaryColor { get; init; }
 
     /// <summary>
     /// Company tagline.
     /// </summary>
+    [StringLength(200)]
     public string? CompanyTagline { get; init; }
 }
 
@@ -135,16 +148,22 @@ public record AdminCreateOrganizationRequest
     /// <summary>
     /// Organisation display name (3-100 characters).
     /// </summary>
+    [Required(AllowEmptyStrings = false)]
+    [StringLength(100, MinimumLength = 3)]
     public required string Name { get; init; }
 
     /// <summary>
     /// Unique subdomain (3-50 chars, lowercase alphanumeric + hyphens).
     /// </summary>
+    [Required(AllowEmptyStrings = false)]
+    [StringLength(50, MinimumLength = 3)]
+    [RegularExpression("^[a-z0-9-]+$", ErrorMessage = "Subdomain must contain only lowercase letters, digits, and hyphens.")]
     public required string Subdomain { get; init; }
 
     /// <summary>
     /// Optional organisation description (max 500 characters).
     /// </summary>
+    [StringLength(500)]
     public string? Description { get; init; }
 
     /// <summary>
@@ -152,6 +171,9 @@ public record AdminCreateOrganizationRequest
     /// If the email matches an existing PlatformUser, they are added directly.
     /// If new, a pending invitation is created for acceptance on signup.
     /// </summary>
+    [Required(AllowEmptyStrings = false)]
+    [EmailAddress]
+    [StringLength(254)]
     public required string AdminEmail { get; init; }
 
     /// <summary>

--- a/tests/Sorcha.Blueprint.Service.Tests/ActionSubmissionRequestValidationTests.cs
+++ b/tests/Sorcha.Blueprint.Service.Tests/ActionSubmissionRequestValidationTests.cs
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Sorcha.Blueprint.Service.Models.Requests;
+
+namespace Sorcha.Blueprint.Service.Tests;
+
+/// <summary>
+/// Hot-path safety for VAL-001 (#327): the RequestValidationFilter is applied to the action-submission
+/// endpoints, so a realistic *valid* <see cref="ActionSubmissionRequest"/> MUST pass (no false-reject of
+/// the flow every workflow/walkthrough uses), while a missing required field MUST 400 before the handler.
+/// </summary>
+public class ActionSubmissionRequestValidationTests
+{
+    private static async Task<(object? Result, bool NextCalled)> RunAsync(object dto)
+    {
+        var filter = new RequestValidationFilter();
+        var context = EndpointFilterInvocationContext.Create(new DefaultHttpContext(), dto);
+        var nextCalled = false;
+        EndpointFilterDelegate next = _ =>
+        {
+            nextCalled = true;
+            return ValueTask.FromResult<object?>(Results.Ok());
+        };
+        var result = await filter.InvokeAsync(context, next);
+        return (result, nextCalled);
+    }
+
+    private static ActionSubmissionRequest ValidRequest() => new()
+    {
+        BlueprintId = "construction-permit-20260702142305",
+        ActionId = "1",
+        InstanceId = "e74f9a00-df05-430a-ac4b-5fd0afc25930",
+        SenderWallet = "ws11qpcddjp77xyzz3lea9m4jpwq5kk8k8pl5kuvsncylqyx25da9eapuunlcqf",
+        RegisterAddress = "be0658c487284081afea893b6d6d2065",
+        PayloadData = new Dictionary<string, object> { ["projectName"] = "Riverside" },
+        Files = new List<FileAttachment>
+        {
+            new() { FileName = "site.jpg", ContentType = "image/jpeg", ContentBase64 = "iVBORw0KGgo=" },
+        },
+    };
+
+    [Fact]
+    public async Task RealisticValidSubmission_PassesFilter()
+    {
+        var (_, nextCalled) = await RunAsync(ValidRequest());
+        nextCalled.Should().BeTrue("a valid action submission must not be rejected by input validation");
+    }
+
+    [Fact]
+    public async Task EmptyBlueprintId_Rejected400()
+    {
+        var (result, nextCalled) = await RunAsync(ValidRequest() with { BlueprintId = "" });
+        nextCalled.Should().BeFalse();
+        (result as IStatusCodeHttpResult)?.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
+    }
+
+    [Fact]
+    public async Task FileAttachmentMissingContent_Rejected400()
+    {
+        var bad = ValidRequest() with
+        {
+            Files = new List<FileAttachment>
+            {
+                new() { FileName = "x.jpg", ContentType = "image/jpeg", ContentBase64 = "" },
+            },
+        };
+        var (result, nextCalled) = await RunAsync(bad);
+        nextCalled.Should().BeFalse("a file attachment with empty content must be rejected");
+        (result as IStatusCodeHttpResult)?.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
+    }
+}

--- a/tests/Sorcha.ServiceDefaults.Tests/RequestValidationFilterTests.cs
+++ b/tests/Sorcha.ServiceDefaults.Tests/RequestValidationFilterTests.cs
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.ComponentModel.DataAnnotations;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+
+namespace Sorcha.ServiceDefaults.Tests;
+
+/// <summary>
+/// Tests for <see cref="RequestValidationFilter"/> (VAL-001, #327) — DataAnnotations on request DTOs
+/// short-circuit to 400 ValidationProblem before the handler runs; valid requests pass through.
+/// </summary>
+public class RequestValidationFilterTests
+{
+    public record SampleRequest
+    {
+        [Required(AllowEmptyStrings = false)]
+        [StringLength(10, MinimumLength = 2)]
+        public string? Name { get; init; }
+
+        public SampleNested? Nested { get; init; }
+    }
+
+    public record SampleNested
+    {
+        [RegularExpression("^#[0-9a-fA-F]{6}$")]
+        public string? Colour { get; init; }
+    }
+
+    // Type with no validation attributes — must be skipped entirely (e.g. an injected service arg).
+    public record NoAttributes
+    {
+        public string? Anything { get; init; }
+    }
+
+    private static async Task<(object? Result, bool NextCalled)> RunAsync(object dto)
+    {
+        var filter = new RequestValidationFilter();
+        var context = EndpointFilterInvocationContext.Create(new DefaultHttpContext(), dto);
+        var nextCalled = false;
+        EndpointFilterDelegate next = _ =>
+        {
+            nextCalled = true;
+            return ValueTask.FromResult<object?>(Results.Ok());
+        };
+        var result = await filter.InvokeAsync(context, next);
+        return (result, nextCalled);
+    }
+
+    private static int? StatusOf(object? result) => (result as IStatusCodeHttpResult)?.StatusCode;
+
+    [Fact]
+    public async Task Valid_CallsNext()
+    {
+        var (_, nextCalled) = await RunAsync(new SampleRequest { Name = "OK" });
+        nextCalled.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task MissingRequired_ShortCircuitsWith400()
+    {
+        var (result, nextCalled) = await RunAsync(new SampleRequest { Name = "" });
+        nextCalled.Should().BeFalse("an invalid request must not reach the handler");
+        StatusOf(result).Should().Be(StatusCodes.Status400BadRequest);
+    }
+
+    [Fact]
+    public async Task TooShort_ShortCircuitsWith400()
+    {
+        var (result, nextCalled) = await RunAsync(new SampleRequest { Name = "x" }); // min length 2
+        nextCalled.Should().BeFalse();
+        StatusOf(result).Should().Be(StatusCodes.Status400BadRequest);
+    }
+
+    [Fact]
+    public async Task InvalidNestedDto_ShortCircuitsWith400()
+    {
+        var (result, nextCalled) = await RunAsync(
+            new SampleRequest { Name = "OK", Nested = new SampleNested { Colour = "not-a-colour" } });
+        nextCalled.Should().BeFalse("nested request DTOs must be validated too");
+        StatusOf(result).Should().Be(StatusCodes.Status400BadRequest);
+    }
+
+    [Fact]
+    public async Task ValidNestedDto_CallsNext()
+    {
+        var (_, nextCalled) = await RunAsync(
+            new SampleRequest { Name = "OK", Nested = new SampleNested { Colour = "#1A2B3C" } });
+        nextCalled.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task TypeWithoutAttributes_IsSkipped_CallsNext()
+    {
+        var (_, nextCalled) = await RunAsync(new NoAttributes { Anything = "" });
+        nextCalled.Should().BeTrue("types with no validation attributes (e.g. injected services) are not validated");
+    }
+}


### PR DESCRIPTION
- **test: [450] migrate Sorcha.Wallet.Providers.Azure.Tests to xunit.v3 + re-enable in CI**
- **feat: [327] request-DTO validation seam + annotate Tenant organisation DTOs (VAL-001)**
