### PR TITLE
fix: [174] route format:binary document-upload fields to FileRenderer

### DIFF
--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/Forms/FormSchemaService.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/Forms/FormSchemaService.cs
@@ -404,12 +404,13 @@ public class FormSchemaService : IFormSchemaService
         {
             controlType = ControlTypes.DateTime;
         }
-        else if (format is "file-reference")
+        else if (format is "file-reference" or "binary")
         {
-            // File-attachment primitive (Feature 085) — routes to FileRenderer, which handles the
-            // x-file extension (accept/capture/embedAs) and, for embed-token image fields, the
-            // camera-first PortraitCaptureControl. Without this the field falls through to a plain
-            // text line and never reaches the file/camera control.
+            // File-upload primitives — Sorcha's file-attachment format (Feature 085,
+            // "file-reference", carries the x-file extension for accept/capture/embedAs and the
+            // camera-first PortraitCaptureControl) and the OpenAPI byte-content convention
+            // ("binary", used by document-upload fields). Both route to FileRenderer; without this
+            // they fall through to a plain text line and never reach the file/camera control.
             controlType = ControlTypes.File;
         }
         else

--- a/tests/Sorcha.UI.Core.Tests/Components/Forms/FormSchemaServiceTests.cs
+++ b/tests/Sorcha.UI.Core.Tests/Components/Forms/FormSchemaServiceTests.cs
@@ -256,6 +256,28 @@ public class FormSchemaServiceTests
     }
 
     [Fact]
+    public void AutoGenerateForm_StringWithBinaryFormat_DispatchesToFile()
+    {
+        // Document-upload fields use the OpenAPI byte-content convention (type:string, format:binary),
+        // e.g. SelfBuildHouse "Building Specification (PDF)". They must also route to the File control
+        // rather than falling through to a text line.
+        var schema = JsonDocument.Parse("""
+        {
+            "type": "object",
+            "properties": {
+                "spec": { "type": "string", "format": "binary", "title": "Building Specification (PDF)" }
+            }
+        }
+        """);
+
+        var form = _sut.AutoGenerateForm(new[] { schema });
+
+        var spec = form.Elements.FirstOrDefault(e => e.Scope == "/spec");
+        spec.Should().NotBeNull();
+        spec!.ControlType.Should().Be(Sorcha.Blueprint.Models.ControlTypes.File);
+    }
+
+    [Fact]
     public void AutoGenerateForm_XAddressLookupFalse_RemainsTextLine()
     {
         // Explicit `x-address-lookup: false` should NOT dispatch to postcode lookup.


### PR DESCRIPTION
Audit follow-up to the file-reference fix: format "binary" (OpenAPI byte-content, used by 22
document-upload fields across the SelfBuildHouse warrant/planning templates — "Building
Specification (PDF)", "Structural Calculations Package", etc.) was also unhandled by the control-type
resolver and fell through to a text line. Routed "binary" -> ControlTypes.File alongside
"file-reference". +regression test.

Known remaining gap (separate work): type:array multi-value fields (e.g. "Treatment Chemicals"
lists) have no array handling and fall through to a single text line; ControlTypes.Choice has a
renderer but is never assigned by the resolver. Needs a repeatable/list control — tracked separately.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UDmeAycWwQ5Y8PXuz4iub6
