### PR TITLE
fix: [P1] genesis docket sealing — drop request-validation from the internal docket-write endpoint

### DIFF
--- a/src/Services/Sorcha.Register.Service/Program.cs
+++ b/src/Services/Sorcha.Register.Service/Program.cs
@@ -1897,7 +1897,12 @@ docketsGroup.MapPost("/", async (
     return Results.Created($"/api/registers/{registerId}/dockets/{inserted.Id}", inserted);
 })
 .Produces(StatusCodes.Status409Conflict)
-.WithRequestValidation()
+// No .WithRequestValidation() here: this is an INTERNAL validator->register endpoint carrying an
+// already hash/signature-verified docket + its ledger transactions. The request-validation seam
+// recurses into WriteDocketRequest.Transactions and runs user-input DataAnnotations over ledger txs —
+// which wrongly rejects a genesis docket (the genesis control tx has an empty PrevTxId, failing
+// TransactionModel's [StringLength(64, MinimumLength=64)]) and 400s new-register sealing. Machine-to-
+// machine ledger writes must not be gated by user-input validation.
 .WithName("WriteDocket")
 .WithSummary("Write a confirmed docket")
 .WithDescription("Writes a consensus-confirmed docket to the register. Used by Validator Service.")

--- a/tests/Sorcha.Register.Service.Tests/Endpoints/DocketWriteGenesisValidationTests.cs
+++ b/tests/Sorcha.Register.Service.Tests/Endpoints/DocketWriteGenesisValidationTests.cs
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Net;
+using System.Net.Http.Json;
+using FluentAssertions;
+using Sorcha.Register.Models;
+using Sorcha.Register.Models.Enums;
+using Sorcha.Register.Service.Tests.Helpers;
+using Xunit;
+
+namespace Sorcha.Register.Service.Tests.Endpoints;
+
+/// <summary>
+/// Regression guard for the P1 (2026-07-04): new-register genesis sealing broke because the internal
+/// validator->register docket-write endpoint (POST /api/registers/{id}/dockets) carried
+/// <c>.WithRequestValidation()</c>. That seam recurses into <c>WriteDocketRequest.Transactions</c> and
+/// runs user-input DataAnnotations over the embedded ledger transactions — and a GENESIS control tx has
+/// an empty <c>PrevTxId</c> (nothing precedes genesis), which fails <c>TransactionModel</c>'s
+/// <c>[StringLength(64, MinimumLength = 64)]</c> → 400 → the genesis docket never persists.
+///
+/// The fix removed request-validation from this internal, already-crypto-verified machine endpoint. This
+/// test asserts the endpoint no longer rejects a genesis docket whose control tx has an empty PrevTxId
+/// (i.e. NOT a validation 400), so the seam can't be silently re-added.
+/// </summary>
+[Collection("RegisterWebApp")]
+public class DocketWriteGenesisValidationTests : IClassFixture<RegisterServiceWebApplicationFactory>
+{
+    private readonly HttpClient _client;
+
+    public DocketWriteGenesisValidationTests(RegisterServiceWebApplicationFactory factory)
+    {
+        _client = factory.CreateClient();
+    }
+
+    [Fact]
+    public async Task WriteDocket_GenesisDocketWithEmptyPrevTxIdControlTx_IsNotRejectedByValidation()
+    {
+        // A fresh register id → the genesis (DocketNumber 0) create-on-sync path.
+        var registerId = "genval" + Guid.NewGuid().ToString("N");
+
+        // The genesis control transaction: PrevTxId is empty because nothing precedes genesis. This is
+        // the exact shape that tripped TransactionModel.[StringLength(64, MinimumLength = 64)] under the
+        // recursive request-validation seam.
+        var genesisTx = new TransactionModel
+        {
+            TxId = new string('a', 64),
+            PrevTxId = string.Empty,
+            RegisterId = registerId,
+            SenderWallet = "test-wallet",
+            TimeStamp = DateTime.UtcNow,
+            Signature = "test-signature",
+            Payloads = Array.Empty<PayloadModel>(),
+            MetaData = new TransactionMetaData
+            {
+                RegisterId = registerId,
+                TransactionType = TransactionType.Control,
+            },
+        };
+
+        var request = new
+        {
+            DocketId = new string('b', 64),
+            DocketNumber = 0L,
+            PreviousHash = (string?)null,
+            DocketHash = new string('b', 64),
+            CreatedAt = DateTimeOffset.UtcNow,
+            TransactionIds = new[] { genesisTx.TxId },
+            ProposerValidatorId = "test-validator",
+            MerkleRoot = new string('c', 64),
+            Transactions = new[] { genesisTx },
+        };
+
+        var response = await _client.PostAsJsonAsync($"/api/registers/{registerId}/dockets", request);
+
+        // The key regression assertion: the recursive user-input validation reject is gone. A downstream
+        // business outcome (created / conflict / etc.) is fine — a 400 BadRequest is NOT, because that is
+        // the validation failure this fix removed.
+        response.StatusCode.Should().NotBe(HttpStatusCode.BadRequest,
+            "an internal docket write of a genesis docket (control tx with empty PrevTxId) must not be " +
+            "rejected by user-input request validation");
+    }
+}


### PR DESCRIPTION
New-register creation was broken platform-wide: the validator builds docket 0 and POSTs it to the
register-service's POST /api/registers/{id}/dockets, which 400'd, so no genesis docket ever sealed →
no roster → blueprint publish then 403s. Existing registers (incl. the SSR) were unaffected because
they sealed before the regression.

Root cause: that internal endpoint carried .WithRequestValidation(). The request-validation seam
recurses into IEnumerable properties, so it validated every ledger transaction embedded in
WriteDocketRequest.Transactions with user-input DataAnnotations. A GENESIS control transaction has an
empty PrevTxId (nothing precedes genesis), which fails TransactionModel's
[StringLength(64, MinimumLength = 64)] → 400. Non-genesis txs carry a real 64-char PrevTxId, so only
genesis dockets broke. The seam was applied over-eagerly (VAL-001 sweep) to a machine-to-machine
endpoint whose docket + txs are already hash/signature-verified upstream.

Fix: remove .WithRequestValidation() from the docket-write endpoint. Regression test (in-process,
WebApplicationFactory): a genesis docket whose control tx has an empty PrevTxId must NOT be rejected
with a validation 400 — verified it catches the bug (fails with the seam re-added, passes with the
fix). Full suite: 318 passed / 9 skipped. Found running the AIAS demo against n1.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UDmeAycWwQ5Y8PXuz4iub6
