### PR TITLE
fix: [344] verify request-object JWT signature per RFC 9101 §4 (+ optional key pin)

### DIFF
--- a/src/Apps/Sorcha.Agent/Commands/HaipPresentCommand.cs
+++ b/src/Apps/Sorcha.Agent/Commands/HaipPresentCommand.cs
@@ -1,9 +1,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Sorcha Contributors
 
-using System.Buffers.Text;
 using System.CommandLine;
-using System.Net.Http.Json;
 using System.Text.Json;
 using Sorcha.Agent.Haip;
 using Sorcha.Cryptography.SdJwt;
@@ -37,11 +35,18 @@ public class HaipPresentCommand : Command
             Description = "Wallet directory for keys and credentials",
             DefaultValueFactory = _ => "./wallet"
         };
+        var verifierThumbprintOption = new Option<string?>("--verifier-jwk-thumbprint")
+        {
+            Description = "RFC 7638 thumbprint of the trusted verifier's signing jwk. When set, the signed " +
+                          "request object's key is pinned to it (RFC 9101 §4 trust anchor); a mismatch is refused. " +
+                          "When omitted, the signature is still verified for integrity but the key is unpinned."
+        };
 
         Options.Add(requestUriOption);
         Options.Add(credentialOption);
         Options.Add(discloseOption);
         Options.Add(walletDirOption);
+        Options.Add(verifierThumbprintOption);
 
         this.SetAction(async (parseResult, cancellationToken) =>
         {
@@ -49,14 +54,15 @@ public class HaipPresentCommand : Command
             var credentialType = parseResult.GetValue(credentialOption)!;
             var disclose = parseResult.GetValue(discloseOption)!;
             var walletDir = parseResult.GetValue(walletDirOption) ?? "./wallet";
+            var verifierThumbprint = parseResult.GetValue(verifierThumbprintOption);
 
-            return await ExecuteAsync(requestUri, credentialType, disclose, walletDir, cancellationToken);
+            return await ExecuteAsync(requestUri, credentialType, disclose, walletDir, verifierThumbprint, cancellationToken);
         });
     }
 
     private static async Task<int> ExecuteAsync(
         string requestUri, string credentialType, string disclose,
-        string walletDir, CancellationToken ct)
+        string walletDir, string? expectedVerifierJwkThumbprint, CancellationToken ct)
     {
         try
         {
@@ -81,23 +87,19 @@ public class HaipPresentCommand : Command
 
             using var httpClient = new HttpClient();
 
-            // Step 3: Fetch the request object. Per RFC 9101 §4 the verifier
-            // returns a signed JWT with content-type
-            // application/oauth-authz-req+jwt. The claims live in the JWT
-            // payload, so decode it rather than parsing the raw response as
-            // JSON. Signature verification is the verifier's job on
-            // direct_post — we only need the payload to build the
-            // presentation. Feature 107 PR 2 fix.
+            // Step 3: Fetch the request object. Per RFC 9101 §4 the verifier returns a signed JWT
+            // (application/oauth-authz-req+jwt). We VERIFY its signature against the JOSE-header-embedded
+            // jwk before acting on any claim, and pin to --verifier-jwk-thumbprint when supplied (#344).
             Console.WriteLine($"[haip present] Fetching request object from {requestUri}");
             JsonElement requestObject;
             try
             {
                 var responseText = await httpClient.GetStringAsync(requestUri, ct);
-                requestObject = ParseRequestObjectPayload(responseText);
+                requestObject = ParseRequestObjectPayload(responseText, expectedVerifierJwkThumbprint);
             }
             catch (Exception ex)
             {
-                Console.Error.WriteLine($"[ERROR] Failed to fetch request object: {ex.Message}");
+                Console.Error.WriteLine($"[ERROR] Failed to fetch/verify request object: {ex.Message}");
                 return 2;
             }
 
@@ -176,43 +178,55 @@ public class HaipPresentCommand : Command
     }
 
     /// <summary>
-    /// Parses the verifier's RFC 9101 §4 request-object response. The
-    /// response may be either a signed JWT (starts with <c>eyJ</c> —
-    /// <c>application/oauth-authz-req+jwt</c>) or a bare JSON object
-    /// (legacy callers). Returns the payload as a <see cref="JsonElement"/>
-    /// either way.
+    /// Parses AND verifies the verifier's RFC 9101 §4 request-object response before any claim is used.
+    /// A signed JWT (starts with <c>eyJ</c>, <c>application/oauth-authz-req+jwt</c>) has its signature
+    /// verified against the JOSE-header-embedded <c>jwk</c> (rejecting <c>alg:none</c> / tampering); when
+    /// <paramref name="expectedVerifierJwkThumbprint"/> is supplied the signing key is additionally pinned
+    /// to that RFC 7638 thumbprint (else it verifies integrity only and warns that the key is unpinned).
+    /// A bare JSON object is accepted as an unsigned legacy body with a warning. Issue #344.
     /// </summary>
-    internal static JsonElement ParseRequestObjectPayload(string responseText)
+    internal static JsonElement ParseRequestObjectPayload(string responseText, string? expectedVerifierJwkThumbprint = null)
     {
         var trimmed = responseText.Trim();
 
-        // Bare JSON object.
+        // Bare JSON object — unsigned. HAIP 1.0 §6.1 mandates a signed request object; accept unsigned
+        // only for legacy/local callers, and say so loudly.
         if (trimmed.StartsWith('{'))
         {
+            Console.Error.WriteLine(
+                "[WARN] Request object is an unsigned JSON body — there is no signature to verify " +
+                "(HAIP 1.0 §6.1 expects a signed application/oauth-authz-req+jwt).");
             return JsonSerializer.Deserialize<JsonElement>(trimmed);
         }
 
-        // JWT/JWS-compact: every base64url-encoded JOSE header that begins with
-        // '{"alg"' or '{"typ"' (i.e. any compliant JWS or JWE) base64url-encodes
-        // to a string starting with "eyJ". Anything else here is a server error
-        // page, redirect body, plain text, or other non-JOSE response.
+        // Compact JWS (base64url JOSE header ⇒ starts "eyJ"). RFC 9101 §4: verify the request-object
+        // signature against its embedded jwk BEFORE acting on any claim.
         if (trimmed.StartsWith("eyJ", StringComparison.Ordinal))
         {
-            // TODO(SEC): tracked in issue #344 — agent should verify the JWT
-            // signature against the verifier's JWKS per RFC 9101 §4 before
-            // acting on its claims. Today the agent is a demo/test tool
-            // against trusted localhost verifiers only; any production use
-            // must fetch jwks_uri from the verifier's well-known config and
-            // validate the signature before reaching this point.
-            var parts = trimmed.Split('.');
-            if (parts.Length < 2)
+            if (!SdJwtService.TryVerifyCompactJwsWithEmbeddedJwk(
+                    trimmed, out var payload, out var thumbprint, out var verifyError))
             {
-                throw new InvalidOperationException(
-                    "Request object looks like a JWT (begins with 'eyJ') but does not have at least " +
-                    "two dot-separated segments — cannot extract payload.");
+                throw new InvalidOperationException($"Request object signature verification failed: {verifyError}");
             }
-            var payloadBytes = Base64Url.DecodeFromChars(parts[1].AsSpan());
-            return JsonSerializer.Deserialize<JsonElement>(payloadBytes);
+
+            if (!string.IsNullOrWhiteSpace(expectedVerifierJwkThumbprint))
+            {
+                if (!string.Equals(expectedVerifierJwkThumbprint, thumbprint, StringComparison.Ordinal))
+                {
+                    throw new InvalidOperationException(
+                        $"Request object signing key is not the pinned verifier key (expected thumbprint " +
+                        $"'{expectedVerifierJwkThumbprint}', got '{thumbprint}'). Refusing to present.");
+                }
+            }
+            else
+            {
+                Console.Error.WriteLine(
+                    $"[WARN] Request object signature verified but the signing key is UNPINNED (jwk thumbprint " +
+                    $"'{thumbprint}'). Pass --verifier-jwk-thumbprint to bind to a known verifier (RFC 9101 §4 " +
+                    "trust anchor); without it a substituted-key MITM cannot be detected.");
+            }
+
+            return payload;
         }
 
         // Anything else — give the caller a quoted preview so they can see what

--- a/src/Common/Sorcha.Cryptography/SdJwt/SdJwtService.cs
+++ b/src/Common/Sorcha.Cryptography/SdJwt/SdJwtService.cs
@@ -886,6 +886,91 @@ public class SdJwtService : ISdJwtService
         }
     }
 
+    /// <summary>
+    /// Verifies a compact JWS whose JOSE header embeds the signing public key as a <c>jwk</c> — e.g. an
+    /// RFC 9101 §4 request object served as <c>application/oauth-authz-req+jwt</c>. Rejects <c>alg:none</c>,
+    /// headers with no embedded key, alg/key-type confusion, and any bad or tampered signature. The payload
+    /// is returned ONLY when the signature verifies against the embedded key.
+    /// <para>
+    /// This proves <b>integrity</b> (the payload was not altered after signing), NOT <b>authenticity</b>:
+    /// a substituted-key attacker can re-sign with their own key and it will still verify. Callers MUST pin
+    /// the returned <paramref name="jwkThumbprint"/> (RFC 7638) to a known verifier key to close that gap.
+    /// </para>
+    /// </summary>
+    /// <returns><c>true</c> (and sets <paramref name="payload"/> + <paramref name="jwkThumbprint"/>) when the
+    /// embedded-key signature is valid; otherwise <c>false</c> with <paramref name="error"/> set.</returns>
+    public static bool TryVerifyCompactJwsWithEmbeddedJwk(
+        string compactJws, out JsonElement payload, out string? jwkThumbprint, out string? error)
+    {
+        payload = default;
+        jwkThumbprint = null;
+        error = null;
+
+        if (string.IsNullOrWhiteSpace(compactJws)) { error = "empty token"; return false; }
+        var parts = compactJws.Split('.');
+        if (parts.Length != 3) { error = "not a 3-part compact JWS"; return false; }
+
+        JsonElement header;
+        try { header = JsonSerializer.Deserialize<JsonElement>(Base64UrlDecode(parts[0])); }
+        catch (Exception ex) { error = $"invalid JOSE header: {ex.Message}"; return false; }
+
+        var alg = header.TryGetProperty("alg", out var algEl) ? algEl.GetString() : null;
+        if (string.IsNullOrEmpty(alg) || string.Equals(alg, "none", StringComparison.OrdinalIgnoreCase))
+        {
+            error = $"unsigned or 'alg:none' request object rejected (alg='{alg ?? "<missing>"}')";
+            return false;
+        }
+
+        if (!header.TryGetProperty("jwk", out var jwk) || jwk.ValueKind != JsonValueKind.Object)
+        {
+            error = "JOSE header carries no embedded 'jwk' to verify against";
+            return false;
+        }
+
+        var keyBytes = ExportPublicKeyFromJwk(jwk, out var keyAlg);
+        if (keyBytes == null)
+        {
+            error = "unsupported or invalid embedded jwk (only P-256 EC and Ed25519 OKP are accepted)";
+            return false;
+        }
+
+        // The declared JOSE alg must match the key we resolved — block alg/key-type confusion.
+        if (!string.Equals(MapAlgorithm(alg), keyAlg, StringComparison.Ordinal))
+        {
+            error = $"header alg '{alg}' does not match embedded key type '{keyAlg}'";
+            return false;
+        }
+
+        byte[] signature;
+        try { signature = Base64UrlDecode(parts[2]); }
+        catch (Exception ex) { error = $"invalid signature encoding: {ex.Message}"; return false; }
+
+        var signingInput = Encoding.UTF8.GetBytes($"{parts[0]}.{parts[1]}");
+        bool ok;
+        try { ok = Verify(signingInput, signature, keyBytes, keyAlg); }
+        catch (Exception ex) { error = $"signature verification error: {ex.Message}"; return false; }
+        if (!ok) { error = "request object signature is invalid"; return false; }
+
+        try { payload = JsonSerializer.Deserialize<JsonElement>(Base64UrlDecode(parts[1])); }
+        catch (Exception ex) { error = $"invalid payload: {ex.Message}"; return false; }
+
+        jwkThumbprint = ComputeJwkThumbprint(jwk);
+        return true;
+    }
+
+    /// <summary>RFC 7638 JWK thumbprint — base64url SHA-256 of the canonical required members.</summary>
+    private static string? ComputeJwkThumbprint(JsonElement jwk)
+    {
+        if (!jwk.TryGetProperty("kty", out var ktyEl)) return null;
+        var canonical = ktyEl.GetString() switch
+        {
+            "OKP" => $"{{\"crv\":\"{jwk.GetProperty("crv").GetString()}\",\"kty\":\"OKP\",\"x\":\"{jwk.GetProperty("x").GetString()}\"}}",
+            "EC" => $"{{\"crv\":\"{jwk.GetProperty("crv").GetString()}\",\"kty\":\"EC\",\"x\":\"{jwk.GetProperty("x").GetString()}\",\"y\":\"{jwk.GetProperty("y").GetString()}\"}}",
+            _ => null,
+        };
+        return canonical is null ? null : Base64UrlEncode(SHA256.HashData(Encoding.UTF8.GetBytes(canonical)));
+    }
+
     private static string CreateDisclosure(string claimName, object claimValue)
     {
         var salt = Base64Url.EncodeToString(RandomNumberGenerator.GetBytes(16));

--- a/tests/Sorcha.Agent.Tests/Commands/HaipPresentCommandTests.cs
+++ b/tests/Sorcha.Agent.Tests/Commands/HaipPresentCommandTests.cs
@@ -2,6 +2,7 @@
 // Copyright (c) 2026 Sorcha Contributors
 
 using System.Buffers.Text;
+using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
 using FluentAssertions;
@@ -11,17 +12,41 @@ using Xunit;
 namespace Sorcha.Agent.Tests.Commands;
 
 /// <summary>
-/// Tests for HaipPresentCommand.ParseRequestObjectPayload, the response-format
-/// detector for OpenID4VP request objects fetched from a verifier. Issue #346
-/// tightened the detection so non-JSON, non-JWT bodies (HTML error pages,
-/// redirect bodies, plain text) produce a clear error with a quoted preview
-/// rather than falling into the JWT-decode branch and surfacing a cryptic
-/// base64 error.
+/// Tests for HaipPresentCommand.ParseRequestObjectPayload, the response detector + verifier for OpenID4VP
+/// request objects fetched from a verifier. Issue #346 tightened detection so non-JSON, non-JWT bodies
+/// produce a clear error with a quoted preview. Issue #344 added RFC 9101 §4 signature verification: a
+/// signed request object's JWS is verified against its embedded jwk (rejecting alg:none / tampering) before
+/// any claim is used, and the signing key can be pinned to a trusted RFC 7638 thumbprint.
 /// </summary>
 public class HaipPresentCommandTests
 {
     private static string Base64UrlEncode(string s) =>
         Base64Url.EncodeToString(Encoding.UTF8.GetBytes(s));
+
+    /// <summary>
+    /// Signs a request-object payload with a fresh ES256 (P-256) key, embedding the public key as a
+    /// JOSE-header jwk exactly as the verifier's RequestObjectSigner does. Returns the compact JWS and the
+    /// RFC 7638 thumbprint of the embedded jwk.
+    /// </summary>
+    private static (string Jwt, string Thumbprint) SignEs256(string payloadJson)
+    {
+        using var ecdsa = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        var p = ecdsa.ExportParameters(includePrivateParameters: false);
+        var x = Base64Url.EncodeToString(p.Q.X!);
+        var y = Base64Url.EncodeToString(p.Q.Y!);
+
+        var headerJson = $"{{\"alg\":\"ES256\",\"typ\":\"oauth-authz-req+jwt\",\"jwk\":{{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"{x}\",\"y\":\"{y}\"}}}}";
+        var h = Base64Url.EncodeToString(Encoding.UTF8.GetBytes(headerJson));
+        var pl = Base64Url.EncodeToString(Encoding.UTF8.GetBytes(payloadJson));
+        var signingInput = Encoding.ASCII.GetBytes($"{h}.{pl}");
+        var sig = ecdsa.SignData(signingInput, HashAlgorithmName.SHA256, DSASignatureFormat.IeeeP1363FixedFieldConcatenation);
+        var jwt = $"{h}.{pl}.{Base64Url.EncodeToString(sig)}";
+
+        // RFC 7638 thumbprint for an EC key: canonical members {crv, kty, x, y} in lexicographic order.
+        var canonical = $"{{\"crv\":\"P-256\",\"kty\":\"EC\",\"x\":\"{x}\",\"y\":\"{y}\"}}";
+        var thumbprint = Base64Url.EncodeToString(SHA256.HashData(Encoding.UTF8.GetBytes(canonical)));
+        return (jwt, thumbprint);
+    }
 
     [Fact]
     public void ParseRequestObjectPayload_BareJsonObject_DeserialisesPayload()
@@ -45,19 +70,63 @@ public class HaipPresentCommandTests
     }
 
     [Fact]
-    public void ParseRequestObjectPayload_CompactJwt_ReturnsPayloadSegment()
+    public void ParseRequestObjectPayload_ValidSignedJwt_ReturnsVerifiedPayload()
     {
-        // A real JWS-compact: header.payload.signature, all base64url. We don't
-        // verify the signature here (issue #344 tracks that); we just need the
-        // payload segment to decode to JSON.
-        var header = Base64UrlEncode("""{"alg":"none","typ":"oauth-authz-req+jwt"}""");
-        var body = Base64UrlEncode("""{"client_id":"demo","nonce":"xyz"}""");
-        var jwt = $"{header}.{body}.";
+        var (jwt, _) = SignEs256("""{"client_id":"demo","nonce":"xyz"}""");
 
         var payload = HaipPresentCommand.ParseRequestObjectPayload(jwt);
 
         payload.GetProperty("client_id").GetString().Should().Be("demo");
         payload.GetProperty("nonce").GetString().Should().Be("xyz");
+    }
+
+    [Fact]
+    public void ParseRequestObjectPayload_PinnedThumbprintMatches_ReturnsPayload()
+    {
+        var (jwt, thumbprint) = SignEs256("""{"client_id":"demo","nonce":"xyz"}""");
+
+        var payload = HaipPresentCommand.ParseRequestObjectPayload(jwt, thumbprint);
+
+        payload.GetProperty("client_id").GetString().Should().Be("demo");
+    }
+
+    [Fact]
+    public void ParseRequestObjectPayload_PinnedThumbprintMismatch_Throws()
+    {
+        var (jwt, _) = SignEs256("""{"client_id":"demo","nonce":"xyz"}""");
+
+        var act = () => HaipPresentCommand.ParseRequestObjectPayload(jwt, "NOT_THE_REAL_THUMBPRINT");
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*not the pinned verifier key*");
+    }
+
+    [Fact]
+    public void ParseRequestObjectPayload_TamperedPayload_Throws()
+    {
+        var (jwt, _) = SignEs256("""{"client_id":"demo","nonce":"xyz"}""");
+        var parts = jwt.Split('.');
+        // Swap the payload for a different one but keep the original signature — verification must fail.
+        var tampered = $"{parts[0]}.{Base64UrlEncode("""{"client_id":"attacker","nonce":"xyz"}""")}.{parts[2]}";
+
+        var act = () => HaipPresentCommand.ParseRequestObjectPayload(tampered);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*signature verification failed*");
+    }
+
+    [Fact]
+    public void ParseRequestObjectPayload_AlgNoneJwt_Rejected()
+    {
+        // An unsigned "alg:none" token must never be trusted (the classic JWT downgrade bypass).
+        var header = Base64UrlEncode("""{"alg":"none","typ":"oauth-authz-req+jwt"}""");
+        var body = Base64UrlEncode("""{"client_id":"demo","nonce":"xyz"}""");
+        var jwt = $"{header}.{body}.";
+
+        var act = () => HaipPresentCommand.ParseRequestObjectPayload(jwt);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*verification failed*");
     }
 
     [Fact]
@@ -97,13 +166,12 @@ public class HaipPresentCommandTests
     }
 
     [Fact]
-    public void ParseRequestObjectPayload_LeadingEyJButOnlyOneSegment_Throws()
+    public void ParseRequestObjectPayload_LeadingEyJButNotThreeSegments_Throws()
     {
-        // Defensive: something starts with "eyJ" but isn't a real JWT. The detector
-        // routes it down the JWT branch but the missing-segments check catches it.
+        // Something starts with "eyJ" but isn't a real 3-segment JWS — verification rejects it.
         var act = () => HaipPresentCommand.ParseRequestObjectPayload("eyJalgIsNoneAndNoDot");
 
         act.Should().Throw<InvalidOperationException>()
-            .WithMessage("*JWT*at least two dot-separated segments*");
+            .WithMessage("*verification failed*3-part*");
     }
 }

--- a/tests/Sorcha.Cryptography.Tests/SdJwt/SdJwtRequestObjectVerifyTests.cs
+++ b/tests/Sorcha.Cryptography.Tests/SdJwt/SdJwtRequestObjectVerifyTests.cs
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Buffers.Text;
+using System.Security.Cryptography;
+using System.Text;
+using FluentAssertions;
+using Sorcha.Cryptography.SdJwt;
+using Xunit;
+
+namespace Sorcha.Cryptography.Tests.SdJwt;
+
+/// <summary>
+/// Tests for <see cref="SdJwtService.TryVerifyCompactJwsWithEmbeddedJwk"/> (issue #344) — the RFC 9101 §4
+/// request-object verifier that validates a compact JWS against its JOSE-header-embedded jwk, for both
+/// algorithms the verifier's RequestObjectSigner emits (ES256 P-256 and EdDSA Ed25519), and rejects
+/// alg:none, no-jwk, and tampered signatures.
+/// </summary>
+public class SdJwtRequestObjectVerifyTests
+{
+    private static string B64(byte[] b) => Base64Url.EncodeToString(b);
+    private static string B64(string s) => Base64Url.EncodeToString(Encoding.UTF8.GetBytes(s));
+
+    private static string SignEs256(string payloadJson, out string thumbprint)
+    {
+        using var ecdsa = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        var p = ecdsa.ExportParameters(includePrivateParameters: false);
+        var x = B64(p.Q.X!);
+        var y = B64(p.Q.Y!);
+        var header = $"{{\"alg\":\"ES256\",\"typ\":\"oauth-authz-req+jwt\",\"jwk\":{{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"{x}\",\"y\":\"{y}\"}}}}";
+        var h = B64(header);
+        var pl = B64(payloadJson);
+        var sig = ecdsa.SignData(Encoding.ASCII.GetBytes($"{h}.{pl}"), HashAlgorithmName.SHA256, DSASignatureFormat.IeeeP1363FixedFieldConcatenation);
+        thumbprint = B64(SHA256.HashData(Encoding.UTF8.GetBytes($"{{\"crv\":\"P-256\",\"kty\":\"EC\",\"x\":\"{x}\",\"y\":\"{y}\"}}")));
+        return $"{h}.{pl}.{B64(sig)}";
+    }
+
+    private static string SignEdDsa(string payloadJson, out string thumbprint)
+    {
+        var kp = Sodium.PublicKeyAuth.GenerateKeyPair();
+        var x = B64(kp.PublicKey);
+        var header = $"{{\"alg\":\"EdDSA\",\"typ\":\"oauth-authz-req+jwt\",\"jwk\":{{\"kty\":\"OKP\",\"crv\":\"Ed25519\",\"x\":\"{x}\"}}}}";
+        var h = B64(header);
+        var pl = B64(payloadJson);
+        var sig = Sodium.PublicKeyAuth.SignDetached(Encoding.ASCII.GetBytes($"{h}.{pl}"), kp.PrivateKey);
+        thumbprint = B64(SHA256.HashData(Encoding.UTF8.GetBytes($"{{\"crv\":\"Ed25519\",\"kty\":\"OKP\",\"x\":\"{x}\"}}")));
+        return $"{h}.{pl}.{B64(sig)}";
+    }
+
+    [Fact]
+    public void Es256_ValidSignature_VerifiesAndReturnsPayloadAndThumbprint()
+    {
+        var jwt = SignEs256("""{"client_id":"demo","nonce":"n1"}""", out var expectedThumbprint);
+
+        var ok = SdJwtService.TryVerifyCompactJwsWithEmbeddedJwk(jwt, out var payload, out var thumbprint, out var error);
+
+        ok.Should().BeTrue(error);
+        payload.GetProperty("client_id").GetString().Should().Be("demo");
+        thumbprint.Should().Be(expectedThumbprint);
+    }
+
+    [Fact]
+    public void EdDsa_ValidSignature_VerifiesAndReturnsPayloadAndThumbprint()
+    {
+        var jwt = SignEdDsa("""{"client_id":"demo","nonce":"n2"}""", out var expectedThumbprint);
+
+        var ok = SdJwtService.TryVerifyCompactJwsWithEmbeddedJwk(jwt, out var payload, out var thumbprint, out var error);
+
+        ok.Should().BeTrue(error);
+        payload.GetProperty("nonce").GetString().Should().Be("n2");
+        thumbprint.Should().Be(expectedThumbprint);
+    }
+
+    [Fact]
+    public void AlgNone_IsRejected()
+    {
+        var header = B64("""{"alg":"none","typ":"oauth-authz-req+jwt","jwk":{"kty":"OKP","crv":"Ed25519","x":"AAAA"}}""");
+        var body = B64("""{"client_id":"demo"}""");
+        var jwt = $"{header}.{body}.";
+
+        var ok = SdJwtService.TryVerifyCompactJwsWithEmbeddedJwk(jwt, out _, out _, out var error);
+
+        ok.Should().BeFalse();
+        error.Should().Contain("alg:none");
+    }
+
+    [Fact]
+    public void NoEmbeddedJwk_IsRejected()
+    {
+        var jwt = SignEs256("""{"client_id":"demo"}""", out _);
+        // Replace the header with one that has no jwk (breaks the signature too, but the missing-jwk check fires first).
+        var noJwkHeader = B64("""{"alg":"ES256","typ":"oauth-authz-req+jwt"}""");
+        var body = jwt.Split('.')[1];
+        var tampered = $"{noJwkHeader}.{body}.{jwt.Split('.')[2]}";
+
+        var ok = SdJwtService.TryVerifyCompactJwsWithEmbeddedJwk(tampered, out _, out _, out var error);
+
+        ok.Should().BeFalse();
+        error.Should().Contain("no embedded 'jwk'");
+    }
+
+    [Fact]
+    public void TamperedPayload_IsRejected()
+    {
+        var jwt = SignEs256("""{"client_id":"demo","nonce":"n1"}""", out _);
+        var parts = jwt.Split('.');
+        var tampered = $"{parts[0]}.{B64("""{"client_id":"attacker","nonce":"n1"}""")}.{parts[2]}";
+
+        var ok = SdJwtService.TryVerifyCompactJwsWithEmbeddedJwk(tampered, out _, out _, out var error);
+
+        ok.Should().BeFalse();
+        error.Should().Contain("signature is invalid");
+    }
+}


### PR DESCRIPTION
The sorcha-agent's `haip present` used to base64url-decode the request-object payload and act on its
claims (nonce, client_id, response_uri) with ZERO signature verification — a `TODO(SEC)` named #344.
An attacker on the path could hand the agent an arbitrary request object (redirect the presentation
to their own response_uri, swap the nonce) and it would comply.

- New reusable primitive `SdJwtService.TryVerifyCompactJwsWithEmbeddedJwk` (Sorcha.Cryptography): verifies
  a compact JWS against the signing key embedded in its JOSE `jwk` header — the exact shape the verifier's
  RequestObjectSigner emits (ES256 P-256 / EdDSA Ed25519). Rejects `alg:none`, missing-jwk, alg/key-type
  confusion, and any tampered signature; returns the RFC 7638 thumbprint of the signing key. Reuses the
  existing `ExportPublicKeyFromJwk` + `Verify` primitives.
- `HaipPresentCommand` now verifies the request object before using any claim, and adds
  `--verifier-jwk-thumbprint` to PIN the signing key to a trusted verifier (RFC 9101 §4 trust anchor);
  a mismatch is refused. Without the pin the signature is still verified for integrity but the agent warns
  the key is unpinned (a substituted-key MITM can't be detected). Unsigned bare-JSON bodies are accepted
  as a warned legacy path. `alg:none` and tampering are hard-rejected.

Note the verifier embeds its key inline as a `jwk` header (no JWKS endpoint yet), so full authenticity
needs the `--verifier-jwk-thumbprint` pin; a served `jwks_uri` is the follow-up (remedy B).

Tests: 5 crypto-level (ES256 + EdDSA valid, alg:none, no-jwk, tampered — 401/401) and agent-level
(valid signed, pin match/mismatch, tampered, alg:none — 157/157).

Closes #344.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UDmeAycWwQ5Y8PXuz4iub6
