### PR TITLE
fix: [174] route file-reference fields to FileRenderer + enforce required $ref fields on wizard advance

### DIFF
--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Forms/SorchaFormRenderer.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Forms/SorchaFormRenderer.razor
@@ -1037,8 +1037,14 @@
                 bool hasPageErrors = false;
                 foreach (var (scope, fieldErrors) in errors)
                 {
-                    var fieldName = scope.StartsWith('/') ? scope[1..] : scope;
-                    if (pageFields.Contains(fieldName))
+                    var trimmed = scope.StartsWith('/') ? scope[1..] : scope;
+                    // $ref core-primitive fields (PersonName, PostalAddress, ...) surface validation
+                    // errors at nested pointers ("/name/givenName"); the page lists only the top-level
+                    // field ("name"). Match on the first path segment so a missing required nested field
+                    // still blocks the wizard from advancing (otherwise the error is dropped and Next
+                    // proceeds past unfilled required data).
+                    var topLevelField = trimmed.Contains('/') ? trimmed[..trimmed.IndexOf('/')] : trimmed;
+                    if (pageFields.Contains(topLevelField))
                     {
                         _formContext.SetErrors(scope, fieldErrors);
                         hasPageErrors = true;

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/Forms/FormSchemaService.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/Forms/FormSchemaService.cs
@@ -404,6 +404,14 @@ public class FormSchemaService : IFormSchemaService
         {
             controlType = ControlTypes.DateTime;
         }
+        else if (format is "file-reference")
+        {
+            // File-attachment primitive (Feature 085) — routes to FileRenderer, which handles the
+            // x-file extension (accept/capture/embedAs) and, for embed-token image fields, the
+            // camera-first PortraitCaptureControl. Without this the field falls through to a plain
+            // text line and never reaches the file/camera control.
+            controlType = ControlTypes.File;
+        }
         else
         {
             controlType = type switch

--- a/tests/Sorcha.UI.Core.Tests/Components/Forms/FormSchemaServiceTests.cs
+++ b/tests/Sorcha.UI.Core.Tests/Components/Forms/FormSchemaServiceTests.cs
@@ -228,6 +228,34 @@ public class FormSchemaServiceTests
     }
 
     [Fact]
+    public void AutoGenerateForm_StringWithFileReferenceFormat_DispatchesToFile()
+    {
+        // Feature 085 file-attachment primitive: a string field with format "file-reference"
+        // must route to the File control (FileRenderer, which handles x-file accept/capture/embedAs
+        // and the camera-first portrait control). Without the mapping it fell through to a plain
+        // text line and the file/camera field never rendered.
+        var schema = JsonDocument.Parse("""
+        {
+            "type": "object",
+            "properties": {
+                "portrait": {
+                    "type": "string",
+                    "title": "Portrait photo",
+                    "format": "file-reference",
+                    "x-file": { "accept": ["image/jpeg"], "capture": "user", "embedAs": "image-token-jpeg-240x320" }
+                }
+            }
+        }
+        """);
+
+        var form = _sut.AutoGenerateForm(new[] { schema });
+
+        var portrait = form.Elements.FirstOrDefault(e => e.Scope == "/portrait");
+        portrait.Should().NotBeNull();
+        portrait!.ControlType.Should().Be(Sorcha.Blueprint.Models.ControlTypes.File);
+    }
+
+    [Fact]
     public void AutoGenerateForm_XAddressLookupFalse_RemainsTextLine()
     {
         // Explicit `x-address-lookup: false` should NOT dispatch to postcode lookup.


### PR DESCRIPTION
Two form-renderer bugs, both rooted in the $ref core-primitive handling:

1. File/camera field never rendered. FormSchemaService's control-type resolver had no case for
   format "file-reference" — it fell through to ControlTypes.TextLine, so the AIAS portrait field
   (and every file field, Feature 085) rendered as a plain text box and never reached FileRenderer
   (where the x-file accept/capture/embedAs handling + the camera-first PortraitCaptureControl live).
   Added format "file-reference" -> ControlTypes.File, mirroring how sorcha-holder-key and
   x-address-lookup already select their renderers. +regression test.

2. Wizard advanced past unfilled required fields. HandleNext matched validation-error scopes against
   the page's top-level field names, but $ref primitives (PersonName, PostalAddress...) surface
   errors at nested pointers ("/name/givenName") — which never matched "name", so the errors were
   dropped and Next proceeded. Now matches on the first path segment so missing required nested
   fields block advance.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UDmeAycWwQ5Y8PXuz4iub6
