### PR TITLE
perf: [T1-A2] push register by-type / paginated reads down to Mongo

### DIFF
--- a/src/Core/Sorcha.Register.Core/Managers/QueryManager.cs
+++ b/src/Core/Sorcha.Register.Core/Managers/QueryManager.cs
@@ -59,20 +59,27 @@ public class QueryManager
         if (page < 1) page = 1;
         if (pageSize < 1 || pageSize > 100) pageSize = 20;
 
-        var query = await _repository.GetTransactionsAsync(registerId, cancellationToken);
-
-        // Apply filter if provided
-        if (filter != null)
+        int total;
+        List<TransactionModel> items;
+        if (filter is null)
         {
-            query = query.Where(filter);
+            // No predicate: count + newest-first page fully pushed down (index-backed, no materialisation).
+            total = (int)await _repository.CountTransactionsAsync(registerId, cancellationToken);
+            items = (await _repository.GetLatestTransactionsAsync(
+                registerId, (page - 1) * pageSize, pageSize, cancellationToken)).ToList();
         }
-
-        var total = query.Count();
-        var items = query
-            .OrderByDescending(t => t.TimeStamp)
-            .Skip((page - 1) * pageSize)
-            .Take(pageSize)
-            .ToList();
+        else
+        {
+            // Predicate: push it to the store (index-backed where the predicate allows), then count +
+            // page over the matched subset rather than the whole ledger.
+            var matches = (await _repository.QueryTransactionsAsync(registerId, filter, cancellationToken)).ToList();
+            total = matches.Count;
+            items = matches
+                .OrderByDescending(t => t.TimeStamp)
+                .Skip((page - 1) * pageSize)
+                .Take(pageSize)
+                .ToList();
+        }
 
         return new PaginatedResult<TransactionModel>
         {

--- a/src/Services/Sorcha.Register.Service/Program.cs
+++ b/src/Services/Sorcha.Register.Service/Program.cs
@@ -2080,13 +2080,17 @@ app.MapGet("/api/registers/{registerId}/blueprints/published", async (
     // Post-#876 publishes are TransactionType.BlueprintPublish; pre-#876 publishes were
     // TransactionType.Control + TrackingData["transactionType"]="BlueprintPublish".
     // Both eras coexist forever, so this filter must accept either.
-    var allTransactions = (await repository.GetTransactionsAsync(registerId)).ToList();
-    var publishTransactions = allTransactions
+    // Pushed down: two index-backed type queries (BlueprintPublish + pre-#876 Control), then the
+    // BlueprintId filter in memory over that small subset — avoids materialising the whole ledger.
+    var byPublish = await repository.GetTransactionsByTypeAsync(
+        registerId, TransactionType.BlueprintPublish, TransactionSort.TimeStampDescending);
+    var byControl = await repository.GetTransactionsByTypeAsync(
+        registerId, TransactionType.Control, TransactionSort.TimeStampDescending);
+    var publishTransactions = byPublish.Concat(byControl)
         .Where(tx => tx.MetaData != null
-            && (tx.MetaData.TransactionType == Sorcha.Register.Models.Enums.TransactionType.BlueprintPublish
-                || tx.MetaData.TransactionType == Sorcha.Register.Models.Enums.TransactionType.Control)
             && !string.IsNullOrEmpty(tx.MetaData.BlueprintId)
             && tx.MetaData.BlueprintId != "genesis")
+        .OrderByDescending(tx => tx.TimeStamp)
         .ToList();
 
     var blueprints = publishTransactions.Select(tx =>
@@ -2197,11 +2201,9 @@ governanceGroup.MapGet("/history", async (
         return Results.NotFound(new { error = "Register not found" });
     }
 
-    var transactions = await repository.GetTransactionsAsync(registerId);
-    var controlTxs = transactions
-        .Where(t => t.MetaData != null && t.MetaData.TransactionType == Sorcha.Register.Models.Enums.TransactionType.Control)
-        .OrderByDescending(t => t.DocketNumber ?? 0)
-        .ToList();
+    // Pushed down: Control transactions, docket descending (index-backed) — then page in memory.
+    var controlTxs = await repository.GetTransactionsByTypeAsync(
+        registerId, TransactionType.Control, TransactionSort.DocketNumberDescending);
 
     var pagedTxs = controlTxs
         .Skip((page - 1) * pageSize)
@@ -2484,12 +2486,9 @@ governanceGroup.MapGet("/proposals", async (
         return Results.NotFound(new { error = "Register not found" });
     }
 
-    // Get all Control transactions and extract those with governance operations
-    var transactions = await repository.GetTransactionsAsync(registerId);
-    var controlTxs = transactions
-        .Where(t => t.MetaData != null && t.MetaData.TransactionType == TransactionType.Control)
-        .OrderByDescending(t => t.DocketNumber ?? 0)
-        .ToList();
+    // Pushed down: Control transactions, docket descending (index-backed) — then filter/page in memory.
+    var controlTxs = await repository.GetTransactionsByTypeAsync(
+        registerId, TransactionType.Control, TransactionSort.DocketNumberDescending);
 
     // Filter to Control TXs that have governance operation metadata
     var governanceProposals = controlTxs

--- a/src/Services/Sorcha.Register.Service/Services/SystemRegisterService.cs
+++ b/src/Services/Sorcha.Register.Service/Services/SystemRegisterService.cs
@@ -400,22 +400,25 @@ public class SystemRegisterService
             return new List<TransactionModel>();
         }
 
-        var allTransactions = await _transactionManager.GetTransactionsAsync(
-            SystemRegisterConstants.SystemRegisterId, cancellationToken);
+        // Pushed down: two index-backed type queries (post-#876 BlueprintPublish + pre-#876 Control),
+        // then the non-genesis BlueprintId filter in memory over that small subset. TrackingData is not
+        // reliably persisted through the validator pipeline, so we use BlueprintId from MetaData.
+        var byPublish = await _transactionManager.GetTransactionsByTypeAsync(
+            SystemRegisterConstants.SystemRegisterId,
+            Sorcha.Register.Models.Enums.TransactionType.BlueprintPublish,
+            Sorcha.Register.Models.Enums.TransactionSort.TimeStampDescending,
+            cancellationToken: cancellationToken);
+        var byControl = await _transactionManager.GetTransactionsByTypeAsync(
+            SystemRegisterConstants.SystemRegisterId,
+            Sorcha.Register.Models.Enums.TransactionType.Control,
+            Sorcha.Register.Models.Enums.TransactionSort.TimeStampDescending,
+            cancellationToken: cancellationToken);
 
-        // Materialize before filtering — IQueryable expression trees cannot use
-        // null-propagating operators or out variables
-        var materialized = allTransactions.ToList();
-
-        // Filter for blueprint transactions: post-#876 BlueprintPublish OR pre-#876 Control
-        // with a non-genesis BlueprintId. TrackingData is not reliably persisted through the
-        // validator pipeline, so we use BlueprintId from MetaData which IS stored.
-        return materialized
+        return byPublish.Concat(byControl)
             .Where(t => t.MetaData is not null
-                && (t.MetaData.TransactionType == Sorcha.Register.Models.Enums.TransactionType.BlueprintPublish
-                    || t.MetaData.TransactionType == Sorcha.Register.Models.Enums.TransactionType.Control)
                 && !string.IsNullOrEmpty(t.MetaData.BlueprintId)
                 && t.MetaData.BlueprintId != "genesis")
+            .OrderByDescending(t => t.TimeStamp)
             .ToList();
     }
 

--- a/tests/Sorcha.Register.Service.Tests/RegisterMockHelpers.cs
+++ b/tests/Sorcha.Register.Service.Tests/RegisterMockHelpers.cs
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using Moq;
+using Sorcha.Register.Core.Storage;
+using Sorcha.Register.Models;
+using Sorcha.Register.Models.Enums;
+
+namespace Sorcha.Register.Service.Tests;
+
+/// <summary>
+/// Shared Moq helpers for register repository tests.
+/// </summary>
+internal static class RegisterMockHelpers
+{
+    /// <summary>
+    /// Stubs <c>GetTransactionsByTypeAsync</c> to derive its result at call time from whatever
+    /// <c>GetTransactionsAsync</c> the test sets up on the same mock — filtering to the requested
+    /// <see cref="TransactionType"/> and honouring skip/take. This lets tests that predate the
+    /// pushed-down read methods (T1) keep stubbing only <c>GetTransactionsAsync</c>.
+    /// </summary>
+    public static void StubTransactionsByTypeReadThrough(Mock<IRegisterRepository> mock)
+    {
+        mock.Setup(r => r.GetTransactionsByTypeAsync(
+                It.IsAny<string>(),
+                It.IsAny<TransactionType>(),
+                It.IsAny<TransactionSort>(),
+                It.IsAny<int>(),
+                It.IsAny<int>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(async (string rid, TransactionType type, TransactionSort _, int skip, int take, CancellationToken ct) =>
+            {
+                var all = await mock.Object.GetTransactionsAsync(rid, ct);
+                var q = all.Where(t => t.MetaData != null && t.MetaData.TransactionType == type).Skip(skip);
+                if (take > 0) q = q.Take(take);
+                return (IReadOnlyList<TransactionModel>)q.ToList();
+            });
+    }
+}

--- a/tests/Sorcha.Register.Service.Tests/Services/SystemRegisterBootstrapperTests.cs
+++ b/tests/Sorcha.Register.Service.Tests/Services/SystemRegisterBootstrapperTests.cs
@@ -32,6 +32,7 @@ public class SystemRegisterBootstrapperTests
 
     public SystemRegisterBootstrapperTests()
     {
+        RegisterMockHelpers.StubTransactionsByTypeReadThrough(_mockRepository);
         // Default: blueprint queries return existing blueprints (skip seeding which needs template files)
         _mockRepository
             .Setup(r => r.GetTransactionsAsync(SystemRegisterConstants.SystemRegisterId, It.IsAny<CancellationToken>()))

--- a/tests/Sorcha.Register.Service.Tests/Unit/SystemRegisterBlueprintTests.cs
+++ b/tests/Sorcha.Register.Service.Tests/Unit/SystemRegisterBlueprintTests.cs
@@ -34,6 +34,7 @@ public class SystemRegisterBlueprintTests
     public SystemRegisterBlueprintTests()
     {
         _mockRepository = new Mock<IRegisterRepository>();
+        RegisterMockHelpers.StubTransactionsByTypeReadThrough(_mockRepository);
         var mockEventPublisher = new Mock<IEventPublisher>();
         _mockValidatorClient = new Mock<IValidatorServiceClient>();
         _mockSigningService = new Mock<ISystemWalletSigningService>();

--- a/tests/Sorcha.Register.Service.Tests/Unit/SystemRegisterBootstrapTests.cs
+++ b/tests/Sorcha.Register.Service.Tests/Unit/SystemRegisterBootstrapTests.cs
@@ -43,6 +43,7 @@ public class SystemRegisterBootstrapTests
     public SystemRegisterBootstrapTests()
     {
         _mockRepository = new Mock<IRegisterRepository>();
+        RegisterMockHelpers.StubTransactionsByTypeReadThrough(_mockRepository);
         _mockValidatorClient = new Mock<IValidatorServiceClient>();
         _mockSigningService = new Mock<ISystemWalletSigningService>();
         _mockHashProvider = new Mock<IHashProvider>();


### PR DESCRIPTION
Migrates the predicate/by-type call sites off the materialise-all GetTransactionsAsync + in-memory LINQ:
- GET /blueprints/published + SystemRegisterService.GetBlueprintTransactions -> two index-backed
  GetTransactionsByTypeAsync queries (BlueprintPublish + pre-#876 Control), then the non-genesis
  BlueprintId filter in memory over that small subset. Deliberately two typed queries rather than a
  QueryTransactionsAsync(compound predicate) to avoid any LINQ3 translation risk on the critical
  system-register path.
- GET /governance/history + /governance/proposals -> GetTransactionsByTypeAsync(Control, DocketNumber
  desc), page/TrackingData-filter in memory.
- QueryManager.GetTransactionsPaginatedAsync -> CountTransactionsAsync + GetLatestTransactionsAsync
  when unfiltered; QueryTransactionsAsync(predicate) + in-memory page when a predicate is supplied.

Tests: a shared RegisterMockHelpers.StubTransactionsByTypeReadThrough derives GetTransactionsByTypeAsync
from the GetTransactionsAsync stub the SystemRegister tests already set up (filter by requested type),
so the manager-mock tests keep working without per-case edits. Register suites green: Core 325,
Service 317.

Remaining (T1-A2 tail, documented): the graph-cursor endpoint (needs a count-before method — a
totalCount semantic decision) and the inherent full-scans (orphan sweep, stats aggregate → projection/
$group follow-up). Next: T1-B (OData revival). Plan: docs/audits/2026-07-04-register-read-pushdown-plan.md.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UDmeAycWwQ5Y8PXuz4iub6
