### PR TITLE
feat: [327] request-DTO validation for Sorcha.Haip.Service (VAL-001)

### DIFF
--- a/src/Services/Sorcha.Haip.Service/Endpoints/OfferEndpoints.cs
+++ b/src/Services/Sorcha.Haip.Service/Endpoints/OfferEndpoints.cs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Sorcha Contributors
 
+using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Hosting;
 using Sorcha.Haip.Service.Services;
@@ -29,6 +31,7 @@ public static class OfferEndpoints
                 "Returns the offer details and a URI for QR code rendering.")
             .Produces<object>(StatusCodes.Status201Created)
             .Produces(StatusCodes.Status400BadRequest)
+            .WithRequestValidation() // VAL-001 (#327): DataAnnotations on CreateOfferRequest → 400 ValidationProblem
             .RequireAuthorization(AuthorizationPolicies.RequireService); // SEC-013
 
         group.MapGet("/{offerId:guid}", GetOfferStatus)
@@ -97,9 +100,18 @@ public static class OfferEndpoints
 /// </summary>
 public class CreateOfferRequest
 {
+    /// <summary>Wallet address of the issuing org (required).</summary>
+    [Required(AllowEmptyStrings = false)]
     public required string IssuerWalletAddress { get; init; }
+
+    /// <summary>Tenant/org scope the offer is created under (required).</summary>
+    [Required(AllowEmptyStrings = false)]
     public required string TenantId { get; init; }
+
+    /// <summary>Credential type (vct) to offer (required).</summary>
+    [Required(AllowEmptyStrings = false)]
     public required string CredentialType { get; init; }
+
     public Dictionary<string, object>? Claims { get; init; }
     public List<string>? DisclosablePaths { get; init; }
 }

--- a/src/Services/Sorcha.Haip.Service/Endpoints/VerifierEndpoints.cs
+++ b/src/Services/Sorcha.Haip.Service/Endpoints/VerifierEndpoints.cs
@@ -1,8 +1,10 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Sorcha Contributors
 
+using System.ComponentModel.DataAnnotations;
 using System.Text.Json;
 
+using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Hosting;
 using Sorcha.Blueprint.Models.Credentials;
@@ -36,6 +38,7 @@ public static class VerifierEndpoints
                 "citizen wallet PWA (consumer tier), or desk verifier (platform/org tier).")
             .Produces<object>(StatusCodes.Status201Created)
             .Produces(StatusCodes.Status400BadRequest)
+            .WithRequestValidation() // VAL-001 (#327): DataAnnotations on CreatePresentationRequestBody → 400 ValidationProblem
             .RequireAuthorization(); // Feature 164 B3: any authenticated caller (FR-008)
 
         // Public — wallet fetches the signed Request Object
@@ -367,7 +370,10 @@ public static class VerifierEndpoints
 /// <summary>Request to create a presentation request.</summary>
 public class CreatePresentationRequestBody
 {
+    /// <summary>Credential type (vct) the presentation must satisfy (required).</summary>
+    [Required(AllowEmptyStrings = false)]
     public required string CredentialType { get; init; }
+
     public List<string>? RequiredClaims { get; init; }
     public List<string>? AcceptedIssuers { get; init; }
 }


### PR DESCRIPTION
## VAL-001 (#327) — Sorcha.Haip.Service slice

Applies the already-merged `RequestValidationFilter` seam (`.WithRequestValidation()`, PR #1096) to Haip. Because Haip implements OAuth/OID4VCI + OID4VP **protocol** endpoints, this slice is deliberately conservative: only Sorcha-internal request DTOs with unambiguously-required fields are gated. `[Required]` only — no regexes on tokens/nonces/JWTs/base64/DIDs/codes.

### DTOs annotated + endpoints wired
- **`CreateOfferRequest`** (`Endpoints/OfferEndpoints.cs`) — `[Required(AllowEmptyStrings=false)]` on `IssuerWalletAddress`, `TenantId`, `CredentialType` (mirrors the existing manual null/empty checks). Wired on `POST /api/v1/offers` (service-to-service, internal).
- **`CreatePresentationRequestBody`** (`Endpoints/VerifierEndpoints.cs`) — `[Required(AllowEmptyStrings=false)]` on `CredentialType`. Wired on `POST /api/v1/verifier/requests` (authenticated Sorcha callers: Blueprint / PWA / desk verifier). Note: `PresentationRequest` in `Models/VerifierModels.cs` is a stored Redis model, **not** the body DTO — the actual bound body is `CreatePresentationRequestBody`.

### Deliberately skipped (with why)
- **`CredentialRequest`** (`Models/HaipModels.cs`, bound in `CredentialEndpoints`) — **skipped**. This is the OID4VCI credential endpoint. The handler performs careful, spec-driven validation and returns interop-critical OAuth error bodies (`invalid_proof`, `unsupported_credential_format`, `unsupported_credential_type`, etc.). Gating it with a generic `400 ValidationProblem` would replace those spec-shaped errors and risk breaking wallet interop. Its fields also legitimately default/optional (`Format` has a default, `Vct` and `Proof` optional at bind time). Left unwired by design.
- **`TokenRequest`** (`Models/HaipModels.cs`) — **skipped / not applicable**. Despite carrying `[FromForm]` attributes, it is **not bound** by any endpoint: `POST /token` (`TokenEndpoints`) reads the form manually via `HttpContext.Request.ReadFormAsync` and validates `grant_type` / `pre-authorized_code` inline with OAuth error bodies. Nothing to wire.

### Build / test
- `dotnet build src/Services/Sorcha.Haip.Service/...` — **0 errors** (only pre-existing NuGet-vuln + cref warnings).
- `dotnet test tests/Sorcha.Haip.Service.Tests` — **73 passed, 0 failed**.

Addresses #327 (Haip service; sweep spans services — do NOT auto-close).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UDmeAycWwQ5Y8PXuz4iub6