### PR TITLE
fix: [174] keep decoded claims in the PWA credential Details expander for identity cards (2.0.7-dev)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -30,7 +30,7 @@
 
     <!-- Package / NuGet version (allows the -dev prerelease suffix locally). -->
     <Version>$(SorchaMajor).$(SorchaMinor).$(SorchaPatch)</Version>
-    <Version Condition="'$(GITHUB_RUN_NUMBER)' == ''">$(SorchaMajor).0.6-dev</Version>
+    <Version Condition="'$(GITHUB_RUN_NUMBER)' == ''">$(SorchaMajor).0.7-dev</Version>
 
     <!-- Assembly identity must be purely numeric (x.x.x.x). -->
     <AssemblyVersion>$(SorchaMajor).$(SorchaMinor).$(SorchaPatch).0</AssemblyVersion>

--- a/src/Apps/Sorcha.Wallet.Pwa/Pages/CredentialDetail.razor
+++ b/src/Apps/Sorcha.Wallet.Pwa/Pages/CredentialDetail.razor
@@ -98,6 +98,20 @@
         @* Progressive disclosure — machine identifiers stay collapsed. *@
         <MudExpansionPanels Class="mb-3" data-testid="credential-detail-details">
             <MudExpansionPanel Text="Details">
+                @* For identity credentials the claims are on the card face; keep the full decoded
+                   list here (as the web detail view does) so nothing is lost. *@
+                @if (_cardConfig is not null && _claims.Count > 0)
+                {
+                    <MudList T="string" Dense="true" Class="mb-3" data-testid="credential-detail-claims">
+                        @foreach (var claim in _claims)
+                        {
+                            <MudListItem T="string">
+                                <MudText Typo="Typo.caption" Color="Color.Secondary">@PrettyName(claim.Name)</MudText>
+                                <MudText Typo="Typo.body1">@claim.Value</MudText>
+                            </MudListItem>
+                        }
+                    </MudList>
+                }
                 <div class="mb-3">
                     <MudText Typo="Typo.caption" Color="Color.Secondary">Credential ID</MudText>
                     <div class="d-flex align-center gap-1">


### PR DESCRIPTION
Rendering identity credentials as the ID card removed the credential-detail-claims list from the PWA
main view, breaking CredentialDetailTests (which uses an identity Vct and asserts the decoded claims).
The claims now live in the "Details" expander for identity credentials — matching the web detail
view's full-claims table, losing no information, and keeping the test's assertion valid. Non-identity
credentials keep the claims in the main card as before.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UDmeAycWwQ5Y8PXuz4iub6
