### PR TITLE
fix: [340] surface the portrait-gate drop to the submitter (not just the server log)

### DIFF
--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/NewSubmissionWorkspace.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/NewSubmissionWorkspace.razor
@@ -207,6 +207,17 @@
                 : $"Submission started — instance {result.InstanceId[..Math.Min(8, result.InstanceId.Length)]}...";
             Feedback.ShowSuccess(message);
 
+            // Surface server-side credential warnings (e.g. the F107 portrait was too large and was
+            // omitted from the credential) so the drop isn't silent to the submitter (issue #340).
+            // Persist (autoDismissMs: 0) — the user should acknowledge a dropped claim.
+            if (result.Warnings is { Count: > 0 })
+            {
+                foreach (var warning in result.Warnings)
+                {
+                    Feedback.ShowWarning(warning, autoDismissMs: 0);
+                }
+            }
+
             // HAIP external wallet interactions — show QR dialog before navigating away
             if (result.CredentialOffer is { } offer)
             {

--- a/src/Services/Sorcha.Blueprint.Service/Services/Implementation/ActionExecutionService.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Services/Implementation/ActionExecutionService.cs
@@ -540,6 +540,11 @@ public class ActionExecutionService : IActionExecutionService, IPresentationRout
         var callerIssuerOrgName = caller?.FindFirst("org_name")?.Value;
         var callerIssuerTenantId = caller?.FindFirst("org_id")?.Value;
 
+        // Client-facing warnings raised while building the credential claims (e.g. the F107 portrait
+        // size gate dropping an oversized image). Surfaced on the response so the drop is visible to the
+        // submitter, not only in the server log (issue #340). Threaded to both the HAIP and internal paths.
+        var credentialWarnings = new List<string>();
+
         CreateOfferResult? haipOfferResult = null;
         if (actionDef.CredentialIssuanceConfig != null
             && actionDef.CredentialIssuanceConfig.TargetAudience == TargetAudience.HaipExternalWallet)
@@ -562,7 +567,8 @@ public class ActionExecutionService : IActionExecutionService, IPresentationRout
             {
                 var haipClaims = BuildClaimsFromMappings(
                     actionDef.CredentialIssuanceConfig.ClaimMappings,
-                    mergedData!);
+                    mergedData!,
+                    credentialWarnings);
                 var haipClaimsForWire = haipClaims.ToDictionary(kvp => kvp.Key, kvp => kvp.Value!);
 
                 _logger.LogInformation(
@@ -689,7 +695,7 @@ public class ActionExecutionService : IActionExecutionService, IPresentationRout
             try
             {
                 localWalletCredential = await IssueCredentialFromActionAsync(
-                    actionDef, mergedData, request.SenderWallet, instance, issuerOrgName, issuerTenantId, holderJwk, cancellationToken);
+                    actionDef, mergedData, request.SenderWallet, instance, issuerOrgName, issuerTenantId, holderJwk, credentialWarnings, cancellationToken);
             }
             catch (Exception ex) when (ex is not InvalidOperationException)
             {
@@ -1152,7 +1158,11 @@ public class ActionExecutionService : IActionExecutionService, IPresentationRout
             NextActions = [],
             IsComplete = false,
             Calculations = calculations,
-            Warnings = validationResult.Warnings,
+            // Merge schema-validation warnings with any credential-claim warnings raised during issuance
+            // (e.g. the portrait size gate dropping the image) so the submitter sees them (issue #340).
+            Warnings = credentialWarnings.Count > 0
+                ? (validationResult.Warnings ?? new List<string>()).Concat(credentialWarnings).ToList()
+                : validationResult.Warnings,
             IssuedCredentialId = issuedCredential?.CredentialId,
             IssuedCredential = issuedCredentialResponse,
             CredentialOffer = haipOfferResult != null
@@ -1964,18 +1974,23 @@ public class ActionExecutionService : IActionExecutionService, IPresentationRout
     /// </summary>
     private Dictionary<string, object?> BuildClaimsFromMappings(
         IEnumerable<Sorcha.Blueprint.Models.Credentials.ClaimMapping>? mappings,
-        IReadOnlyDictionary<string, object?> mergedData)
-        => BuildClaimsFromMappings(mappings, mergedData, _logger);
+        IReadOnlyDictionary<string, object?> mergedData,
+        ICollection<string>? warnings = null)
+        => BuildClaimsFromMappings(mappings, mergedData, _logger, warnings);
 
     /// <summary>
     /// Static logger-injected overload used by unit tests so the helper can
     /// be exercised without needing the full <see cref="ActionExecutionService"/>
-    /// constructor graph.
+    /// constructor graph. When <paramref name="warnings"/> is supplied, a
+    /// client-facing message is appended for each claim the server drops (e.g. an
+    /// oversized portrait) so the caller can surface it on the submission response
+    /// instead of the drop being visible only in the server log (issue #340).
     /// </summary>
     internal static Dictionary<string, object?> BuildClaimsFromMappings(
         IEnumerable<Sorcha.Blueprint.Models.Credentials.ClaimMapping>? mappings,
         IReadOnlyDictionary<string, object?> mergedData,
-        ILogger logger)
+        ILogger logger,
+        ICollection<string>? warnings = null)
     {
         var claims = new Dictionary<string, object?>();
         if (mappings is null) return claims;
@@ -2001,6 +2016,10 @@ public class ActionExecutionService : IActionExecutionService, IPresentationRout
                         "Warning code: {WarningCode}",
                         mapping.ClaimName, PortraitTokenMaxBase64Chars, portraitBase64.Length,
                         ValidationWarningCodes.CredentialPortraitOversize);
+                    warnings?.Add(
+                        $"The portrait image for '{mapping.ClaimName}' exceeded the " +
+                        $"{PortraitTokenMaxBase64Chars:N0}-character limit and was omitted from the credential " +
+                        $"({ValidationWarningCodes.CredentialPortraitOversize}). Re-submit with a smaller image to include it.");
                     continue;
                 }
 
@@ -2131,6 +2150,7 @@ public class ActionExecutionService : IActionExecutionService, IPresentationRout
         string? issuerOrgName,
         string? issuerTenantId,
         JsonElement? holderJwk,
+        ICollection<string> warnings,
         CancellationToken cancellationToken)
     {
         var config = actionDef.CredentialIssuanceConfig!;
@@ -2143,7 +2163,7 @@ public class ActionExecutionService : IActionExecutionService, IPresentationRout
         // extraction walks the pointer segment-by-segment through nested
         // dictionaries and JsonElement objects. Missing segments log a
         // warning and skip the claim rather than failing the whole issue.
-        var claims = BuildClaimsFromMappings(config.ClaimMappings, mergedData!);
+        var claims = BuildClaimsFromMappings(config.ClaimMappings, mergedData!, warnings);
         // Wallet client expects non-nullable values. Safe because
         // TryResolveJsonPointer returns false on null-valued segments —
         // BuildClaimsFromMappings never produces a null value. If that

--- a/tests/Sorcha.Blueprint.Service.Tests/Services/BuildClaimsFromMappingsPortraitTests.cs
+++ b/tests/Sorcha.Blueprint.Service.Tests/Services/BuildClaimsFromMappingsPortraitTests.cs
@@ -117,6 +117,52 @@ public class BuildClaimsFromMappingsPortraitTests
     }
 
     [Fact]
+    public void BuildClaimsFromMappings_PortraitOversize_CollectsClientWarning()
+    {
+        // #340 — when a warnings sink is supplied, the dropped portrait must surface a client-facing
+        // message (not only a server log line) so the submitter can be told the image was omitted.
+        var payload = new Dictionary<string, object?>
+        {
+            ["portrait"] = new Dictionary<string, object?>
+            {
+                ["tokenImageBase64"] = new string('A', Base64BoundBytes + 1)
+            },
+            ["givenName"] = "Alex"
+        };
+
+        var mappings = Mappings(
+            ("portrait", "/portrait/tokenImageBase64"),
+            ("givenName", "/givenName"));
+
+        var warnings = new List<string>();
+        var claims = ActionExecutionService.BuildClaimsFromMappings(
+            mappings, payload, NullLogger.Instance, warnings);
+
+        claims.Should().NotContainKey("portrait");
+        warnings.Should().ContainSingle()
+            .Which.Should().Contain("portrait").And.Contain("omitted");
+    }
+
+    [Fact]
+    public void BuildClaimsFromMappings_NoDroppedClaims_NoWarnings()
+    {
+        var payload = new Dictionary<string, object?>
+        {
+            ["portrait"] = new Dictionary<string, object?> { ["tokenImageBase64"] = Base64String(5_000) },
+            ["givenName"] = "Alex"
+        };
+
+        var mappings = Mappings(
+            ("portrait", "/portrait/tokenImageBase64"),
+            ("givenName", "/givenName"));
+
+        var warnings = new List<string>();
+        ActionExecutionService.BuildClaimsFromMappings(mappings, payload, NullLogger.Instance, warnings);
+
+        warnings.Should().BeEmpty();
+    }
+
+    [Fact]
     public void BuildClaimsFromMappings_NonPortraitClaimsUnaffectedBySizeGate()
     {
         // A non-portrait claim with a very long value is NOT size-gated —


### PR DESCRIPTION
The F107 server-side portrait size gate drops an oversized `tokenImageBase64` claim, issues the
credential without it, and recorded the drop ONLY via LogWarning — `BuildClaimsFromMappings` returned
just the claims dictionary, so the WARN_CRED_PORTRAIT_OVERSIZE_001 code never reached the response and
the citizen got a portrait-less credential with no indication why.

Thread a warnings channel end-to-end (the response DTO already had the field):
- `BuildClaimsFromMappings` takes an optional warnings sink; the portrait gate appends a client-facing
  message when it drops the image. Threaded through `IssueCredentialFromActionAsync` and the HAIP claims
  path via one accumulator in `ExecuteAsync`, merged into `ActionSubmissionResponse.Warnings` alongside
  schema-validation warnings.
- The web client already deserialises into `ActionSubmissionResultViewModel.Warnings`;
  `NewSubmissionWorkspace` now renders each via `IInlineFeedback.ShowWarning` (persistent — a dropped
  claim should be acknowledged).

Tests: BuildClaimsFromMappings collects a single client warning on oversize + none when nothing drops
(896/896 Blueprint tests). Chose the warnings-channel remedy over a client-only pre-check so the server
stays authoritative and honest to every client (agent/API too); a client-side resize hint remains a
complementary UX follow-up.

Closes #340.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UDmeAycWwQ5Y8PXuz4iub6
