### PR TITLE
fix: [1077] agent decision fails closed when the external-check runner is ABSENT, not just faulting

### DIFF
--- a/src/Apps/Sorcha.Agent/Decision/RulesDecisionEngine.cs
+++ b/src/Apps/Sorcha.Agent/Decision/RulesDecisionEngine.cs
@@ -23,6 +23,13 @@ public class RulesDecisionEngine : IDecisionEngine
     private readonly IExternalCheckRunner? _checkRunner;
     private readonly ILogger<RulesDecisionEngine>? _logger;
 
+    // #1077: true when ANY rule condition references a "checks.*" fact. When the rules depend on
+    // external checks we must FAIL CLOSED if no check facts are available (runner absent / no checks
+    // configured / HasChecks false / faulted) — otherwise the "checks.X == false" reject rules
+    // silently no-op (null != false in strict ==) and the catch-all approve fires, issuing a
+    // credential with zero verification. Computed once — the rules are fixed for the engine's life.
+    private readonly bool _rulesRequireChecks;
+
     /// <summary>Creates a rules engine over <paramref name="rules"/> with no external checks.</summary>
     public RulesDecisionEngine(ActorRule[] rules, ILogger<RulesDecisionEngine>? logger = null)
         : this(rules, null, logger)
@@ -39,6 +46,14 @@ public class RulesDecisionEngine : IDecisionEngine
         _rules = rules;
         _checkRunner = checkRunner;
         _logger = logger;
+
+        // A rule "requires checks" if its serialised condition references a "checks." fact path
+        // (e.g. { "var": "checks.postcodeExists" }). Inclusive by design: a false positive only ever
+        // causes a conservative hold (fail-safe), whereas a miss would re-open the zero-verification
+        // hole. Agents with no such rules are entirely unaffected.
+        _rulesRequireChecks = rules.Any(r =>
+            r.Condition is not null
+            && r.Condition.ToJsonString().Contains("checks.", StringComparison.Ordinal));
     }
 
     public async Task<ActionDecision> DecideAsync(PendingAction action, CancellationToken cancellationToken = default)
@@ -60,6 +75,23 @@ public class RulesDecisionEngine : IDecisionEngine
                     action.ActionName);
                 return new ActionDecision("hold", null, "External checks unavailable; application held for manual review");
             }
+        }
+
+        // #1077: fail closed when the rules DEPEND on external checks but no check facts are available.
+        // This covers the absence modes the block above does NOT: a null runner, a runner with
+        // HasChecks == false, or no ChecksFile configured (e.g. a stale agent build) — any of which
+        // leaves checksFacts null while the reject rules reference checks.*. Without this guard those
+        // rejects silently no-op and the catch-all approve issues a credential with zero verification
+        // (observed live: fake postcode "ZZ99 9ZZ" approved). Agents whose rules don't reference
+        // checks.* have _rulesRequireChecks == false and are unaffected.
+        if (checksFacts is null && _rulesRequireChecks)
+        {
+            _logger?.LogError(
+                "Rules for action {ActionName} reference external checks but no check facts are available "
+                + "(no check runner configured/available); holding for manual review (fail-closed, #1077).",
+                action.ActionName);
+            return new ActionDecision("hold", null,
+                "External checks are required by policy but were unavailable; application held for manual review");
         }
 
         foreach (var rule in _rules)

--- a/tests/Sorcha.Agent.Tests/Decision/Checks/RulesDecisionEngineChecksTests.cs
+++ b/tests/Sorcha.Agent.Tests/Decision/Checks/RulesDecisionEngineChecksTests.cs
@@ -153,6 +153,57 @@ public class RulesDecisionEngineChecksTests
         decision.Reasoning.Should().Contain("manual review");
     }
 
+    [Fact]
+    public async Task Decide_RulesRequireChecks_RunnerAbsent_HoldsFailClosed()
+    {
+        // #1077 — the exact live bug: no check runner is wired (e.g. a stale agent build predating the
+        // external-check hook), yet the rules reference checks.*. Previously the checks block was
+        // skipped entirely, the reject rules no-op'd (null != false), and the catch-all approve fired —
+        // issuing a credential with zero verification (fake postcode ZZ99 9ZZ approved). Must hold.
+        var engine = new RulesDecisionEngine(AiasRules()); // no runner at all
+
+        var decision = await engine.DecideAsync(Action());
+
+        decision.Decision.Should().Be("hold", "rules requiring checks must fail closed when no runner is wired");
+        decision.Payload.Should().BeNull();
+        decision.Reasoning.Should().Contain("manual review");
+    }
+
+    [Fact]
+    public async Task Decide_RulesRequireChecks_RunnerHasNoChecks_HoldsFailClosed()
+    {
+        // Runner present but empty (HasChecks == false — e.g. an unresolved/empty ChecksFile). Same
+        // absence hole as a null runner: checksFacts stays null while rules reference checks.*.
+        var engine = new RulesDecisionEngine(AiasRules(), new ExternalCheckRunner([]));
+
+        var decision = await engine.DecideAsync(Action());
+
+        decision.Decision.Should().Be("hold", "an empty runner (HasChecks false) must also fail closed");
+        decision.Payload.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Decide_RulesDoNotReferenceChecks_RunnerAbsent_ApprovesNormally_NoForcedHold()
+    {
+        // Regression guard: an agent whose rules do NOT reference checks.* must be unaffected — no
+        // runner, no forced hold. The fail-closed guard is scoped to rules that actually depend on checks.
+        var noCheckRules = new[]
+        {
+            new ActorRule
+            {
+                ActionName = ActionName,
+                Condition = JsonNode.Parse("""{ "==": [ true, true ] }"""),
+                Decision = "approve",
+                Payload = JsonNode.Parse("""{ "decision": "approved", "verificationNotes": "No checks needed." }""")!.AsObject(),
+            },
+        };
+        var engine = new RulesDecisionEngine(noCheckRules); // no runner, no checks references
+
+        var decision = await engine.DecideAsync(Action());
+
+        decision.Decision.Should().Be("approve", "agents without checks.* rules must not be force-held");
+    }
+
     /// <summary>
     /// Runner stub that throws at the runner level, bypassing per-check fault containment.
     /// Exercises the null-checksFacts path in <see cref="RulesDecisionEngine.DecideAsync"/>.


### PR DESCRIPTION
RulesDecisionEngine.DecideAsync only failed closed when the check runner FAULTED. When the runner was
absent (null), had no checks (HasChecks == false), or no ChecksFile was configured (e.g. a stale agent
build predating the external-check hook), the entire checks block was skipped, checksFacts stayed null,
the "checks.X == false" reject rules silently no-op'd (null != false in strict ==), and the catch-all
approve fired — issuing a credential with ZERO verification. Observed live: a non-existent postcode
"ZZ99 9ZZ" was approved.

Fix: the engine now computes once whether any rule condition references a "checks.*" fact
(_rulesRequireChecks). In DecideAsync, if checksFacts is null AND the rules require checks, it holds
for manual review (fail closed) — covering all absence modes uniformly (null runner / HasChecks false /
fault). Agents whose rules do not reference checks.* are unaffected (no forced hold). Detection is
inclusive by design: a false positive only ever causes a conservative hold, never a missed check.

3 new tests: runner-absent → hold (the exact bug), empty runner (HasChecks false) → hold, and the
regression guard that no-checks agents still approve normally. Agent suite: 160 passed.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UDmeAycWwQ5Y8PXuz4iub6
