### PR TITLE
perf: [T1-A3] push the transaction-graph cursor read down to Mongo — completes Part A

### DIFF
--- a/src/Core/Sorcha.Register.Core/Storage/IReadOnlyRegisterRepository.cs
+++ b/src/Core/Sorcha.Register.Core/Storage/IReadOnlyRegisterRepository.cs
@@ -102,6 +102,15 @@ public interface IReadOnlyRegisterRepository
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Counts transactions strictly older than <paramref name="before"/> (by <c>TimeStamp</c>) without
+    /// materialising them — the total for cursor pagination (rides the <c>TimeStamp</c> index).
+    /// </summary>
+    Task<long> CountTransactionsBeforeAsync(
+        string registerId,
+        DateTime before,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Gets transactions of a given <see cref="TransactionType"/>, sorted and paged, pushed down to
     /// the store (rides the <c>MetaData.TransactionType</c> index). <paramref name="take"/> of 0
     /// returns all matches.

--- a/src/Core/Sorcha.Register.Storage.InMemory/InMemoryRegisterRepository.cs
+++ b/src/Core/Sorcha.Register.Storage.InMemory/InMemoryRegisterRepository.cs
@@ -184,6 +184,9 @@ public class InMemoryRegisterRepository : IRegisterRepository
     public Task<long> CountTransactionsAsync(string registerId, CancellationToken cancellationToken = default)
         => Task.FromResult((long)RegisterTxs(registerId).Count());
 
+    public Task<long> CountTransactionsBeforeAsync(string registerId, DateTime before, CancellationToken cancellationToken = default)
+        => Task.FromResult((long)RegisterTxs(registerId).Count(t => t.TimeStamp < before));
+
     public Task<IReadOnlyList<TransactionModel>> GetTransactionsByTypeAsync(
         string registerId,
         Sorcha.Register.Models.Enums.TransactionType transactionType,

--- a/src/Core/Sorcha.Register.Storage.MongoDB/MongoRegisterRepository.cs
+++ b/src/Core/Sorcha.Register.Storage.MongoDB/MongoRegisterRepository.cs
@@ -587,6 +587,14 @@ public class MongoRegisterRepository : IRegisterRepository
     }
 
     /// <inheritdoc/>
+    public async Task<long> CountTransactionsBeforeAsync(string registerId, DateTime before, CancellationToken cancellationToken = default)
+    {
+        var transactions = GetTransactionsCollection(registerId);
+        var filter = Builders<TransactionModel>.Filter.Lt(t => t.TimeStamp, before);
+        return await transactions.CountDocumentsAsync(filter, cancellationToken: cancellationToken);
+    }
+
+    /// <inheritdoc/>
     public async Task<IReadOnlyList<TransactionModel>> GetTransactionsByTypeAsync(
         string registerId,
         TransactionType transactionType,

--- a/src/Core/Sorcha.Register.Storage/CachedRegisterRepository.cs
+++ b/src/Core/Sorcha.Register.Storage/CachedRegisterRepository.cs
@@ -239,6 +239,9 @@ public class CachedRegisterRepository : IRegisterRepository
     public Task<long> CountTransactionsAsync(string registerId, CancellationToken cancellationToken = default)
         => _innerRepository.CountTransactionsAsync(registerId, cancellationToken);
 
+    public Task<long> CountTransactionsBeforeAsync(string registerId, DateTime before, CancellationToken cancellationToken = default)
+        => _innerRepository.CountTransactionsBeforeAsync(registerId, before, cancellationToken);
+
     public Task<IReadOnlyList<TransactionModel>> GetTransactionsByTypeAsync(
         string registerId,
         Sorcha.Register.Models.Enums.TransactionType transactionType,

--- a/src/Services/Sorcha.Register.Service/Program.cs
+++ b/src/Services/Sorcha.Register.Service/Program.cs
@@ -1184,26 +1184,24 @@ transactionsGroup.MapGet("/graph", async (
         return Results.NotFound(new { error = "Register not found" });
     }
 
-    // Get all transactions for the register
-    var transactionsQuery = await repository.GetTransactionsAsync(registerId);
-    var transactions = transactionsQuery.OrderByDescending(t => t.TimeStamp).AsEnumerable();
-
-    // Cursor-based pagination: if 'before' is specified, find that transaction's timestamp
-    // and filter to transactions older than it
-    if (!string.IsNullOrEmpty(before))
+    // Cursor-based pagination pushed down to the store: resolve the cursor tx by id, then a single
+    // index-backed page of transactions older than it (newest-first) + a count for totalCount/hasMore.
+    // No cursor (or an unknown cursor) → the latest page. Never materialises the whole ledger.
+    long totalCount;
+    IReadOnlyList<TransactionModel> pageTxs;
+    if (!string.IsNullOrEmpty(before)
+        && await repository.GetTransactionAsync(registerId, before) is { } cursorTx)
     {
-        var cursorTx = transactionsQuery.FirstOrDefault(t => t.TxId == before);
-        if (cursorTx is not null)
-        {
-            transactions = transactions.Where(t => t.TimeStamp < cursorTx.TimeStamp);
-        }
+        totalCount = await repository.CountTransactionsBeforeAsync(registerId, cursorTx.TimeStamp);
+        pageTxs = await repository.GetTransactionsBeforeAsync(registerId, cursorTx.TimeStamp, effectiveLimit);
+    }
+    else
+    {
+        totalCount = await repository.CountTransactionsAsync(registerId);
+        pageTxs = await repository.GetLatestTransactionsAsync(registerId, 0, effectiveLimit);
     }
 
-    var allFiltered = transactions.ToList();
-    var totalCount = allFiltered.Count;
-
-    var nodes = allFiltered
-        .Take(effectiveLimit)
+    var nodes = pageTxs
         .Select(t => new TransactionGraphNodeDto(
             t.TxId,
             t.PrevTxId,
@@ -1218,7 +1216,7 @@ transactionsGroup.MapGet("/graph", async (
     return Results.Ok(new TransactionGraphResponse(
         registerId,
         nodes,
-        totalCount,
+        (int)totalCount,
         totalCount > nodes.Length));
 })
 .WithName("GetTransactionGraph")

--- a/tests/Sorcha.Register.Storage.Tests/RegisterRepositoryContractTests.cs
+++ b/tests/Sorcha.Register.Storage.Tests/RegisterRepositoryContractTests.cs
@@ -509,4 +509,19 @@ public abstract class RegisterRepositoryContractTests
         before[0].TxId.Should().StartWith("bf-2"); // newest-first
         before[1].TxId.Should().StartWith("bf-1");
     }
+
+    [Fact]
+    public async Task CountTransactionsBeforeAsync_CountsStrictlyOlder()
+    {
+        var sut = Sut;
+        const string reg = "contract-count-before";
+        await sut.InsertRegisterAsync(CreateRegister(reg));
+        var t0 = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        await sut.InsertTransactionAsync(Tx("cb-1", reg, t0));
+        await sut.InsertTransactionAsync(Tx("cb-2", reg, t0.AddMinutes(1)));
+        await sut.InsertTransactionAsync(Tx("cb-3", reg, t0.AddMinutes(2)));
+
+        (await sut.CountTransactionsBeforeAsync(reg, t0.AddMinutes(2))).Should().Be(2); // cb-1, cb-2
+        (await sut.CountTransactionsBeforeAsync(reg, t0)).Should().Be(0); // strictly before, none
+    }
 }


### PR DESCRIPTION
Migrates the last index-able site (GET /registers/{id}/transactions/graph) off the materialise-all
pattern: resolve the cursor tx by id, then a single index-backed GetTransactionsBeforeAsync page +
CountTransactionsBeforeAsync (new) for totalCount/hasMore. No cursor / unknown cursor → the latest page.

Adds CountTransactionsBeforeAsync (CountDocuments(Lt(TimeStamp, before)), rides the TimeStamp index) to
the repo interface + all three impls + the caching decorator, with a contract test.

Part A is now complete: every index-able register transaction read is pushed down to Mongo. The only
remaining GetTransactionsAsync (materialise-all) callers are the three inherent full-scans that genuinely
need every transaction — orphan-transaction detect/purge (all txs vs docket membership) and the stats
aggregate — documented in the plan (§3.3) for a later projection/$group pass, not elimination.

Register suites green: Storage 80, Core 325, Service 317.
Plan: docs/audits/2026-07-04-register-read-pushdown-plan.md.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UDmeAycWwQ5Y8PXuz4iub6
