### PR TITLE
fix: [787] Gap A — make orphaned pending txs observable at both UnregisterFromMonitoring sites

### DIFF
--- a/src/Services/Sorcha.Validator.Service/Services/DocketBuildTriggerService.cs
+++ b/src/Services/Sorcha.Validator.Service/Services/DocketBuildTriggerService.cs
@@ -23,6 +23,7 @@ public class DocketBuildTriggerService : BackgroundService
     private readonly DocketBuildConfiguration _config;
     private readonly ValidatorConfiguration _validatorConfig;
     private readonly ISystemWalletProvider _systemWalletProvider;
+    private readonly ValidatorMempoolMetrics _metrics;
     private readonly ILogger<DocketBuildTriggerService> _logger;
 
     // Track last build time per register
@@ -53,6 +54,7 @@ public class DocketBuildTriggerService : BackgroundService
         IOptions<DocketBuildConfiguration> config,
         IOptions<ValidatorConfiguration> validatorConfig,
         ISystemWalletProvider systemWalletProvider,
+        ValidatorMempoolMetrics metrics,
         ILogger<DocketBuildTriggerService> logger)
     {
         _scopeFactory = scopeFactory ?? throw new ArgumentNullException(nameof(scopeFactory));
@@ -60,6 +62,7 @@ public class DocketBuildTriggerService : BackgroundService
         _config = config?.Value ?? throw new ArgumentNullException(nameof(config));
         _validatorConfig = validatorConfig?.Value ?? throw new ArgumentNullException(nameof(validatorConfig));
         _systemWalletProvider = systemWalletProvider ?? throw new ArgumentNullException(nameof(systemWalletProvider));
+        _metrics = metrics ?? throw new ArgumentNullException(nameof(metrics));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -355,10 +358,7 @@ public class DocketBuildTriggerService : BackgroundService
                         var retryCount = _genesisRetryCount.AddOrUpdate(registerId, 1, (_, count) => count + 1);
                         if (retryCount >= 3)
                         {
-                            _logger.LogWarning(
-                                "Genesis docket write failed {RetryCount} times for register {RegisterId}. Unmonitoring register. Admin attention needed. Error: {Message}",
-                                retryCount, registerId, ex.Message);
-                            _registry.UnregisterFromMonitoring(registerId);
+                            await UnmonitorAfterGenesisFailureAsync(scope, registerId, retryCount, ex.Message, cancellationToken);
                         }
                         else
                         {
@@ -395,10 +395,7 @@ public class DocketBuildTriggerService : BackgroundService
                     var retryCount = _genesisRetryCount.AddOrUpdate(registerId, 1, (_, count) => count + 1);
                     if (retryCount >= 3)
                     {
-                        _logger.LogWarning(
-                            "Genesis docket write failed {RetryCount} times for register {RegisterId}. Unmonitoring register. Admin attention needed. Error: {Message}",
-                            retryCount, registerId, ex.Message);
-                        _registry.UnregisterFromMonitoring(registerId);
+                        await UnmonitorAfterGenesisFailureAsync(scope, registerId, retryCount, ex.Message, cancellationToken);
                     }
                     else
                     {
@@ -413,6 +410,62 @@ public class DocketBuildTriggerService : BackgroundService
         {
             _logger.LogDebug("No docket built for register {RegisterId} (verified queue empty or not ready)", registerId);
         }
+    }
+
+    /// <summary>
+    /// Issue #787 Gap A: after a genesis docket-0 write has failed the retry limit, this validator
+    /// cannot bootstrap the register, so it must stop monitoring it. Before releasing, we query the
+    /// per-register unverified pool count so an orphaning of pending transactions is observable and
+    /// alertable rather than silent. Any pending transactions cannot be sealed here (genesis is
+    /// unwritable) — they will be evicted by the pool retry limit (Gap B, #1092).
+    /// </summary>
+    /// <remarks>
+    /// The pending-count query is guarded: a pool-count failure must NEVER prevent the unregister,
+    /// which always happens. This method does not throw.
+    /// </remarks>
+    internal async Task UnmonitorAfterGenesisFailureAsync(
+        IServiceScope scope,
+        string registerId,
+        int retryCount,
+        string error,
+        CancellationToken ct)
+    {
+        long? pendingCount = null;
+        try
+        {
+            var poller = scope.ServiceProvider.GetRequiredService<ITransactionPoolPoller>();
+            pendingCount = await poller.GetUnverifiedCountAsync(registerId, ct);
+        }
+        catch (Exception countEx)
+        {
+            _logger.LogWarning(countEx,
+                "Failed to read unverified pool count for register {RegisterId} while un-monitoring after genesis failure — count unknown",
+                registerId);
+        }
+
+        if (pendingCount is > 0)
+        {
+            _logger.LogCritical(
+                "Genesis docket write failed {RetryCount} times for register {RegisterId}; un-monitoring while {PendingCount} unverified transaction(s) are still pending. " +
+                "The register cannot bootstrap and the orphaned transactions will be evicted by the pool retry limit. ADMIN ATTENTION NEEDED. Error: {Message}",
+                retryCount, registerId, pendingCount, error);
+            _metrics.RecordUnregisteredWithPending(registerId, "genesis-failure", pendingCount.Value);
+        }
+        else if (pendingCount is null)
+        {
+            _logger.LogCritical(
+                "Genesis docket write failed {RetryCount} times for register {RegisterId}; un-monitoring register (pending count unknown). " +
+                "The register cannot bootstrap. ADMIN ATTENTION NEEDED. Error: {Message}",
+                retryCount, registerId, error);
+        }
+        else
+        {
+            _logger.LogWarning(
+                "Genesis docket write failed {RetryCount} times for register {RegisterId}. Un-monitoring register (no pending transactions). Admin attention needed. Error: {Message}",
+                retryCount, registerId, error);
+        }
+
+        _registry.UnregisterFromMonitoring(registerId);
     }
 
     /// <summary>

--- a/src/Services/Sorcha.Validator.Service/Services/RegisterMonitoringBootstrap.cs
+++ b/src/Services/Sorcha.Validator.Service/Services/RegisterMonitoringBootstrap.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Sorcha.Register.Core.Events;
 using Sorcha.ServiceClients.Register;
+using Sorcha.Validator.Service.Services.Interfaces;
 
 namespace Sorcha.Validator.Service.Services;
 
@@ -29,6 +30,7 @@ public sealed class RegisterMonitoringBootstrap : BackgroundService
     private readonly IServiceScopeFactory _scopeFactory;
     private readonly IRegisterMonitoringRegistry _registry;
     private readonly IValidatorKeyProvider _keyProvider;
+    private readonly ValidatorMempoolMetrics _metrics;
     private readonly IEventSubscriber? _eventSubscriber;
     private readonly ILogger<RegisterMonitoringBootstrap> _logger;
 
@@ -36,12 +38,14 @@ public sealed class RegisterMonitoringBootstrap : BackgroundService
         IServiceScopeFactory scopeFactory,
         IRegisterMonitoringRegistry registry,
         IValidatorKeyProvider keyProvider,
+        ValidatorMempoolMetrics metrics,
         ILogger<RegisterMonitoringBootstrap> logger,
         IEventSubscriber? eventSubscriber = null)
     {
         _scopeFactory = scopeFactory ?? throw new ArgumentNullException(nameof(scopeFactory));
         _registry = registry ?? throw new ArgumentNullException(nameof(registry));
         _keyProvider = keyProvider ?? throw new ArgumentNullException(nameof(keyProvider));
+        _metrics = metrics ?? throw new ArgumentNullException(nameof(metrics));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _eventSubscriber = eventSubscriber;
     }
@@ -171,10 +175,7 @@ public sealed class RegisterMonitoringBootstrap : BackgroundService
             // Remove no-longer-rostered (drain-on-remove semantics live in ValidationEngineService).
             foreach (var remove in toRemove)
             {
-                _registry.UnregisterFromMonitoring(remove);
-                _logger.LogInformation(
-                    "Monitoring released for register {RegisterId} — validator key no longer on roster",
-                    remove);
+                await ReleaseDerosteredRegisterAsync(remove, ct);
             }
 
             return true;
@@ -184,6 +185,51 @@ public sealed class RegisterMonitoringBootstrap : BackgroundService
             _logger.LogWarning(ex, "Monitoring reconcile failed");
             return false;
         }
+    }
+
+    /// <summary>
+    /// Issue #787 Gap A: releases a register this validator is no longer on the roster for. Before
+    /// un-monitoring, we query the per-register unverified pool count so that releasing a register
+    /// with still-pending transactions is observable and alertable rather than silent. This validator
+    /// can't seal those transactions (it's off the roster) — they must be handled by the register's
+    /// current roster (via replication) or be evicted by the pool retry limit (Gap B, #1092).
+    /// </summary>
+    /// <remarks>
+    /// The pending-count query is guarded: a pool-count failure must NEVER prevent the release, which
+    /// always happens. This method does not throw.
+    /// </remarks>
+    internal async Task ReleaseDerosteredRegisterAsync(string registerId, CancellationToken ct)
+    {
+        long? pendingCount = null;
+        try
+        {
+            using var scope = _scopeFactory.CreateScope();
+            var poller = scope.ServiceProvider.GetRequiredService<ITransactionPoolPoller>();
+            pendingCount = await poller.GetUnverifiedCountAsync(registerId, ct);
+        }
+        catch (Exception countEx)
+        {
+            _logger.LogWarning(countEx,
+                "Failed to read unverified pool count for register {RegisterId} while releasing a de-rostered register — count unknown",
+                registerId);
+        }
+
+        if (pendingCount is > 0)
+        {
+            _logger.LogWarning(
+                "Monitoring released for register {RegisterId} — validator key no longer on roster — while {PendingCount} unverified transaction(s) are still pending. " +
+                "This validator cannot seal them; they must be handled by the register's current roster or evicted by the pool retry limit.",
+                registerId, pendingCount);
+            _metrics.RecordUnregisteredWithPending(registerId, "roster-change", pendingCount.Value);
+        }
+        else
+        {
+            _logger.LogInformation(
+                "Monitoring released for register {RegisterId} — validator key no longer on roster{PendingSuffix}",
+                registerId, pendingCount is null ? " (pending count unknown)" : string.Empty);
+        }
+
+        _registry.UnregisterFromMonitoring(registerId);
     }
 
     private async Task HandleRelationshipChangedAsync(RegisterRelationshipChangedEvent evt, CancellationToken ct)

--- a/src/Services/Sorcha.Validator.Service/Services/ValidatorMempoolMetrics.cs
+++ b/src/Services/Sorcha.Validator.Service/Services/ValidatorMempoolMetrics.cs
@@ -26,6 +26,7 @@ public sealed class ValidatorMempoolMetrics : IDisposable
 
     private readonly Meter _meter;
     private readonly Counter<long> _leaseExpired;
+    private readonly Counter<long> _unregisteredWithPending;
 
     /// <summary>Creates the meter and registers the counter instrument.</summary>
     public ValidatorMempoolMetrics(IMeterFactory meterFactory)
@@ -37,6 +38,11 @@ public sealed class ValidatorMempoolMetrics : IDisposable
             name: "sorcha_validator_mempool_lease_expired_total",
             unit: "{lease}",
             description: "Validator mempool leases that auto-released because they expired without ConfirmAsync. High values indicate the validator is dying mid-seal or lease duration is too short.");
+
+        _unregisteredWithPending = _meter.CreateCounter<long>(
+            name: "sorcha_validator_monitoring_unregistered_with_pending_total",
+            unit: "{register}",
+            description: "Registers un-monitored (genesis-failure or roster-change) while unverified transactions were still pending — the orphans are left to the pool retry-limit eviction (Gap B). Non-zero values need admin attention (issue #787 Gap A).");
     }
 
     /// <summary>
@@ -49,6 +55,25 @@ public sealed class ValidatorMempoolMetrics : IDisposable
         if (count <= 0) return;
         ArgumentException.ThrowIfNullOrWhiteSpace(registerId);
         _leaseExpired.Add(count, new KeyValuePair<string, object?>("register_id", registerId));
+    }
+
+    /// <summary>
+    /// Records that a register was un-monitored while <paramref name="pendingCount"/> unverified
+    /// transactions were still in its pool (issue #787 Gap A). Increments the counter once, tagged
+    /// with the <paramref name="reason"/> — <c>"genesis-failure"</c> or <c>"roster-change"</c>.
+    /// </summary>
+    /// <param name="registerId">The register that was un-monitored.</param>
+    /// <param name="reason">Why the register was un-monitored: <c>"genesis-failure"</c> | <c>"roster-change"</c>.</param>
+    /// <param name="pendingCount">The number of orphaned pending transactions (surfaced as a tag).</param>
+    public void RecordUnregisteredWithPending(string registerId, string reason, long pendingCount)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(registerId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(reason);
+        _unregisteredWithPending.Add(
+            1,
+            new KeyValuePair<string, object?>("reason", reason),
+            new KeyValuePair<string, object?>("register_id", registerId),
+            new KeyValuePair<string, object?>("pending_count", pendingCount));
     }
 
     /// <inheritdoc />

--- a/tests/Sorcha.Validator.Service.Tests/Services/DocketBuildTriggerGenesisUnmonitorTests.cs
+++ b/tests/Sorcha.Validator.Service.Tests/Services/DocketBuildTriggerGenesisUnmonitorTests.cs
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Diagnostics.Metrics;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using Sorcha.Validator.Service.Configuration;
+using Sorcha.Validator.Service.Services;
+using Sorcha.Validator.Service.Services.Interfaces;
+
+namespace Sorcha.Validator.Service.Tests.Services;
+
+/// <summary>
+/// Issue #787 Gap A — <see cref="DocketBuildTriggerService.UnmonitorAfterGenesisFailureAsync"/> must make
+/// the orphaning of pending transactions on a genesis-failure un-monitor observable (LogCritical + metric)
+/// rather than silent, while ALWAYS releasing the register from monitoring even if the pool count query
+/// fails. The metric is asserted deterministically via a raw <see cref="MeterListener"/> over the real
+/// <see cref="ValidatorMempoolMetrics"/> meter.
+/// </summary>
+[Collection("ValidatorMempoolMetrics unregistered counter")]
+public sealed class DocketBuildTriggerGenesisUnmonitorTests : IDisposable
+{
+    private const string RegisterId = "reg-genesis-787";
+
+    private readonly Mock<IRegisterMonitoringRegistry> _registry = new(MockBehavior.Strict);
+    private readonly Mock<ITransactionPoolPoller> _poller = new();
+    private readonly Mock<ILogger<DocketBuildTriggerService>> _logger = new();
+    private readonly ServiceProvider _meterProvider;
+    private readonly ValidatorMempoolMetrics _metrics;
+    private readonly List<(string Instrument, long Value, Dictionary<string, object?> Tags)> _measurements = new();
+    private readonly MeterListener _listener;
+
+    public DocketBuildTriggerGenesisUnmonitorTests()
+    {
+        _meterProvider = new ServiceCollection().AddMetrics().BuildServiceProvider();
+        _metrics = new ValidatorMempoolMetrics(_meterProvider.GetRequiredService<IMeterFactory>());
+
+        _listener = new MeterListener
+        {
+            InstrumentPublished = (instrument, listener) =>
+            {
+                if (instrument.Meter.Name == ValidatorMempoolMetrics.MeterName)
+                {
+                    listener.EnableMeasurementEvents(instrument);
+                }
+            }
+        };
+        _listener.SetMeasurementEventCallback<long>((inst, value, tags, _) =>
+            _measurements.Add((inst.Name, value, TagsToDict(tags))));
+        _listener.Start();
+
+        _registry.Setup(r => r.UnregisterFromMonitoring(It.IsAny<string>()));
+    }
+
+    private DocketBuildTriggerService CreateSut() => new(
+        Mock.Of<IServiceScopeFactory>(),
+        _registry.Object,
+        Options.Create(new DocketBuildConfiguration()),
+        Options.Create(new ValidatorConfiguration { SystemWalletAddress = "test-addr" }),
+        Mock.Of<ISystemWalletProvider>(),
+        _metrics,
+        _logger.Object);
+
+    /// <summary>Real scope whose provider resolves the mocked <see cref="ITransactionPoolPoller"/>.</summary>
+    private IServiceScope CreatePollerScope()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton(_poller.Object);
+        var provider = services.BuildServiceProvider();
+        return provider.CreateScope();
+    }
+
+    private const string UnregisteredMetric = "sorcha_validator_monitoring_unregistered_with_pending_total";
+
+    [Fact]
+    public async Task UnmonitorAfterGenesisFailure_PendingGreaterThanZero_Unregisters_LogsCritical_IncrementsMetric()
+    {
+        _poller.Setup(p => p.GetUnverifiedCountAsync(RegisterId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(7);
+        var sut = CreateSut();
+        using var scope = CreatePollerScope();
+
+        await sut.UnmonitorAfterGenesisFailureAsync(scope, RegisterId, retryCount: 3, error: "boom", CancellationToken.None);
+
+        _registry.Verify(r => r.UnregisterFromMonitoring(RegisterId), Times.Once);
+
+        var metric = _measurements.Should().ContainSingle(m => m.Instrument == UnregisteredMetric).Subject;
+        metric.Value.Should().Be(1);
+        metric.Tags.Should().Contain("reason", "genesis-failure");
+        metric.Tags.Should().Contain("register_id", RegisterId);
+        metric.Tags.Should().Contain("pending_count", 7L);
+
+        VerifyLog(LogLevel.Critical, Times.AtLeastOnce());
+    }
+
+    [Fact]
+    public async Task UnmonitorAfterGenesisFailure_PendingZero_Unregisters_NoMetric_NoCritical()
+    {
+        _poller.Setup(p => p.GetUnverifiedCountAsync(RegisterId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(0);
+        var sut = CreateSut();
+        using var scope = CreatePollerScope();
+
+        await sut.UnmonitorAfterGenesisFailureAsync(scope, RegisterId, retryCount: 3, error: "boom", CancellationToken.None);
+
+        _registry.Verify(r => r.UnregisterFromMonitoring(RegisterId), Times.Once);
+        _measurements.Should().NotContain(m => m.Instrument == UnregisteredMetric);
+        VerifyLog(LogLevel.Critical, Times.Never());
+    }
+
+    [Fact]
+    public async Task UnmonitorAfterGenesisFailure_CountQueryThrows_StillUnregisters_NoMetric_NoThrow()
+    {
+        _poller.Setup(p => p.GetUnverifiedCountAsync(RegisterId, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("redis down"));
+        var sut = CreateSut();
+        using var scope = CreatePollerScope();
+
+        var act = async () => await sut.UnmonitorAfterGenesisFailureAsync(
+            scope, RegisterId, retryCount: 3, error: "boom", CancellationToken.None);
+
+        await act.Should().NotThrowAsync();
+        _registry.Verify(r => r.UnregisterFromMonitoring(RegisterId), Times.Once);
+        _measurements.Should().NotContain(m => m.Instrument == UnregisteredMetric);
+    }
+
+    private void VerifyLog(LogLevel level, Times times) =>
+        _logger.Verify(
+            l => l.Log(
+                level,
+                It.IsAny<EventId>(),
+                It.IsAny<It.IsAnyType>(),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            times);
+
+    private static Dictionary<string, object?> TagsToDict(ReadOnlySpan<KeyValuePair<string, object?>> tags)
+    {
+        var dict = new Dictionary<string, object?>();
+        foreach (var kvp in tags)
+        {
+            dict[kvp.Key] = kvp.Value;
+        }
+        return dict;
+    }
+
+    public void Dispose()
+    {
+        _listener.Dispose();
+        _meterProvider.Dispose();
+    }
+}

--- a/tests/Sorcha.Validator.Service.Tests/Services/RegisterMonitoringBootstrapReleaseTests.cs
+++ b/tests/Sorcha.Validator.Service.Tests/Services/RegisterMonitoringBootstrapReleaseTests.cs
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Diagnostics.Metrics;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Sorcha.Validator.Service.Services;
+using Sorcha.Validator.Service.Services.Interfaces;
+
+namespace Sorcha.Validator.Service.Tests.Services;
+
+/// <summary>
+/// Issue #787 Gap A — <see cref="RegisterMonitoringBootstrap.ReleaseDerosteredRegisterAsync"/> must make
+/// the release of a de-rostered register that still has pending transactions observable (LogWarning +
+/// metric) rather than silent, while ALWAYS releasing it from monitoring even if the pool count query
+/// fails. The metric is asserted deterministically via a raw <see cref="MeterListener"/> over the real
+/// <see cref="ValidatorMempoolMetrics"/> meter.
+/// </summary>
+[Collection("ValidatorMempoolMetrics unregistered counter")]
+public sealed class RegisterMonitoringBootstrapReleaseTests : IDisposable
+{
+    private const string RegisterId = "reg-roster-787";
+    private const string UnregisteredMetric = "sorcha_validator_monitoring_unregistered_with_pending_total";
+
+    private readonly Mock<IRegisterMonitoringRegistry> _registry = new(MockBehavior.Strict);
+    private readonly Mock<ITransactionPoolPoller> _poller = new();
+    private readonly Mock<IValidatorKeyProvider> _keyProvider = new();
+    private readonly Mock<ILogger<RegisterMonitoringBootstrap>> _logger = new();
+    private readonly ServiceProvider _provider;
+    private readonly ValidatorMempoolMetrics _metrics;
+    private readonly List<(string Instrument, long Value, Dictionary<string, object?> Tags)> _measurements = new();
+    private readonly MeterListener _listener;
+
+    public RegisterMonitoringBootstrapReleaseTests()
+    {
+        // Real scope factory whose scoped provider resolves the mocked poller — the SUT calls
+        // _scopeFactory.CreateScope() internally, so we must NOT hand-mock IServiceScopeFactory.
+        var services = new ServiceCollection();
+        services.AddMetrics();
+        services.AddSingleton(_poller.Object);
+        _provider = services.BuildServiceProvider();
+
+        _metrics = new ValidatorMempoolMetrics(_provider.GetRequiredService<IMeterFactory>());
+
+        _listener = new MeterListener
+        {
+            InstrumentPublished = (instrument, listener) =>
+            {
+                if (instrument.Meter.Name == ValidatorMempoolMetrics.MeterName)
+                {
+                    listener.EnableMeasurementEvents(instrument);
+                }
+            }
+        };
+        _listener.SetMeasurementEventCallback<long>((inst, value, tags, _) =>
+            _measurements.Add((inst.Name, value, TagsToDict(tags))));
+        _listener.Start();
+
+        _registry.Setup(r => r.UnregisterFromMonitoring(It.IsAny<string>()));
+    }
+
+    private RegisterMonitoringBootstrap CreateSut() => new(
+        _provider.GetRequiredService<IServiceScopeFactory>(),
+        _registry.Object,
+        _keyProvider.Object,
+        _metrics,
+        _logger.Object);
+
+    [Fact]
+    public async Task ReleaseDerostered_PendingGreaterThanZero_Releases_LogsWarning_IncrementsMetric()
+    {
+        _poller.Setup(p => p.GetUnverifiedCountAsync(RegisterId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(4);
+        var sut = CreateSut();
+
+        await sut.ReleaseDerosteredRegisterAsync(RegisterId, CancellationToken.None);
+
+        _registry.Verify(r => r.UnregisterFromMonitoring(RegisterId), Times.Once);
+
+        var metric = _measurements.Should().ContainSingle(m => m.Instrument == UnregisteredMetric).Subject;
+        metric.Value.Should().Be(1);
+        metric.Tags.Should().Contain("reason", "roster-change");
+        metric.Tags.Should().Contain("register_id", RegisterId);
+        metric.Tags.Should().Contain("pending_count", 4L);
+
+        VerifyLog(LogLevel.Warning, Times.AtLeastOnce());
+    }
+
+    [Fact]
+    public async Task ReleaseDerostered_PendingZero_ReleasesQuietly_NoMetric()
+    {
+        _poller.Setup(p => p.GetUnverifiedCountAsync(RegisterId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(0);
+        var sut = CreateSut();
+
+        await sut.ReleaseDerosteredRegisterAsync(RegisterId, CancellationToken.None);
+
+        _registry.Verify(r => r.UnregisterFromMonitoring(RegisterId), Times.Once);
+        _measurements.Should().NotContain(m => m.Instrument == UnregisteredMetric);
+    }
+
+    [Fact]
+    public async Task ReleaseDerostered_CountQueryThrows_StillReleases_NoMetric_NoThrow()
+    {
+        _poller.Setup(p => p.GetUnverifiedCountAsync(RegisterId, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("redis down"));
+        var sut = CreateSut();
+
+        var act = async () => await sut.ReleaseDerosteredRegisterAsync(RegisterId, CancellationToken.None);
+
+        await act.Should().NotThrowAsync();
+        _registry.Verify(r => r.UnregisterFromMonitoring(RegisterId), Times.Once);
+        _measurements.Should().NotContain(m => m.Instrument == UnregisteredMetric);
+    }
+
+    private void VerifyLog(LogLevel level, Times times) =>
+        _logger.Verify(
+            l => l.Log(
+                level,
+                It.IsAny<EventId>(),
+                It.IsAny<It.IsAnyType>(),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            times);
+
+    private static Dictionary<string, object?> TagsToDict(ReadOnlySpan<KeyValuePair<string, object?>> tags)
+    {
+        var dict = new Dictionary<string, object?>();
+        foreach (var kvp in tags)
+        {
+            dict[kvp.Key] = kvp.Value;
+        }
+        return dict;
+    }
+
+    public void Dispose()
+    {
+        _listener.Dispose();
+        _provider.Dispose();
+    }
+}


### PR DESCRIPTION
The two monitoring-unregister sites (genesis-failure in DocketBuildTriggerService, roster-change in
RegisterMonitoringBootstrap) previously released a register while pending transactions could still be
sitting in its unverified pool — silently. In both cases this validator cannot seal those txs
(genesis unwritable / off the roster), so deferring is pointless; the correct fix is to make the
orphaning OBSERVABLE and ALERTABLE while always still unregistering:

- Before each unregister, query ITransactionPoolPoller.GetUnverifiedCountAsync(registerId) (resolved
  from the existing scope factory), guarded so a count-read failure never blocks the unregister.
- pending > 0 → LogCritical (genesis) / LogWarning (roster) with the count, + new metric
  sorcha_validator_monitoring_unregistered_with_pending_total{reason=genesis-failure|roster-change}
  on ValidatorMempoolMetrics. pending == 0 → quiet log. Unknown (query threw) → treated as Critical
  for genesis. The unregister ALWAYS runs.
- Orphaned txs are evicted by the pool retry limit (Gap B, #1092); operators now get a signal.

Guard logic extracted into internal UnmonitorAfterGenesisFailureAsync / ReleaseDerosteredRegisterAsync
for full branch testability. 6 new tests (pending>0 / ==0 / count-query-throws at each site) assert
UnregisterFromMonitoring is always called, the metric fires once with the right reason/count tags via
a MeterListener, and the throw path never blocks the release. Validator suite: 995 passed, 0 failed.

The reconcile safety-threshold (refuse to prune when toRemove==current && count>=3) is unchanged by
this work (only the loop body was extracted) and not separately covered — noted for follow-up.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UDmeAycWwQ5Y8PXuz4iub6
