### PR TITLE
fix: [136] passkey + social login must downgrade tier to entitlement (consumer holder-keys 403)

### DIFF
--- a/src/Services/Sorcha.Tenant.Service/Endpoints/PublicPasskeyEndpoints.cs
+++ b/src/Services/Sorcha.Tenant.Service/Endpoints/PublicPasskeyEndpoints.cs
@@ -239,9 +239,13 @@ public static class PublicPasskeyEndpoints
                     statusCode: StatusCodes.Status500InternalServerError);
             }
 
-            // Issue JWT
+            // Issue JWT. Spec 136: a newly-registered public user has no platform roles, so resolve
+            // by entitlement — the Platform default downgrades to Consumer — rather than minting the
+            // raw Platform default (which would 403 on consumer-tier endpoints).
+            var registrationTier = TierResolver.ResolvePreference(
+                Sorcha.ServiceDefaults.Auth.Tier.Platform, isExplicit: false, userIdentity.Roles).Tier;
             var tokenResponse = await tokenService.GenerateUserTokenAsync(
-                userIdentity, publicOrg, platformUser.Id, cancellationToken: ct);
+                userIdentity, publicOrg, platformUser.Id, registrationTier, cancellationToken: ct);
 
             logger.LogInformation(
                 "Public passkey registration completed for PlatformUser {PlatformUserId}",
@@ -379,11 +383,18 @@ public static class PublicPasskeyEndpoints
                     statusCode: StatusCodes.Status500InternalServerError);
             }
 
-            // Issue JWT. The wallet requests tier:"consumer" (a safe downgrade);
-            // any other value keeps the platform default — no escalation here.
-            var mintTier = string.Equals(request.Tier, "consumer", StringComparison.OrdinalIgnoreCase)
+            // Issue JWT. Spec 136: resolve the effective tier by ENTITLEMENT, exactly like the
+            // password path (LoginService → TierResolver.ResolvePreference). An explicit
+            // tier:"consumer" (the wallet/PWA) is honoured; otherwise the /app default of Platform
+            // downgrades to the holder's entitlement. Without this, a pure Consumer signing in with a
+            // passkey from /app received a Platform token they aren't entitled to, which then 403'd on
+            // every consumer-tier endpoint (e.g. GET /api/v1/wallet/holder-keys during credential
+            // application). The naive "keeps the platform default" behaviour skipped the downgrade.
+            var explicitConsumer = string.Equals(request.Tier, "consumer", StringComparison.OrdinalIgnoreCase);
+            var preferredTier = explicitConsumer
                 ? Sorcha.ServiceDefaults.Auth.Tier.Consumer
                 : Sorcha.ServiceDefaults.Auth.Tier.Platform;
+            var mintTier = TierResolver.ResolvePreference(preferredTier, explicitConsumer, userIdentity.Roles).Tier;
             var tokenResponse = await tokenService.GenerateUserTokenAsync(
                 userIdentity, publicOrg, platformUser.Id, mintTier, platformUser.EmailVerified, ct);
 

--- a/src/Services/Sorcha.Tenant.Service/Endpoints/SocialLoginEndpoints.cs
+++ b/src/Services/Sorcha.Tenant.Service/Endpoints/SocialLoginEndpoints.cs
@@ -418,8 +418,14 @@ public static class SocialLoginEndpoints
                 statusCode: StatusCodes.Status500InternalServerError);
         }
 
-        // Issue JWT — wallet users get Consumer-tier tokens; app users get Platform-tier.
-        var mintTier = isWallet ? Tier.Consumer : Tier.Platform;
+        // Issue JWT. Spec 136: resolve by ENTITLEMENT like the password path. The wallet surface is an
+        // explicit Consumer request; the /app surface's Platform default downgrades to the holder's
+        // entitlement — a pure Consumer must NOT get a Platform token (it 403s on consumer-tier
+        // endpoints such as GET /api/v1/wallet/holder-keys). Previously "app users get Platform-tier"
+        // skipped the downgrade, matching the passkey-login bug.
+        var preferredTier = isWallet ? Tier.Consumer : Tier.Platform;
+        var mintTier = Sorcha.Tenant.Service.Services.TierResolver
+            .ResolvePreference(preferredTier, isExplicit: isWallet, userIdentity.Roles).Tier;
         var tokenResponse = await tokenService.GenerateUserTokenAsync(
             userIdentity, publicOrg, platformUser.Id, mintTier, platformUser.EmailVerified, ct);
 


### PR DESCRIPTION
Passkey login/registration and social login minted the tier with a naive check
(request.Tier=="consumer"/surface=="wallet" ? Consumer : Platform) and otherwise kept the Platform
default — skipping the FR-008/009 entitlement downgrade the password path applies via
TierResolver.ResolvePreference. So a pure Consumer signing in with a passkey (or social) from /app
received a Platform token they aren't entitled to, which then 403'd on every consumer-tier endpoint —
e.g. GET /api/v1/wallet/holder-keys during credential application ("We couldn't reach your wallet to
secure your identity keys"). All three sites now delegate to TierResolver.ResolvePreference so the
/app Platform default downgrades to Consumer for a non-entitled holder, matching password login.
Core downgrade logic already covered by TierResolverTests.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UDmeAycWwQ5Y8PXuz4iub6
