### PR TITLE
feat: [174] credential ID card — add issuer, share the exact card across web + PWA (2.0.6-dev)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -30,7 +30,7 @@
 
     <!-- Package / NuGet version (allows the -dev prerelease suffix locally). -->
     <Version>$(SorchaMajor).$(SorchaMinor).$(SorchaPatch)</Version>
-    <Version Condition="'$(GITHUB_RUN_NUMBER)' == ''">$(SorchaMajor).0.5-dev</Version>
+    <Version Condition="'$(GITHUB_RUN_NUMBER)' == ''">$(SorchaMajor).0.6-dev</Version>
 
     <!-- Assembly identity must be purely numeric (x.x.x.x). -->
     <AssemblyVersion>$(SorchaMajor).$(SorchaMinor).$(SorchaPatch).0</AssemblyVersion>

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Models/User/Credentials/CredentialCardViewModel.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Models/User/Credentials/CredentialCardViewModel.cs
@@ -101,6 +101,9 @@ public class CredentialDetailViewModel
     public string CredentialId { get; set; } = string.Empty;
     public string Type { get; set; } = string.Empty;
     public string IssuerDid { get; set; } = string.Empty;
+
+    /// <summary>Friendly issuer name (org name where known, else derived from the DID) for the card header.</summary>
+    public string IssuerName { get; set; } = string.Empty;
     public string SubjectDid { get; set; } = string.Empty;
     public string Status { get; set; } = CredentialStatus.Active;
     public DateTimeOffset IssuedAt { get; set; }

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/Credentials/CredentialApiService.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/Credentials/CredentialApiService.cs
@@ -466,6 +466,7 @@ public class CredentialApiService : ICredentialApiService
             CredentialId = entity.Id ?? string.Empty,
             Type = entity.Type ?? string.Empty,
             IssuerDid = entity.IssuerDid ?? string.Empty,
+            IssuerName = ExtractIssuerName(entity.IssuerDid),
             SubjectDid = entity.SubjectDid ?? string.Empty,
             Status = entity.Status ?? CredentialStatus.Active,
             IssuedAt = entity.IssuedAt,

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/Credentials/CredentialIdCard.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/Credentials/CredentialIdCard.cs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Sorcha Contributors
 
+using System.Linq;
 using System.Text;
 using Sorcha.Blueprint.Models;
 using Sorcha.UI.Core.Models.Credentials;
@@ -11,7 +12,9 @@ namespace Sorcha.UI.Core.Services.Credentials;
 /// <summary>
 /// Adapts a held credential to the shared <see cref="IdCardLayoutConfig"/> so identity credentials
 /// render as the same styled ID card the citizen saw at application review, rather than a raw claims
-/// table. Non-identity credentials fall back to the tabular detail view.
+/// table. The core <see cref="BuildConfig(string?, string?, string?, IReadOnlyDictionary{string, string?})"/>
+/// is model-agnostic so BOTH the web detail dialog and the wallet PWA detail page produce an identical
+/// card. Non-identity credentials fall back to each host's tabular view.
 /// </summary>
 public static class CredentialIdCard
 {
@@ -23,27 +26,43 @@ public static class CredentialIdCard
 
     /// <summary>
     /// True when the credential type denotes an identity credential (renders as an ID card). Pragmatic
-    /// v1 heuristic — the type name contains "identity" (e.g. AssuredIdentityCredential). A richer
+    /// v1 heuristic — the type/vct name contains "identity" (e.g. AssuredIdentityCredential). A richer
     /// credential-type registry can replace this later without changing callers.
     /// </summary>
     public static bool IsIdentityCredential(string? credentialType)
         => !string.IsNullOrWhiteSpace(credentialType)
            && credentialType.Contains("identity", System.StringComparison.OrdinalIgnoreCase);
 
-    /// <summary>Builds an <see cref="IdCardLayoutConfig"/> for a credential's card face.</summary>
+    /// <summary>Builds an <see cref="IdCardLayoutConfig"/> from a web detail view model.</summary>
     public static IdCardLayoutConfig BuildConfig(CredentialDetailViewModel credential)
     {
         System.ArgumentNullException.ThrowIfNull(credential);
+        var claims = credential.Claims.ToDictionary(
+            kv => kv.Key, kv => kv.Value?.ToString(), System.StringComparer.Ordinal);
+        var issuer = string.IsNullOrWhiteSpace(credential.IssuerName) ? null : credential.IssuerName;
+        return BuildConfig(credential.Type, PrettyCredentialName(credential.Type), issuer, claims);
+    }
 
-        var claims = credential.Claims;
+    /// <summary>
+    /// Model-agnostic card builder — used by both the web dialog and the wallet PWA page so the card is
+    /// identical in both. <paramref name="claims"/> is the flat claim map (claimName → value).
+    /// </summary>
+    public static IdCardLayoutConfig BuildConfig(
+        string? credentialType,
+        string? credentialName,
+        string? issuerName,
+        IReadOnlyDictionary<string, string?> claims)
+    {
+        System.ArgumentNullException.ThrowIfNull(claims);
+
         var fieldValues = new Dictionary<string, object?>(System.StringComparer.Ordinal);
         var pointers = new List<string>();
 
         // Prefer a computed fullName; otherwise synthesise "Given Family" from the granular parts so
         // the card always shows a name line rather than three separate name fields.
-        if (!ClaimHasText(claims, "fullName"))
+        if (!HasText(claims, "fullName"))
         {
-            var joined = string.Join(" ", new[] { ClaimText(claims, "givenName"), ClaimText(claims, "familyName") }
+            var joined = string.Join(" ", new[] { Text(claims, "givenName"), Text(claims, "familyName") }
                 .Where(s => !string.IsNullOrWhiteSpace(s)));
             if (!string.IsNullOrWhiteSpace(joined))
             {
@@ -56,14 +75,14 @@ public static class CredentialIdCard
         {
             var pointer = "/" + key;
             if (fieldValues.ContainsKey(pointer)) continue; // already synthesised (fullName)
-            var text = ClaimText(claims, key);
+            var text = Text(claims, key);
             if (string.IsNullOrWhiteSpace(text)) continue;
             fieldValues[pointer] = text;
             pointers.Add(pointer);
         }
 
         // Portrait → the sibling pointer IdCardLayout scans for the card photo.
-        var portrait = ClaimText(claims, PortraitClaim);
+        var portrait = Text(claims, PortraitClaim);
         if (!string.IsNullOrWhiteSpace(portrait))
         {
             fieldValues["/portrait/tokenImageBase64"] = portrait;
@@ -71,13 +90,12 @@ public static class CredentialIdCard
 
         var section = new IdCardSection(Title: "Identity", OriginatingPageIndex: 0, FieldPointers: pointers);
 
+        var name = string.IsNullOrWhiteSpace(credentialName) ? PrettyCredentialName(credentialType) : credentialName;
         return new IdCardLayoutConfig
         {
-            // No friendly issuer name is threaded through the credential model yet (only the DID);
-            // the prettified credential type carries the card identity. Issuer-org-name display is a
-            // follow-up (resolve the DID or carry it at issuance).
-            IssuerName = PrettyCredentialName(credential.Type),
-            CredentialName = PrettyCredentialName(credential.Type),
+            // The issuer org name where known; otherwise the credential name carries the card identity.
+            IssuerName = string.IsNullOrWhiteSpace(issuerName) ? name : issuerName!,
+            CredentialName = name,
             ColourTheme = XReviewColourTheme.IdentityNavy,
             Watermark = IdCardWatermark.Issued,
             FieldValues = fieldValues,
@@ -86,14 +104,14 @@ public static class CredentialIdCard
         };
     }
 
-    private static bool ClaimHasText(IReadOnlyDictionary<string, object> claims, string key)
-        => !string.IsNullOrWhiteSpace(ClaimText(claims, key));
+    private static bool HasText(IReadOnlyDictionary<string, string?> claims, string key)
+        => !string.IsNullOrWhiteSpace(Text(claims, key));
 
-    private static string? ClaimText(IReadOnlyDictionary<string, object> claims, string key)
-        => claims.TryGetValue(key, out var v) ? v?.ToString() : null;
+    private static string? Text(IReadOnlyDictionary<string, string?> claims, string key)
+        => claims.TryGetValue(key, out var v) ? v : null;
 
     // "AssuredIdentityCredential" -> "Assured Identity". Strips a trailing "Credential", splits camelCase.
-    private static string PrettyCredentialName(string type)
+    private static string PrettyCredentialName(string? type)
     {
         if (string.IsNullOrWhiteSpace(type)) return "Credential";
         var trimmed = type.EndsWith("Credential", System.StringComparison.OrdinalIgnoreCase) && type.Length > 10

--- a/src/Apps/Sorcha.Wallet.Pwa/Pages/CredentialDetail.razor
+++ b/src/Apps/Sorcha.Wallet.Pwa/Pages/CredentialDetail.razor
@@ -14,7 +14,10 @@
 @using Microsoft.AspNetCore.Authorization
 @attribute [Authorize]
 @using Sorcha.UI.Core.Components.Forms
+@using Sorcha.UI.Core.Components.Forms.Layouts
 @using Sorcha.UI.Core.Components.Wallet
+@using Sorcha.UI.Core.Models.Forms
+@using Sorcha.UI.Core.Services.Credentials
 @using Sorcha.Wallet.Pwa.Services
 @using Sorcha.Wallet.Pwa.Services.Presentation
 @inject ICredentialCache Credentials
@@ -41,43 +44,56 @@
     }
     else
     {
-        <MudCard Class="mb-3">
-            <MudCardHeader>
-                <CardHeaderContent>
-                    <MudText Typo="Typo.h6">@_title</MudText>
-                    @if (_caption is not null)
-                    {
-                        <MudText Typo="Typo.caption" Color="Color.Secondary">@_caption</MudText>
-                    }
-                </CardHeaderContent>
-            </MudCardHeader>
-            <MudCardContent>
-                @* Lead with plain-language status. *@
-                <div class="d-flex align-center gap-1 mb-3" data-testid="credential-detail-status">
-                    <MudIcon Icon="@_statusIcon" Color="@_statusColor" Size="Size.Small" />
-                    <MudText Typo="Typo.body1" Color="@_statusColor">@_statusText</MudText>
-                </div>
-
-                @if (_claims.Count == 0)
-                {
-                    <MudText Typo="Typo.body2" Color="Color.Secondary" data-testid="credential-detail-no-claims">
-                        This credential discloses no individual claims.
-                    </MudText>
-                }
-                else
-                {
-                    <MudList T="string" Dense="true" data-testid="credential-detail-claims">
-                        @foreach (var claim in _claims)
+        @if (_cardConfig is not null)
+        {
+            @* Identity credential — the same styled ID card as the web detail view and the application
+               review card (shared IdCardLayout + CredentialIdCard adapter), so both stay in sync. *@
+            <IdCardLayout Config="_cardConfig" />
+            <div class="d-flex align-center gap-1 my-3" data-testid="credential-detail-status">
+                <MudIcon Icon="@_statusIcon" Color="@_statusColor" Size="Size.Small" />
+                <MudText Typo="Typo.body1" Color="@_statusColor">@_statusText</MudText>
+            </div>
+        }
+        else
+        {
+            <MudCard Class="mb-3">
+                <MudCardHeader>
+                    <CardHeaderContent>
+                        <MudText Typo="Typo.h6">@_title</MudText>
+                        @if (_caption is not null)
                         {
-                            <MudListItem T="string">
-                                <MudText Typo="Typo.caption" Color="Color.Secondary">@PrettyName(claim.Name)</MudText>
-                                <MudText Typo="Typo.body1">@claim.Value</MudText>
-                            </MudListItem>
+                            <MudText Typo="Typo.caption" Color="Color.Secondary">@_caption</MudText>
                         }
-                    </MudList>
-                }
-            </MudCardContent>
-        </MudCard>
+                    </CardHeaderContent>
+                </MudCardHeader>
+                <MudCardContent>
+                    @* Lead with plain-language status. *@
+                    <div class="d-flex align-center gap-1 mb-3" data-testid="credential-detail-status">
+                        <MudIcon Icon="@_statusIcon" Color="@_statusColor" Size="Size.Small" />
+                        <MudText Typo="Typo.body1" Color="@_statusColor">@_statusText</MudText>
+                    </div>
+
+                    @if (_claims.Count == 0)
+                    {
+                        <MudText Typo="Typo.body2" Color="Color.Secondary" data-testid="credential-detail-no-claims">
+                            This credential discloses no individual claims.
+                        </MudText>
+                    }
+                    else
+                    {
+                        <MudList T="string" Dense="true" data-testid="credential-detail-claims">
+                            @foreach (var claim in _claims)
+                            {
+                                <MudListItem T="string">
+                                    <MudText Typo="Typo.caption" Color="Color.Secondary">@PrettyName(claim.Name)</MudText>
+                                    <MudText Typo="Typo.body1">@claim.Value</MudText>
+                                </MudListItem>
+                            }
+                        </MudList>
+                    }
+                </MudCardContent>
+            </MudCard>
+        }
 
         @* Progressive disclosure — machine identifiers stay collapsed. *@
         <MudExpansionPanels Class="mb-3" data-testid="credential-detail-details">
@@ -121,6 +137,7 @@
 
     private CachedCredential? _credential;
     private bool _loading = true;
+    private IdCardLayoutConfig? _cardConfig;
 
     private string _title = "";
     private string? _caption;
@@ -143,6 +160,16 @@
         _caption = string.Equals(issuer, _title, StringComparison.OrdinalIgnoreCase) ? null : issuer;
 
         _claims = SdJwtReader.ReadDisclosedClaims(_credential.RawSdJwt);
+
+        // Identity credentials render as the shared ID card (same as the web detail view + the
+        // application review), driven by the model-agnostic CredentialIdCard adapter.
+        if (CredentialIdCard.IsIdentityCredential(_credential.Vct))
+        {
+            var claimsDict = new Dictionary<string, string?>(StringComparer.Ordinal);
+            foreach (var c in _claims) claimsDict[c.Name] = c.Value;
+            _cardConfig = CredentialIdCard.BuildConfig(
+                _credential.Vct, CredentialDisplay.Name(_credential), CredentialDisplay.Issuer(_credential), claimsDict);
+        }
 
         var (status, text) = CredentialDisplay.ExpiryStatus(
             SdJwtReader.ReadExpiry(_credential.RawSdJwt), DateTimeOffset.UtcNow);

--- a/tests/Sorcha.UI.Core.Tests/Services/Credentials/CredentialIdCardTests.cs
+++ b/tests/Sorcha.UI.Core.Tests/Services/Credentials/CredentialIdCardTests.cs
@@ -65,4 +65,52 @@ public class CredentialIdCardTests
 
         cfg.FieldValues["/fullName"].Should().Be("Stuart Fraser");
     }
+
+    [Fact]
+    public void BuildConfig_IssuerName_FlowsToCardHeader()
+    {
+        var cred = new CredentialDetailViewModel
+        {
+            Type = "AssuredIdentityCredential",
+            IssuerName = "Acme Identity Assurance Services",
+            Claims = new Dictionary<string, object> { ["fullName"] = "Stuart Fraser" },
+        };
+
+        var cfg = CredentialIdCard.BuildConfig(cred);
+
+        cfg.IssuerName.Should().Be("Acme Identity Assurance Services");
+        cfg.CredentialName.Should().Be("Assured Identity");
+    }
+
+    [Fact]
+    public void BuildConfig_ModelAgnostic_MatchesModelOverload_ForWebPwaParity()
+    {
+        // The web (CredentialDetailViewModel) and the PWA (CachedCredential) feed the SAME
+        // model-agnostic core, so the rendered card is identical. Guard that parity.
+        var cred = new CredentialDetailViewModel
+        {
+            Type = "AssuredIdentityCredential",
+            IssuerName = "AIAS",
+            Claims = new Dictionary<string, object>
+            {
+                ["fullName"] = "Stuart Fraser",
+                ["dateOfBirth"] = "1968-08-19",
+                ["portrait"] = "IMG",
+            },
+        };
+        var claims = new Dictionary<string, string?>
+        {
+            ["fullName"] = "Stuart Fraser",
+            ["dateOfBirth"] = "1968-08-19",
+            ["portrait"] = "IMG",
+        };
+
+        var fromModel = CredentialIdCard.BuildConfig(cred);
+        var fromPrimitives = CredentialIdCard.BuildConfig("AssuredIdentityCredential", "Assured Identity", "AIAS", claims);
+
+        fromPrimitives.IssuerName.Should().Be(fromModel.IssuerName);
+        fromPrimitives.CredentialName.Should().Be(fromModel.CredentialName);
+        fromPrimitives.FieldValues["/fullName"].Should().Be(fromModel.FieldValues["/fullName"]);
+        fromPrimitives.FieldValues["/portrait/tokenImageBase64"].Should().Be(fromModel.FieldValues["/portrait/tokenImageBase64"]);
+    }
 }


### PR DESCRIPTION
- Issuer on the card header: CredentialDetailViewModel now carries IssuerName (populated from the
  issuer, DID-derived until the detail API returns the org name); it flows to the card header.
- Web + PWA in sync: CredentialIdCard.BuildConfig is now model-agnostic (type + name + issuer +
  claims map) so BOTH the web detail dialog (CredentialDetailViewModel) and the wallet PWA detail
  page (CachedCredential + SD-JWT claims) produce the IDENTICAL IdCardLayout. The PWA CredentialDetail
  page now renders the same styled ID card for identity credentials, with its existing claims list
  used for non-identity ones and the technical view kept in the Details expander.
+2 tests incl. a web/PWA parity guard. Follow-up: thread the issuer org name into the detail API.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UDmeAycWwQ5Y8PXuz4iub6
