### PR TITLE
perf: [audit F9] standalone UserIdentity.Email index, squashed into InitialCreate

### DIFF
--- a/src/Services/Sorcha.Tenant.Service/Data/TenantDbContext.cs
+++ b/src/Services/Sorcha.Tenant.Service/Data/TenantDbContext.cs
@@ -517,6 +517,12 @@ public class TenantDbContext : DbContext
                 .IsUnique()
                 .HasDatabaseName("UQ_UserIdentity_Org_Email");  // Email must be unique within organization
 
+            // perf audit F9: GetUserByEmailAsync filters on Email alone, but the unique composite above
+            // leads with OrganizationId so it can't serve an email-only lookup (→ sequential scan on a
+            // login-adjacent path). A standalone Email index makes it an index seek.
+            entity.HasIndex(e => e.Email)
+                .HasDatabaseName("IX_UserIdentity_Email");
+
             entity.HasIndex(e => e.OrganizationId);
             entity.HasIndex(e => e.Status);
 

--- a/src/Services/Sorcha.Tenant.Service/Migrations/20260513152714_InitialCreate.Designer.cs
+++ b/src/Services/Sorcha.Tenant.Service/Migrations/20260513152714_InitialCreate.Designer.cs
@@ -1590,6 +1590,9 @@ namespace Sorcha.Tenant.Service.Migrations
 
                     b.HasIndex("Status");
 
+                    b.HasIndex("Email")
+                        .HasDatabaseName("IX_UserIdentity_Email");
+
                     b.HasIndex("OrganizationId", "Email")
                         .IsUnique()
                         .HasDatabaseName("UQ_UserIdentity_Org_Email");

--- a/src/Services/Sorcha.Tenant.Service/Migrations/20260513152714_InitialCreate.cs
+++ b/src/Services/Sorcha.Tenant.Service/Migrations/20260513152714_InitialCreate.cs
@@ -1185,6 +1185,12 @@ namespace Sorcha.Tenant.Service.Migrations
                 unique: true);
 
             migrationBuilder.CreateIndex(
+                name: "IX_UserIdentity_Email",
+                schema: "public",
+                table: "UserIdentities",
+                column: "Email");
+
+            migrationBuilder.CreateIndex(
                 name: "UQ_UserPreferences_UserId",
                 schema: "public",
                 table: "UserPreferences",

--- a/src/Services/Sorcha.Tenant.Service/Migrations/TenantDbContextModelSnapshot.cs
+++ b/src/Services/Sorcha.Tenant.Service/Migrations/TenantDbContextModelSnapshot.cs
@@ -1513,6 +1513,9 @@ namespace Sorcha.Tenant.Service.Migrations
 
                     b.HasIndex("Status");
 
+                    b.HasIndex("Email")
+                        .HasDatabaseName("IX_UserIdentity_Email");
+
                     b.HasIndex("OrganizationId", "Email")
                         .IsUnique()
                         .HasDatabaseName("UQ_UserIdentity_Org_Email");


### PR DESCRIPTION
GetUserByEmailAsync filters on Email alone, but the only Email index is the unique composite
(OrganizationId, Email) which leads with OrganizationId — so an email-only lookup (a login-adjacent
path) couldn't use it and did a sequential scan. Adds a standalone IX_UserIdentity_Email index.

Per the pre-release squash convention, this is folded into the existing InitialCreate migration
(Up CreateIndex + Designer + ModelSnapshot) rather than a new migration file — a fresh `down -v` DB
gets it in the single migration. Done via `dotnet ef migrations add` (temp) → fold → delete-temp, so
the snapshot format is tooling-correct; the ModelSnapshot diff is exactly the two index lines (no EF
version bump or entity reordering).

Verified on this machine:
- `dotnet ef migrations has-pending-model-changes` → No changes (no MigrateAsync PendingModelChanges warning).
- `dotnet ef database update` against a fresh scratch DB applied InitialCreate cleanly and
  `pg_indexes` confirmed IX_UserIdentity_Email was created.

First of the EF-index audit items; the Tenant inbox partial index and the Blueprint composites/partials
follow the same squash pattern.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UDmeAycWwQ5Y8PXuz4iub6
