### PR TITLE
perf: [audit F11] sort-aligned composite indexes on Instances/Actions, squashed into InitialCreate

### DIFF
--- a/src/Services/Sorcha.Blueprint.Service/Data/BlueprintDbContext.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Data/BlueprintDbContext.cs
@@ -76,8 +76,12 @@ public class BlueprintDbContext : DbContext
             entity.ToTable("Actions");
             entity.HasKey(e => e.TransactionHash);
             entity.Property(e => e.Content).HasColumnType("jsonb");
-            entity.HasIndex(e => new { e.WalletAddress, e.RegisterAddress })
-                .HasDatabaseName("IX_Actions_Wallet_Register");
+            // perf audit F11: the by-wallet list query filters (WalletAddress, RegisterAddress) then
+            // ORDER BY CreatedAt DESC — a sort-aligned composite serves filter + sort + page from one index
+            // (the leading columns still serve the plain (WalletAddress, RegisterAddress) lookup).
+            entity.HasIndex(e => new { e.WalletAddress, e.RegisterAddress, e.CreatedAt })
+                .HasDatabaseName("IX_Actions_Wallet_Register_CreatedAt")
+                .IsDescending(false, false, true);
             entity.HasIndex(e => e.IdempotencyKey)
                 .IsUnique()
                 .HasDatabaseName("UX_Actions_IdempotencyKey")
@@ -115,9 +119,18 @@ public class BlueprintDbContext : DbContext
             entity.Property(e => e.ActiveBranches).HasColumnType("jsonb");
             entity.Property(e => e.Metadata).HasColumnType("jsonb");
             entity.Property(e => e.Version).IsConcurrencyToken();
-            entity.HasIndex(e => e.BlueprintId).HasDatabaseName("IX_Instances_BlueprintId");
-            entity.HasIndex(e => e.RegisterId).HasDatabaseName("IX_Instances_RegisterId");
-            entity.HasIndex(e => e.State).HasDatabaseName("IX_Instances_State");
+            // perf audit F11: list/history queries filter on these then ORDER BY CreatedAt/UpdatedAt DESC —
+            // sort-aligned composites serve filter + sort + page from the index (the leading column still
+            // serves the plain lookups the single-column indexes used to).
+            entity.HasIndex(e => new { e.BlueprintId, e.CreatedAt })
+                .HasDatabaseName("IX_Instances_BlueprintId_CreatedAt")
+                .IsDescending(false, true);
+            entity.HasIndex(e => new { e.RegisterId, e.CreatedAt })
+                .HasDatabaseName("IX_Instances_RegisterId_CreatedAt")
+                .IsDescending(false, true);
+            entity.HasIndex(e => new { e.State, e.UpdatedAt })
+                .HasDatabaseName("IX_Instances_State_UpdatedAt")
+                .IsDescending(false, true);
         });
 
         // Feature 142 — RehearsalPass configuration

--- a/src/Services/Sorcha.Blueprint.Service/Data/Migrations/20260528205017_InitialCreate.Designer.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Data/Migrations/20260528205017_InitialCreate.Designer.cs
@@ -59,8 +59,9 @@ namespace Sorcha.Blueprint.Service.Data.Migrations
                         .HasDatabaseName("UX_Actions_IdempotencyKey")
                         .HasFilter("\"IdempotencyKey\" IS NOT NULL");
 
-                    b.HasIndex("WalletAddress", "RegisterAddress")
-                        .HasDatabaseName("IX_Actions_Wallet_Register");
+                    b.HasIndex("WalletAddress", "RegisterAddress", "CreatedAt")
+                        .IsDescending(false, false, true)
+                        .HasDatabaseName("IX_Actions_Wallet_Register_CreatedAt");
 
                     b.ToTable("Actions", "blueprint");
                 });
@@ -294,14 +295,17 @@ namespace Sorcha.Blueprint.Service.Data.Migrations
 
                     b.HasKey("Id");
 
-                    b.HasIndex("BlueprintId")
-                        .HasDatabaseName("IX_Instances_BlueprintId");
+                    b.HasIndex("BlueprintId", "CreatedAt")
+                        .IsDescending(false, true)
+                        .HasDatabaseName("IX_Instances_BlueprintId_CreatedAt");
 
-                    b.HasIndex("RegisterId")
-                        .HasDatabaseName("IX_Instances_RegisterId");
+                    b.HasIndex("RegisterId", "CreatedAt")
+                        .IsDescending(false, true)
+                        .HasDatabaseName("IX_Instances_RegisterId_CreatedAt");
 
-                    b.HasIndex("State")
-                        .HasDatabaseName("IX_Instances_State");
+                    b.HasIndex("State", "UpdatedAt")
+                        .IsDescending(false, true)
+                        .HasDatabaseName("IX_Instances_State_UpdatedAt");
 
                     b.ToTable("Instances", "blueprint");
                 });

--- a/src/Services/Sorcha.Blueprint.Service/Data/Migrations/20260528205017_InitialCreate.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Data/Migrations/20260528205017_InitialCreate.cs
@@ -198,10 +198,11 @@ namespace Sorcha.Blueprint.Service.Data.Migrations
                 filter: "\"TransactionHash\" IS NULL");
 
             migrationBuilder.CreateIndex(
-                name: "IX_Actions_Wallet_Register",
+                name: "IX_Actions_Wallet_Register_CreatedAt",
                 schema: "blueprint",
                 table: "Actions",
-                columns: new[] { "WalletAddress", "RegisterAddress" });
+                columns: new[] { "WalletAddress", "RegisterAddress", "CreatedAt" },
+                descending: new[] { false, false, true });
 
             migrationBuilder.CreateIndex(
                 name: "UX_Actions_IdempotencyKey",
@@ -243,22 +244,25 @@ namespace Sorcha.Blueprint.Service.Data.Migrations
                 column: "TransactionHash");
 
             migrationBuilder.CreateIndex(
-                name: "IX_Instances_BlueprintId",
+                name: "IX_Instances_BlueprintId_CreatedAt",
                 schema: "blueprint",
                 table: "Instances",
-                column: "BlueprintId");
+                columns: new[] { "BlueprintId", "CreatedAt" },
+                descending: new[] { false, true });
 
             migrationBuilder.CreateIndex(
-                name: "IX_Instances_RegisterId",
+                name: "IX_Instances_RegisterId_CreatedAt",
                 schema: "blueprint",
                 table: "Instances",
-                column: "RegisterId");
+                columns: new[] { "RegisterId", "CreatedAt" },
+                descending: new[] { false, true });
 
             migrationBuilder.CreateIndex(
-                name: "IX_Instances_State",
+                name: "IX_Instances_State_UpdatedAt",
                 schema: "blueprint",
                 table: "Instances",
-                column: "State");
+                columns: new[] { "State", "UpdatedAt" },
+                descending: new[] { false, true });
 
             migrationBuilder.CreateIndex(
                 name: "IX_PublishOverrides_Blueprint_OverriddenAt",

--- a/src/Services/Sorcha.Blueprint.Service/Data/Migrations/BlueprintDbContextModelSnapshot.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Data/Migrations/BlueprintDbContextModelSnapshot.cs
@@ -56,8 +56,9 @@ namespace Sorcha.Blueprint.Service.Data.Migrations
                         .HasDatabaseName("UX_Actions_IdempotencyKey")
                         .HasFilter("\"IdempotencyKey\" IS NOT NULL");
 
-                    b.HasIndex("WalletAddress", "RegisterAddress")
-                        .HasDatabaseName("IX_Actions_Wallet_Register");
+                    b.HasIndex("WalletAddress", "RegisterAddress", "CreatedAt")
+                        .IsDescending(false, false, true)
+                        .HasDatabaseName("IX_Actions_Wallet_Register_CreatedAt");
 
                     b.ToTable("Actions", "blueprint");
                 });
@@ -291,14 +292,17 @@ namespace Sorcha.Blueprint.Service.Data.Migrations
 
                     b.HasKey("Id");
 
-                    b.HasIndex("BlueprintId")
-                        .HasDatabaseName("IX_Instances_BlueprintId");
+                    b.HasIndex("BlueprintId", "CreatedAt")
+                        .IsDescending(false, true)
+                        .HasDatabaseName("IX_Instances_BlueprintId_CreatedAt");
 
-                    b.HasIndex("RegisterId")
-                        .HasDatabaseName("IX_Instances_RegisterId");
+                    b.HasIndex("RegisterId", "CreatedAt")
+                        .IsDescending(false, true)
+                        .HasDatabaseName("IX_Instances_RegisterId_CreatedAt");
 
-                    b.HasIndex("State")
-                        .HasDatabaseName("IX_Instances_State");
+                    b.HasIndex("State", "UpdatedAt")
+                        .IsDescending(false, true)
+                        .HasDatabaseName("IX_Instances_State_UpdatedAt");
 
                     b.ToTable("Instances", "blueprint");
                 });


### PR DESCRIPTION
The instance list/history and by-wallet action queries filter on a column then ORDER BY CreatedAt/
UpdatedAt DESC, but the indexes were single-column (BlueprintId/RegisterId/State) or a 2-col composite
without the sort key — so Postgres seeked the filter then did an explicit sort of the matched set per
page. Replace them with sort-aligned composites so filter + sort + pagination are served straight from
the index; the leading columns still serve the plain lookups the old indexes did (so nothing regresses).

  IX_Instances_BlueprintId            -> IX_Instances_BlueprintId_CreatedAt   (BlueprintId, CreatedAt DESC)
  IX_Instances_RegisterId             -> IX_Instances_RegisterId_CreatedAt    (RegisterId, CreatedAt DESC)
  IX_Instances_State                  -> IX_Instances_State_UpdatedAt         (State, UpdatedAt DESC)
  IX_Actions_Wallet_Register          -> IX_Actions_Wallet_Register_CreatedAt (WalletAddress, RegisterAddress, CreatedAt DESC)

Replace (not add) — squashed into the existing Blueprint InitialCreate per the pre-release convention
(temp migration for EF's exact `descending:` syntax -> fold the modified CreateIndex/HasIndex into
InitialCreate + Designer + snapshot -> delete temp).

Verified on this machine:
- has-pending-model-changes -> No changes.
- dotnet ef database update (fresh scratch DB): the four composite indexes created and the old
  single-column indexes are gone (count 0).

Completes the audit's EF-index items (F9 #1107, F14 #1108/#1109, F11 here).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UDmeAycWwQ5Y8PXuz4iub6
