### PR TITLE
feat: [174] portrait camera capture + fix draft ID card gold-data population

### DIFF
--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Forms/Controls/FileRenderer.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Forms/Controls/FileRenderer.razor
@@ -4,6 +4,7 @@
 @using Microsoft.AspNetCore.Components.Forms
 @using Microsoft.Extensions.Logging
 @using Sorcha.Blueprint.Models
+@using Sorcha.UI.Components.User.Components.Capture
 @using Sorcha.UI.Core.Models.Forms
 @using Sorcha.UI.Core.Services.Forms
 
@@ -14,10 +15,21 @@
 <MudStack Spacing="1">
     <MudText Typo="Typo.body2">@Control.Title</MudText>
 
-    <InputFile OnChange="OnFileSelected"
-               disabled="@(IsDisabled || FormContext?.IsReadOnly == true)"
-               capture="@_captureAttribute"
-               accept="@_acceptAttribute" />
+    @if (_useCameraCapture)
+    {
+        @* Image-capture fields (embedAs token image) get the camera-first control: a live getUserMedia
+           camera capture with an upload fallback. Desktop browsers ignore <input capture>, so the plain
+           file input below can never open a webcam — this control can. *@
+        <PortraitCaptureControl HelpText="Take a photo with your camera, or upload an image."
+                                OnCaptured="OnPortraitCaptured" />
+    }
+    else
+    {
+        <InputFile OnChange="OnFileSelected"
+                   disabled="@(IsDisabled || FormContext?.IsReadOnly == true)"
+                   capture="@_captureAttribute"
+                   accept="@_acceptAttribute" />
+    }
 
     @if (_resizeInProgress)
     {
@@ -74,6 +86,10 @@
     private string? _acceptAttribute;
     private bool _showPortraitTips;
 
+    // True when this field wants a captured, embed-sized portrait (embedAs token image) — it then
+    // renders the camera-first PortraitCaptureControl instead of the plain file input.
+    private bool _useCameraCapture;
+
     // Platform ceiling — acts as the fallback when the schema doesn't
     // declare an explicit `x-file.maxSizePerFile`. The per-field limit is
     // preferred because it bounds the WASM buffer for camera capture on
@@ -117,6 +133,7 @@
         _captureAttribute = null;
         _acceptAttribute = null;
         _showPortraitTips = false;
+        _useCameraCapture = false;
 
         if (FormContext?.DataSchema is null) return;
 
@@ -129,7 +146,36 @@
             _captureAttribute = FileFieldCaptureHelper.GetCaptureAttribute(ext);
             _acceptAttribute = ext.Accept.Length > 0 ? string.Join(",", ext.Accept) : null;
             _showPortraitTips = FileFieldCaptureHelper.ShouldResizeForEmbed(ext);
+            // Camera-first only for embed-token image fields, and never in read-only mode.
+            _useCameraCapture = _showPortraitTips
+                && !IsDisabled
+                && FormContext?.IsReadOnly != true;
         }
+    }
+
+    /// <summary>
+    /// Handles a portrait produced by <c>PortraitCaptureControl</c> (camera snapshot or uploaded image,
+    /// already resized to the 240×320 embed token). Stores it at the same sibling pointer the file path
+    /// uses (<c>&lt;scope&gt;/tokenImageBase64</c>) and marks the field answered.
+    /// </summary>
+    private void OnPortraitCaptured(string base64Token)
+    {
+        if (string.IsNullOrEmpty(base64Token)) return;
+
+        var scope = Control.Scope;
+        _resizeWarning = null;
+        FormContext?.SetValue(scope, "portrait.jpg");
+        FormContext?.SetValue($"{scope}/tokenImageBase64", base64Token);
+
+        _selectedFile = new FileAttachmentInfo
+        {
+            FileName = "portrait.jpg",
+            ContentType = "image/jpeg",
+            Size = 0,
+            Content = System.Array.Empty<byte>(),
+            Scope = scope,
+        };
+        _fileDisplayText = "Portrait captured";
     }
 
     private async Task OnFileSelected(InputFileChangeEventArgs e)

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Extensions/ServiceCollectionExtensions.cs
@@ -4,6 +4,7 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Sorcha.UI.Components.User.Services.Capture;
 using Sorcha.UI.Components.User.Services.Verification;
 using Sorcha.UI.Core.Services;
 using Sorcha.Verifier.Engine;
@@ -49,6 +50,11 @@ public static class ServiceCollectionExtensions
     {
         // Feature 173: anonymous client for the three social-link step-up endpoints (F168 contract).
         services.AddScoped<IAnonymousSocialLinkClientService, AnonymousSocialLinkClientService>();
+
+        // Feature 174 follow-up: getUserMedia-backed camera for portrait-capture form fields
+        // (backs PortraitCaptureControl). TryAdd so a host stub (e.g. a PWA without the JS module)
+        // can override it.
+        services.TryAddScoped<IWebCameraService, WebCameraService>();
 
         // Verify seams — Feature 163 (PR B2-components).
         // TryAdd* ensures a host override registered before this call wins.

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/Capture/WebCameraService.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/Capture/WebCameraService.cs
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using Microsoft.JSInterop;
+
+namespace Sorcha.UI.Components.User.Services.Capture;
+
+/// <summary>
+/// getUserMedia-backed <see cref="IWebCameraService"/> (Feature 174 follow-up). Bridges to the
+/// <c>window.SorchaPortrait</c> JS module (loaded from <c>js/sorcha-portrait.js</c>) which opens the
+/// device camera in a capture overlay and returns a resized base64 JPEG. Works on desktop and mobile
+/// (unlike the native <c>&lt;input capture&gt;</c> path, which desktop browsers ignore).
+/// </summary>
+public sealed class WebCameraService(IJSRuntime js) : IWebCameraService
+{
+    private readonly IJSRuntime _js = js;
+
+    /// <inheritdoc />
+    public async Task<bool> IsCameraSupportedAsync(CancellationToken ct = default)
+    {
+        try
+        {
+            return await _js.InvokeAsync<bool>("SorchaPortrait.isCameraSupported", ct);
+        }
+        catch (JSException)
+        {
+            // Module not loaded (e.g. PWA host without the script) — treat as unsupported so the
+            // control falls back to file upload rather than showing a dead camera button.
+            return false;
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<string?> CapturePortraitAsync(PortraitCaptureRequest request, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        try
+        {
+            return await _js.InvokeAsync<string?>(
+                "SorchaPortrait.capturePortrait",
+                ct,
+                request.TargetWidth,
+                request.TargetHeight,
+                request.JpegQuality);
+        }
+        catch (JSException ex) when (ex.Message.Contains("camera-permission-denied", StringComparison.Ordinal))
+        {
+            // Surface permission denial distinctly so the control shows the "check camera permission"
+            // recovery message rather than a generic failure.
+            throw new UnauthorizedAccessException("camera-permission-denied", ex);
+        }
+    }
+}

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/Forms/ReviewSummaryDataSource.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/Forms/ReviewSummaryDataSource.cs
@@ -51,13 +51,21 @@ public sealed class ReviewSummaryDataSource
                     // from "filled with null value" — both render as empty
                     // on the card, but the dictionary explicitly lists every
                     // field the citizen was asked about.
-                    if (formContext.FormData.TryGetValue(pointer, out var value))
+                    if (formContext.FormData.TryGetValue(pointer, out var value) && value is not null)
                     {
                         fieldValues[pointer] = value;
                     }
                     else
                     {
-                        fieldValues[pointer] = null;
+                        // Complex core-primitive ($ref) fields — PersonName, PostalAddress,
+                        // DateOfBirth, etc. — are stored FLATTENED at leaf pointers
+                        // ("/name/givenName", "/address/line1"), never at the parent pointer the
+                        // card looks up. Without this the whole id-card renders empty for every
+                        // $ref field. Gather the human-readable leaf values (in encounter order)
+                        // and join them. Long/base64 leaves are excluded: the portrait token
+                        // ("/portrait/tokenImageBase64") is rendered as the card image separately,
+                        // and holder-key material is not display data.
+                        fieldValues[pointer] = GatherFlattenedDisplayValue(formContext.FormData, pointer);
                     }
                 }
 
@@ -93,5 +101,35 @@ public sealed class ReviewSummaryDataSource
     {
         if (string.IsNullOrEmpty(fieldName)) return "/";
         return fieldName.StartsWith('/') ? fieldName : "/" + fieldName;
+    }
+
+    // Longest human-readable leaf we keep on the card. Real display detail (names, dates, emails,
+    // address lines) is short; embedded portrait tokens and holder-key material are far longer, so
+    // this length gate cleanly excludes them from the card's text fields.
+    private const int MaxDisplayLeafLength = 256;
+
+    /// <summary>
+    /// Reconstructs a display value for a complex ($ref) field whose parent pointer isn't in the
+    /// form data because its renderer wrote flattened leaf pointers (e.g. <c>/name/givenName</c>,
+    /// <c>/address/line1</c>). Joins the non-empty, human-readable leaves under
+    /// <paramref name="pointer"/> in encounter order (which follows input/schema order), excluding
+    /// long/base64 leaves (portrait token image, holder-key material). Returns null when nothing
+    /// displayable was captured.
+    /// </summary>
+    internal static string? GatherFlattenedDisplayValue(
+        IReadOnlyDictionary<string, object?> formData,
+        string pointer)
+    {
+        var prefix = pointer + "/";
+        var parts = new List<string>();
+        foreach (var kv in formData)
+        {
+            if (!kv.Key.StartsWith(prefix, StringComparison.Ordinal) || kv.Value is null) continue;
+            var text = kv.Value as string ?? kv.Value.ToString();
+            if (string.IsNullOrWhiteSpace(text) || text.Length > MaxDisplayLeafLength) continue;
+            parts.Add(text);
+        }
+
+        return parts.Count > 0 ? string.Join(" ", parts) : null;
     }
 }

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web/wwwroot/app/index.html
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web/wwwroot/app/index.html
@@ -148,5 +148,8 @@
     <!-- QR code generation -->
     <script src="js/qrcode.min.js"></script>
     <script src="js/qrcode-interop.js"></script>
+
+    <!-- Portrait camera capture + JPEG resize (Feature 174 follow-up) -->
+    <script src="js/sorcha-portrait.js"></script>
 </body>
 </html>

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web/wwwroot/app/js/sorcha-portrait.js
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web/wwwroot/app/js/sorcha-portrait.js
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+//
+// SorchaPortrait — browser camera capture + JPEG resize for form portrait fields
+// (Feature 174 follow-up; backs IWebCameraService + PortraitCaptureControl.resizeJpeg).
+//
+// window.SorchaPortrait.isCameraSupported() -> bool
+// window.SorchaPortrait.capturePortrait(w, h, quality) -> base64 JPEG (no data: prefix) | null (cancel)
+//     throws "camera-permission-denied" when the user blocks the camera.
+// window.SorchaPortrait.resizeJpeg(base64, w, h, quality) -> base64 JPEG (no data: prefix)
+(function () {
+  "use strict";
+
+  function isCameraSupported() {
+    return !!(navigator.mediaDevices && typeof navigator.mediaDevices.getUserMedia === "function");
+  }
+
+  // Draw a source (video or image) center-cropped to the target aspect ratio, scaled to w×h.
+  function drawCropped(source, sw, sh, w, h) {
+    const canvas = document.createElement("canvas");
+    canvas.width = w;
+    canvas.height = h;
+    const ctx = canvas.getContext("2d");
+    const targetAspect = w / h;
+    const srcAspect = sw / sh;
+    let cropW = sw, cropH = sh, cropX = 0, cropY = 0;
+    if (srcAspect > targetAspect) {
+      // source too wide — crop the sides
+      cropW = Math.round(sh * targetAspect);
+      cropX = Math.round((sw - cropW) / 2);
+    } else {
+      // source too tall — crop top/bottom
+      cropH = Math.round(sw / targetAspect);
+      cropY = Math.round((sh - cropH) / 2);
+    }
+    ctx.drawImage(source, cropX, cropY, cropW, cropH, 0, 0, w, h);
+    return canvas;
+  }
+
+  function toBase64Jpeg(canvas, quality) {
+    const url = canvas.toDataURL("image/jpeg", quality);
+    const comma = url.indexOf(",");
+    return comma >= 0 ? url.substring(comma + 1) : url;
+  }
+
+  async function capturePortrait(w, h, quality) {
+    if (!isCameraSupported()) {
+      throw new Error("camera-not-supported");
+    }
+    let stream;
+    try {
+      stream = await navigator.mediaDevices.getUserMedia({
+        video: { facingMode: "user", width: { ideal: 1280 }, height: { ideal: 720 } },
+        audio: false,
+      });
+    } catch (err) {
+      // NotAllowedError / SecurityError => the user (or policy) blocked the camera.
+      throw new Error("camera-permission-denied");
+    }
+
+    return await new Promise((resolve) => {
+      // Full-screen capture overlay: live preview + Capture / Cancel.
+      const overlay = document.createElement("div");
+      overlay.setAttribute("data-testid", "portrait-camera-overlay");
+      overlay.style.cssText =
+        "position:fixed;inset:0;z-index:20000;background:rgba(0,0,0,0.92);" +
+        "display:flex;flex-direction:column;align-items:center;justify-content:center;gap:16px;padding:16px;";
+
+      const video = document.createElement("video");
+      video.autoplay = true;
+      video.playsInline = true;
+      video.muted = true;
+      video.style.cssText = "max-width:min(92vw,480px);max-height:70vh;border-radius:8px;background:#000;transform:scaleX(-1);";
+      video.srcObject = stream;
+
+      const bar = document.createElement("div");
+      bar.style.cssText = "display:flex;gap:12px;";
+
+      function mkBtn(label, primary, testid) {
+        const b = document.createElement("button");
+        b.textContent = label;
+        b.setAttribute("data-testid", testid);
+        b.style.cssText =
+          "padding:12px 24px;border:none;border-radius:24px;font-size:16px;cursor:pointer;" +
+          (primary ? "background:#f5a623;color:#1a1a1a;font-weight:600;" : "background:#3a3a3a;color:#fff;");
+        return b;
+      }
+      const capBtn = mkBtn("Capture", true, "portrait-camera-capture");
+      const cancelBtn = mkBtn("Cancel", false, "portrait-camera-cancel");
+      bar.appendChild(capBtn);
+      bar.appendChild(cancelBtn);
+      overlay.appendChild(video);
+      overlay.appendChild(bar);
+      document.body.appendChild(overlay);
+
+      function cleanup() {
+        try { stream.getTracks().forEach((t) => t.stop()); } catch (_) {}
+        if (overlay.parentNode) overlay.parentNode.removeChild(overlay);
+      }
+
+      capBtn.addEventListener("click", () => {
+        try {
+          const sw = video.videoWidth || 1280;
+          const sh = video.videoHeight || 720;
+          const canvas = drawCropped(video, sw, sh, w, h);
+          const b64 = toBase64Jpeg(canvas, quality);
+          cleanup();
+          resolve(b64);
+        } catch (_) {
+          cleanup();
+          resolve(null);
+        }
+      });
+      cancelBtn.addEventListener("click", () => { cleanup(); resolve(null); });
+    });
+  }
+
+  function resizeJpeg(base64, w, h, quality) {
+    return new Promise((resolve) => {
+      const img = new Image();
+      img.onload = () => {
+        try {
+          const canvas = drawCropped(img, img.naturalWidth, img.naturalHeight, w, h);
+          resolve(toBase64Jpeg(canvas, quality));
+        } catch (_) {
+          resolve(base64); // fall back to the original on any canvas error
+        }
+      };
+      img.onerror = () => resolve(base64);
+      img.src = "data:image/jpeg;base64," + base64;
+    });
+  }
+
+  window.SorchaPortrait = { isCameraSupported, capturePortrait, resizeJpeg };
+})();

--- a/tests/Sorcha.UI.Core.Tests/Services/Forms/ReviewSummaryDataSourceTests.cs
+++ b/tests/Sorcha.UI.Core.Tests/Services/Forms/ReviewSummaryDataSourceTests.cs
@@ -147,6 +147,48 @@ public class ReviewSummaryDataSourceTests
     }
 
     [Fact]
+    public void BuildConfig_ComplexRefField_GathersFlattenedLeavesForDisplay()
+    {
+        // The AIAS regression: a section field is the $ref PARENT ("name"), but the renderer stores the
+        // core-primitive value flattened at leaf pointers ("/name/givenName", "/name/familyName"). The
+        // card looks up "/name" — which isn't in the form data — so without gathering it renders empty.
+        var pages = new List<BlueprintPageDefinition>
+        {
+            new() { Title = "About you", Sections = [new BlueprintSectionDefinition { Title = "Your name", Fields = ["name"] }] }
+        };
+        var ctx = new FormContext();
+        ctx.FormData["/name/givenName"] = "Alex";
+        ctx.FormData["/name/familyName"] = "MacLeod";
+
+        var sut = new ReviewSummaryDataSource();
+
+        var cfg = sut.BuildConfig(CitizenReview(), ctx, ActionRuntimeState.CitizenDraft, pages);
+
+        cfg.FieldValues["/name"].Should().Be("Alex MacLeod");
+    }
+
+    [Fact]
+    public void BuildConfig_FlattenedGather_ExcludesLongTokenImageLeaves()
+    {
+        // The portrait section stores both a short display value and a huge base64 token image at
+        // "/portrait/tokenImageBase64" — the token must NOT leak into the card's text (it's the image).
+        var pages = new List<BlueprintPageDefinition>
+        {
+            new() { Title = "Photo", Sections = [new BlueprintSectionDefinition { Title = "Portrait", Fields = ["portrait"] }] }
+        };
+        var ctx = new FormContext();
+        ctx.FormData["/portrait/fileName"] = "portrait.jpg";
+        ctx.FormData["/portrait/tokenImageBase64"] = new string('A', 5000); // base64 blob
+
+        var sut = new ReviewSummaryDataSource();
+
+        var cfg = sut.BuildConfig(CitizenReview(), ctx, ActionRuntimeState.CitizenDraft, pages);
+
+        cfg.FieldValues["/portrait"].Should().Be("portrait.jpg");
+        ((string?)cfg.FieldValues["/portrait"]).Should().NotContain("AAAA");
+    }
+
+    [Fact]
     public void BuildConfig_PagesWithoutSections_SkippedFromSectionList()
     {
         var pages = new List<BlueprintPageDefinition>


### PR DESCRIPTION
Two tightly-coupled form-renderer fixes for the AIAS portrait flow:

1. Camera capture for portrait fields. FileRenderer used a plain <input type=file capture>,
   which desktop browsers ignore (mobile-only), so the camera never opened on desktop. Feature
   125/107 shipped PortraitCaptureControl + IWebCameraService but never the JS backend. This adds:
   - js/sorcha-portrait.js: getUserMedia capture overlay + canvas resize (works desktop + mobile)
   - WebCameraService: IWebCameraService impl bridging to the JS module (+ DI registration)
   - FileRenderer now renders the camera-first PortraitCaptureControl for embed-token image fields
     (camera default, upload fallback), storing the 240x320 token at <scope>/tokenImageBase64.

2. Draft ID card showed no gold data. The id-card review reads FormData["/name"], but $ref core
   primitives (PersonName, PostalAddress...) are stored FLATTENED at leaf pointers
   ("/name/givenName", "/address/line1"), so every complex field rendered empty.
   ReviewSummaryDataSource now gathers the flattened, human-readable leaves (excluding long/base64
   leaves like the portrait token and holder keys) so the card populates. +2 regression tests.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UDmeAycWwQ5Y8PXuz4iub6
