### PR TITLE
docs: mark register read-pushdown Part A complete + capture the B reframing

### DIFF
--- a/.claude/skills/mongodb/references/patterns.md
+++ b/.claude/skills/mongodb/references/patterns.md
@@ -226,6 +226,39 @@ var total = await _collection.EstimatedDocumentCountAsync(ct);
 var filtered = await _collection.CountDocumentsAsync(filter, options, ct);
 ```
 
+### Push the query down — never materialise-then-LINQ
+
+The single worst read anti-pattern: load the whole collection, then filter/sort/page/count in memory.
+Every read becomes O(collection) — fetching one document, the latest page, or a count all stream +
+deserialize everything first. On an append-only collection it only gets worse.
+
+```csharp
+// BAD — materialises the entire collection, then LINQ-to-Objects (O(collection) per read).
+// This is exactly the register T1 bottleneck (2026-07-04): GetTransactionsAsync did
+// Find(Empty).ToList().AsQueryable() and ~18 call sites filtered/sorted/paged/counted in memory.
+var all = (await coll.Find(FilterDefinition<T>.Empty).ToListAsync(ct)).AsQueryable();
+var page = all.Where(x => x.Type == t).OrderByDescending(x => x.Ts).Skip(s).Take(n).ToList();
+var total = all.Count();
+
+// GOOD — filter + sort + skip/limit + count all pushed to the server (index-backed).
+var page = await coll.Find(Builders<T>.Filter.Eq(x => x.Type, t))
+    .SortByDescending(x => x.Ts).Skip(s).Limit(n).ToListAsync(ct);
+var total = await coll.CountDocumentsAsync(Builders<T>.Filter.Eq(x => x.Type, t), cancellationToken: ct);
+```
+
+- **Expose intent-revealing repo methods** (`GetLatestTransactions(skip, take)`,
+  `GetTransactionsByType(type, sort, skip, take)`, `CountTransactions`, `CountTransactionsBefore`,
+  cursor `GetTransactionsBefore(before, take)`), not a blanket `Task<IQueryable<T>>` that leaks the
+  materialise-all shape to callers. See `IReadOnlyRegisterRepository` +
+  `docs/audits/2026-07-04-register-read-pushdown-plan.md`.
+- **Cursor pagination:** `Find(Lt(Ts, cursor)).SortByDescending(Ts).Limit(n)` + a `CountDocuments(Lt)`
+  for `hasMore` — no full scan, no offset skip cost.
+- **A pushed-down filter is only cheap on an indexed field** — align the predicate/sort to an existing
+  index or you've just moved the COLLSCAN server-side (see the index section above).
+- **Genuine full-scans** (e.g. "every doc not in set X", cross-doc aggregate) can't be eliminated — but
+  still `.Project(...)` to only the needed fields and stream (`IAsyncCursor`/`IAsyncEnumerable`) rather
+  than building a giant in-memory `List`; or move the aggregate into a `$group` pipeline.
+
 ---
 
 ## Testing with Testcontainers

--- a/docs/audits/2026-07-04-register-read-pushdown-plan.md
+++ b/docs/audits/2026-07-04-register-read-pushdown-plan.md
@@ -1,7 +1,29 @@
 # Register read pushdown + OData revival — design plan
 
-**Status:** proposed · **Author:** perf initiative (T1 follow-up) · **Date:** 2026-07-04
+**Status:** Part A shipped · **Author:** perf initiative (T1 follow-up) · **Date:** 2026-07-04
 **Prereq shipped:** the three Mongo tx indexes (#1106) that these pushed-down queries seek against.
+
+> **Update 2026-07-04 — Part A complete (#1112 doc, #1113 A1, #1114 A2, #1115 A3).**
+> Every index-able register transaction read is now pushed down to Mongo. The pushed-down methods
+> (`GetLatestTransactions/Transaction`, `CountTransactions`, `CountTransactionsBefore`,
+> `GetTransactionsByType`, `GetTransactionsBefore`) + `TransactionSort` enum live on
+> `IReadOnlyRegisterRepository` (all three impls + cache decorator + `TransactionManager`), with
+> contract tests. **Use these — not the materialise-all `GetTransactionsAsync`** — for new register
+> read paths. `GetTransactionsAsync` (Find(Empty).ToList().AsQueryable()) is now reserved for the three
+> inherent full-scans below.
+>
+> **Remaining (deliberately not done):**
+> - **Inherent full-scans** (§3.3): orphan-transaction detect/purge (`Program.cs`) + register statistics
+>   (`QueryManager.GetTransactionStatistics`) genuinely need every transaction. Follow-up = projection /
+>   `$group`, not elimination.
+> - **Part B (OData revival) — reframed as a small feature, not wiring.** On inspection the OData surface
+>   is dead (`AddOData` registered, no `MapControllers`, no gateway route) AND the Explorer
+>   (`ODataQueryBuilder.razor` → `ODataQueryService`) was built assuming a **single global `Transactions`
+>   collection** — but storage is **per-register databases** (`sorcha_register_{id}`). So B needs a
+>   **per-register-routed** OData controller (`/odata/registers/{registerId}/Transactions`, `[EnableQuery]`
+>   over `collection.AsQueryable()` = `IMongoQueryable`, allowed-field/`$top` constraints) **and** an
+>   Explorer **register-selector UX** (the client must pass `registerId`). Server side is mechanical +
+>   testable; the selector UX is real UI work. Treat B as its own focused piece.
 
 ## 1. Problem
 


### PR DESCRIPTION
- Design doc: status → Part A shipped (#1112-#1115); the pushed-down read methods to use instead of
  GetTransactionsAsync; the three inherent full-scans left as a projection/$group follow-up; and the
  Part B reframing (dead OData surface + Explorer assumed a global collection while storage is
  per-register DBs, so B = a per-register-routed controller + a register-selector UX, not wiring).
- mongodb skill: new "Push the query down — never materialise-then-LINQ" pattern (the T1 anti-pattern +
  the intent-revealing repo-method fix, cursor pagination, index alignment, and the full-scan caveat).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UDmeAycWwQ5Y8PXuz4iub6
