### PR TITLE
perf: [audit F14] partial index for the file-metadata orphan sweep, squashed into InitialCreate

### DIFF
--- a/src/Services/Sorcha.Blueprint.Service/Data/BlueprintDbContext.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Data/BlueprintDbContext.cs
@@ -94,6 +94,13 @@ public class BlueprintDbContext : DbContext
         {
             entity.ToTable("FileMetadata");
             entity.HasKey(e => e.Id);
+
+            // perf audit F14: the orphan-chunk sweep filters TransactionHash IS NULL AND CreatedAt < cutoff
+            // (EfCoreActionStore). A partial index on CreatedAt over the null-TransactionHash subset keeps
+            // the periodic sweep O(orphan working set) instead of scanning all file metadata.
+            entity.HasIndex(e => e.CreatedAt)
+                .HasDatabaseName("IX_FileMetadata_Orphans")
+                .HasFilter("\"TransactionHash\" IS NULL");
         });
 
         // Instance configuration

--- a/src/Services/Sorcha.Blueprint.Service/Data/Migrations/20260528205017_InitialCreate.Designer.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Data/Migrations/20260528205017_InitialCreate.Designer.cs
@@ -223,6 +223,10 @@ namespace Sorcha.Blueprint.Service.Data.Migrations
 
                     b.HasIndex("TransactionHash");
 
+                    b.HasIndex("CreatedAt")
+                        .HasDatabaseName("IX_FileMetadata_Orphans")
+                        .HasFilter("\"TransactionHash\" IS NULL");
+
                     b.ToTable("FileMetadata", "blueprint");
                 });
 

--- a/src/Services/Sorcha.Blueprint.Service/Data/Migrations/20260528205017_InitialCreate.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Data/Migrations/20260528205017_InitialCreate.cs
@@ -191,6 +191,13 @@ namespace Sorcha.Blueprint.Service.Data.Migrations
                 });
 
             migrationBuilder.CreateIndex(
+                name: "IX_FileMetadata_Orphans",
+                schema: "blueprint",
+                table: "FileMetadata",
+                column: "CreatedAt",
+                filter: "\"TransactionHash\" IS NULL");
+
+            migrationBuilder.CreateIndex(
                 name: "IX_Actions_Wallet_Register",
                 schema: "blueprint",
                 table: "Actions",

--- a/src/Services/Sorcha.Blueprint.Service/Data/Migrations/BlueprintDbContextModelSnapshot.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Data/Migrations/BlueprintDbContextModelSnapshot.cs
@@ -220,6 +220,10 @@ namespace Sorcha.Blueprint.Service.Data.Migrations
 
                     b.HasIndex("TransactionHash");
 
+                    b.HasIndex("CreatedAt")
+                        .HasDatabaseName("IX_FileMetadata_Orphans")
+                        .HasFilter("\"TransactionHash\" IS NULL");
+
                     b.ToTable("FileMetadata", "blueprint");
                 });
 


### PR DESCRIPTION
The 5-minute OrphanChunkCleanup sweep filters TransactionHash IS NULL AND CreatedAt < cutoff
(EfCoreActionStore), but FileMetadata only had the FK index on TransactionHash — so the sweep scanned
all file metadata. A partial index on CreatedAt over the null-TransactionHash subset keeps it
O(orphan working set).

Folded into the existing Blueprint InitialCreate migration per the pre-release squash convention (same
process as #1107/#1108): temp migration -> fold CreateIndex + snapshot -> restore ModelSnapshot from
master + hand-add the index line -> delete temp.

Verified on this machine:
- has-pending-model-changes -> No changes.
- dotnet ef database update (fresh scratch DB) created:
  CREATE INDEX "IX_FileMetadata_Orphans" ON blueprint."FileMetadata" (CreatedAt) WHERE ("TransactionHash" IS NULL)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UDmeAycWwQ5Y8PXuz4iub6
