### PR TITLE
fix/814 validator idle stall selfheal

### DIFF
--- a/.claude/skills/network-bootstrap/references/troubleshooting.md
+++ b/.claude/skills/network-bootstrap/references/troubleshooting.md
@@ -297,3 +297,32 @@ the health gate). wallet-service running ALONE cannot auto-generate a `validator
 window. Just bring up the rest of the stack (`docker compose … up -d`) and verify the system
 register seals. (A 409 with NO prior import attempt is the real "validator raced ahead and
 auto-generated the wrong wallet" case — see "Genesis ingested but docket never seals".)
+
+## Validator stops sealing after long idle — healthy but silent (#814)
+
+**Symptom:** After a node sits idle for a long time (hours→days), the validator **stops persisting
+sealed dockets**. New submissions "succeed" at the API (register id / tx id returned) but Mongo shows
+`dockets=0 tx=0` for the register, and workflow action-execute calls time out at ~60s
+(`TimeoutException … not confirmed within 60s`). The validator container is **`running` / `healthy`,
+`RestartCount=0`** — nothing looks wrong. `docker restart sorcha-validator-service` fixes it
+immediately (sealing returns to ~0.1s).
+
+**Root cause:** a keep-alive connection (Redis or the wallet-service gRPC channel) goes stale after
+idle; an `await` in `ValidationEngineService.ProcessRegisterAsync` hangs, its in-memory "already
+processing" flag is never released, and every later batch skips that register forever. Restart clears
+the in-memory flag + runs the startup pool drain, which is why it recovers. Full analysis:
+[[814-validator-idle-stall]].
+
+**Diagnose:** confirm the register DB exists but is empty
+(`db.getSiblingDB("sorcha_register_<id>").dockets.countDocuments({})` → 0) while the Redis monitoring
+set still lists it (`docker exec sorcha-redis redis-cli SMEMBERS validator:monitoring:registers`) — a
+still-monitored-but-not-processed register is the signature. NB the validator logs to **OTLP/Aspire,
+not `docker logs`** on the docker stacks, so `docker logs sorcha-validator-service` is empty — use the
+Mongo/Redis state, not logs.
+
+**Immediate fix:** `docker restart sorcha-validator-service`.
+**Permanent fix (#814):** cycle timeouts + self-healing slot reclaim + Redis keep-alive/reconnect.
+Watch `sorcha_validator_validation_cycle_timeout_total` and
+`sorcha_validator_validation_slot_reclaimed_total` (a non-zero reclaim counter means the timeout guard
+was bypassed and needs a look). **Reproducing on demand is impractical** — it needed a ~16-day idle;
+65 min is not enough (onset depends on when a socket actually dies).

--- a/src/Services/Sorcha.Validator.Service/Extensions/VerifiedQueueExtensions.cs
+++ b/src/Services/Sorcha.Validator.Service/Extensions/VerifiedQueueExtensions.cs
@@ -48,7 +48,20 @@ public static class VerifiedQueueExtensions
             {
                 var connectionString = configuration.GetSorchaRedisConnectionString("Validator");
                 services.AddSingleton<IConnectionMultiplexer>(_ =>
-                    ConnectionMultiplexer.Connect(connectionString));
+                {
+                    // Harden against stale connections after long idle (issue #814): KeepAlive PINGs
+                    // detect a dead socket, AbortOnConnectFail=false + ConnectRetry auto-reconnect,
+                    // and explicit sync/async timeouts ensure a wedged connection makes operations
+                    // THROW (callers catch and retry) rather than hang and freeze the validation loop.
+                    var options = ConfigurationOptions.Parse(connectionString);
+                    options.AbortOnConnectFail = false;
+                    options.KeepAlive = 30;        // seconds between PINGs to detect a dead socket
+                    options.ConnectRetry = 5;
+                    options.ConnectTimeout = 5000;
+                    options.SyncTimeout = 5000;
+                    options.AsyncTimeout = 5000;
+                    return ConnectionMultiplexer.Connect(options);
+                });
             }
             services.AddSingleton<IVerifiedTransactionQueue, RedisVerifiedTransactionQueue>();
             storageLog.RegisterPersistent(

--- a/src/Services/Sorcha.Validator.Service/README.md
+++ b/src/Services/Sorcha.Validator.Service/README.md
@@ -464,6 +464,36 @@ message HealthStatusResponse {
 - `IsGenesis` = true
 - Special validation rules (no previous hash required)
 
+### Sealing pipeline & idle-stall resilience (issue #814)
+
+Sealing runs as a **two-stage pipeline**, each a `BackgroundService` loop over the Redis-backed
+`RegisterMonitoringRegistry` (`GetAll()`):
+
+1. **Validation** — `ValidationEngineService` polls each monitored register's **unverified pool**,
+   validates, and enqueues to the **verified queue**.
+2. **Docket build** — `DocketBuildTriggerService` drains the verified queue and seals a docket.
+
+**The failure mode (#814):** after a long idle a keep-alive connection (Redis or the wallet-service
+gRPC channel) goes stale. An `await` inside `ValidationEngineService.ProcessRegisterAsync` then *hangs*
+instead of throwing; the in-memory "already processing" flag (released only in a `finally`) is never
+released, so every later batch **skips that register forever** — the validator stays healthy but stops
+sealing. A restart recovered only because it cleared the in-memory flag and ran the startup pool drain.
+
+**The guards now in place:**
+- Each per-register cycle (both stages) is bounded by a linked `CancellationTokenSource`
+  (`ValidationTimeout` / 30 s), so a stale connection **throws** (caught → loop continues → the flag
+  is released) rather than hanging.
+- `_activeRegisters` is keyed by start time; a slot held past `StuckReclaimAfter`
+  (`max(3× ValidationTimeout, 90 s)`) is **reclaimed** — belt-and-braces for an await that ignores
+  cancellation and outlives its timeout.
+- The Redis multiplexer uses `KeepAlive` PINGs, `AbortOnConnectFail=false` + `ConnectRetry`
+  auto-reconnect, and explicit sync/async timeouts so a dead socket surfaces as a throw.
+
+**Observability** — the condition is no longer silent. Watch these counters
+(`Sorcha.Validator.Mempool` meter): `sorcha_validator_validation_cycle_timeout_total` (a cycle hit the
+stale-connection guard) and `sorcha_validator_validation_slot_reclaimed_total` (a stuck slot was
+reclaimed — any non-zero value means the timeout guard was itself bypassed and needs investigation).
+
 ---
 
 ## Configuration

--- a/src/Services/Sorcha.Validator.Service/Services/DocketBuildTriggerService.cs
+++ b/src/Services/Sorcha.Validator.Service/Services/DocketBuildTriggerService.cs
@@ -48,6 +48,11 @@ public class DocketBuildTriggerService : BackgroundService
     // Used when we haven't resolved the actual TTL yet.
     private const int DefaultOperationalTtlSeconds = 60;
 
+    // Upper bound on a single register's docket-build cycle. A stale register-service/Redis
+    // connection after long idle must make the cycle THROW (caught → loop continues) rather than
+    // hang and freeze the whole docket-build loop (issue #814 defense-in-depth for stage 2).
+    private static readonly TimeSpan DocketBuildCycleTimeout = TimeSpan.FromSeconds(30);
+
     public DocketBuildTriggerService(
         IServiceScopeFactory scopeFactory,
         IRegisterMonitoringRegistry registry,
@@ -133,7 +138,17 @@ public class DocketBuildTriggerService : BackgroundService
                 {
                     try
                     {
-                        await CheckAndBuildDocketAsync(registerId, stoppingToken);
+                        // Bound each register's cycle so a stale backend connection after idle cannot
+                        // hang and freeze the docket-build loop (issue #814 defense-in-depth).
+                        using var buildCts = CancellationTokenSource.CreateLinkedTokenSource(stoppingToken);
+                        buildCts.CancelAfter(DocketBuildCycleTimeout);
+                        await CheckAndBuildDocketAsync(registerId, buildCts.Token);
+                    }
+                    catch (OperationCanceledException) when (!stoppingToken.IsCancellationRequested)
+                    {
+                        _logger.LogError(
+                            "Docket-build cycle for register {RegisterId} exceeded {TimeoutSeconds:F0}s and was aborted to keep the docket-build loop alive (issue #814)",
+                            registerId, DocketBuildCycleTimeout.TotalSeconds);
                     }
                     catch (Exception ex)
                     {

--- a/src/Services/Sorcha.Validator.Service/Services/ValidationEngineService.cs
+++ b/src/Services/Sorcha.Validator.Service/Services/ValidationEngineService.cs
@@ -19,11 +19,24 @@ public class ValidationEngineService : BackgroundService
     private readonly IVerifiedTransactionQueue _verifiedQueue;
     private readonly IRegisterMonitoringRegistry _monitoringRegistry;
     private readonly ValidationEngineConfiguration _config;
+    private readonly ValidatorMempoolMetrics _metrics;
     private readonly ILogger<ValidationEngineService> _logger;
 
-    // Track active registers being validated
-    private readonly HashSet<string> _activeRegisters = [];
+    // Track active registers being validated, keyed by when processing STARTED (issue #814).
+    // The value is the start time so a flag that was never released (a processing await that hung
+    // and outlived its timeout, e.g. a call that ignores cancellation on a stale connection) can be
+    // reclaimed instead of skipping the register forever. A HashSet with a finally-only release was
+    // the original wedge: one hung await stranded the flag and every later batch skipped the register.
+    private readonly Dictionary<string, DateTimeOffset> _activeRegisters = new(StringComparer.Ordinal);
     private readonly object _registersLock = new();
+
+    // A register whose processing flag has been held longer than this is treated as STUCK and
+    // reclaimed. Comfortably longer than the per-register ValidationTimeout so a genuinely-in-flight
+    // register (bounded by that timeout) is never falsely reclaimed.
+    private TimeSpan StuckReclaimAfter => TimeSpan.FromTicks(Math.Max(_config.ValidationTimeout.Ticks * 3, TimeSpan.FromSeconds(90).Ticks));
+
+    // Testable clock seam (avoids taking a new IClock dependency across every call site).
+    internal Func<DateTimeOffset> Now { get; set; } = () => DateTimeOffset.UtcNow;
 
     public ValidationEngineService(
         IServiceScopeFactory scopeFactory,
@@ -31,6 +44,7 @@ public class ValidationEngineService : BackgroundService
         IVerifiedTransactionQueue verifiedQueue,
         IRegisterMonitoringRegistry monitoringRegistry,
         IOptions<ValidationEngineConfiguration> config,
+        ValidatorMempoolMetrics metrics,
         ILogger<ValidationEngineService> logger)
     {
         _scopeFactory = scopeFactory ?? throw new ArgumentNullException(nameof(scopeFactory));
@@ -38,6 +52,7 @@ public class ValidationEngineService : BackgroundService
         _verifiedQueue = verifiedQueue ?? throw new ArgumentNullException(nameof(verifiedQueue));
         _monitoringRegistry = monitoringRegistry ?? throw new ArgumentNullException(nameof(monitoringRegistry));
         _config = config?.Value ?? throw new ArgumentNullException(nameof(config));
+        _metrics = metrics ?? throw new ArgumentNullException(nameof(metrics));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -104,22 +119,42 @@ public class ValidationEngineService : BackgroundService
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(registerId);
 
-        // Check if already processing this register
+        // Admission guard (issue #814): skip a register only while it is GENUINELY in flight. A flag
+        // held past StuckReclaimAfter means a prior cycle never released it (a hung await that
+        // outlived its timeout / ignored cancellation) — reclaim it so validation resumes rather than
+        // skipping this register forever. The original HashSet + finally-only release was the wedge:
+        // one hung await stranded the flag and every later batch skipped the register permanently.
         lock (_registersLock)
         {
-            if (_activeRegisters.Contains(registerId))
+            if (_activeRegisters.TryGetValue(registerId, out var startedAt))
             {
-                _logger.LogDebug("Already processing register {RegisterId}, skipping", registerId);
-                return 0;
+                var heldFor = Now() - startedAt;
+                if (heldFor < StuckReclaimAfter)
+                {
+                    _logger.LogDebug("Already processing register {RegisterId}, skipping", registerId);
+                    return 0;
+                }
+
+                _logger.LogWarning(
+                    "Register {RegisterId} validation slot held {HeldSeconds:F0}s (> {ThresholdSeconds:F0}s) — reclaiming a stuck slot so validation can resume (issue #814)",
+                    registerId, heldFor.TotalSeconds, StuckReclaimAfter.TotalSeconds);
+                _metrics.RecordValidationSlotReclaimed(registerId);
             }
-            _activeRegisters.Add(registerId);
+            _activeRegisters[registerId] = Now();
         }
+
+        // Bound the whole cycle: after a long idle a stale Redis/gRPC connection must make the awaits
+        // THROW (caught below → loop continues, finally releases the flag), never hang forever and
+        // wedge the validation loop. This is the core #814 fix.
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        timeoutCts.CancelAfter(_config.ValidationTimeout);
+        var opCt = timeoutCts.Token;
 
         try
         {
             // Poll transactions from unverified pool
             var transactions = await _poolPoller.PollTransactionsAsync(
-                registerId, _config.BatchSize, ct);
+                registerId, _config.BatchSize, opCt);
 
             if (transactions.Count == 0)
             {
@@ -133,7 +168,7 @@ public class ValidationEngineService : BackgroundService
             // Validate the batch (create scope for scoped IValidationEngine)
             using var scope = _scopeFactory.CreateScope();
             var validationEngine = scope.ServiceProvider.GetRequiredService<IValidationEngine>();
-            var results = await validationEngine.ValidateBatchAsync(transactions, ct);
+            var results = await validationEngine.ValidateBatchAsync(transactions, opCt);
 
             var validCount = 0;
             var invalidCount = 0;
@@ -181,7 +216,7 @@ public class ValidationEngineService : BackgroundService
             // Return any transactions that couldn't be queued
             if (transactionsToReturn.Count > 0)
             {
-                await _poolPoller.ReturnTransactionsAsync(registerId, transactionsToReturn, ct);
+                await _poolPoller.ReturnTransactionsAsync(registerId, transactionsToReturn, opCt);
             }
 
             _logger.LogInformation(
@@ -189,6 +224,18 @@ public class ValidationEngineService : BackgroundService
                 registerId, validCount, invalidCount);
 
             return validCount;
+        }
+        catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !ct.IsCancellationRequested)
+        {
+            // The processing cycle exceeded ValidationTimeout (a stale connection after idle, most
+            // likely). Abort THIS cycle and return — the finally releases the slot and the next batch
+            // retries. Pending transactions stay in the unverified pool. Without this, the await would
+            // hang forever and wedge the entire validation loop (issue #814).
+            _logger.LogError(
+                "Register {RegisterId} validation cycle exceeded {TimeoutSeconds:F0}s and was aborted to keep the validation loop alive (issue #814); pending transactions remain in the pool for the next cycle",
+                registerId, _config.ValidationTimeout.TotalSeconds);
+            _metrics.RecordValidationCycleTimeout(registerId);
+            return 0;
         }
         finally
         {

--- a/src/Services/Sorcha.Validator.Service/Services/ValidatorMempoolMetrics.cs
+++ b/src/Services/Sorcha.Validator.Service/Services/ValidatorMempoolMetrics.cs
@@ -27,6 +27,8 @@ public sealed class ValidatorMempoolMetrics : IDisposable
     private readonly Meter _meter;
     private readonly Counter<long> _leaseExpired;
     private readonly Counter<long> _unregisteredWithPending;
+    private readonly Counter<long> _validationCycleTimeout;
+    private readonly Counter<long> _validationSlotReclaimed;
 
     /// <summary>Creates the meter and registers the counter instrument.</summary>
     public ValidatorMempoolMetrics(IMeterFactory meterFactory)
@@ -43,6 +45,16 @@ public sealed class ValidatorMempoolMetrics : IDisposable
             name: "sorcha_validator_monitoring_unregistered_with_pending_total",
             unit: "{register}",
             description: "Registers un-monitored (genesis-failure or roster-change) while unverified transactions were still pending — the orphans are left to the pool retry-limit eviction (Gap B). Non-zero values need admin attention (issue #787 Gap A).");
+
+        _validationCycleTimeout = _meter.CreateCounter<long>(
+            name: "sorcha_validator_validation_cycle_timeout_total",
+            unit: "{register}",
+            description: "Per-register validation cycles aborted for exceeding ValidationTimeout — the guard that stops a stale Redis/gRPC connection after idle from hanging and wedging the whole validation loop (issue #814). Sustained non-zero values mean a backend connection is unhealthy.");
+
+        _validationSlotReclaimed = _meter.CreateCounter<long>(
+            name: "sorcha_validator_validation_slot_reclaimed_total",
+            unit: "{register}",
+            description: "Stuck per-register validation slots reclaimed because a prior cycle never released the in-memory flag (a hung await that outlived its timeout). Belt-and-braces recovery for the issue #814 wedge; any non-zero value means the timeout guard was itself bypassed and needs investigation.");
     }
 
     /// <summary>
@@ -74,6 +86,26 @@ public sealed class ValidatorMempoolMetrics : IDisposable
             new KeyValuePair<string, object?>("reason", reason),
             new KeyValuePair<string, object?>("register_id", registerId),
             new KeyValuePair<string, object?>("pending_count", pendingCount));
+    }
+
+    /// <summary>
+    /// Records that a per-register validation cycle was aborted for exceeding ValidationTimeout
+    /// (issue #814 — the stale-connection hang guard fired). Increments once, tagged with the register.
+    /// </summary>
+    public void RecordValidationCycleTimeout(string registerId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(registerId);
+        _validationCycleTimeout.Add(1, new KeyValuePair<string, object?>("register_id", registerId));
+    }
+
+    /// <summary>
+    /// Records that a stuck per-register validation slot was reclaimed because a prior cycle never
+    /// released it (issue #814 belt-and-braces recovery). Increments once, tagged with the register.
+    /// </summary>
+    public void RecordValidationSlotReclaimed(string registerId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(registerId);
+        _validationSlotReclaimed.Add(1, new KeyValuePair<string, object?>("register_id", registerId));
     }
 
     /// <inheritdoc />

--- a/tests/Sorcha.Validator.Service.Tests/Services/ValidationEngineServiceIdleStallTests.cs
+++ b/tests/Sorcha.Validator.Service.Tests/Services/ValidationEngineServiceIdleStallTests.cs
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Sorcha.Validator.Service.Configuration;
+using Sorcha.Validator.Service.Models;
+using Sorcha.Validator.Service.Services;
+using Sorcha.Validator.Service.Services.Interfaces;
+
+namespace Sorcha.Validator.Service.Tests.Services;
+
+/// <summary>
+/// Issue #814 — the validator wedged after long idle: a validation-cycle await hung on a stale
+/// Redis/gRPC connection, the in-memory "already processing" flag was never released, and every later
+/// batch skipped the register forever (silent, healthy, no sealing). These tests assert the two guards
+/// in <see cref="ValidationEngineService.ProcessRegisterAsync"/>: (1) a hung cycle is bounded by
+/// ValidationTimeout so it THROWS and releases the slot rather than hanging; (2) a slot that somehow
+/// stays stuck (an await that ignored cancellation) is reclaimed on a later cycle instead of skipping
+/// the register forever. Metrics are asserted via a raw <see cref="MeterListener"/>.
+/// </summary>
+[Collection("ValidatorMempoolMetrics unregistered counter")]
+public sealed class ValidationEngineServiceIdleStallTests : IDisposable
+{
+    private const string RegisterId = "reg-idle-814";
+
+    private readonly Mock<ITransactionPoolPoller> _poller = new();
+    private readonly ServiceProvider _meterProvider;
+    private readonly ValidatorMempoolMetrics _metrics;
+    private readonly List<(string Instrument, long Value, Dictionary<string, object?> Tags)> _measurements = new();
+    private readonly MeterListener _listener;
+
+    public ValidationEngineServiceIdleStallTests()
+    {
+        _meterProvider = new ServiceCollection().AddMetrics().BuildServiceProvider();
+        _metrics = new ValidatorMempoolMetrics(_meterProvider.GetRequiredService<IMeterFactory>());
+
+        _listener = new MeterListener
+        {
+            InstrumentPublished = (instrument, listener) =>
+            {
+                if (instrument.Meter.Name == ValidatorMempoolMetrics.MeterName)
+                    listener.EnableMeasurementEvents(instrument);
+            }
+        };
+        _listener.SetMeasurementEventCallback<long>((inst, value, tags, _) =>
+            _measurements.Add((inst.Name, value, TagsToDict(tags))));
+        _listener.Start();
+    }
+
+    // Short timeout so the "hung cycle" test resolves fast; StuckReclaimAfter floors at 90s so the
+    // reclaim test drives the clock seam instead of waiting.
+    private ValidationEngineService CreateSut(TimeSpan? timeout = null) => new(
+        Mock.Of<IServiceScopeFactory>(),
+        _poller.Object,
+        Mock.Of<IVerifiedTransactionQueue>(),
+        Mock.Of<IRegisterMonitoringRegistry>(),
+        Options.Create(new ValidationEngineConfiguration { ValidationTimeout = timeout ?? TimeSpan.FromMilliseconds(300) }),
+        _metrics,
+        NullLogger<ValidationEngineService>.Instance);
+
+    [Fact]
+    public async Task ProcessRegisterAsync_CycleHangsRespectingCancellation_TimesOut_ReleasesSlot_RecordsMetric()
+    {
+        // Poll hangs but honours the token → the ValidationTimeout CTS cancels it → the cycle throws,
+        // is caught, and returns 0 WITHOUT hanging. Second call proves the slot was released.
+        var calls = 0;
+        _poller.Setup(p => p.PollTransactionsAsync(RegisterId, It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .Returns(async (string _, int _, CancellationToken ct) =>
+            {
+                Interlocked.Increment(ref calls);
+                await Task.Delay(Timeout.Infinite, ct); // cancelled by the timeout
+                return (IReadOnlyList<Transaction>)Array.Empty<Transaction>();
+            });
+
+        var sut = CreateSut(TimeSpan.FromMilliseconds(300));
+
+        var sw = Stopwatch.StartNew();
+        var result = await sut.ProcessRegisterAsync(RegisterId).WaitAsync(TimeSpan.FromSeconds(5));
+        sw.Stop();
+
+        result.Should().Be(0);
+        sw.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(4), "the timeout must abort the hung cycle, not hang");
+        _measurements.Should().ContainSingle(m => m.Instrument == "sorcha_validator_validation_cycle_timeout_total")
+            .Which.Tags.Should().Contain("register_id", RegisterId);
+
+        // Slot released → a second cycle actually re-enters the poller (not skipped).
+        var before = calls;
+        await sut.ProcessRegisterAsync(RegisterId).WaitAsync(TimeSpan.FromSeconds(5));
+        calls.Should().BeGreaterThan(before, "the released slot must let the next cycle run, not skip");
+    }
+
+    [Fact]
+    public async Task ProcessRegisterAsync_SlotStuckPastThreshold_IsReclaimed_AndProceeds()
+    {
+        // First cycle IGNORES cancellation and hangs forever — the slot is never released (the exact
+        // #814 wedge). A later cycle, past StuckReclaimAfter, must reclaim the slot and proceed.
+        var baseTime = new DateTimeOffset(2026, 7, 7, 12, 0, 0, TimeSpan.Zero);
+        var sut = CreateSut();
+        sut.Now = () => baseTime;
+
+        var first = true;
+        _poller.Setup(p => p.PollTransactionsAsync(RegisterId, It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .Returns(() =>
+            {
+                if (first)
+                {
+                    first = false;
+                    return HangForeverIgnoringCancellation();
+                }
+                return Task.FromResult((IReadOnlyList<Transaction>)Array.Empty<Transaction>());
+            });
+
+        // Fire the wedged cycle: runs synchronously through the admission guard (adds the slot at
+        // baseTime) then hangs at the poll await. Do not await it.
+        _ = sut.ProcessRegisterAsync(RegisterId);
+        await Task.Delay(100); // let it reach and park on the poll
+
+        // Advance the clock past the reclaim threshold (floors at 90s) and run a fresh cycle.
+        sut.Now = () => baseTime.AddSeconds(120);
+        var result = await sut.ProcessRegisterAsync(RegisterId).WaitAsync(TimeSpan.FromSeconds(5));
+
+        result.Should().Be(0);
+        _measurements.Should().ContainSingle(m => m.Instrument == "sorcha_validator_validation_slot_reclaimed_total")
+            .Which.Tags.Should().Contain("register_id", RegisterId);
+    }
+
+    [Fact]
+    public async Task ProcessRegisterAsync_SlotHeldWithinThreshold_IsSkipped_NotReclaimed()
+    {
+        // A genuinely in-flight register (slot held only briefly) must still be skipped — no double
+        // processing, no spurious reclaim.
+        var baseTime = new DateTimeOffset(2026, 7, 7, 12, 0, 0, TimeSpan.Zero);
+        var sut = CreateSut();
+        sut.Now = () => baseTime;
+
+        var pollCalls = 0;
+        _poller.Setup(p => p.PollTransactionsAsync(RegisterId, It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .Returns(() => { Interlocked.Increment(ref pollCalls); return HangForeverIgnoringCancellation(); });
+
+        _ = sut.ProcessRegisterAsync(RegisterId);
+        await Task.Delay(100);
+
+        sut.Now = () => baseTime.AddSeconds(10); // well under the 90s threshold
+        var result = await sut.ProcessRegisterAsync(RegisterId).WaitAsync(TimeSpan.FromSeconds(5));
+
+        result.Should().Be(0, "an in-flight register is skipped");
+        pollCalls.Should().Be(1, "the second cycle must skip, not re-enter the poller");
+        _measurements.Should().NotContain(m => m.Instrument == "sorcha_validator_validation_slot_reclaimed_total");
+    }
+
+    private static async Task<IReadOnlyList<Transaction>> HangForeverIgnoringCancellation()
+    {
+        await Task.Delay(Timeout.Infinite, CancellationToken.None);
+        return Array.Empty<Transaction>();
+    }
+
+    private static Dictionary<string, object?> TagsToDict(ReadOnlySpan<KeyValuePair<string, object?>> tags)
+    {
+        var dict = new Dictionary<string, object?>();
+        foreach (var kv in tags) dict[kv.Key] = kv.Value;
+        return dict;
+    }
+
+    public void Dispose()
+    {
+        _listener.Dispose();
+        _meterProvider.Dispose();
+    }
+}


### PR DESCRIPTION
- **fix: [814] self-heal the validator idle-stall — bound validation/docket cycles + reclaim stuck slots**
- **docs: [814] validator idle-stall pipeline resilience — README + troubleshooting skill**
