### PR TITLE
fix: [220] stop pre-allocation passing a synthetic credential id to the status list

### DIFF
--- a/src/Services/Sorcha.Blueprint.Service/Services/Implementation/ActionExecutionService.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Services/Implementation/ActionExecutionService.cs
@@ -2210,9 +2210,12 @@ public class ActionExecutionService : IActionExecutionService, IPresentationRout
         {
             try
             {
-                var preAllocationId = $"pending-{Guid.NewGuid()}";
+                // #220: allocation is keyed by (listId, index), not by credential id — and the real
+                // urn:uuid: id doesn't exist until the wallet signs the credential below. Pass null
+                // rather than a synthetic "pending-{guid}" so a future persistent status-list store
+                // can't mistake the placeholder for a real credential key.
                 var allocation = await _statusListManager.AllocateIndexAsync(
-                    senderWallet, instance.RegisterId, preAllocationId, cancellationToken);
+                    senderWallet, instance.RegisterId, credentialId: null, cancellationToken);
                 preAllocatedStatusListUrl = allocation.StatusListUrl;
                 preAllocatedStatusListIndex = allocation.Index;
 

--- a/src/Services/Sorcha.Blueprint.Service/Services/StatusListManager.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Services/StatusListManager.cs
@@ -19,10 +19,14 @@ public interface IStatusListManager
         string issuerWallet, string registerId, string purpose, CancellationToken ct = default);
 
     /// <summary>
-    /// Allocates the next available index in the list. Returns the allocated index.
+    /// Allocates the next available index in the list. Allocation is keyed solely by
+    /// <c>(listId, index)</c> — the returned <see cref="StatusListAllocation"/> is the identity a
+    /// credential's <c>credentialStatus</c> points at. <paramref name="credentialId"/> is optional
+    /// context for logging only and is NOT stored or used as a key; pass <c>null</c> when allocating
+    /// before the credential is signed (pre-allocation), rather than a synthetic placeholder (issue #220).
     /// </summary>
     Task<StatusListAllocation> AllocateIndexAsync(
-        string issuerWallet, string registerId, string credentialId, CancellationToken ct = default);
+        string issuerWallet, string registerId, string? credentialId, CancellationToken ct = default);
 
     /// <summary>
     /// Sets or clears a bit at the given index.
@@ -93,7 +97,7 @@ public class StatusListManager : IStatusListManager, IDisposable
 
     /// <inheritdoc />
     public async Task<StatusListAllocation> AllocateIndexAsync(
-        string issuerWallet, string registerId, string credentialId, CancellationToken ct = default)
+        string issuerWallet, string registerId, string? credentialId, CancellationToken ct = default)
     {
         var list = await GetOrCreateListAsync(issuerWallet, registerId, "revocation", ct);
         var semaphore = _locks.GetOrAdd(list.Id, _ => new SemaphoreSlim(1, 1));
@@ -110,7 +114,7 @@ public class StatusListManager : IStatusListManager, IDisposable
 
             _logger.LogInformation(
                 "Allocated index {Index} in status list {ListId} for credential {CredentialId}",
-                index, list.Id, credentialId);
+                index, list.Id, credentialId ?? "(pre-allocation — not yet signed)");
 
             var url = $"{_baseUrl}/{list.Id}";
             return new StatusListAllocation(list.Id, index, url);

--- a/tests/Sorcha.Blueprint.Service.Tests/StatusList/StatusListManagerTests.cs
+++ b/tests/Sorcha.Blueprint.Service.Tests/StatusList/StatusListManagerTests.cs
@@ -87,6 +87,18 @@ public class StatusListManagerTests
     }
 
     [Fact]
+    public async Task AllocateIndexAsync_NullCredentialId_AllocatesNormally()
+    {
+        // #220: pre-allocation happens before the credential is signed, so credentialId is null.
+        // Allocation is keyed by (listId, index) — it must succeed and return a normal allocation.
+        var alloc = await _manager.AllocateIndexAsync("issuer-1", "register-1", credentialId: null);
+
+        alloc.Index.Should().Be(0);
+        alloc.ListId.Should().Be("issuer-1-register-1-revocation-1");
+        alloc.StatusListUrl.Should().NotBeNullOrEmpty();
+    }
+
+    [Fact]
     public async Task AllocateIndexAsync_WhenFull_ThrowsInvalidOperationException()
     {
         // Pre-create a list and fill it


### PR DESCRIPTION
Status-list pre-allocation happens before the wallet signs the credential, so the real urn:uuid: id
doesn't exist yet — the code fabricated a `pending-{Guid}` and passed it to AllocateIndexAsync. That id
is only ever logged (allocation is keyed by (listId, index), never by credential id), but a synthetic
value that *looks* like a real credential id is a latent trap: a future persistent status-list store
(spec 095) that begins keying on it would bind the wrong key.

Remedy B (the honest-contract fix; the persistent-store design stays with spec 095): make the
credentialId parameter nullable and pass `null` at pre-allocation instead of a fake placeholder. The
XML doc now states plainly that allocation is (listId, index)-keyed and the id is log-only context. The
legitimate endpoint path (POST allocate, which has a real CredentialId) is unchanged; the log line
tolerates null ("pre-allocation — not yet signed").

Test: AllocateIndexAsync with a null credentialId allocates normally (895/895 Blueprint tests).

Closes #220.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UDmeAycWwQ5Y8PXuz4iub6
