### PR TITLE
fix: [338] thread ActionRuntimeState through SorchaFormRenderer to the review summary

### DIFF
--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Forms/SorchaFormRenderer.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Forms/SorchaFormRenderer.razor
@@ -100,7 +100,7 @@
                         var priorPages = Layout.Pages.Take(_currentPage).ToList();
                         <ReviewSummaryRenderer Page="@wizardPage"
                                                PriorPages="@priorPages"
-                                               RuntimeState="ActionRuntimeState.CitizenDraft"
+                                               RuntimeState="@RuntimeState"
                                                ActionCredentialRequirements="@Action?.CredentialRequirements"
                                                ActionCredentialIssuanceConfig="@Action?.CredentialIssuanceConfig"
                                                OnEditSection="HandleReviewEdit" />
@@ -292,6 +292,14 @@
 @code {
     [Parameter] public Sorcha.Blueprint.Models.Action? Action { get; set; }
     [Parameter] public JsonDocument? PreviousData { get; set; }
+
+    /// <summary>
+    /// Feature 107 — the lifecycle state the review/id-card is being rendered in (draft vs assessor-pending
+    /// vs issued credential), which drives the review summary's watermark/footer treatment. Defaults to
+    /// <see cref="ActionRuntimeState.CitizenDraft"/>; assessor and wallet-detail hosts set it explicitly so
+    /// the review page is no longer hard-pinned to the Draft watermark (issue #338).
+    /// </summary>
+    [Parameter] public ActionRuntimeState RuntimeState { get; set; } = ActionRuntimeState.CitizenDraft;
 
     /// <summary>
     /// Feature 152 — editable values to seed the form with on (re)open, keyed by JSON Pointer scope


### PR DESCRIPTION
The review-summary seam was half-wired: ReviewSummaryRenderer accepts a RuntimeState parameter (and
maps it to the id-card watermark/footer), but its only caller, SorchaFormRenderer, hard-coded
RuntimeState="ActionRuntimeState.CitizenDraft" — so every review page rendered the Draft watermark and
the AssessorPending / IssuedCredential states were unreachable, blocking the Feature 107 PR 2 assessor path.

Expose RuntimeState as a parameter on SorchaFormRenderer (default CitizenDraft) and bind it through to
ReviewSummaryRenderer. Backward-compatible: every existing caller keeps CitizenDraft; the assessor and
wallet-detail hosts (PR 2) now set it explicitly to reach the Pending / Issued watermarks.

Test rationale: the RuntimeState->watermark mapping is already covered by
ReviewSummaryRendererTests.ResolveWatermark; a render-through test would require driving a multi-page
MudBlazor wizard to the review page in bUnit, the exact commit-on-blur brittleness SorchaFormRendererDraftTests
documents. The change here is a one-line, compile-verified, backward-compatible parameter binding.

Closes #338.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UDmeAycWwQ5Y8PXuz4iub6
