### PR TITLE
perf: [audit F6] jitter SignalR reconnect delays to avoid thundering-herd after deploy

### DIFF
--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/Shared/PresentationHubConnection.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/Shared/PresentationHubConnection.cs
@@ -78,14 +78,12 @@ public sealed class PresentationHubConnection : IAsyncDisposable
                         options.AccessTokenProvider = _accessTokenProvider;
                     }
                 })
-                .WithAutomaticReconnect(new[]
-                {
+                .WithAutomaticReconnect(new Sorcha.ServiceClients.Http.Hub.SorchaHubConnectionBuilder.JitteredRetryPolicy(
                     TimeSpan.FromSeconds(0),
                     TimeSpan.FromSeconds(2),
                     TimeSpan.FromSeconds(5),
                     TimeSpan.FromSeconds(10),
-                    TimeSpan.FromSeconds(30)
-                });
+                    TimeSpan.FromSeconds(30)));
 
             _hubConnection = builder.Build();
 

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/Shared/RegisterHubConnection.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/Shared/RegisterHubConnection.cs
@@ -132,14 +132,12 @@ public class RegisterHubConnection : IAsyncDisposable
                         options.AccessTokenProvider = _accessTokenProvider;
                     }
                 })
-                .WithAutomaticReconnect(new[]
-                {
+                .WithAutomaticReconnect(new SorchaHubConnectionBuilder.JitteredRetryPolicy(
                     TimeSpan.FromSeconds(0),
                     TimeSpan.FromSeconds(2),
                     TimeSpan.FromSeconds(5),
                     TimeSpan.FromSeconds(10),
-                    TimeSpan.FromSeconds(30)
-                })
+                    TimeSpan.FromSeconds(30)))
                 .Build();
 
             // Register event handlers

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/Shared/TenantHubConnection.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/Shared/TenantHubConnection.cs
@@ -91,14 +91,12 @@ public sealed class TenantHubConnection : IAsyncDisposable
                 {
                     options.AccessTokenProvider = _accessTokenProvider;
                 })
-                .WithAutomaticReconnect(new[]
-                {
+                .WithAutomaticReconnect(new SorchaHubConnectionBuilder.JitteredRetryPolicy(
                     TimeSpan.FromSeconds(0),
                     TimeSpan.FromSeconds(2),
                     TimeSpan.FromSeconds(5),
                     TimeSpan.FromSeconds(10),
-                    TimeSpan.FromSeconds(30)
-                })
+                    TimeSpan.FromSeconds(30)))
                 .Build();
 
             _hubConnection.On<string, DateTimeOffset, string>("InboxEntryAdded", async (entryId, occurredAt, traceId) =>

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/Shared/WalletHubConnection.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/Shared/WalletHubConnection.cs
@@ -148,14 +148,12 @@ public class WalletHubConnection : IAsyncDisposable
                         return token;
                     };
                 })
-                .WithAutomaticReconnect(new[]
-                {
+                .WithAutomaticReconnect(new SorchaHubConnectionBuilder.JitteredRetryPolicy(
                     TimeSpan.FromSeconds(0),
                     TimeSpan.FromSeconds(2),
                     TimeSpan.FromSeconds(5),
                     TimeSpan.FromSeconds(10),
-                    TimeSpan.FromSeconds(30)
-                })
+                    TimeSpan.FromSeconds(30)))
                 .Build();
 
             RegisterEventHandlers();

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/Admin/BlueprintHubConnection.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/Admin/BlueprintHubConnection.cs
@@ -141,14 +141,12 @@ public class BlueprintHubConnection : IAsyncDisposable
                         return token;
                     };
                 })
-                .WithAutomaticReconnect(new[]
-                {
+                .WithAutomaticReconnect(new SorchaHubConnectionBuilder.JitteredRetryPolicy(
                     TimeSpan.FromSeconds(0),
                     TimeSpan.FromSeconds(2),
                     TimeSpan.FromSeconds(5),
                     TimeSpan.FromSeconds(10),
-                    TimeSpan.FromSeconds(30)
-                })
+                    TimeSpan.FromSeconds(30)))
                 .Build();
 
             // Register event handlers for server-to-client calls

--- a/src/Apps/Sorcha.Wallet.Pwa/Services/CitizenWalletHubConnection.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Services/CitizenWalletHubConnection.cs
@@ -83,14 +83,12 @@ public sealed class CitizenWalletHubConnection : IAsyncDisposable
                     return record?.AccessToken;
                 };
             })
-            .WithAutomaticReconnect(new[]
-            {
+            .WithAutomaticReconnect(new Sorcha.ServiceClients.Http.Hub.SorchaHubConnectionBuilder.JitteredRetryPolicy(
                 TimeSpan.Zero,
                 TimeSpan.FromSeconds(2),
                 TimeSpan.FromSeconds(5),
                 TimeSpan.FromSeconds(10),
-                TimeSpan.FromSeconds(30),
-            })
+                TimeSpan.FromSeconds(30)))
             .Build();
 
         _connection.On<string>("CredentialAvailable", credentialId =>

--- a/src/Common/Sorcha.ServiceClients.Http/Hub/SorchaHubConnectionBuilder.cs
+++ b/src/Common/Sorcha.ServiceClients.Http/Hub/SorchaHubConnectionBuilder.cs
@@ -106,4 +106,38 @@ public static class SorchaHubConnectionBuilder
             return jittered < MinDelay ? MinDelay : jittered;
         }
     }
+
+    /// <summary>
+    /// Finite reconnection policy that jitters a caller-supplied delay schedule ±20 % and gives up
+    /// after the last delay (returns <c>null</c>). Use this in place of a bare <c>TimeSpan[]</c> in
+    /// <see cref="Microsoft.AspNetCore.SignalR.Client.HubConnectionBuilderExtensions.WithAutomaticReconnect(IHubConnectionBuilder, IRetryPolicy)"/>
+    /// so that many clients don't reconnect in lockstep after a server restart / deploy
+    /// (thundering-herd). Unlike <see cref="InfiniteRetryPolicy"/> it is finite, preserving the
+    /// "then fall back to a background retry loop" semantics some hub clients layer on top.
+    /// The ±20 % jitter and 100 ms floor match <see cref="InfiniteRetryPolicy"/>.
+    /// </summary>
+    public sealed class JitteredRetryPolicy : IRetryPolicy
+    {
+        private readonly TimeSpan[] _nominalDelays;
+        private readonly Func<double> _randomNextDouble;
+
+        /// <summary>Creates a policy over the given nominal reconnect delays (jittered ±20 %).</summary>
+        public JitteredRetryPolicy(params TimeSpan[] nominalDelays)
+            : this(nominalDelays, static () => Random.Shared.NextDouble())
+        {
+        }
+
+        // Constructor for deterministic unit testing.
+        internal JitteredRetryPolicy(TimeSpan[] nominalDelays, Func<double> randomNextDouble)
+        {
+            ArgumentNullException.ThrowIfNull(nominalDelays);
+            _nominalDelays = nominalDelays;
+            _randomNextDouble = randomNextDouble;
+        }
+
+        public TimeSpan? NextRetryDelay(RetryContext retryContext)
+            => retryContext.PreviousRetryCount >= _nominalDelays.Length
+                ? null
+                : InfiniteRetryPolicy.ApplyJitter(_nominalDelays[retryContext.PreviousRetryCount], _randomNextDouble());
+    }
 }

--- a/tests/Sorcha.ServiceClients.Tests/Hub/SorchaHubConnectionBuilderTests.cs
+++ b/tests/Sorcha.ServiceClients.Tests/Hub/SorchaHubConnectionBuilderTests.cs
@@ -135,4 +135,58 @@ public class SorchaHubConnectionBuilderTests
             TimeSpan.FromMilliseconds(50), random: 0.0);
         floored.Should().Be(SorchaHubConnectionBuilder.InfiniteRetryPolicy.MinDelay);
     }
+
+    // --- Perf audit F6: finite jittered reconnect (hub-client sites) -----------
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(2)]
+    [InlineData(3)]
+    [InlineData(4)]
+    public void JitteredRetryPolicy_WithinSchedule_ReturnsJitteredNominal(int previousRetryCount)
+    {
+        var delays = new[]
+        {
+            TimeSpan.Zero, TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(5),
+            TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(30)
+        };
+        // random=0.5 → multiplier 1.0, so jittered == nominal (except the 0s slot,
+        // which the 100ms floor lifts to MinDelay).
+        var policy = new SorchaHubConnectionBuilder.JitteredRetryPolicy(delays, static () => 0.5);
+
+        var actual = policy.NextRetryDelay(new RetryContext { PreviousRetryCount = previousRetryCount });
+
+        actual.Should().NotBeNull();
+        var expected = delays[previousRetryCount] < SorchaHubConnectionBuilder.InfiniteRetryPolicy.MinDelay
+            ? SorchaHubConnectionBuilder.InfiniteRetryPolicy.MinDelay
+            : delays[previousRetryCount];
+        actual!.Value.Should().Be(expected);
+    }
+
+    [Fact]
+    public void JitteredRetryPolicy_AfterScheduleExhausted_ReturnsNull()
+    {
+        // The distinguishing behaviour vs InfiniteRetryPolicy: it gives up after the
+        // last delay so the hub client's own background-retry loop can take over.
+        var delays = new[] { TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(5) };
+        var policy = new SorchaHubConnectionBuilder.JitteredRetryPolicy(delays, static () => 0.5);
+
+        policy.NextRetryDelay(new RetryContext { PreviousRetryCount = 2 }).Should().BeNull();
+        policy.NextRetryDelay(new RetryContext { PreviousRetryCount = 5 }).Should().BeNull();
+    }
+
+    [Fact]
+    public void JitteredRetryPolicy_SpreadsWithin20PercentBand()
+    {
+        var seed = new Random(42);
+        var delays = new[] { TimeSpan.FromSeconds(30) };
+        var policy = new SorchaHubConnectionBuilder.JitteredRetryPolicy(delays, () => seed.NextDouble());
+
+        for (var i = 0; i < 500; i++)
+        {
+            var delay = policy.NextRetryDelay(new RetryContext { PreviousRetryCount = 0 })!.Value;
+            (delay.TotalMilliseconds / 30_000.0).Should().BeInRange(0.80, 1.20);
+        }
+    }
 }


### PR DESCRIPTION
The six hub-client sites (Presentation/Register/Tenant/Wallet/Blueprint + the PWA CitizenWallet) each
passed a bare fixed TimeSpan[] {0,2,5,10,30}s to WithAutomaticReconnect — so every connected client
reconnects in lockstep after a server restart / deploy, hammering the gateway in synchronised waves.

Adds a shared finite JitteredRetryPolicy to SorchaHubConnectionBuilder that jitters a caller-supplied
schedule ±20% (100ms floor), reusing the exact jitter maths already proven for the infinite policy
(Feature 118 / InfiniteRetryPolicy). It is deliberately FINITE — it returns null after the last delay,
preserving the "then fall back to a background retry loop" semantics some clients (e.g.
RegisterHubConnection) layer on top; only InfiniteRetryPolicy (mobile/CLI) retries forever. Each site
keeps its own schedule, now wrapped with jitter rather than replaced.

Tests: 3 new cases (jittered-within-band, gives-up-after-schedule → null, ±20% spread over 500 samples);
full ServiceClients suite 240 passed. All three consumer projects (Components.User, UI.Core, Wallet.Pwa)
build clean.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UDmeAycWwQ5Y8PXuz4iub6
