### PR TITLE
feat: [327] request-DTO validation for Sorcha.Validator.Service (VAL-001)

### DIFF
--- a/src/Services/Sorcha.Validator.Service/Endpoints/AdminEndpoints.cs
+++ b/src/Services/Sorcha.Validator.Service/Endpoints/AdminEndpoints.cs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Sorcha Contributors
 
+using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Mvc;
 using Sorcha.Validator.Service.Services;
 
@@ -53,6 +55,7 @@ public static class AdminEndpoints
                 Message = $"Validator started for register {request.RegisterId}"
             });
         })
+        .WithRequestValidation()
         .WithName("StartValidator")
         .WithSummary("Start validator for a register")
         .WithDescription("Begins validation processing for the specified register")
@@ -96,6 +99,7 @@ public static class AdminEndpoints
                 MemPoolPersisted = request.PersistMemPool
             });
         })
+        .WithRequestValidation()
         .WithName("StopValidator")
         .WithSummary("Stop validator for a register")
         .WithDescription("Gracefully stops validation processing for the specified register")
@@ -192,6 +196,8 @@ public record StartValidatorRequest
     /// <summary>
     /// Register ID to validate
     /// </summary>
+    [Required(AllowEmptyStrings = false)]
+    [StringLength(256)]
     public required string RegisterId { get; init; }
 }
 
@@ -203,6 +209,8 @@ public record StopValidatorRequest
     /// <summary>
     /// Register ID to stop
     /// </summary>
+    [Required(AllowEmptyStrings = false)]
+    [StringLength(256)]
     public required string RegisterId { get; init; }
 
     /// <summary>

--- a/src/Services/Sorcha.Validator.Service/Endpoints/ValidationEndpoints.cs
+++ b/src/Services/Sorcha.Validator.Service/Endpoints/ValidationEndpoints.cs
@@ -2,7 +2,9 @@
 // Copyright (c) 2026 Sorcha Contributors
 
 using System.Buffers.Text;
+using System.ComponentModel.DataAnnotations;
 using System.Text.Json;
+using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Mvc;
 using Sorcha.Validator.Service.Models;
 using Sorcha.Validator.Service.Services;
@@ -20,6 +22,7 @@ public static class ValidationEndpoints
     public static RouteGroupBuilder MapValidationEndpoints(this RouteGroupBuilder group)
     {
         group.MapPost("/validate", ValidateTransaction)
+            .WithRequestValidation()
             .WithName("ValidateTransaction")
             .WithSummary("Validate a transaction and submit it to the memory pool")
             .WithDescription("Validates transaction structure, payload hash, wallet signatures, and per-sender sequence number, then submits the transaction to the unverified pool for downstream consensus and docket sealing. Call this when an AI agent needs to record a signed action on a Sorcha register and obtain a verifiable receipt that the validator accepted it.")
@@ -207,16 +210,35 @@ public static class ValidationEndpoints
 /// </summary>
 public record ValidateTransactionRequest
 {
+    [Required(AllowEmptyStrings = false)]
+    [StringLength(256)]
     public required string TransactionId { get; init; }
+
+    [Required(AllowEmptyStrings = false)]
+    [StringLength(256)]
     public required string RegisterId { get; init; }
+
+    [StringLength(256)]
     public string? BlueprintId { get; init; }
+
+    [StringLength(256)]
     public string? ActionId { get; init; }
+
     public required JsonElement Payload { get; init; }
+
+    [Required(AllowEmptyStrings = false)]
+    [StringLength(1024)]
     public required string PayloadHash { get; init; }
+
+    [Required]
     public required List<SignatureRequest> Signatures { get; init; }
+
     public required DateTimeOffset CreatedAt { get; init; }
     public DateTimeOffset? ExpiresAt { get; init; }
+
+    [StringLength(256)]
     public string? PreviousTransactionId { get; init; }
+
     public TransactionPriority Priority { get; init; } = TransactionPriority.Normal;
     public Dictionary<string, string>? Metadata { get; init; }
 
@@ -224,6 +246,7 @@ public record ValidateTransactionRequest
     /// Per-sender monotonic sequence number for replay protection (SEC-AUDIT 4.2).
     /// Must equal sender's last sequence number + 1 on the target register.
     /// </summary>
+    [Range(0, long.MaxValue)]
     public long SequenceNumber { get; init; }
 
     /// <summary>
@@ -239,9 +262,19 @@ public record ValidateTransactionRequest
 /// </summary>
 public record SignatureRequest
 {
+    [Required(AllowEmptyStrings = false)]
+    [StringLength(8192)]
     public required string PublicKey { get; init; }
+
+    [Required(AllowEmptyStrings = false)]
+    [StringLength(8192)]
     public required string SignatureValue { get; init; }
+
+    [Required(AllowEmptyStrings = false)]
+    [StringLength(64)]
     public required string Algorithm { get; init; }
+
+    [StringLength(256)]
     public string? SignedBy { get; init; }
 }
 

--- a/src/Services/Sorcha.Validator.Service/Endpoints/ValidatorRegistrationEndpoints.cs
+++ b/src/Services/Sorcha.Validator.Service/Endpoints/ValidatorRegistrationEndpoints.cs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Sorcha Contributors
 
+using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Mvc;
 using Sorcha.Validator.Service.Services;
 using Sorcha.Validator.Service.Services.Interfaces;
@@ -18,6 +20,7 @@ public static class ValidatorRegistrationEndpoints
     public static RouteGroupBuilder MapValidatorRegistrationEndpoints(this RouteGroupBuilder group)
     {
         group.MapPost("/register", RegisterValidator)
+            .WithRequestValidation()
             .WithName("RegisterValidator")
             .WithSummary("Register as a validator for a register")
             .WithDescription("Registers this validator node for participation in consensus. In public mode, registration is immediate. In consent mode, registration is pending until approved.")
@@ -55,6 +58,7 @@ public static class ValidatorRegistrationEndpoints
             .Produces(StatusCodes.Status401Unauthorized);
 
         group.MapPost("/{registerId}/{validatorId}/approve", ApproveValidator)
+            .WithRequestValidation()
             .WithName("ApproveValidator")
             .WithSummary("Approve a pending validator")
             .WithDescription("Approves a pending validator registration (consent mode only). Requires register owner authorization.")
@@ -63,6 +67,7 @@ public static class ValidatorRegistrationEndpoints
             .Produces(StatusCodes.Status401Unauthorized);
 
         group.MapPost("/{registerId}/{validatorId}/reject", RejectValidator)
+            .WithRequestValidation()
             .WithName("RejectValidator")
             .WithSummary("Reject a pending validator")
             .WithDescription("Rejects a pending validator registration (consent mode only). Requires register owner authorization.")
@@ -78,6 +83,7 @@ public static class ValidatorRegistrationEndpoints
             .Produces(StatusCodes.Status401Unauthorized);
 
         group.MapPost("/{registerId}/{validatorId}/suspend", SuspendValidator)
+            .WithRequestValidation()
             .WithName("SuspendValidator")
             .WithSummary("Suspend an active validator")
             .WithDescription("Suspends an active validator, preventing consensus participation. Cannot suspend the last active validator. Requires SystemAdmin authorization.")
@@ -87,6 +93,7 @@ public static class ValidatorRegistrationEndpoints
             .Produces(StatusCodes.Status401Unauthorized);
 
         group.MapPost("/{registerId}/{validatorId}/reactivate", ReactivateValidator)
+            .WithRequestValidation()
             .WithName("ReactivateValidator")
             .WithSummary("Reactivate a suspended validator")
             .WithDescription("Reactivates a previously suspended validator. Only valid from Suspended state. Requires SystemAdmin authorization.")
@@ -96,6 +103,7 @@ public static class ValidatorRegistrationEndpoints
             .Produces(StatusCodes.Status401Unauthorized);
 
         group.MapPost("/{registerId}/{validatorId}/revoke", RevokeValidator)
+            .WithRequestValidation()
             .WithName("RevokeValidator")
             .WithSummary("Permanently revoke a validator")
             .WithDescription("Permanently revokes a validator (terminal state). Cannot be re-activated. Cannot revoke the last active validator. Requires SystemAdmin authorization.")
@@ -732,9 +740,13 @@ public static class ValidatorRegistrationEndpoints
 public record SuspendValidatorRequest
 {
     /// <summary>Wallet address of administrator</summary>
+    [Required(AllowEmptyStrings = false)]
+    [StringLength(256)]
     public required string SuspendedBy { get; init; }
 
     /// <summary>Reason for suspension</summary>
+    [Required(AllowEmptyStrings = false)]
+    [StringLength(2048)]
     public required string Reason { get; init; }
 }
 
@@ -744,9 +756,12 @@ public record SuspendValidatorRequest
 public record ReactivateValidatorRequest
 {
     /// <summary>Wallet address of administrator</summary>
+    [Required(AllowEmptyStrings = false)]
+    [StringLength(256)]
     public required string ReactivatedBy { get; init; }
 
     /// <summary>Optional notes</summary>
+    [StringLength(2048)]
     public string? Notes { get; init; }
 }
 
@@ -756,9 +771,13 @@ public record ReactivateValidatorRequest
 public record RevokeValidatorRequest
 {
     /// <summary>Wallet address of administrator</summary>
+    [Required(AllowEmptyStrings = false)]
+    [StringLength(256)]
     public required string RevokedBy { get; init; }
 
     /// <summary>Reason for revocation</summary>
+    [Required(AllowEmptyStrings = false)]
+    [StringLength(2048)]
     public required string Reason { get; init; }
 }
 
@@ -768,15 +787,23 @@ public record RevokeValidatorRequest
 public record RegisterValidatorRequest
 {
     /// <summary>Register ID to join</summary>
+    [Required(AllowEmptyStrings = false)]
+    [StringLength(256)]
     public required string RegisterId { get; init; }
 
     /// <summary>Validator's unique identifier (wallet address)</summary>
+    [Required(AllowEmptyStrings = false)]
+    [StringLength(256)]
     public required string ValidatorId { get; init; }
 
     /// <summary>Validator's public key for signature verification</summary>
+    [Required(AllowEmptyStrings = false)]
+    [StringLength(8192)]
     public required string PublicKey { get; init; }
 
     /// <summary>gRPC endpoint for peer communication</summary>
+    [Required(AllowEmptyStrings = false)]
+    [StringLength(512)]
     public required string GrpcEndpoint { get; init; }
 
     /// <summary>Optional metadata</summary>
@@ -789,9 +816,12 @@ public record RegisterValidatorRequest
 public record ApproveValidatorRequest
 {
     /// <summary>Wallet address of approver (register owner)</summary>
+    [Required(AllowEmptyStrings = false)]
+    [StringLength(256)]
     public required string ApprovedBy { get; init; }
 
     /// <summary>Optional approval notes</summary>
+    [StringLength(2048)]
     public string? ApprovalNotes { get; init; }
 }
 
@@ -801,8 +831,12 @@ public record ApproveValidatorRequest
 public record RejectValidatorRequest
 {
     /// <summary>Wallet address of rejector (register owner)</summary>
+    [Required(AllowEmptyStrings = false)]
+    [StringLength(256)]
     public required string RejectedBy { get; init; }
 
     /// <summary>Reason for rejection</summary>
+    [Required(AllowEmptyStrings = false)]
+    [StringLength(2048)]
     public required string Reason { get; init; }
 }

--- a/tests/Sorcha.Validator.Service.Tests/Endpoints/AdminEndpointsTests.cs
+++ b/tests/Sorcha.Validator.Service.Tests/Endpoints/AdminEndpointsTests.cs
@@ -148,10 +148,12 @@ public class AdminEndpointsTests : IClassFixture<WebApplicationFactory<Program>>
         var response = await client.PostAsJsonAsync("/api/admin/validators/start", request);
 
         // Assert
+        // Request-DTO validation (VAL-001) short-circuits to an RFC 7807 ValidationProblem
+        // before the handler, so the empty RegisterId surfaces under the "errors" dictionary.
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
 
         var result = await response.Content.ReadFromJsonAsync<JsonElement>();
-        result.GetProperty("error").GetString().Should().Contain("RegisterId is required");
+        result.GetProperty("errors").TryGetProperty("RegisterId", out _).Should().BeTrue();
     }
 
     [Fact]
@@ -259,10 +261,12 @@ public class AdminEndpointsTests : IClassFixture<WebApplicationFactory<Program>>
         var response = await client.PostAsJsonAsync("/api/admin/validators/stop", request);
 
         // Assert
+        // Request-DTO validation (VAL-001) short-circuits to an RFC 7807 ValidationProblem
+        // before the handler, so the empty RegisterId surfaces under the "errors" dictionary.
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
 
         var result = await response.Content.ReadFromJsonAsync<JsonElement>();
-        result.GetProperty("error").GetString().Should().Contain("RegisterId is required");
+        result.GetProperty("errors").TryGetProperty("RegisterId", out _).Should().BeTrue();
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Adds DataAnnotations-based request-DTO validation to **Sorcha.Validator.Service** via the existing `RequestValidationFilter` seam (`.WithRequestValidation()`), following the pattern from merged PR #1096. Validation runs before the handler and short-circuits to a `400 ValidationProblem` (RFC 7807).

## DTOs annotated

| File | DTOs |
|------|------|
| `Endpoints/AdminEndpoints.cs` | `StartValidatorRequest`, `StopValidatorRequest` |
| `Endpoints/ValidationEndpoints.cs` | `ValidateTransactionRequest`, `SignatureRequest` (nested — validated element-by-element by the filter) |
| `Endpoints/ValidatorRegistrationEndpoints.cs` | `RegisterValidatorRequest`, `ApproveValidatorRequest`, `RejectValidatorRequest`, `SuspendValidatorRequest`, `ReactivateValidatorRequest`, `RevokeValidatorRequest` |

## Endpoints wired with `.WithRequestValidation()`

- `POST /api/admin/validators/start`, `POST /api/admin/validators/stop`
- `POST /api/v1/transactions/validate`
- `POST /register`, and `/{registerId}/{validatorId}/{approve,reject,suspend,reactivate,revoke}`

## Conservative-constraint rationale

- `[Required(AllowEmptyStrings = false)]` on mandatory strings; generous `[StringLength]` bounds (256 for ids/addresses, 512 for the gRPC endpoint, **8192** for public keys / signature values, 2048 for free-form reasons / notes).
- `[Range(0, long.MaxValue)]` on `SequenceNumber` (it is cast to `ulong` downstream).
- **No `[RegularExpression]`** — wallet addresses, DIDs, transaction/payload hashes, signatures, public keys and base64 are all format-risky and a wrong pattern would false-reject valid input, so those fields get `[Required]` + `[StringLength]` only.
- `ThresholdSetupRequest` / `ThresholdSignRequest` already carry FluentValidation validators (`ThresholdValidators.cs`), so they were intentionally left untouched to avoid double/conflicting validation.

## Tests

Updated the two `AdminEndpointsTests` empty-`RegisterId` cases to assert the RFC 7807 `errors` dictionary shape now produced by the filter (previously they asserted the handler's ad-hoc `error` string, which no longer runs). Full suite: **989 passed, 0 failed, 21 skipped**.

Addresses #327 (Validator service; sweep spans services — do NOT auto-close).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UDmeAycWwQ5Y8PXuz4iub6