### PR TITLE
perf: [T1-A1] push register transaction reads down to Mongo — targeted methods + first migrations

### DIFF
--- a/src/Common/Sorcha.Register.Models/Enums/TransactionSort.cs
+++ b/src/Common/Sorcha.Register.Models/Enums/TransactionSort.cs
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+namespace Sorcha.Register.Models.Enums;
+
+/// <summary>
+/// Sort orders supported by the pushed-down register transaction read methods.
+/// Each maps to a store-side sort that rides an existing index (TimeStamp / DocketNumber),
+/// so paging is served from the index rather than an in-memory sort.
+/// </summary>
+public enum TransactionSort
+{
+    /// <summary>Newest first by <c>TimeStamp</c> (the default list ordering).</summary>
+    TimeStampDescending = 0,
+
+    /// <summary>Oldest first by <c>TimeStamp</c> (genesis-first scans, e.g. policy history).</summary>
+    TimeStampAscending = 1,
+
+    /// <summary>Highest docket first by <c>DocketNumber</c> (governance history/proposals).</summary>
+    DocketNumberDescending = 2,
+
+    /// <summary>Lowest docket first by <c>DocketNumber</c> (roster reconstruction — apply in order).</summary>
+    DocketNumberAscending = 3,
+}

--- a/src/Core/Sorcha.Register.Core/Managers/TransactionManager.cs
+++ b/src/Core/Sorcha.Register.Core/Managers/TransactionManager.cs
@@ -138,6 +138,52 @@ public class TransactionManager
         return await _repository.GetTransactionsAsync(registerId, cancellationToken);
     }
 
+    /// <summary>Gets a page of transactions newest-first (store-side, by TimeStamp descending).</summary>
+    public async Task<IReadOnlyList<TransactionModel>> GetLatestTransactionsAsync(
+        string registerId,
+        int skip,
+        int take,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(registerId);
+        return await _repository.GetLatestTransactionsAsync(registerId, skip, take, cancellationToken);
+    }
+
+    /// <summary>Gets the single most recent transaction (store-side, by TimeStamp descending), or null.</summary>
+    public async Task<TransactionModel?> GetLatestTransactionAsync(
+        string registerId,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(registerId);
+        return await _repository.GetLatestTransactionAsync(registerId, cancellationToken);
+    }
+
+    /// <summary>Counts a register's transactions without materialising them (store-side count).</summary>
+    public async Task<long> CountTransactionsAsync(
+        string registerId,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(registerId);
+        return await _repository.CountTransactionsAsync(registerId, cancellationToken);
+    }
+
+    /// <summary>
+    /// Gets transactions of a given <see cref="TransactionType"/>, sorted and paged, pushed down to
+    /// the store (rides the <c>MetaData.TransactionType</c> index). <paramref name="take"/> of 0
+    /// returns all matches.
+    /// </summary>
+    public async Task<IReadOnlyList<TransactionModel>> GetTransactionsByTypeAsync(
+        string registerId,
+        TransactionType transactionType,
+        TransactionSort sort,
+        int skip = 0,
+        int take = 0,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(registerId);
+        return await _repository.GetTransactionsByTypeAsync(registerId, transactionType, sort, skip, take, cancellationToken);
+    }
+
     /// <summary>
     /// Gets transactions by sender address
     /// </summary>

--- a/src/Core/Sorcha.Register.Core/Services/GovernanceRosterService.cs
+++ b/src/Core/Sorcha.Register.Core/Services/GovernanceRosterService.cs
@@ -352,15 +352,15 @@ public class GovernanceRosterService : IGovernanceRosterService
     private async Task<List<TransactionModel>> GetControlTransactionsAsync(
         string registerId, CancellationToken cancellationToken)
     {
-        // Query repository directly instead of HTTP calls
-        var allTransactions = await _repository.GetTransactionsAsync(registerId, cancellationToken);
+        // Pushed down to the store: filter to Control + sort by docket ascending (index-backed),
+        // rather than materialising the whole ledger and filtering/sorting in memory.
+        var controlTxs = await _repository.GetTransactionsByTypeAsync(
+            registerId,
+            TransactionType.Control,
+            TransactionSort.DocketNumberAscending, // apply in docket order for correct roster reconstruction
+            cancellationToken: cancellationToken);
 
-        var controlTxs = allTransactions
-            .Where(t => t.MetaData != null && t.MetaData.TransactionType == TransactionType.Control)
-            .OrderBy(t => t.DocketNumber ?? 0)  // Order by docket for correct roster reconstruction
-            .ToList();
-
-        return controlTxs;
+        return controlTxs.ToList();
     }
 
     private ControlTransactionPayload? DeserializeControlPayload(TransactionModel transaction)

--- a/src/Core/Sorcha.Register.Core/Storage/IReadOnlyRegisterRepository.cs
+++ b/src/Core/Sorcha.Register.Core/Storage/IReadOnlyRegisterRepository.cs
@@ -3,6 +3,7 @@
 
 using System.Linq.Expressions;
 using Sorcha.Register.Models;
+using Sorcha.Register.Models.Enums;
 
 namespace Sorcha.Register.Core.Storage;
 
@@ -72,6 +73,55 @@ public interface IReadOnlyRegisterRepository
     /// </summary>
     Task<IQueryable<TransactionModel>> GetTransactionsAsync(
         string registerId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets a page of transactions ordered newest-first (by <c>TimeStamp</c> descending), pushed down
+    /// to the store — no full-collection materialisation. <paramref name="take"/> of 0 returns all
+    /// from <paramref name="skip"/> onward.
+    /// </summary>
+    Task<IReadOnlyList<TransactionModel>> GetLatestTransactionsAsync(
+        string registerId,
+        int skip,
+        int take,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets the single most recent transaction (by <c>TimeStamp</c> descending), or null if the
+    /// register has none. Pushed down to the store.
+    /// </summary>
+    Task<TransactionModel?> GetLatestTransactionAsync(
+        string registerId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Counts the transactions in a register without materialising them (store-side count).
+    /// </summary>
+    Task<long> CountTransactionsAsync(
+        string registerId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets transactions of a given <see cref="TransactionType"/>, sorted and paged, pushed down to
+    /// the store (rides the <c>MetaData.TransactionType</c> index). <paramref name="take"/> of 0
+    /// returns all matches.
+    /// </summary>
+    Task<IReadOnlyList<TransactionModel>> GetTransactionsByTypeAsync(
+        string registerId,
+        TransactionType transactionType,
+        TransactionSort sort,
+        int skip = 0,
+        int take = 0,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets up to <paramref name="take"/> transactions strictly older than <paramref name="before"/>
+    /// (by <c>TimeStamp</c>), newest-first — cursor pagination without materialisation.
+    /// </summary>
+    Task<IReadOnlyList<TransactionModel>> GetTransactionsBeforeAsync(
+        string registerId,
+        DateTime before,
+        int take,
         CancellationToken cancellationToken = default);
 
     /// <summary>

--- a/src/Core/Sorcha.Register.Storage.InMemory/InMemoryRegisterRepository.cs
+++ b/src/Core/Sorcha.Register.Storage.InMemory/InMemoryRegisterRepository.cs
@@ -168,6 +168,53 @@ public class InMemoryRegisterRepository : IRegisterRepository
         return Task.FromResult(registerTransactions.Values.AsQueryable());
     }
 
+    private IEnumerable<TransactionModel> RegisterTxs(string registerId) =>
+        _transactions.TryGetValue(registerId, out var t) ? t.Values : Enumerable.Empty<TransactionModel>();
+
+    public Task<IReadOnlyList<TransactionModel>> GetLatestTransactionsAsync(string registerId, int skip, int take, CancellationToken cancellationToken = default)
+    {
+        var q = RegisterTxs(registerId).OrderByDescending(t => t.TimeStamp).Skip(skip);
+        if (take > 0) q = q.Take(take);
+        return Task.FromResult<IReadOnlyList<TransactionModel>>(q.ToList());
+    }
+
+    public Task<TransactionModel?> GetLatestTransactionAsync(string registerId, CancellationToken cancellationToken = default)
+        => Task.FromResult(RegisterTxs(registerId).OrderByDescending(t => t.TimeStamp).FirstOrDefault());
+
+    public Task<long> CountTransactionsAsync(string registerId, CancellationToken cancellationToken = default)
+        => Task.FromResult((long)RegisterTxs(registerId).Count());
+
+    public Task<IReadOnlyList<TransactionModel>> GetTransactionsByTypeAsync(
+        string registerId,
+        Sorcha.Register.Models.Enums.TransactionType transactionType,
+        Sorcha.Register.Models.Enums.TransactionSort sort,
+        int skip = 0,
+        int take = 0,
+        CancellationToken cancellationToken = default)
+    {
+        var filtered = RegisterTxs(registerId).Where(t => t.MetaData != null && t.MetaData.TransactionType == transactionType);
+        var ordered = sort switch
+        {
+            Sorcha.Register.Models.Enums.TransactionSort.TimeStampAscending => filtered.OrderBy(t => t.TimeStamp),
+            Sorcha.Register.Models.Enums.TransactionSort.DocketNumberDescending => filtered.OrderByDescending(t => t.DocketNumber ?? 0),
+            Sorcha.Register.Models.Enums.TransactionSort.DocketNumberAscending => filtered.OrderBy(t => t.DocketNumber ?? 0),
+            _ => filtered.OrderByDescending(t => t.TimeStamp),
+        };
+        IEnumerable<TransactionModel> result = ordered;
+        if (skip > 0) result = result.Skip(skip);
+        if (take > 0) result = result.Take(take);
+        return Task.FromResult<IReadOnlyList<TransactionModel>>(result.ToList());
+    }
+
+    public Task<IReadOnlyList<TransactionModel>> GetTransactionsBeforeAsync(string registerId, DateTime before, int take, CancellationToken cancellationToken = default)
+    {
+        IEnumerable<TransactionModel> result = RegisterTxs(registerId)
+            .Where(t => t.TimeStamp < before)
+            .OrderByDescending(t => t.TimeStamp);
+        if (take > 0) result = result.Take(take);
+        return Task.FromResult<IReadOnlyList<TransactionModel>>(result.ToList());
+    }
+
     public Task<TransactionModel?> GetTransactionAsync(
         string registerId,
         string transactionId,

--- a/src/Core/Sorcha.Register.Storage.MongoDB/MongoRegisterRepository.cs
+++ b/src/Core/Sorcha.Register.Storage.MongoDB/MongoRegisterRepository.cs
@@ -559,6 +559,68 @@ public class MongoRegisterRepository : IRegisterRepository
     }
 
     /// <inheritdoc/>
+    public async Task<IReadOnlyList<TransactionModel>> GetLatestTransactionsAsync(string registerId, int skip, int take, CancellationToken cancellationToken = default)
+    {
+        var transactions = GetTransactionsCollection(registerId);
+        var find = transactions.Find(FilterDefinition<TransactionModel>.Empty)
+            .SortByDescending(t => t.TimeStamp)
+            .Skip(skip > 0 ? skip : null);
+        if (take > 0) find = find.Limit(take);
+        return await find.ToListAsync(cancellationToken);
+    }
+
+    /// <inheritdoc/>
+    public async Task<TransactionModel?> GetLatestTransactionAsync(string registerId, CancellationToken cancellationToken = default)
+    {
+        var transactions = GetTransactionsCollection(registerId);
+        return await transactions.Find(FilterDefinition<TransactionModel>.Empty)
+            .SortByDescending(t => t.TimeStamp)
+            .Limit(1)
+            .FirstOrDefaultAsync(cancellationToken);
+    }
+
+    /// <inheritdoc/>
+    public async Task<long> CountTransactionsAsync(string registerId, CancellationToken cancellationToken = default)
+    {
+        var transactions = GetTransactionsCollection(registerId);
+        return await transactions.CountDocumentsAsync(FilterDefinition<TransactionModel>.Empty, cancellationToken: cancellationToken);
+    }
+
+    /// <inheritdoc/>
+    public async Task<IReadOnlyList<TransactionModel>> GetTransactionsByTypeAsync(
+        string registerId,
+        TransactionType transactionType,
+        TransactionSort sort,
+        int skip = 0,
+        int take = 0,
+        CancellationToken cancellationToken = default)
+    {
+        var transactions = GetTransactionsCollection(registerId);
+        var filter = Builders<TransactionModel>.Filter.Eq("MetaData.TransactionType", transactionType);
+        var find = transactions.Find(filter);
+        find = sort switch
+        {
+            TransactionSort.TimeStampAscending => find.SortBy(t => t.TimeStamp),
+            TransactionSort.DocketNumberDescending => find.SortByDescending(t => t.DocketNumber),
+            TransactionSort.DocketNumberAscending => find.SortBy(t => t.DocketNumber),
+            _ => find.SortByDescending(t => t.TimeStamp),
+        };
+        if (skip > 0) find = find.Skip(skip);
+        if (take > 0) find = find.Limit(take);
+        return await find.ToListAsync(cancellationToken);
+    }
+
+    /// <inheritdoc/>
+    public async Task<IReadOnlyList<TransactionModel>> GetTransactionsBeforeAsync(string registerId, DateTime before, int take, CancellationToken cancellationToken = default)
+    {
+        var transactions = GetTransactionsCollection(registerId);
+        var filter = Builders<TransactionModel>.Filter.Lt(t => t.TimeStamp, before);
+        IFindFluent<TransactionModel, TransactionModel> find = transactions.Find(filter).SortByDescending(t => t.TimeStamp);
+        if (take > 0) find = find.Limit(take);
+        return await find.ToListAsync(cancellationToken);
+    }
+
+    /// <inheritdoc/>
     public async Task<TransactionModel?> GetTransactionAsync(string registerId, string transactionId, CancellationToken cancellationToken = default)
     {
         var transactions = GetTransactionsCollection(registerId);

--- a/src/Core/Sorcha.Register.Storage/CachedRegisterRepository.cs
+++ b/src/Core/Sorcha.Register.Storage/CachedRegisterRepository.cs
@@ -229,6 +229,28 @@ public class CachedRegisterRepository : IRegisterRepository
         return _innerRepository.GetTransactionsAsync(registerId, cancellationToken);
     }
 
+    // Pushed-down transaction reads — delegated straight through (store-side query, no caching).
+    public Task<IReadOnlyList<TransactionModel>> GetLatestTransactionsAsync(string registerId, int skip, int take, CancellationToken cancellationToken = default)
+        => _innerRepository.GetLatestTransactionsAsync(registerId, skip, take, cancellationToken);
+
+    public Task<TransactionModel?> GetLatestTransactionAsync(string registerId, CancellationToken cancellationToken = default)
+        => _innerRepository.GetLatestTransactionAsync(registerId, cancellationToken);
+
+    public Task<long> CountTransactionsAsync(string registerId, CancellationToken cancellationToken = default)
+        => _innerRepository.CountTransactionsAsync(registerId, cancellationToken);
+
+    public Task<IReadOnlyList<TransactionModel>> GetTransactionsByTypeAsync(
+        string registerId,
+        Sorcha.Register.Models.Enums.TransactionType transactionType,
+        Sorcha.Register.Models.Enums.TransactionSort sort,
+        int skip = 0,
+        int take = 0,
+        CancellationToken cancellationToken = default)
+        => _innerRepository.GetTransactionsByTypeAsync(registerId, transactionType, sort, skip, take, cancellationToken);
+
+    public Task<IReadOnlyList<TransactionModel>> GetTransactionsBeforeAsync(string registerId, DateTime before, int take, CancellationToken cancellationToken = default)
+        => _innerRepository.GetTransactionsBeforeAsync(registerId, before, take, cancellationToken);
+
     public async Task<TransactionModel?> GetTransactionAsync(
         string registerId,
         string transactionId,

--- a/src/Services/Sorcha.Register.Service/Program.cs
+++ b/src/Services/Sorcha.Register.Service/Program.cs
@@ -601,8 +601,7 @@ registersGroup.MapPost("/{registerId}/disable-dev-mode", async (
         System.Security.Cryptography.SHA256.HashData(System.Text.Encoding.UTF8.GetBytes(txIdSource)))
         .ToLowerInvariant();
 
-    var allTxs = await transactionManager.GetTransactionsAsync(registerId, ct);
-    var chainHead = allTxs.OrderByDescending(t => t.TimeStamp).FirstOrDefault();
+    var chainHead = await transactionManager.GetLatestTransactionAsync(registerId, ct);
 
     var tx = new Sorcha.Register.Models.TransactionModel
     {
@@ -1140,13 +1139,10 @@ transactionsGroup.MapGet("/", async (
     var odataSkip = skip ?? 0;
     var odataTop = top ?? 20;
 
-    var transactions = await manager.GetTransactionsAsync(registerId);
-    var totalCount = transactions.Count();
-    var paged = transactions
-        .OrderByDescending(t => t.TimeStamp)
-        .Skip(odataSkip)
-        .Take(odataTop)
-        .ToList();
+    // Pushed down to the store: count + newest-first page, index-backed (TimeStamp desc), rather
+    // than materialising the whole ledger to count and page in memory.
+    var totalCount = await manager.CountTransactionsAsync(registerId);
+    var paged = await manager.GetLatestTransactionsAsync(registerId, odataSkip, odataTop);
 
     // OData-style paged response
     var page = odataTop > 0 ? (odataSkip / odataTop) + 1 : 1;
@@ -2605,8 +2601,7 @@ governanceGroup.MapPost("/crypto-policy", async (
     var txId = Convert.ToHexString(txIdBytes).ToLowerInvariant();
 
     // Find chain head
-    var allTxs = await transactionManager.GetTransactionsAsync(registerId, ct);
-    var chainHead = allTxs.OrderByDescending(t => t.TimeStamp).FirstOrDefault();
+    var chainHead = await transactionManager.GetLatestTransactionAsync(registerId, ct);
 
     // Build control transaction
     var tx = new Sorcha.Register.Models.TransactionModel
@@ -3451,8 +3446,7 @@ app.MapGet("/api/stats", async (
             var listedTransactionCount = 0;
             foreach (var id in listed)
             {
-                var transactions = await repository.GetTransactionsAsync(id);
-                listedTransactionCount += transactions.Count();
+                listedTransactionCount += (int)await repository.CountTransactionsAsync(id);
             }
             return Results.Ok(new
             {
@@ -3468,8 +3462,7 @@ app.MapGet("/api/stats", async (
         var transactionCount = 0;
         foreach (var register in registers)
         {
-            var transactions = await repository.GetTransactionsAsync(register.Id);
-            transactionCount += transactions.Count();
+            transactionCount += (int)await repository.CountTransactionsAsync(register.Id);
         }
 
         return Results.Ok(new

--- a/src/Services/Sorcha.Register.Service/Services/CryptoPolicyService.cs
+++ b/src/Services/Sorcha.Register.Service/Services/CryptoPolicyService.cs
@@ -80,12 +80,11 @@ public class CryptoPolicyService
     private async Task<CryptoPolicy?> ExtractGenesisPolicyAsync(
         string registerId, CancellationToken ct)
     {
-        // Genesis is the first control transaction on the register
-        var queryable = await _transactionManager.GetTransactionsAsync(registerId, ct);
-        var genesis = queryable
-            .Where(tx => tx.MetaData != null && tx.MetaData.TransactionType == TransactionType.Control)
-            .OrderBy(tx => tx.TimeStamp)
-            .FirstOrDefault();
+        // Genesis is the first control transaction on the register — pushed down to the store
+        // (earliest Control by TimeStamp) instead of materialising the whole ledger.
+        var earliestControl = await _transactionManager.GetTransactionsByTypeAsync(
+            registerId, TransactionType.Control, TransactionSort.TimeStampAscending, skip: 0, take: 1, cancellationToken: ct);
+        var genesis = earliestControl.FirstOrDefault();
 
         if (genesis?.Payloads == null || genesis.Payloads.Length == 0)
             return null;
@@ -105,14 +104,11 @@ public class CryptoPolicyService
     {
         var policies = new List<CryptoPolicy>();
 
-        var queryable = await _transactionManager.GetTransactionsAsync(registerId, ct);
-
-        // Materialize control transactions then filter in-memory for policy updates
-        var controlTxs = queryable
-            .Where(tx => tx.MetaData != null && tx.MetaData.TransactionType == TransactionType.Control)
-            .OrderBy(tx => tx.TimeStamp)
-            .AsEnumerable()
-            .Where(IsCryptoPolicyUpdate);
+        // Pushed down to the store: all Control txs, earliest first (index-backed), then the
+        // policy-update filter in memory over that small subset.
+        var allControl = await _transactionManager.GetTransactionsByTypeAsync(
+            registerId, TransactionType.Control, TransactionSort.TimeStampAscending, cancellationToken: ct);
+        var controlTxs = allControl.Where(IsCryptoPolicyUpdate);
 
         foreach (var tx in controlTxs)
         {

--- a/src/Services/Sorcha.Register.Service/Services/SystemRegisterService.cs
+++ b/src/Services/Sorcha.Register.Service/Services/SystemRegisterService.cs
@@ -441,12 +441,8 @@ public class SystemRegisterService
             return null;
         }
 
-        var allTransactions = await _transactionManager.GetTransactionsAsync(
+        var latestTx = await _transactionManager.GetLatestTransactionAsync(
             SystemRegisterConstants.SystemRegisterId, cancellationToken);
-
-        var latestTx = allTransactions
-            .OrderByDescending(t => t.TimeStamp)
-            .FirstOrDefault();
 
         return latestTx?.TxId;
     }

--- a/tests/Sorcha.Register.Core.Tests/Integration/GovernanceIntegrationTests.cs
+++ b/tests/Sorcha.Register.Core.Tests/Integration/GovernanceIntegrationTests.cs
@@ -89,6 +89,13 @@ public class GovernanceIntegrationTests
         _repositoryMock
             .Setup(r => r.GetTransactionsAsync(RegisterId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(transactions.AsQueryable());
+        // The roster service now reads control txs via the pushed-down GetTransactionsByTypeAsync.
+        _repositoryMock
+            .Setup(r => r.GetTransactionsByTypeAsync(RegisterId, TransactionType.Control, It.IsAny<TransactionSort>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(transactions
+                .Where(t => t.MetaData is not null && t.MetaData.TransactionType == TransactionType.Control)
+                .OrderBy(t => t.DocketNumber ?? 0)
+                .ToList());
     }
 
     [Fact]

--- a/tests/Sorcha.Register.Core.Tests/Integration/RosterDeterminismTests.cs
+++ b/tests/Sorcha.Register.Core.Tests/Integration/RosterDeterminismTests.cs
@@ -71,6 +71,12 @@ public class RosterDeterminismTests
         mockRepository
             .Setup(r => r.GetTransactionsAsync(RegisterId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(transactions.AsQueryable());
+        mockRepository
+            .Setup(r => r.GetTransactionsByTypeAsync(RegisterId, TransactionType.Control, It.IsAny<TransactionSort>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(transactions
+                .Where(t => t.MetaData is not null && t.MetaData.TransactionType == TransactionType.Control)
+                .OrderBy(t => t.DocketNumber ?? 0)
+                .ToList());
 
         var logger = new Mock<ILogger<GovernanceRosterService>>();
         return new GovernanceRosterService(mockRepository.Object, logger.Object);
@@ -143,6 +149,9 @@ public class RosterDeterminismTests
         mockRepository
             .Setup(r => r.GetTransactionsAsync(RegisterId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(Array.Empty<TransactionModel>().AsQueryable());
+        mockRepository
+            .Setup(r => r.GetTransactionsByTypeAsync(RegisterId, TransactionType.Control, It.IsAny<TransactionSort>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<TransactionModel>());
 
         var logger = new Mock<ILogger<GovernanceRosterService>>();
         var service = new GovernanceRosterService(mockRepository.Object, logger.Object);

--- a/tests/Sorcha.Register.Core.Tests/Services/GovernanceRosterServiceTests.cs
+++ b/tests/Sorcha.Register.Core.Tests/Services/GovernanceRosterServiceTests.cs
@@ -29,6 +29,15 @@ public class GovernanceRosterServiceTests
         _repositoryMock
             .Setup(r => r.GetTransactionsAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Array.Empty<TransactionModel>().AsQueryable());
+        _repositoryMock
+            .Setup(r => r.GetTransactionsByTypeAsync(
+                It.IsAny<string>(),
+                It.IsAny<TransactionType>(),
+                It.IsAny<TransactionSort>(),
+                It.IsAny<int>(),
+                It.IsAny<int>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<TransactionModel>());
     }
 
     // --- GetCurrentRosterAsync ---
@@ -93,9 +102,7 @@ public class GovernanceRosterServiceTests
             Payloads = []
         };
 
-        _repositoryMock
-            .Setup(r => r.GetTransactionsAsync(TestRegisterId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new[] { controlTx, actionTx }.AsQueryable());
+        SetupControlTransactions(controlTx, actionTx);
 
         var result = await _service.GetCurrentRosterAsync(TestRegisterId);
 
@@ -136,9 +143,7 @@ public class GovernanceRosterServiceTests
             }],
         };
 
-        _repositoryMock
-            .Setup(r => r.GetTransactionsAsync(TestRegisterId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new[] { genesisTx, noiseTx }.AsQueryable());
+        SetupControlTransactions(genesisTx, noiseTx);
 
         var result = await _service.GetCurrentRosterAsync(TestRegisterId);
 
@@ -353,5 +358,26 @@ public class GovernanceRosterServiceTests
         _repositoryMock
             .Setup(r => r.GetTransactionsAsync(TestRegisterId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(transactions.AsQueryable());
+
+        // The service now reads control transactions via the pushed-down GetTransactionsByTypeAsync;
+        // mirror the store contract: filter to Control, docket ascending.
+        StubControlByType(transactions);
+    }
+
+    private void StubControlByType(params TransactionModel[] transactions)
+    {
+        var control = transactions
+            .Where(t => t.MetaData is not null && t.MetaData.TransactionType == TransactionType.Control)
+            .OrderBy(t => t.DocketNumber ?? 0)
+            .ToList();
+        _repositoryMock
+            .Setup(r => r.GetTransactionsByTypeAsync(
+                TestRegisterId,
+                TransactionType.Control,
+                It.IsAny<TransactionSort>(),
+                It.IsAny<int>(),
+                It.IsAny<int>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(control);
     }
 }

--- a/tests/Sorcha.Register.Service.Tests/Unit/CryptoPolicyServiceTests.cs
+++ b/tests/Sorcha.Register.Service.Tests/Unit/CryptoPolicyServiceTests.cs
@@ -25,6 +25,26 @@ public class CryptoPolicyServiceTests
     public CryptoPolicyServiceTests()
     {
         _repositoryMock = new Mock<IRegisterRepository>();
+
+        // The service now reads control transactions via the pushed-down GetTransactionsByTypeAsync.
+        // Each test stubs the mock via GetTransactionsAsync, so derive the by-type result from that same
+        // stub at call time (filter to Control, TimeStamp ascending, honour skip/take) — one setup covers
+        // every case.
+        _repositoryMock
+            .Setup(x => x.GetTransactionsByTypeAsync(
+                It.IsAny<string>(), TransactionType.Control, It.IsAny<TransactionSort>(),
+                It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .Returns(async (string rid, TransactionType _, TransactionSort _, int skip, int take, CancellationToken ct) =>
+            {
+                var all = await _repositoryMock.Object.GetTransactionsAsync(rid, ct);
+                var q = all
+                    .Where(t => t.MetaData != null && t.MetaData.TransactionType == TransactionType.Control)
+                    .OrderBy(t => t.TimeStamp)
+                    .Skip(skip);
+                if (take > 0) q = q.Take(take);
+                return (IReadOnlyList<TransactionModel>)q.ToList();
+            });
+
         _transactionManager = new TransactionManager(
             _repositoryMock.Object,
             Mock.Of<IEventPublisher>());

--- a/tests/Sorcha.Register.Service.Tests/Unit/RegisterCreationOrchestratorTests.cs
+++ b/tests/Sorcha.Register.Service.Tests/Unit/RegisterCreationOrchestratorTests.cs
@@ -1078,6 +1078,17 @@ public class RegisterCreationOrchestratorTests
         repositoryMock
             .Setup(r => r.GetTransactionsAsync(initiateResponse.RegisterId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new[] { genesisTxModel }.AsQueryable());
+        // The roster service now reads control txs via the pushed-down GetTransactionsByTypeAsync.
+        repositoryMock
+            .Setup(r => r.GetTransactionsByTypeAsync(
+                initiateResponse.RegisterId,
+                Sorcha.Register.Models.Enums.TransactionType.Control,
+                It.IsAny<Sorcha.Register.Models.Enums.TransactionSort>(),
+                It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { genesisTxModel }
+                .Where(t => t.MetaData is not null && t.MetaData.TransactionType == Sorcha.Register.Models.Enums.TransactionType.Control)
+                .OrderBy(t => t.DocketNumber ?? 0)
+                .ToList());
 
         var rosterLogger = new Mock<ILogger<Sorcha.Register.Core.Services.GovernanceRosterService>>();
         var rosterService = new Sorcha.Register.Core.Services.GovernanceRosterService(

--- a/tests/Sorcha.Register.Storage.Tests/RegisterRepositoryContractTests.cs
+++ b/tests/Sorcha.Register.Storage.Tests/RegisterRepositoryContractTests.cs
@@ -408,4 +408,105 @@ public abstract class RegisterRepositoryContractTests
         Signature = "test-signature",
         PrevTxId = string.Empty
     };
+
+    // ===========================
+    // Pushed-down transaction reads (perf T1)
+    // ===========================
+
+    private static TransactionModel Tx(
+        string txId, string registerId, DateTime ts,
+        TransactionType type = TransactionType.Action, ulong? docket = null) => new()
+    {
+        TxId = txId.PadRight(64, '0'),
+        RegisterId = registerId,
+        SenderWallet = "sender-wallet",
+        RecipientsWallets = new List<string> { "recipient-wallet" },
+        TimeStamp = ts,
+        DocketNumber = docket,
+        Signature = "sig",
+        PrevTxId = string.Empty,
+        MetaData = new TransactionMetaData { RegisterId = registerId, TransactionType = type },
+    };
+
+    [Fact]
+    public async Task GetLatestTransactionsAsync_ReturnsNewestFirstPage()
+    {
+        var sut = Sut;
+        const string reg = "contract-latest-page";
+        await sut.InsertRegisterAsync(CreateRegister(reg));
+        var t0 = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        await sut.InsertTransactionAsync(Tx("lp-1", reg, t0));
+        await sut.InsertTransactionAsync(Tx("lp-2", reg, t0.AddMinutes(1)));
+        await sut.InsertTransactionAsync(Tx("lp-3", reg, t0.AddMinutes(2)));
+
+        var page = await sut.GetLatestTransactionsAsync(reg, skip: 0, take: 2);
+
+        page.Should().HaveCount(2);
+        page[0].TxId.Should().StartWith("lp-3"); // newest first
+        page[1].TxId.Should().StartWith("lp-2");
+    }
+
+    [Fact]
+    public async Task GetLatestTransactionAsync_ReturnsSingleNewest()
+    {
+        var sut = Sut;
+        const string reg = "contract-latest-one";
+        await sut.InsertRegisterAsync(CreateRegister(reg));
+        var t0 = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        await sut.InsertTransactionAsync(Tx("lo-1", reg, t0));
+        await sut.InsertTransactionAsync(Tx("lo-2", reg, t0.AddMinutes(5)));
+
+        var latest = await sut.GetLatestTransactionAsync(reg);
+
+        latest.Should().NotBeNull();
+        latest!.TxId.Should().StartWith("lo-2");
+    }
+
+    [Fact]
+    public async Task CountTransactionsAsync_ReturnsCount()
+    {
+        var sut = Sut;
+        const string reg = "contract-count-tx";
+        await sut.InsertRegisterAsync(CreateRegister(reg));
+        await sut.InsertTransactionAsync(Tx("ct-1", reg, DateTime.UtcNow));
+        await sut.InsertTransactionAsync(Tx("ct-2", reg, DateTime.UtcNow.AddSeconds(1)));
+
+        (await sut.CountTransactionsAsync(reg)).Should().Be(2);
+    }
+
+    [Fact]
+    public async Task GetTransactionsByTypeAsync_FiltersToTypeAndSortsByDocketAscending()
+    {
+        var sut = Sut;
+        const string reg = "contract-by-type";
+        await sut.InsertRegisterAsync(CreateRegister(reg));
+        var t0 = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        await sut.InsertTransactionAsync(Tx("bt-ctrl-0", reg, t0, TransactionType.Control, docket: 0));
+        await sut.InsertTransactionAsync(Tx("bt-action", reg, t0.AddMinutes(1), TransactionType.Action, docket: 1));
+        await sut.InsertTransactionAsync(Tx("bt-ctrl-2", reg, t0.AddMinutes(2), TransactionType.Control, docket: 2));
+
+        var ctrl = await sut.GetTransactionsByTypeAsync(reg, TransactionType.Control, TransactionSort.DocketNumberAscending);
+
+        ctrl.Should().HaveCount(2, "only Control transactions match");
+        ctrl[0].TxId.Should().StartWith("bt-ctrl-0"); // docket ascending
+        ctrl[1].TxId.Should().StartWith("bt-ctrl-2");
+    }
+
+    [Fact]
+    public async Task GetTransactionsBeforeAsync_ReturnsStrictlyOlderNewestFirst()
+    {
+        var sut = Sut;
+        const string reg = "contract-before";
+        await sut.InsertRegisterAsync(CreateRegister(reg));
+        var t0 = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        await sut.InsertTransactionAsync(Tx("bf-1", reg, t0));
+        await sut.InsertTransactionAsync(Tx("bf-2", reg, t0.AddMinutes(1)));
+        await sut.InsertTransactionAsync(Tx("bf-3", reg, t0.AddMinutes(2)));
+
+        var before = await sut.GetTransactionsBeforeAsync(reg, t0.AddMinutes(2), take: 10);
+
+        before.Should().HaveCount(2, "bf-3 at the cursor is excluded (strictly before)");
+        before[0].TxId.Should().StartWith("bf-2"); // newest-first
+        before[1].TxId.Should().StartWith("bf-1");
+    }
 }


### PR DESCRIPTION
Adds index-aligned, pushed-down read methods to IReadOnlyRegisterRepository (all three impls +
CachedRegisterRepository + TransactionManager), replacing the in-memory
Find(Empty).ToList().AsQueryable() + LINQ pattern at the clean/mechanical call sites:

New methods (each Find(filter).Sort().Skip().Limit() / CountDocuments, riding the shipped indexes):
- GetLatestTransactionsAsync(skip, take) / GetLatestTransactionAsync — TimeStamp desc
- CountTransactionsAsync — CountDocuments (no materialisation)
- GetTransactionsByTypeAsync(type, sort, skip, take) — MetaData.TransactionType index; TxSort enum
  (TimeStamp asc/desc, DocketNumber asc/desc)
- GetTransactionsBeforeAsync(before, take) — TimeStamp cursor pagination

Migrated 9 sites (the index-able, semantics-preserving ones):
- GovernanceRosterService.GetControlTransactions -> GetTransactionsByTypeAsync(Control, DocketNumber asc)
- CryptoPolicyService genesis + policy-history -> GetTransactionsByTypeAsync(Control, TimeStamp asc)
- SystemRegisterService.GetLatestTransactionId + two Program.cs chain-head reads -> GetLatestTransactionAsync
- Program.cs GET transactions -> CountTransactionsAsync + GetLatestTransactionsAsync (page)
- Program.cs two /api/stats counts -> CountTransactionsAsync

Tests: 5 new contract tests for the pushed-down methods (run against InMemory + Cached); mock setups
updated where services now read via GetTransactionsByTypeAsync (a single call-time read-through stub for
CryptoPolicyServiceTests). Register suites green: Storage 78, Core 325, Service 317.

Predicate-heavy sites (published-blueprints, proposals, filtered-paginate, graph cursor) and the inherent
full-scans (orphan sweep, stats aggregate) follow in T1-A2; the OData revival is T1-B. Design:
docs/audits/2026-07-04-register-read-pushdown-plan.md.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UDmeAycWwQ5Y8PXuz4iub6
