### PR TITLE
perf: quick wins batch 1 — Mongo indexes, hash-options reuse, wallet-read throttle, gossip channel reuse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -290,3 +290,6 @@ deploy/
 /demo-nodes.json
 /state.json
 /demo-citizen-state.json
+
+# BenchmarkDotNet run artifacts
+BenchmarkDotNet.Artifacts/

--- a/src/Common/Sorcha.Cryptography/Utilities/DocketHasher.cs
+++ b/src/Common/Sorcha.Cryptography/Utilities/DocketHasher.cs
@@ -14,6 +14,16 @@ namespace Sorcha.Cryptography.Utilities;
 /// </summary>
 public class DocketHasher
 {
+    // Canonical hash-input serialization: exact property names, no whitespace. Hoisted to a single
+    // shared instance (perf audit T10) — a fresh JsonSerializerOptions per call rebuilds an un-shared
+    // converter/metadata cache. Output is byte-identical to the previous per-call options, so docket/
+    // transaction hashes are unchanged (this MUST stay deterministic — it feeds the hash).
+    private static readonly JsonSerializerOptions HashInputJsonOptions = new()
+    {
+        PropertyNamingPolicy = null,
+        WriteIndented = false
+    };
+
     private readonly IHashProvider _hashProvider;
 
     public DocketHasher(IHashProvider hashProvider)
@@ -49,11 +59,7 @@ public class DocketHasher
             Timestamp = timestamp.ToUnixTimeMilliseconds() // Unix timestamp for determinism
         };
 
-        var json = JsonSerializer.Serialize(hashInput, new JsonSerializerOptions
-        {
-            PropertyNamingPolicy = null, // Use exact property names
-            WriteIndented = false // No whitespace
-        });
+        var json = JsonSerializer.Serialize(hashInput, HashInputJsonOptions);
 
         var bytes = Encoding.UTF8.GetBytes(json);
         var hashBytes = _hashProvider.ComputeHash(bytes, hashType);
@@ -97,11 +103,7 @@ public class DocketHasher
             Timestamp = timestamp.ToUnixTimeMilliseconds()
         };
 
-        var json = JsonSerializer.Serialize(hashInput, new JsonSerializerOptions
-        {
-            PropertyNamingPolicy = null,
-            WriteIndented = false
-        });
+        var json = JsonSerializer.Serialize(hashInput, HashInputJsonOptions);
 
         var bytes = Encoding.UTF8.GetBytes(json);
         var hashBytes = _hashProvider.ComputeHash(bytes, hashType);

--- a/src/Core/Sorcha.Register.Storage.MongoDB/MongoRegisterRepository.cs
+++ b/src/Core/Sorcha.Register.Storage.MongoDB/MongoRegisterRepository.cs
@@ -350,7 +350,27 @@ public class MongoRegisterRepository : IRegisterRepository
             new(Builders<TransactionModel>.IndexKeys
                 .Ascending("MetaData.TransactionType")
                 .Ascending("MetaData.TrackingData.originalTxId"),
-                new CreateIndexOptions { Name = "IX_Transactions_Revocation_OriginalTxId" })
+                new CreateIndexOptions { Name = "IX_Transactions_Revocation_OriginalTxId" }),
+
+            // perf (2026-07-04 audit T2): recipient-wallet inbox routing —
+            // GetAllTransactionsByRecipientAddressAsync does AnyEq(RecipientsWallets) sorted by TimeStamp desc.
+            // Multikey on the array + a scalar sort key (Mongo allows one array field per compound index).
+            new(Builders<TransactionModel>.IndexKeys
+                .Ascending(t => t.RecipientsWallets)
+                .Descending(t => t.TimeStamp),
+                new CreateIndexOptions { Name = "IX_Transactions_Recipients_TimeStamp" }),
+
+            // perf (T2): credential verify/revoke — GetCredentialIssuanceTransactionAsync filters
+            // MetaData.TrackingData.type + MetaData.TrackingData.credentialId (previously a COLLSCAN).
+            new(Builders<TransactionModel>.IndexKeys
+                .Ascending("MetaData.TrackingData.type")
+                .Ascending("MetaData.TrackingData.credentialId"),
+                new CreateIndexOptions { Name = "IX_Transactions_TrackingData_CredentialId" }),
+
+            // perf (T2): get-transactions-by-instance filters MetaData.InstanceId ALONE; the
+            // (BlueprintId, InstanceId) compound above can't serve an InstanceId-only predicate (wrong prefix).
+            new(Builders<TransactionModel>.IndexKeys.Ascending("MetaData.InstanceId"),
+                new CreateIndexOptions { Name = "IX_Transactions_InstanceId" })
         };
         await collection.Indexes.CreateManyAsync(transactionIndexes);
     }

--- a/src/Core/Sorcha.Wallet.Core/Repositories/EfCoreWalletRepository.cs
+++ b/src/Core/Sorcha.Wallet.Core/Repositories/EfCoreWalletRepository.cs
@@ -15,6 +15,9 @@ namespace Sorcha.Wallet.Core.Repositories;
 /// </summary>
 public class EfCoreWalletRepository : IWalletRepository
 {
+    /// <summary>Only re-stamp <c>LastAccessedAt</c> on read when it's staler than this (perf audit T12).</summary>
+    private static readonly TimeSpan LastAccessedBumpThreshold = TimeSpan.FromMinutes(5);
+
     private readonly WalletDbContext _context;
     private readonly ILogger<EfCoreWalletRepository> _logger;
 
@@ -120,9 +123,12 @@ public class EfCoreWalletRepository : IWalletRepository
             .AsNoTracking()
             .FirstOrDefaultAsync(w => w.Address == address, cancellationToken);
 
-        if (wallet != null)
+        if (wallet != null &&
+            DateTime.UtcNow - wallet.LastAccessedAt > LastAccessedBumpThreshold)
         {
-            // Update last accessed time in a separate operation to avoid tracking issues
+            // perf audit T12: GetByAddressAsync is the hottest wallet read; the previous unconditional
+            // bump added a second round-trip to EVERY read. Only bump when the stamp is stale beyond the
+            // threshold — last-accessed is coarse telemetry, so ~5-minute granularity is ample.
             await UpdateLastAccessedAsync(address, cancellationToken);
         }
 

--- a/src/Services/Sorcha.Peer.Service/Distribution/TransactionDistributionService.cs
+++ b/src/Services/Sorcha.Peer.Service/Distribution/TransactionDistributionService.cs
@@ -259,10 +259,20 @@ public class TransactionDistributionService
                 cancellationToken);
         }
 
+        // perf audit T4/F2: reuse the pooled gRPC channel for a connected peer rather than building and
+        // tearing down a fresh HTTP/2 connection (TCP+TLS handshake) per gossip message. Only create a
+        // throwaway channel when the peer isn't in the pool; the pool owns (and must not dispose) its own.
+        GrpcChannel? ownedChannel = null;
         try
         {
-            var address = $"http://{peer.Address}:{peer.Port}";
-            using var channel = GrpcChannel.ForAddress(address);
+            var channel = _peerConnectionPool?.GetChannel(peer.PeerId);
+            if (channel is null)
+            {
+                var address = $"http://{peer.Address}:{peer.Port}";
+                ownedChannel = GrpcChannel.ForAddress(address);
+                channel = ownedChannel;
+            }
+
             var client = new Protos.TransactionDistribution.TransactionDistributionClient(channel);
 
             var request = new Protos.TransactionNotification
@@ -288,6 +298,10 @@ public class TransactionDistributionService
             _logger.LogWarning(ex, "Failed to send transaction {TxId} to peer {PeerId}",
                 transaction.TransactionId, peer.PeerId);
             return false;
+        }
+        finally
+        {
+            ownedChannel?.Dispose();
         }
     }
 

--- a/tests/Sorcha.TransactionHandler.Benchmarks/DocketHashOptionsBenchmark.cs
+++ b/tests/Sorcha.TransactionHandler.Benchmarks/DocketHashOptionsBenchmark.cs
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Text;
+using System.Text.Json;
+using BenchmarkDotNet.Attributes;
+
+namespace Sorcha.TransactionHandler.Benchmarks;
+
+/// <summary>
+/// Perf-audit T10 evidence: the DocketHasher serialize step formerly allocated a fresh
+/// <see cref="JsonSerializerOptions"/> per call (once per transaction AND once per docket during sealing).
+/// A fresh options instance rebuilds an un-shared converter/metadata cache, so the serialize pays that
+/// cost every time. <c>PerCallOptions</c> reproduces the old pattern; <c>SharedOptions</c> is the shipped
+/// change. Both produce byte-identical JSON (verified separately by the crypto determinism tests).
+/// </summary>
+[MemoryDiagnoser]
+public class DocketHashOptionsBenchmark
+{
+    // Representative docket-sealing hash input (matches DocketHasher.ComputeTransactionHash's shape).
+    private readonly object _hashInput = new
+    {
+        TransactionId = "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+        PayloadHash = "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
+        Timestamp = 1_720_080_000_000L,
+    };
+
+    private static readonly JsonSerializerOptions SharedHashOptions = new()
+    {
+        PropertyNamingPolicy = null,
+        WriteIndented = false,
+    };
+
+    [Benchmark(Baseline = true, Description = "new JsonSerializerOptions per call (old)")]
+    public byte[] PerCallOptions()
+    {
+        var json = JsonSerializer.Serialize(_hashInput, new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = null,
+            WriteIndented = false,
+        });
+        return Encoding.UTF8.GetBytes(json);
+    }
+
+    [Benchmark(Description = "shared static JsonSerializerOptions (new)")]
+    public byte[] SharedOptions()
+    {
+        var json = JsonSerializer.Serialize(_hashInput, SharedHashOptions);
+        return Encoding.UTF8.GetBytes(json);
+    }
+}

--- a/tests/Sorcha.TransactionHandler.Benchmarks/Program.cs
+++ b/tests/Sorcha.TransactionHandler.Benchmarks/Program.cs
@@ -1,4 +1,4 @@
 using BenchmarkDotNet.Running;
-using Sorcha.TransactionHandler.Benchmarks;
 
-BenchmarkRunner.Run<TransactionBenchmarks>();
+// Run any benchmark in this assembly; select with --filter (e.g. --filter *DocketHashOptions*).
+BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);


### PR DESCRIPTION
From the 2026-07-04 performance analysis (docs/audits). Safe, non-schema quick wins:

- **T2 — three missing Mongo indexes** on the Register transaction collection: recipient-wallet inbox
  routing (RecipientsWallets + TimeStamp), credential verify/revoke (TrackingData.type+credentialId),
  and get-transactions-by-instance (MetaData.InstanceId, which the (BlueprintId,InstanceId) compound
  can't serve alone). These queries already push their filter to Mongo via Find/QueryTransactionsAsync,
  so they were COLLSCANs purely for lack of an index — now index seeks.
- **T10 — DocketHasher JsonSerializerOptions reuse**: hoist the per-call `new JsonSerializerOptions`
  (allocated once per transaction AND once per docket during sealing) to a single static readonly.
  Output is byte-identical (same settings) so docket/transaction hashes are unchanged — verified by the
  401 crypto tests incl. the determinism suite.
- **T12 — throttle the wallet-read LastAccessedAt bump**: GetByAddressAsync is the hottest wallet read
  and previously fired a second UPDATE on every call; now only bumps when the stamp is stale (>5 min).
- **T4/F2 — reuse pooled gRPC channel in transaction gossip** instead of building+disposing a fresh
  HTTP/2 channel per message; falls back to a throwaway channel only for unpooled peers (pool owns its own).

No behaviour change beyond the intended perf: hashes byte-identical, LastAccessedAt is coarse telemetry,
gossip semantics unchanged. (EF index additions + gRPC client singleton + the remaining audit items are
separate follow-up batches — EF ones will squash into InitialCreate per the pre-release convention.)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UDmeAycWwQ5Y8PXuz4iub6
