### PR TITLE
feat: [327] request-DTO validation for Sorcha.Wallet.Service (VAL-001, safe surface only)

### DIFF
--- a/src/Services/Sorcha.Wallet.Service/Endpoints/CredentialEndpoints.cs
+++ b/src/Services/Sorcha.Wallet.Service/Endpoints/CredentialEndpoints.cs
@@ -3,9 +3,11 @@
 
 #pragma warning disable ASPDEPR002 // WithOpenApi is deprecated; using it for co-located endpoint examples until transformer API stabilizes
 
+using System.ComponentModel.DataAnnotations;
 using System.Text.Json;
 using System.Xml;
 
+using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Mvc;
 
 using Sorcha.Blueprint.Models.Credentials;
@@ -75,6 +77,7 @@ public static class CredentialEndpoints
             .Produces(StatusCodes.Status404NotFound);
 
         credentialGroup.MapPost("/", StoreCredential)
+            .WithRequestValidation()
             .WithName("StoreCredential")
             .WithSummary("Store a credential in a wallet")
             .WithDescription("Stores a pre-issued verifiable credential in the specified wallet.")
@@ -110,6 +113,7 @@ public static class CredentialEndpoints
             });
 
         credentialGroup.MapPatch("/{credentialId}/status", UpdateCredentialStatus)
+            .WithRequestValidation()
             .WithName("UpdateCredentialStatus")
             .WithSummary("Update a credential's status")
             .WithDescription("Updates the status of a credential (e.g., Active \u2192 Revoked).")
@@ -123,6 +127,7 @@ public static class CredentialEndpoints
         // Feature 106 state machine (PendingAcceptance → Active / Declined) without
         // breaking existing SorchaInternal callers.
         credentialGroup.MapPatch("/{credentialId}", PatchCredentialStatus)
+            .WithRequestValidation()
             .WithName("PatchCredentialStatus")
             .WithSummary("Holder accept or decline a pending credential (Feature 106)")
             .WithDescription(
@@ -135,6 +140,7 @@ public static class CredentialEndpoints
             .Produces(StatusCodes.Status409Conflict);
 
         credentialGroup.MapPost("/issue", IssueCredential)
+            .WithRequestValidation()
             .WithName("IssueCredential")
             .WithSummary("Issue a new credential using the wallet's signing key")
             .WithDescription("Creates and signs a new SD-JWT VC credential using the wallet's private key, stores it, and returns the issued credential.")
@@ -827,10 +833,20 @@ public static class CredentialEndpoints
 /// </summary>
 public class StoreCredentialRequest
 {
+    [Required(AllowEmptyStrings = false)]
+    [StringLength(512)]
     public required string CredentialId { get; init; }
+
+    [Required(AllowEmptyStrings = false)]
+    [StringLength(256)]
     public required string Type { get; init; }
+
+    [Required(AllowEmptyStrings = false)]
     public required string IssuerDid { get; init; }
+
+    [Required(AllowEmptyStrings = false)]
     public required string SubjectDid { get; init; }
+
     public required string ClaimsJson { get; init; }
     public required DateTimeOffset IssuedAt { get; init; }
     public DateTimeOffset? ExpiresAt { get; init; }
@@ -844,8 +860,14 @@ public class StoreCredentialRequest
 /// </summary>
 public class IssueCredentialRequest
 {
+    [Required(AllowEmptyStrings = false)]
+    [StringLength(256)]
     public required string CredentialType { get; init; }
+
+    [Required]
     public required Dictionary<string, object> Claims { get; init; }
+
+    [Required(AllowEmptyStrings = false)]
     public required string RecipientWallet { get; init; }
     public string? ExpiryDuration { get; init; }
     public List<string>? DisclosableClaims { get; init; }
@@ -922,6 +944,8 @@ public class IssueCredentialRequest
 /// </summary>
 public class UpdateStatusRequest
 {
+    [Required(AllowEmptyStrings = false)]
+    [StringLength(64)]
     public required string Status { get; init; }
 }
 

--- a/src/Services/Sorcha.Wallet.Service/Endpoints/OrgKeyEndpoints.cs
+++ b/src/Services/Sorcha.Wallet.Service/Endpoints/OrgKeyEndpoints.cs
@@ -1,6 +1,10 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Sorcha Contributors
 
+using System.ComponentModel.DataAnnotations;
+
+using Microsoft.AspNetCore.Builder;
+
 using Sorcha.Wallet.Core.Domain.Enums;
 using Sorcha.Wallet.Core.Services.Interfaces;
 
@@ -37,6 +41,7 @@ public static class OrgKeyEndpoints
 
         // POST /api/wallets/org/{orgId}/derive-key - Derive user key
         orgKeyGroup.MapPost("/{orgId}/derive-key", DeriveUserKey)
+            .WithRequestValidation()
             .WithName("DeriveOrgUserKey")
             .WithSummary("Derive a user key from the organisation master key")
             .WithDescription(
@@ -244,5 +249,8 @@ public static class OrgKeyEndpoints
     /// <param name="UserId">Subject identifier of the user to derive a key for.</param>
     /// <param name="DepartmentId">Department index in the derivation hierarchy (default 0).</param>
     /// <param name="KeyUsage">Intended key usage purpose (Identity, VCIssuance, Governance, Communications, ServiceAuth).</param>
-    public record DeriveKeyRequest(string UserId, uint DepartmentId = 0, string KeyUsage = "Identity");
+    public record DeriveKeyRequest(
+        [property: Required(AllowEmptyStrings = false)] string UserId,
+        uint DepartmentId = 0,
+        string KeyUsage = "Identity");
 }

--- a/src/Services/Sorcha.Wallet.Service/Endpoints/WalletEndpoints.cs
+++ b/src/Services/Sorcha.Wallet.Service/Endpoints/WalletEndpoints.cs
@@ -6,6 +6,7 @@
 using System.Security.Claims;
 using System.Security.Cryptography;
 
+using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 
@@ -206,6 +207,7 @@ public static class WalletEndpoints
 
         // PATCH /api/v1/wallets/{address} - Update wallet metadata
         walletGroup.MapPatch("/{address}", UpdateWallet)
+            .WithRequestValidation()
             .WithName("UpdateWallet")
             .WithSummary("Update wallet metadata")
             .WithDescription("Update wallet name and tags")
@@ -275,6 +277,7 @@ public static class WalletEndpoints
 
         // POST /api/v1/wallets/{address}/addresses - Register derived address
         walletGroup.MapPost("/{address}/addresses", RegisterDerivedAddress)
+            .WithRequestValidation()
             .WithName("RegisterDerivedAddress")
             .WithSummary("Register a client-derived HD address")
             .WithDescription("Register an HD wallet address that was derived client-side. " +
@@ -306,6 +309,7 @@ public static class WalletEndpoints
 
         // PATCH /api/v1/wallets/{address}/addresses/{id} - Update address metadata
         walletGroup.MapPatch("/{address}/addresses/{id:guid}", UpdateAddress)
+            .WithRequestValidation()
             .WithName("UpdateAddress")
             .WithSummary("Update address metadata")
             .WithDescription("Update address label, notes, tags, and metadata")

--- a/src/Services/Sorcha.Wallet.Service/Models/GenerateAddressRequest.cs
+++ b/src/Services/Sorcha.Wallet.Service/Models/GenerateAddressRequest.cs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Sorcha Contributors
+using System.ComponentModel.DataAnnotations;
+
 namespace Sorcha.Wallet.Service.Models;
 
 /// <summary>
@@ -10,5 +12,6 @@ public class GenerateAddressRequest
     /// <summary>
     /// Optional derivation path (BIP44 format)
     /// </summary>
+    [StringLength(120)]
     public string? DerivationPath { get; set; }
 }

--- a/src/Services/Sorcha.Wallet.Service/Models/UpdateAddressRequest.cs
+++ b/src/Services/Sorcha.Wallet.Service/Models/UpdateAddressRequest.cs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Sorcha Contributors
+using System.ComponentModel.DataAnnotations;
+
 namespace Sorcha.Wallet.Service.Models;
 
 /// <summary>
@@ -10,16 +12,19 @@ public class UpdateAddressRequest
     /// <summary>
     /// Updated label (null to leave unchanged)
     /// </summary>
+    [StringLength(200)]
     public string? Label { get; set; }
 
     /// <summary>
     /// Updated notes (null to leave unchanged)
     /// </summary>
+    [StringLength(2000)]
     public string? Notes { get; set; }
 
     /// <summary>
     /// Updated tags (null to leave unchanged)
     /// </summary>
+    [StringLength(1000)]
     public string? Tags { get; set; }
 
     /// <summary>


### PR DESCRIPTION
## VAL-001 (#327) — Wallet Service, safe surface only

Wires the merged `RequestValidationFilter` seam (`.WithRequestValidation()`, from PR #1096) onto the **non-crypto** management/credential endpoints of `Sorcha.Wallet.Service`, and annotates their request DTOs with conservative DataAnnotations. **This is the hot-path wallet service — crypto/recovery endpoints are deliberately left ungated.**

### SAFE tier — annotated AND wired (`.WithRequestValidation()`)
| DTO | Endpoint | Annotations added |
|-----|----------|-------------------|
| `StoreCredentialRequest` | `POST …/credentials` | `[Required(AllowEmptyStrings=false)]` on CredentialId/Type/IssuerDid/SubjectDid; generous `[StringLength]` on CredentialId/Type |
| `IssueCredentialRequest` | `POST …/credentials/issue` | `[Required]` on CredentialType/Claims/RecipientWallet; `[StringLength(256)]` on CredentialType |
| `UpdateStatusRequest` | `PATCH …/credentials/{id}/status` **and** `PATCH …/credentials/{id}` | `[Required(AllowEmptyStrings=false)]` + `[StringLength(64)]` on Status |
| `UpdateWalletRequest` | `PATCH …/wallets/{address}` | pre-annotated (`[StringLength]` on Name) — endpoint newly wired |
| `UpdateAddressRequest` | `PATCH …/wallets/{address}/addresses/{id}` | generous `[StringLength]` on Label/Notes/Tags |
| `RegisterDerivedAddressRequest` | `POST …/wallets/{address}/addresses` | pre-annotated (`[Required]` + existing BIP44 path regex) — endpoint newly wired |
| `GenerateAddressRequest` | *(not bound to any endpoint)* | light `[StringLength(120)]` on DerivationPath; nothing to wire |
| `DeriveKeyRequest` | `POST /api/wallets/org/{orgId}/derive-key` | `[property: Required(AllowEmptyStrings=false)]` on UserId |

No regexes were added to wallet addresses, DIDs, hex ids, keys, or base64. The pre-existing BIP44 regex on `RegisterDerivedAddressRequest.DerivationPath` matches all real usage (verified against the integration-test paths `m/44'/0'/0'/0/{i}`), so enforcing it does not break valid registrations.

### CRYPTO/RECOVERY tier — deliberately LEFT UNGATED
These carry signatures/keys/base64/ciphertext and drive core wallet crypto flows; a wrong constraint would permanently break signing/encryption/recovery. They need walkthrough verification before any enforcement, so their endpoints were **not** wired:

`SignTransactionRequest`, `VerifySignatureRequest`, `EncryptPayloadRequest`, `DecryptPayloadRequest`, `EncapsulateRequest`, `DecapsulateRequest`, `GrantAccessRequest`, `RecoverWalletRequest`, `RecoverOrgRequest`, `RecoverPasskeyRequest`, `SystemWalletRequest`, `RecoverSystemWalletRequest`, `PresentationRequest`, `CreatePresentationRequestDto`.

### Verification
- `dotnet build src/Services/Sorcha.Wallet.Service` — 0 errors
- `dotnet test tests/Sorcha.Wallet.Service.Tests` — 850 passed, 0 failed

Addresses #327 (Wallet service, safe surface; crypto hot-paths deferred — do NOT auto-close).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UDmeAycWwQ5Y8PXuz4iub6