### PR TITLE
fix: [174] id-card polish — de-duplicate name, show 'Secured' tick for holder keys (2.0.4-dev)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -30,7 +30,7 @@
 
     <!-- Package / NuGet version (allows the -dev prerelease suffix locally). -->
     <Version>$(SorchaMajor).$(SorchaMinor).$(SorchaPatch)</Version>
-    <Version Condition="'$(GITHUB_RUN_NUMBER)' == ''">$(SorchaMajor).0.3-dev</Version>
+    <Version Condition="'$(GITHUB_RUN_NUMBER)' == ''">$(SorchaMajor).0.4-dev</Version>
 
     <!-- Assembly identity must be purely numeric (x.x.x.x). -->
     <AssemblyVersion>$(SorchaMajor).$(SorchaMinor).$(SorchaPatch).0</AssemblyVersion>

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Forms/Layouts/IdCardLayout.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Forms/Layouts/IdCardLayout.razor
@@ -66,7 +66,18 @@
                         {
                             <div class="id-card-field">
                                 <dt>@FormatLabel(pointer)</dt>
-                                <dd>@FormatValue(Config.FieldValues.GetValueOrDefault(pointer))</dd>
+                                @{ var fieldValue = Config.FieldValues.GetValueOrDefault(pointer); }
+                                @if (fieldValue is string marker && marker == IdCardLayoutConfig.SecuredDeliveryMarker)
+                                {
+                                    <dd class="id-card-secured">
+                                        <MudIcon Icon="@Icons.Material.Filled.CheckCircle" Color="Color.Success" Size="Size.Small" />
+                                        <span>Secured</span>
+                                    </dd>
+                                }
+                                else
+                                {
+                                    <dd>@FormatValue(fieldValue)</dd>
+                                }
                             </div>
                         }
                     </dl>

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Models/User/Forms/IdCardLayoutConfig.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Models/User/Forms/IdCardLayoutConfig.cs
@@ -55,6 +55,14 @@ public sealed record IdCardSection(
 /// </summary>
 public sealed record IdCardLayoutConfig
 {
+    /// <summary>
+    /// Sentinel <see cref="FieldValues"/> value marking a secure-delivery / holder-key field. Its real
+    /// value is cryptographic key material (JWK + public key), not human-readable, so the card renders
+    /// a "Secured" confirmation tick instead of the keys. Set by <c>ReviewSummaryDataSource</c>,
+    /// rendered by <c>IdCardLayout</c>.
+    /// </summary>
+    public const string SecuredDeliveryMarker = "sorcha-secured";
+
     public required string IssuerName { get; init; }
     public required string CredentialName { get; init; }
     public required XReviewColourTheme ColourTheme { get; init; }

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/Forms/ReviewSummaryDataSource.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/Forms/ReviewSummaryDataSource.cs
@@ -47,6 +47,17 @@ public sealed class ReviewSummaryDataSource
 
                 foreach (var pointer in fieldPointers)
                 {
+                    // Secure-delivery / holder-key field (Feature 137): its flattened children are
+                    // cryptographic key material (holderJwk / encryptionPublicKey / algorithm), not
+                    // human-readable detail. Mark it so the card shows a "Secured" tick instead of
+                    // dumping the JWK + keys onto the card.
+                    if (formContext.FormData.ContainsKey(pointer + "/holderJwk")
+                        || formContext.FormData.ContainsKey(pointer + "/encryptionPublicKey"))
+                    {
+                        fieldValues[pointer] = IdCardLayoutConfig.SecuredDeliveryMarker;
+                        continue;
+                    }
+
                     // ContainsKey distinguishes "unfilled" (present as null)
                     // from "filled with null value" — both render as empty
                     // on the card, but the dictionary explicitly lists every
@@ -137,9 +148,20 @@ public sealed class ReviewSummaryDataSource
             if (!kv.Key.StartsWith(prefix, StringComparison.Ordinal) || kv.Value is null) continue;
             var text = kv.Value as string ?? kv.Value.ToString();
             if (string.IsNullOrWhiteSpace(text) || text.Length > MaxDisplayLeafLength) continue;
-            parts.Add(text);
+            parts.Add(text!.Trim());
         }
 
-        return parts.Count > 0 ? string.Join(" ", parts) : null;
+        // Drop leaves wholly contained in a longer sibling. Core primitives often expose overlapping
+        // leaves — PersonName has givenName + familyName AND a computed fullName — which would render
+        // "Stuart Fraser Stuart Fraser". Keeping only the leaves not subsumed by a longer one yields
+        // "Stuart Fraser". Distinct guards exact duplicates. Address lines don't subsume each other,
+        // so they're all kept.
+        var kept = parts
+            .Where(p => !parts.Any(other =>
+                other.Length > p.Length && other.Contains(p, StringComparison.OrdinalIgnoreCase)))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        return kept.Count > 0 ? string.Join(" ", kept) : null;
     }
 }

--- a/tests/Sorcha.UI.Core.Tests/Services/Forms/ReviewSummaryDataSourceTests.cs
+++ b/tests/Sorcha.UI.Core.Tests/Services/Forms/ReviewSummaryDataSourceTests.cs
@@ -212,6 +212,44 @@ public class ReviewSummaryDataSourceTests
     }
 
     [Fact]
+    public void BuildConfig_PersonNameWithComputedFullName_DoesNotDuplicate()
+    {
+        // PersonName exposes givenName + familyName AND a computed fullName. Joining all three read
+        // "Stuart Fraser Stuart Fraser" on the card. Leaves subsumed by a longer sibling are dropped.
+        var pages = new List<BlueprintPageDefinition>
+        {
+            new() { Title = "About you", Sections = [new BlueprintSectionDefinition { Title = "Your name", Fields = ["name"] }] }
+        };
+        var ctx = new FormContext();
+        ctx.FormData["/name/givenName"] = "Stuart";
+        ctx.FormData["/name/familyName"] = "Fraser";
+        ctx.FormData["/name/fullName"] = "Stuart Fraser";
+
+        var cfg = new ReviewSummaryDataSource().BuildConfig(CitizenReview(), ctx, ActionRuntimeState.CitizenDraft, pages);
+
+        cfg.FieldValues["/name"].Should().Be("Stuart Fraser");
+    }
+
+    [Fact]
+    public void BuildConfig_HolderKeyField_RendersSecuredMarkerNotKeyMaterial()
+    {
+        // The holder-key / secure-delivery field's children are JWK + key material, not display data.
+        // The card must show a "Secured" marker, never the raw keys.
+        var pages = new List<BlueprintPageDefinition>
+        {
+            new() { Title = "Contact", Sections = [new BlueprintSectionDefinition { Title = "Secure delivery", Fields = ["holderKeys"] }] }
+        };
+        var ctx = new FormContext();
+        ctx.FormData["/holderKeys/holderJwk"] = "{\"kty\":\"OKP\",\"crv\":\"Ed25519\",\"x\":\"GgmG0...\"}";
+        ctx.FormData["/holderKeys/encryptionPublicKey"] = "G3ZXgJELcFXMizAeE8ChtBVx6u7eAfJH8XAePwxtoSo=";
+        ctx.FormData["/holderKeys/algorithm"] = "ED25519";
+
+        var cfg = new ReviewSummaryDataSource().BuildConfig(CitizenReview(), ctx, ActionRuntimeState.CitizenDraft, pages);
+
+        cfg.FieldValues["/holderKeys"].Should().Be(IdCardLayoutConfig.SecuredDeliveryMarker);
+    }
+
+    [Fact]
     public void BuildConfig_PagesWithoutSections_SkippedFromSectionList()
     {
         var pages = new List<BlueprintPageDefinition>


### PR DESCRIPTION
Two draft-card readability fixes, both from the $ref leaf gather:
- PersonName exposes givenName + familyName AND a computed fullName, so the card read
  "Stuart Fraser Stuart Fraser". GatherFlattenedDisplayValue now drops leaves wholly contained in a
  longer sibling → "Stuart Fraser". Address lines (no subsumption) are unaffected.
- The holder-key / secure-delivery field dumped raw JWK + key material onto the card. It's now marked
  (SecuredDeliveryMarker) and IdCardLayout renders a green "Secured" check instead of the keys.
+2 regression tests. Bumps dev marker to 2.0.4-dev.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UDmeAycWwQ5Y8PXuz4iub6
