### PR TITLE
perf: [audit F14] partial index for the inbox unread-count query, squashed into InitialCreate

### DIFF
--- a/src/Services/Sorcha.Tenant.Service/Data/TenantDbContext.cs
+++ b/src/Services/Sorcha.Tenant.Service/Data/TenantDbContext.cs
@@ -266,6 +266,13 @@ public class TenantDbContext : DbContext
             entity.HasIndex(e => new { e.PlatformUserId, e.Category, e.OccurredAt })
                 .HasDatabaseName("IX_InboxEntries_PlatformUserId_Category_OccurredAt");
 
+            // perf audit F14: the unread-count + default drawer query filters
+            // PlatformUserId AND ReadAt IS NULL AND DismissedAt IS NULL. A partial index keeps it
+            // O(unread working set) instead of scanning the user's full notification history.
+            entity.HasIndex(e => e.PlatformUserId)
+                .HasDatabaseName("IX_InboxEntries_Unread")
+                .HasFilter("\"ReadAt\" IS NULL AND \"DismissedAt\" IS NULL");
+
             // Cascade delete with PlatformUser.
             entity.HasOne<PlatformUser>()
                 .WithMany()

--- a/src/Services/Sorcha.Tenant.Service/Migrations/20260513152714_InitialCreate.Designer.cs
+++ b/src/Services/Sorcha.Tenant.Service/Migrations/20260513152714_InitialCreate.Designer.cs
@@ -400,6 +400,10 @@ namespace Sorcha.Tenant.Service.Migrations
                     b.HasIndex("PlatformUserId", "Category", "OccurredAt")
                         .HasDatabaseName("IX_InboxEntries_PlatformUserId_Category_OccurredAt");
 
+                    b.HasIndex("PlatformUserId")
+                        .HasDatabaseName("IX_InboxEntries_Unread")
+                        .HasFilter("\"ReadAt\" IS NULL AND \"DismissedAt\" IS NULL");
+
                     b.HasIndex("PlatformUserId", "CorrelationKey", "OccurredAt")
                         .HasDatabaseName("IX_InboxEntries_PlatformUserId_CorrelationKey_OccurredAt");
 

--- a/src/Services/Sorcha.Tenant.Service/Migrations/20260513152714_InitialCreate.cs
+++ b/src/Services/Sorcha.Tenant.Service/Migrations/20260513152714_InitialCreate.cs
@@ -878,6 +878,13 @@ namespace Sorcha.Tenant.Service.Migrations
                 unique: true);
 
             migrationBuilder.CreateIndex(
+                name: "IX_InboxEntries_Unread",
+                schema: "public",
+                table: "InboxEntries",
+                column: "PlatformUserId",
+                filter: "\"ReadAt\" IS NULL AND \"DismissedAt\" IS NULL");
+
+            migrationBuilder.CreateIndex(
                 name: "IX_InvNonce_Nonce",
                 schema: "public",
                 table: "InvitationNonces",

--- a/src/Services/Sorcha.Tenant.Service/Migrations/TenantDbContextModelSnapshot.cs
+++ b/src/Services/Sorcha.Tenant.Service/Migrations/TenantDbContextModelSnapshot.cs
@@ -323,6 +323,10 @@ namespace Sorcha.Tenant.Service.Migrations
                     b.HasIndex("PlatformUserId", "Category", "OccurredAt")
                         .HasDatabaseName("IX_InboxEntries_PlatformUserId_Category_OccurredAt");
 
+                    b.HasIndex("PlatformUserId")
+                        .HasDatabaseName("IX_InboxEntries_Unread")
+                        .HasFilter("\"ReadAt\" IS NULL AND \"DismissedAt\" IS NULL");
+
                     b.HasIndex("PlatformUserId", "CorrelationKey", "OccurredAt")
                         .HasDatabaseName("IX_InboxEntries_PlatformUserId_CorrelationKey_OccurredAt");
 


### PR DESCRIPTION
The unread-count + default drawer query (EfCoreInboxStore) filters
PlatformUserId AND ReadAt IS NULL AND DismissedAt IS NULL, but the existing InboxEntries indexes are
all (PlatformUserId, ...) full indexes — so it scanned the user's whole notification history. A partial
index on PlatformUserId filtered to the unread predicate keeps it O(unread working set).

Folded into the existing InitialCreate migration per the pre-release squash convention (same process as
the Email index #1107): temp migration -> fold CreateIndex + snapshot -> restore ModelSnapshot from
master + hand-add the index line -> delete temp. Mirrors the codebase's existing HasFilter partial-index
style (AuthChallengeToken.IX_..._User_Active).

Verified on this machine:
- has-pending-model-changes -> No changes.
- dotnet ef database update against a fresh scratch DB created:
  CREATE INDEX "IX_InboxEntries_Unread" ON public."InboxEntries" (...) WHERE ("ReadAt" IS NULL AND "DismissedAt" IS NULL)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UDmeAycWwQ5Y8PXuz4iub6
