### PR TITLE
feat: [174] render held identity credentials as the ID card, not a data table (2.0.5-dev)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -30,7 +30,7 @@
 
     <!-- Package / NuGet version (allows the -dev prerelease suffix locally). -->
     <Version>$(SorchaMajor).$(SorchaMinor).$(SorchaPatch)</Version>
-    <Version Condition="'$(GITHUB_RUN_NUMBER)' == ''">$(SorchaMajor).0.4-dev</Version>
+    <Version Condition="'$(GITHUB_RUN_NUMBER)' == ''">$(SorchaMajor).0.5-dev</Version>
 
     <!-- Assembly identity must be purely numeric (x.x.x.x). -->
     <AssemblyVersion>$(SorchaMajor).$(SorchaMinor).$(SorchaPatch).0</AssemblyVersion>

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Credentials/CredentialDetailView.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Credentials/CredentialDetailView.razor
@@ -3,6 +3,9 @@
 
 @using MudBlazor
 @using Sorcha.UI.Core.Models.Credentials
+@using Sorcha.UI.Core.Models.Forms
+@using Sorcha.UI.Core.Services.Credentials
+@using Sorcha.UI.Core.Components.Forms.Layouts
 @using static Sorcha.UI.Core.Models.Credentials.CredentialStatus
 
 <MudDialog>
@@ -14,75 +17,20 @@
     </TitleContent>
     <DialogContent>
         <MudStack Spacing="3">
-            @* Status and metadata *@
-            <MudStack Row="true" Justify="Justify.SpaceBetween" AlignItems="AlignItems.Center">
-                <MudChip T="string" Color="@GetStatusColor()" Variant="Variant.Filled">
-                    @Credential.Status
-                </MudChip>
-                <MudText Typo="Typo.caption" Color="Color.Secondary">
-                    ID: @Credential.CredentialId
-                </MudText>
-            </MudStack>
-
-            <MudDivider />
-
-            @* Key metadata *@
-            <MudSimpleTable Dense="true" Hover="true" Bordered="false">
-                <tbody>
-                    <tr>
-                        <td><MudText Typo="Typo.body2" Color="Color.Secondary">Issuer</MudText></td>
-                        <td><MudText Typo="Typo.body2">@Credential.IssuerDid</MudText></td>
-                    </tr>
-                    <tr>
-                        <td><MudText Typo="Typo.body2" Color="Color.Secondary">Subject</MudText></td>
-                        <td><MudText Typo="Typo.body2">@Credential.SubjectDid</MudText></td>
-                    </tr>
-                    <tr>
-                        <td><MudText Typo="Typo.body2" Color="Color.Secondary">Issued</MudText></td>
-                        <td><MudText Typo="Typo.body2">@Credential.IssuedAt.ToString("yyyy-MM-dd HH:mm:ss")</MudText></td>
-                    </tr>
-                    @if (Credential.ExpiresAt.HasValue)
-                    {
-                        <tr>
-                            <td><MudText Typo="Typo.body2" Color="Color.Secondary">Expires</MudText></td>
-                            <td><MudText Typo="Typo.body2">@Credential.ExpiresAt.Value.ToString("yyyy-MM-dd HH:mm:ss")</MudText></td>
-                        </tr>
-                    }
-                    <tr>
-                        <td><MudText Typo="Typo.body2" Color="Color.Secondary">Usage Policy</MudText></td>
-                        <td><MudText Typo="Typo.body2">@FormatUsagePolicy()</MudText></td>
-                    </tr>
-                    @if (Credential.PresentationCount > 0)
-                    {
-                        <tr>
-                            <td><MudText Typo="Typo.body2" Color="Color.Secondary">Presentations</MudText></td>
-                            <td><MudText Typo="Typo.body2">@Credential.PresentationCount</MudText></td>
-                        </tr>
-                    }
-                </tbody>
-            </MudSimpleTable>
-
-            @* Claims section *@
-            @if (Credential.Claims.Count > 0)
+            @if (_isIdentity && _cardConfig is not null)
             {
-                <MudText Typo="Typo.subtitle2" Class="mt-2">Claims</MudText>
-                <MudSimpleTable Dense="true" Hover="true" Bordered="true">
-                    <thead>
-                        <tr>
-                            <th>Claim</th>
-                            <th>Value</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        @foreach (var claim in Credential.Claims)
-                        {
-                            <tr>
-                                <td><MudText Typo="Typo.body2">@claim.Key</MudText></td>
-                                <td><MudText Typo="Typo.body2">@claim.Value?.ToString()</MudText></td>
-                            </tr>
-                        }
-                    </tbody>
-                </MudSimpleTable>
+                @* Identity credential — render the same styled ID card the citizen saw at review;
+                   the raw/technical view sits behind an expandable "Details" panel below. *@
+                <IdCardLayout Config="_cardConfig" />
+                <MudExpansionPanels Elevation="0" Class="mt-1">
+                    <MudExpansionPanel Text="Details" Icon="@Icons.Material.Filled.Info">
+                        @DetailsContent
+                    </MudExpansionPanel>
+                </MudExpansionPanels>
+            }
+            else
+            {
+                @DetailsContent
             }
         </MudStack>
     </DialogContent>
@@ -149,6 +97,9 @@
 </MudDialog>
 
 @code {
+    private bool _isIdentity;
+    private IdCardLayoutConfig? _cardConfig;
+
     [CascadingParameter]
     private IMudDialogInstance MudDialog { get; set; } = default!;
 
@@ -166,6 +117,84 @@
 
     [Parameter]
     public EventCallback<CredentialLifecycleAction> OnLifecycleAction { get; set; }
+
+    protected override void OnParametersSet()
+    {
+        _isIdentity = CredentialIdCard.IsIdentityCredential(Credential.Type);
+        _cardConfig = _isIdentity ? CredentialIdCard.BuildConfig(Credential) : null;
+    }
+
+    // Raw/technical view — shown directly for non-identity credentials, and behind the "Details"
+    // expansion panel for identity ones.
+    private RenderFragment DetailsContent => @<MudStack Spacing="3">
+        <MudStack Row="true" Justify="Justify.SpaceBetween" AlignItems="AlignItems.Center">
+            <MudChip T="string" Color="@GetStatusColor()" Variant="Variant.Filled">
+                @Credential.Status
+            </MudChip>
+            <MudText Typo="Typo.caption" Color="Color.Secondary">
+                ID: @Credential.CredentialId
+            </MudText>
+        </MudStack>
+
+        <MudDivider />
+
+        <MudSimpleTable Dense="true" Hover="true" Bordered="false">
+            <tbody>
+                <tr>
+                    <td><MudText Typo="Typo.body2" Color="Color.Secondary">Issuer</MudText></td>
+                    <td><MudText Typo="Typo.body2">@Credential.IssuerDid</MudText></td>
+                </tr>
+                <tr>
+                    <td><MudText Typo="Typo.body2" Color="Color.Secondary">Subject</MudText></td>
+                    <td><MudText Typo="Typo.body2">@Credential.SubjectDid</MudText></td>
+                </tr>
+                <tr>
+                    <td><MudText Typo="Typo.body2" Color="Color.Secondary">Issued</MudText></td>
+                    <td><MudText Typo="Typo.body2">@Credential.IssuedAt.ToString("yyyy-MM-dd HH:mm:ss")</MudText></td>
+                </tr>
+                @if (Credential.ExpiresAt.HasValue)
+                {
+                    <tr>
+                        <td><MudText Typo="Typo.body2" Color="Color.Secondary">Expires</MudText></td>
+                        <td><MudText Typo="Typo.body2">@Credential.ExpiresAt.Value.ToString("yyyy-MM-dd HH:mm:ss")</MudText></td>
+                    </tr>
+                }
+                <tr>
+                    <td><MudText Typo="Typo.body2" Color="Color.Secondary">Usage Policy</MudText></td>
+                    <td><MudText Typo="Typo.body2">@FormatUsagePolicy()</MudText></td>
+                </tr>
+                @if (Credential.PresentationCount > 0)
+                {
+                    <tr>
+                        <td><MudText Typo="Typo.body2" Color="Color.Secondary">Presentations</MudText></td>
+                        <td><MudText Typo="Typo.body2">@Credential.PresentationCount</MudText></td>
+                    </tr>
+                }
+            </tbody>
+        </MudSimpleTable>
+
+        @if (Credential.Claims.Count > 0)
+        {
+            <MudText Typo="Typo.subtitle2" Class="mt-2">Claims</MudText>
+            <MudSimpleTable Dense="true" Hover="true" Bordered="true">
+                <thead>
+                    <tr>
+                        <th>Claim</th>
+                        <th>Value</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach (var claim in Credential.Claims)
+                    {
+                        <tr>
+                            <td><MudText Typo="Typo.body2">@claim.Key</MudText></td>
+                            <td><MudText Typo="Typo.body2">@claim.Value?.ToString()</MudText></td>
+                        </tr>
+                    }
+                </tbody>
+            </MudSimpleTable>
+        }
+    </MudStack>;
 
     private Color GetStatusColor() => Credential.Status switch
     {

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Forms/Layouts/IdCardLayout.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Forms/Layouts/IdCardLayout.razor
@@ -151,13 +151,29 @@
         }
     }
 
-    /// <summary>Render a JSON-pointer leaf as a human label ("/givenName" → "Given name").</summary>
+    // User-facing labels for known claim / field keys — "dob"/"dateOfBirth" read "Date of Birth"
+    // rather than the camelCase fallback ("Dob"). Shared by the application review card and the held-
+    // credential card. Unknown keys fall through to the camelCase splitter below.
+    private static readonly Dictionary<string, string> FriendlyLabels = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["dob"] = "Date of Birth", ["dateOfBirth"] = "Date of Birth", ["birthDate"] = "Date of Birth",
+        ["fullName"] = "Name", ["name"] = "Name",
+        ["givenName"] = "Given Name", ["familyName"] = "Family Name", ["middleName"] = "Middle Name",
+        ["email"] = "Email", ["emailAddress"] = "Email",
+        ["address"] = "Address", ["postalAddress"] = "Address",
+        ["portrait"] = "Photo", ["holderKeys"] = "Secure Delivery",
+        ["assuranceLevel"] = "Assurance Level",
+    };
+
+    /// <summary>Render a JSON-pointer leaf as a human label ("/dateOfBirth" → "Date of Birth").</summary>
     private static string FormatLabel(string pointer)
     {
         var leaf = pointer.TrimStart('/');
         var lastSlash = leaf.LastIndexOf('/');
         if (lastSlash >= 0) leaf = leaf[(lastSlash + 1)..];
         if (string.IsNullOrEmpty(leaf)) return pointer;
+
+        if (FriendlyLabels.TryGetValue(leaf, out var friendly)) return friendly;
 
         // camelCase → "Camel case"
         var chars = new StringBuilder();

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/Credentials/CredentialIdCard.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/Credentials/CredentialIdCard.cs
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Text;
+using Sorcha.Blueprint.Models;
+using Sorcha.UI.Core.Models.Credentials;
+using Sorcha.UI.Core.Models.Forms;
+
+namespace Sorcha.UI.Core.Services.Credentials;
+
+/// <summary>
+/// Adapts a held credential to the shared <see cref="IdCardLayoutConfig"/> so identity credentials
+/// render as the same styled ID card the citizen saw at application review, rather than a raw claims
+/// table. Non-identity credentials fall back to the tabular detail view.
+/// </summary>
+public static class CredentialIdCard
+{
+    // Claims shown on the card face, in order, when present. Everything else — granular name parts,
+    // the portrait blob, DIDs, status — belongs in the expandable technical details, not the face.
+    private static readonly string[] FaceClaims = ["fullName", "dateOfBirth", "address", "email", "assuranceLevel"];
+
+    private const string PortraitClaim = "portrait";
+
+    /// <summary>
+    /// True when the credential type denotes an identity credential (renders as an ID card). Pragmatic
+    /// v1 heuristic — the type name contains "identity" (e.g. AssuredIdentityCredential). A richer
+    /// credential-type registry can replace this later without changing callers.
+    /// </summary>
+    public static bool IsIdentityCredential(string? credentialType)
+        => !string.IsNullOrWhiteSpace(credentialType)
+           && credentialType.Contains("identity", System.StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>Builds an <see cref="IdCardLayoutConfig"/> for a credential's card face.</summary>
+    public static IdCardLayoutConfig BuildConfig(CredentialDetailViewModel credential)
+    {
+        System.ArgumentNullException.ThrowIfNull(credential);
+
+        var claims = credential.Claims;
+        var fieldValues = new Dictionary<string, object?>(System.StringComparer.Ordinal);
+        var pointers = new List<string>();
+
+        // Prefer a computed fullName; otherwise synthesise "Given Family" from the granular parts so
+        // the card always shows a name line rather than three separate name fields.
+        if (!ClaimHasText(claims, "fullName"))
+        {
+            var joined = string.Join(" ", new[] { ClaimText(claims, "givenName"), ClaimText(claims, "familyName") }
+                .Where(s => !string.IsNullOrWhiteSpace(s)));
+            if (!string.IsNullOrWhiteSpace(joined))
+            {
+                fieldValues["/fullName"] = joined;
+                pointers.Add("/fullName");
+            }
+        }
+
+        foreach (var key in FaceClaims)
+        {
+            var pointer = "/" + key;
+            if (fieldValues.ContainsKey(pointer)) continue; // already synthesised (fullName)
+            var text = ClaimText(claims, key);
+            if (string.IsNullOrWhiteSpace(text)) continue;
+            fieldValues[pointer] = text;
+            pointers.Add(pointer);
+        }
+
+        // Portrait → the sibling pointer IdCardLayout scans for the card photo.
+        var portrait = ClaimText(claims, PortraitClaim);
+        if (!string.IsNullOrWhiteSpace(portrait))
+        {
+            fieldValues["/portrait/tokenImageBase64"] = portrait;
+        }
+
+        var section = new IdCardSection(Title: "Identity", OriginatingPageIndex: 0, FieldPointers: pointers);
+
+        return new IdCardLayoutConfig
+        {
+            // No friendly issuer name is threaded through the credential model yet (only the DID);
+            // the prettified credential type carries the card identity. Issuer-org-name display is a
+            // follow-up (resolve the DID or carry it at issuance).
+            IssuerName = PrettyCredentialName(credential.Type),
+            CredentialName = PrettyCredentialName(credential.Type),
+            ColourTheme = XReviewColourTheme.IdentityNavy,
+            Watermark = IdCardWatermark.Issued,
+            FieldValues = fieldValues,
+            Sections = [section],
+            Editable = false,
+        };
+    }
+
+    private static bool ClaimHasText(IReadOnlyDictionary<string, object> claims, string key)
+        => !string.IsNullOrWhiteSpace(ClaimText(claims, key));
+
+    private static string? ClaimText(IReadOnlyDictionary<string, object> claims, string key)
+        => claims.TryGetValue(key, out var v) ? v?.ToString() : null;
+
+    // "AssuredIdentityCredential" -> "Assured Identity". Strips a trailing "Credential", splits camelCase.
+    private static string PrettyCredentialName(string type)
+    {
+        if (string.IsNullOrWhiteSpace(type)) return "Credential";
+        var trimmed = type.EndsWith("Credential", System.StringComparison.OrdinalIgnoreCase) && type.Length > 10
+            ? type[..^10]
+            : type;
+        var sb = new StringBuilder();
+        for (var i = 0; i < trimmed.Length; i++)
+        {
+            if (i > 0 && char.IsUpper(trimmed[i]) && !char.IsUpper(trimmed[i - 1])) sb.Append(' ');
+            sb.Append(trimmed[i]);
+        }
+        return sb.ToString().Trim();
+    }
+}

--- a/tests/Sorcha.UI.Core.Tests/Services/Credentials/CredentialIdCardTests.cs
+++ b/tests/Sorcha.UI.Core.Tests/Services/Credentials/CredentialIdCardTests.cs
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using FluentAssertions;
+using Sorcha.UI.Core.Models.Credentials;
+using Sorcha.UI.Core.Models.Forms;
+using Sorcha.UI.Core.Services.Credentials;
+using Xunit;
+
+namespace Sorcha.UI.Core.Tests.Services.Credentials;
+
+/// <summary>
+/// Tests for <see cref="CredentialIdCard"/> — the held-credential → id-card adapter that renders
+/// identity credentials as the styled ID card rather than a raw claims table.
+/// </summary>
+public class CredentialIdCardTests
+{
+    [Theory]
+    [InlineData("AssuredIdentityCredential", true)]
+    [InlineData("digitalIdentity", true)]
+    [InlineData("MembershipCredential", false)]
+    [InlineData("", false)]
+    [InlineData(null, false)]
+    public void IsIdentityCredential_DetectsByTypeName(string? type, bool expected)
+        => CredentialIdCard.IsIdentityCredential(type).Should().Be(expected);
+
+    [Fact]
+    public void BuildConfig_MapsClaims_Portrait_AndIssuedState()
+    {
+        var cred = new CredentialDetailViewModel
+        {
+            Type = "AssuredIdentityCredential",
+            IssuerDid = "did:sorcha:org:ws1abc",
+            Claims = new Dictionary<string, object>
+            {
+                ["fullName"] = "Stuart Fraser",
+                ["dateOfBirth"] = "1968-08-19",
+                ["email"] = "stuart@example.net",
+                ["portrait"] = "BASE64IMG",
+            },
+        };
+
+        var cfg = CredentialIdCard.BuildConfig(cred);
+
+        cfg.FieldValues["/fullName"].Should().Be("Stuart Fraser");
+        cfg.FieldValues["/dateOfBirth"].Should().Be("1968-08-19");
+        cfg.FieldValues["/email"].Should().Be("stuart@example.net");
+        // portrait maps to the sibling pointer IdCardLayout scans for the card photo
+        cfg.FieldValues["/portrait/tokenImageBase64"].Should().Be("BASE64IMG");
+        cfg.Watermark.Should().Be(IdCardWatermark.Issued);
+        cfg.Editable.Should().BeFalse();
+        cfg.CredentialName.Should().Be("Assured Identity");
+    }
+
+    [Fact]
+    public void BuildConfig_SynthesisesFullNameFromGivenAndFamily()
+    {
+        var cred = new CredentialDetailViewModel
+        {
+            Type = "AssuredIdentityCredential",
+            Claims = new Dictionary<string, object> { ["givenName"] = "Stuart", ["familyName"] = "Fraser" },
+        };
+
+        var cfg = CredentialIdCard.BuildConfig(cred);
+
+        cfg.FieldValues["/fullName"].Should().Be("Stuart Fraser");
+    }
+}


### PR DESCRIPTION
Identity credentials (type contains "identity", e.g. AssuredIdentityCredential) now render in the
credential detail view as the same styled IdCardLayout the citizen saw at application review —
portrait, single name, friendly labels — with the raw metadata + claims table moved behind an
expandable "Details" panel. Non-identity credentials keep the tabular view.

- CredentialIdCard adapter: maps a CredentialDetailViewModel's claims → IdCardLayoutConfig (portrait
  → tokenImageBase64 sibling, fullName synthesised from given+family, Issued watermark, read-only).
- IdCardLayout.FormatLabel: friendly-label map so "dateOfBirth" reads "Date of Birth" (both cards).
- CredentialDetailView: identity → card + expandable technical details; else the existing table.
+3 adapter tests. Follow-up: thread the issuer org name (only the DID is available today).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UDmeAycWwQ5Y8PXuz4iub6
