### PR TITLE
fix: [174] show captured portrait on the draft ID card (+ marker 2.0.3-dev)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -30,7 +30,7 @@
 
     <!-- Package / NuGet version (allows the -dev prerelease suffix locally). -->
     <Version>$(SorchaMajor).$(SorchaMinor).$(SorchaPatch)</Version>
-    <Version Condition="'$(GITHUB_RUN_NUMBER)' == ''">$(SorchaMajor).0.2-dev</Version>
+    <Version Condition="'$(GITHUB_RUN_NUMBER)' == ''">$(SorchaMajor).0.3-dev</Version>
 
     <!-- Assembly identity must be purely numeric (x.x.x.x). -->
     <AssemblyVersion>$(SorchaMajor).$(SorchaMinor).$(SorchaPatch).0</AssemblyVersion>

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/Forms/ReviewSummaryDataSource.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/Forms/ReviewSummaryDataSource.cs
@@ -67,6 +67,16 @@ public sealed class ReviewSummaryDataSource
                         // and holder-key material is not display data.
                         fieldValues[pointer] = GatherFlattenedDisplayValue(formContext.FormData, pointer);
                     }
+
+                    // Carry the embedded portrait token through to the card. IdCardLayout renders the
+                    // photo by scanning FieldValues for a "<field>/tokenImageBase64" entry, but that
+                    // token lives at a child pointer that is never itself a section field — so without
+                    // copying it here the card shows the placeholder even when a portrait was captured.
+                    var tokenPointer = pointer + "/tokenImageBase64";
+                    if (formContext.FormData.TryGetValue(tokenPointer, out var tokenValue) && tokenValue is not null)
+                    {
+                        fieldValues[tokenPointer] = tokenValue;
+                    }
                 }
 
                 sections.Add(new IdCardSection(

--- a/tests/Sorcha.UI.Core.Tests/Services/Forms/ReviewSummaryDataSourceTests.cs
+++ b/tests/Sorcha.UI.Core.Tests/Services/Forms/ReviewSummaryDataSourceTests.cs
@@ -189,6 +189,29 @@ public class ReviewSummaryDataSourceTests
     }
 
     [Fact]
+    public void BuildConfig_PortraitTokenImage_CarriedIntoFieldValuesForCard()
+    {
+        // The captured portrait's embed token lives at a child pointer ("/portrait/tokenImageBase64"),
+        // which is never a section field. IdCardLayout renders the photo by scanning FieldValues for a
+        // "*/tokenImageBase64" entry, so BuildConfig must carry it through — otherwise the card shows the
+        // placeholder even when a portrait was captured.
+        var pages = new List<BlueprintPageDefinition>
+        {
+            new() { Title = "Photo", Sections = [new BlueprintSectionDefinition { Title = "Portrait", Fields = ["portrait"] }] }
+        };
+        var ctx = new FormContext();
+        ctx.FormData["/portrait"] = "portrait.jpg";
+        ctx.FormData["/portrait/tokenImageBase64"] = "BASE64IMAGEDATA";
+
+        var sut = new ReviewSummaryDataSource();
+
+        var cfg = sut.BuildConfig(CitizenReview(), ctx, ActionRuntimeState.CitizenDraft, pages);
+
+        cfg.FieldValues.Should().ContainKey("/portrait/tokenImageBase64");
+        cfg.FieldValues["/portrait/tokenImageBase64"].Should().Be("BASE64IMAGEDATA");
+    }
+
+    [Fact]
     public void BuildConfig_PagesWithoutSections_SkippedFromSectionList()
     {
         var pages = new List<BlueprintPageDefinition>


### PR DESCRIPTION
IdCardLayout renders the card photo by scanning FieldValues for a "<field>/tokenImageBase64" entry,
but ReviewSummaryDataSource only copied the section's top-level field pointers into FieldValues — the
portrait token lives at a child pointer that is never a section field, so the card always showed the
placeholder. BuildConfig now carries the token sibling through. +regression test. Bumps the dev
marker to 2.0.3-dev.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UDmeAycWwQ5Y8PXuz4iub6
