### PR TITLE
feat: [176] agent decides on disclosed application data, not an empty payload

### DIFF
--- a/.claude/skills/sorcha-architecture/SKILL.md
+++ b/.claude/skills/sorcha-architecture/SKILL.md
@@ -1687,3 +1687,54 @@ A credential **cannot embed its own issuance txId** (the SD-JWT is built before 
 Three screens: **Ask** (`Index.razor` — `QuestionPresets`: "Age over 18?" requests only `age_over_18`+`portrait`, "Confirm identity", "Custom"), **QR session** (unchanged OID4VP `direct_post` transport), **Verdict** (`Outcome.razor` — `IdCardLayout`-style header + the four-layer trail via `MudExpansionPanels`, label-left/status-right, disclosed-vs-withheld block proving minimal disclosure, register-anchor as a "tap to verify inclusion proof" beat). PWA shell: `wwwroot/manifest.webmanifest` (scope `/verify/`), `service-worker.js` (shell + `offline.html`; circuit not cached), `js/pwa-install.js` (`beforeinstallprompt`), wired in `App.razor` + an install button in `MainLayout.razor`. Trust runs `requireIssuerSignature:true` with the composite DID-backed resolver — the issuing org **must have an org master key** or its `iss` is the unresolvable bare-wallet form (the [[org-vc-issuer-did-anchoring]] split-brain).
 
 **Out of scope (roadmap):** WASM/offline verifier (path B), hard issuer allowlist, ZK age predicates, the external X.509/EUDI rail + Ed25519 certs, mdoc presentation.
+
+---
+
+## Agent-disclosed prior-action data (Feature 176)
+
+Closes a fail-open hole found live on n1 (2026-07-07): the autonomous `Sorcha.Agent` decided on an **empty**
+payload — it mapped `PendingAction.PreviousPayload` from the `/api/actions/pending` summary's
+`prepopulatedPayload` (a Feature-104 form-prefill seed, empty for the AIAS verify action), which does **not**
+carry the disclosed prior-action application data. Every external check defaulted (missing fields resolve to
+false/null), so a fake postcode "ZZ99 9ZZ" was **approved** and a credential issued. The blueprint grants the
+agent's `verification-analyst` participant `/*` disclosure, but the agent never fetched the disclosed view.
+
+**The endpoint (read-side of the DAD model).** `GET /api/workflows/{instanceId}/actions/{actionId}/disclosures`
+(+ instance-wide `GET /api/workflows/{instanceId}/disclosures`) in `WorkflowDisclosureEndpoints.cs`, filling a
+route the client (`IBlueprintServiceClient.GetDisclosedDataAsync`) and MCP `DisclosedDataTool` already targeted
+but no server implemented. `.RequireAuthorization()`; resolves the **caller's** wallet(s) via the same
+Wallet-Service fallback `ActionEndpoints.ResolveUserWalletAddressesAsync` uses (consumer/service tokens omit
+`wallet_address` under F136 — resolved by `platform_user_id`→owner, #912). Returns `DisclosedActionData`
+(`Models/DisclosedActionData.cs`): `recipientResolved` + merged `disclosedFields` (agent) + a per-prior-action
+`disclosures[]` list `{actionId, actionTitle, disclosedAt, data}` (MCP-compatible wire shape). Non-recipient →
+`200` with `recipientResolved:false` + empty view (distinguishes "no disclosure" from auth failure). No new JWT
+claim.
+
+**The shared resolver (`IActionDisclosureResolver`).** The disclosure logic was extracted from the previously
+private `ActionExecutionService.ApplyDisclosuresAsync` into `ActionDisclosureResolver` so the execution
+(submit) path and the query (read) path share **one** authority (`ActionExecutionService` now delegates to it —
+regression-guarded by the existing DevMode disclosure test). Two methods:
+- **Submit-side** `ApplyDisclosuresAsync(action, data, blueprint, participantWallets, registerId)` — engine
+  `ApplyDisclosures` (per-action JSON-Pointer rules) + participant→wallet resolution → `{wallet → fields}`.
+- **Read-side** `ResolveDisclosedDataAsync(instanceId, actionId, callerWallets, delegationToken)` —
+  **reconstruct-then-clamp**: `IStateReconstructionService.ReconstructAsync` scoped to the caller's wallets
+  yields each required prior action's caller-decryptable view (encrypted **and** dev-mode paths are normalised
+  by StateReconstruction), then the submit-side primitive **clamps** each action's data to the caller
+  participant's entitlement — a belt-and-braces guarantee that the dev-mode merge-everything fallback can never
+  widen disclosure to a non-recipient. `registerId` is derived from the instance (not a param). Fails closed to
+  an empty view on any reconstruction fault.
+
+**Agent consumption (`Sorcha.Agent`).** `IDecisionEngine.RequiresDisclosedPayload` gates the fetch:
+`RulesDecisionEngine` returns `_rulesRequireChecks` (rules referencing `checks.*`), `AiDecisionEngine` returns
+`false` — so only check-dependent agents fetch, and existing simple/persona agents are unaffected (no
+hold-forever regression). Per pending action `RunCommand` calls `DisclosedPayloadEnricher` (over
+`HttpDisclosedDataClient`, a raw GET with the agent's **user** bearer + `X-Delegation-Token` — NOT
+`BlueprintServiceClient`, which mints a service token and would resolve the wrong identity); on a fetch
+failure / non-recipient it **holds** (no submission, retries next poll), else sets `PreviousPayload =
+disclosedFields`. `PollingInboxListener` no longer sources `PreviousPayload` from the summary (kept only the
+`schema→dataSchema` correction). Defense-in-depth: `RulesDecisionEngine` also holds when `_rulesRequireChecks`
+and the payload is empty (mirrors the #1077 hold). US3 explainability: the structured "External checks
+evaluated … (from payload fields: […])" log identifies the evaluated facts + source fields for any decision.
+
+**Witness:** `demos/AIAS/rehearse.ps1` — valid → approved (credential delivered), invalid "ZZ99 9ZZ" → rejected
+(no credential). Spec: `specs/176-agent-disclosed-payload/`.

--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/175-federation-public-read"
+  "feature_directory": "specs/176-agent-disclosed-payload"
 }

--- a/docs/reference/API-DOCUMENTATION.md
+++ b/docs/reference/API-DOCUMENTATION.md
@@ -2125,6 +2125,51 @@ POST /api/execution/disclose
 }
 ```
 
+#### 5. Query Disclosed Prior-Action Data (Feature 176)
+
+Returns the prior-action data of a workflow instance **disclosed to the calling participant**, for the
+action being decided. This is the read-side of the DAD disclosure model — the autonomous agent reads it
+to decide on the applicant's real submitted data (rather than a blank view), and the MCP participant tool
+`sorcha_disclosed_data` consumes the same route. Only fields disclosed to the caller's participant are
+ever returned; the disclosure model is never widened.
+
+```http
+GET /api/workflows/{instanceId}/actions/{actionId}/disclosures
+GET /api/workflows/{instanceId}/disclosures          # instance-wide (anchored on the current action)
+```
+
+**Auth:** authenticated (`.RequireAuthorization()`). The caller's wallet(s) are resolved from the
+`wallet_address` JWT claim when present, else via a Wallet Service lookup keyed by the caller's identity
+(consumer/service-tier tokens omit the wallet binding under Feature 136). Supply the `X-Delegation-Token`
+header to enable disclosure-group decryption on encrypted (non dev-mode) registers.
+
+**Response:** `200 OK`
+```json
+{
+  "instanceId": "59ad957b-…",
+  "actionId": 2,
+  "registerId": "a4f3ac58…",
+  "recipientResolved": true,
+  "disclosures": [
+    {
+      "actionId": 1,
+      "actionTitle": "Submit Assured Identity Application",
+      "disclosedAt": null,
+      "data": { "name": { "fullName": "Ada Lovelace" }, "address": { "postcode": "SW1A 2AA" } }
+    }
+  ],
+  "disclosedFields": {
+    "name": { "fullName": "Ada Lovelace" },
+    "address": { "postcode": "SW1A 2AA" }
+  }
+}
+```
+
+When the caller is **not** a disclosure recipient the endpoint returns `200 OK` with
+`recipientResolved: false` and empty `disclosures` / `disclosedFields` (so a consumer can distinguish
+"nothing disclosed" from an auth failure). A consuming agent treats that — and any fetch failure — as a
+fail-closed hold.
+
 ---
 
 ## Encrypted Action Flow

--- a/specs/176-agent-disclosed-payload/checklists/requirements.md
+++ b/specs/176-agent-disclosed-payload/checklists/requirements.md
@@ -1,0 +1,45 @@
+# Specification Quality Checklist: Autonomous agent decides on disclosed application data
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-07-07
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Validated 2026-07-07. All items pass on the first iteration.
+- The spec stays at the "what/why" level: it requires the agent to decide on the **disclosed** prior-action
+  data (per the platform disclosure model) and to fail closed when that data is unavailable, without
+  prescribing the endpoint or code path — those are deferred to `/speckit.plan`.
+- Grounded in a real, reproduced live defect (AIAS on `n1`, 2026-07-07: invalid postcode "ZZ99 9ZZ"
+  approved), so the acceptance scenarios and success criteria are concrete and independently testable.
+- Two known implementation facts (the disclosed data is currently absent from the pending-actions summary;
+  a provisional field-name correction was already made) are recorded in Assumptions as context, not as
+  requirements — no implementation detail leaks into the FRs or Success Criteria.
+- No `[NEEDS CLARIFICATION]` markers: the "what" is unambiguous. The open design questions (which surface
+  provides the disclosed payload to a service-tier agent; new field vs. dedicated fetch) are implementation
+  choices for the plan phase, not spec ambiguities.

--- a/specs/176-agent-disclosed-payload/contracts/disclosed-data-endpoint.md
+++ b/specs/176-agent-disclosed-payload/contracts/disclosed-data-endpoint.md
@@ -1,0 +1,99 @@
+# Contract: Disclosed prior-action data endpoint + agent consumption
+
+**Feature**: 176-agent-disclosed-payload | **Date**: 2026-07-07
+
+## 1. Blueprint-service endpoint (NEW — fills an already-contracted client route)
+
+### `GET /api/workflows/{instanceId}/actions/{actionId}/disclosures`
+
+Returns the prior-action data disclosed to the **calling participant** for the given action.
+
+- **Also acceptable / align to existing client**: `GET /api/workflows/{instanceId}/disclosures`
+  (instance-wide) — whichever matches `IBlueprintServiceClient.GetDisclosedDataAsync()` /
+  `BlueprintServiceClient.cs:362-368`. The existing client + MCP `DisclosedDataTool` are the contract
+  authority; implement to them.
+
+**Auth**: `.RequireAuthorization()` (authenticated). The caller's wallet(s) are resolved from the token,
+falling back to the Wallet Service when the token has no `wallet_address` claim — identical to
+`ActionEndpoints.cs:178-184`. Disclosure is applied for the resolved caller wallet(s).
+
+**Path params**: `instanceId` (string), `actionId` (int).
+
+**200 response** (`DisclosedActionData`, aligned to the existing client type):
+
+```jsonc
+{
+  "instanceId": "59ad957b-...",
+  "actionId": 2,
+  "registerId": "a4f3ac58...",
+  "recipientResolved": true,
+  "disclosedFields": {
+    "name":    { "givenName": "Ada", "familyName": "Lovelace", "fullName": "Ada Lovelace" },
+    "address": { "line1": "10 Downing St", "postcode": "SW1A 2AA", "country": "GB" },
+    "email":   { "email": "ada@example.test" },
+    "emailVerified": true,
+    "portrait": { "tokenImageBase64": "…" }
+  }
+}
+```
+
+**Behavioural requirements**:
+- `disclosedFields` contains **only** fields disclosed to the caller's participant (`ApplyDisclosures` result).
+  No undisclosed field is present (FR-006/FR-010).
+- When the caller is **not** a disclosure recipient for the action → `recipientResolved=false` and
+  `disclosedFields` empty (drives the agent's fail-closed hold). Return 200 with the empty view (not 403) so
+  the agent can distinguish "no disclosure" from "auth failure"; **or** 404/403 per the existing client's
+  expectation — match the client. (Decide in tasks against the client's error handling.)
+- Same view regardless of register encryption/dev-mode.
+- Documented with `.WithSummary()` / `.WithDescription()`; response model has XML docs (Constitution III).
+
+**Reuse**: disclosure computed by the extracted `IActionDisclosureResolver` (from
+`ActionExecutionService.ApplyDisclosuresAsync`), so the endpoint and the execution path share one
+implementation.
+
+## 2. Shared resolver (NEW seam)
+
+### `IActionDisclosureResolver`
+
+```csharp
+/// Resolves the fields of an instance's prior action(s) disclosed to a given wallet.
+public interface IActionDisclosureResolver
+{
+    /// Returns the disclosed fields for {instanceId, actionId} as seen by {walletAddress}.
+    Task<DisclosedActionData> ResolveAsync(
+        string registerId, string instanceId, int actionId,
+        IReadOnlyCollection<string> callerWallets, CancellationToken ct);
+}
+```
+
+`ActionExecutionService` is refactored to depend on this resolver (no behaviour change; covered by tests to
+prevent drift).
+
+## 3. Client (`IBlueprintServiceClient`)
+
+`GetDisclosedDataAsync(instanceId, actionId?)` — confirm the existing signature + return type; the endpoint is
+written to match it. No new client method unless the existing one's shape needs a documented adjustment.
+
+## 4. Agent consumption (`Sorcha.Agent`)
+
+- **Fetch**: for each discovered pending action, before deciding, call `GetDisclosedDataAsync(instanceId,
+  actionId)` and set `PendingAction.PreviousPayload = disclosedFields`.
+- **Mapping cleanup**: `PollingInboxListener` maps `dataSchema` (not `schema`); `PreviousPayload` now comes
+  from the disclosed-data fetch, not the pending summary.
+- **Fail-closed** (`RulesDecisionEngine`, mirroring the #1077 `_rulesRequireChecks` pattern):
+  - if the disclosed-data fetch **fails** → `hold` ("Disclosed application data unavailable; held for manual review");
+  - if `recipientResolved=false` / `disclosedFields` empty **and** the rules require data → `hold`;
+  - never approve/reject on an empty payload.
+- **Explainability** (FR-008): keep the structured log of evaluated check facts
+  (`External checks evaluated … {facts} (from payload fields: […])`).
+
+## 5. Acceptance (maps to spec Success Criteria)
+
+| Contract behaviour | Spec |
+|---|---|
+| Invalid application (bad postcode) → agent rejects, no credential | SC-001, SC-003, US1-AS1 |
+| Valid application → agent approves, credential delivered | SC-002, US1-AS2 |
+| Endpoint returns only disclosed fields | FR-006/FR-010 |
+| Disclosed data unavailable → agent holds, no decision | SC-004, US2 |
+| Evaluated check facts retrievable/logged | SC-005, US3 |
+| End-to-end regression (valid + invalid) runs unattended | SC-006 |

--- a/specs/176-agent-disclosed-payload/data-model.md
+++ b/specs/176-agent-disclosed-payload/data-model.md
@@ -1,0 +1,86 @@
+# Phase 1 Data Model: Autonomous agent decides on disclosed application data
+
+**Feature**: 176-agent-disclosed-payload | **Date**: 2026-07-07
+
+No new persisted entities. The feature moves existing data (the disclosed prior-action payload) across an
+existing boundary. Entities below are transport/behavioural shapes.
+
+## Entities
+
+### DisclosedActionData (response of the disclosed-data endpoint)
+
+The subset of an instance's accumulated action data that is disclosed to the **calling participant**, keyed by
+the action it originated from.
+
+| Field | Type | Notes |
+|---|---|---|
+| `instanceId` | string | The workflow instance. |
+| `actionId` | int | The action being decided (the one whose prior data is requested). |
+| `registerId` | string | Register the instance lives on. |
+| `disclosedFields` | object (JSON) | The merged, disclosed prior-action payload as a JSON object — the fields the calling participant is entitled to see (e.g. `/name`, `/address`, `/email`, `/portrait`). This is what the agent feeds to its checks as `PreviousPayload`. |
+| `disclosedByAction` | map<int, object> *(optional)* | Same data partitioned by originating action id, when the caller needs provenance. |
+| `recipientResolved` | bool | True when the caller's wallet was resolved and disclosure applied; false → the caller is not a disclosure recipient (drives fail-closed). |
+
+**Shape alignment**: MUST match what `IBlueprintServiceClient.GetDisclosedDataAsync()` already deserialises
+(`BlueprintServiceClient.cs:362-368`). If the existing client type differs, the client contract is the
+authority — the endpoint is written to it (the client + MCP `DisclosedDataTool` are existing consumers).
+
+**Validation / disclosure rules**:
+- Only fields disclosed to the caller's participant appear (`ApplyDisclosures` engine result). No field the
+  applicant did not disclose to that participant is ever present (FR-006/FR-010).
+- Identical view whether the register stores payloads encrypted or in dev-mode plaintext (the endpoint returns
+  the disclosed/decoded-for-recipient view).
+
+### CheckFacts (agent, existing — now populated from real data)
+
+Produced by `ExternalCheckRunner.RunAsync(payload)` over the disclosed payload; merged under the `checks` key
+for the rules engine. Unchanged in shape; changed in that `payload` is now the real disclosed data, not `{}`.
+
+| Field | Type | Notes |
+|---|---|---|
+| `checks.<name>` | bool | One per configured check (e.g. `postcodeExists`, `emailVerified`, `photoPresent`, `profane`). |
+| `checks.<name>Detail` | string? | Optional detail (e.g. the queried postcode). |
+
+### AgentDecision (existing — now correct)
+
+| Field | Type | Notes |
+|---|---|---|
+| `decision` | enum | `approve` \| `reject` \| `hold`. |
+| `payload` | object? | The action payload the agent submits (carries the domain `decision`/`verificationNotes`). |
+| `reasoning` | string? | Human-readable reason (e.g. the on-brand rejection reason). |
+
+**New transition**: `hold` is now also produced when the disclosed payload required by the rules is
+unavailable/empty (FR-005), in addition to the existing #1077 "checks unavailable" hold.
+
+## State / decision transitions (agent, per pending action)
+
+```
+discover pending action
+   │
+   ▼
+fetch DisclosedActionData for (instanceId, actionId)   ──fetch fails / recipientResolved=false──▶  HOLD  (fail-closed)
+   │ success, disclosedFields present
+   ▼
+PreviousPayload := disclosedFields
+   │
+   ▼
+ExternalCheckRunner.RunAsync(PreviousPayload) → CheckFacts
+   │                                   (rules require checks but facts empty ──▶ HOLD, #1077 existing)
+   ▼
+RulesDecisionEngine evaluates rules over CheckFacts
+   │
+   ├─ a reject rule matches ─────▶ REJECT (submit action 2 with rejected payload; no credential)
+   └─ catch-all matches ─────────▶ APPROVE (submit action 2 with approved payload; credential issued)
+```
+
+## Identifiers the agent already has (from `PendingActionSummary`)
+
+`instanceId`, `actionId`, `registerId`, `blueprintId`, `transactionId` — sufficient to key the disclosed-data
+fetch (the endpoint reconstructs prior-action data from the instance's sealed transactions and applies
+disclosure for the caller's wallet).
+
+## Non-goals (data)
+
+- No new stored entity, table, or migration.
+- No change to disclosure rules or which participant is entitled to which field.
+- No change to the `PrepopulatedPayload` (Feature-104) semantics.

--- a/specs/176-agent-disclosed-payload/plan.md
+++ b/specs/176-agent-disclosed-payload/plan.md
@@ -1,0 +1,110 @@
+# Implementation Plan: Autonomous agent decides on disclosed application data
+
+**Branch**: `176-agent-disclosed-payload` | **Date**: 2026-07-07 | **Spec**: [spec.md](./spec.md)
+
+**Input**: Feature specification from `/specs/176-agent-disclosed-payload/spec.md`
+
+## Summary
+
+The autonomous agent currently decides on an empty payload because the disclosed prior-action data is not
+available on the surface it reads (`/api/actions/pending`). This plan implements the already-contracted
+**disclosed-data query endpoint** in the blueprint-service (`GET /api/workflows/{instanceId}/actions/{actionId}/disclosures`,
+already targeted by `IBlueprintServiceClient.GetDisclosedDataAsync()` and the MCP `DisclosedDataTool`),
+backed by a shared disclosure resolver extracted from `ActionExecutionService.ApplyDisclosuresAsync`. The
+agent's inbox/decision layer fetches the disclosed payload per pending action, feeds it to the external-check
+runner, and **holds** (fail-closed, #1077 pattern) when the disclosed data is unavailable. The evaluated
+check facts are logged for explainability. An end-to-end AIAS regression (valid→approved, invalid→rejected)
+plus unit coverage guard the behaviour. Design decision and evidence: see [research.md](./research.md).
+
+## Technical Context
+
+**Language/Version**: .NET 10 / C# 14 (nullable enabled, no Release warnings)
+**Primary Dependencies**: ASP.NET Core Minimal APIs + Scalar (blueprint-service); `Sorcha.ServiceClients.Http`
+(`IBlueprintServiceClient`); `Sorcha.Blueprint.Engine` (`ApplyDisclosures`); `Sorcha.Agent` inbox/decision
+(`PollingInboxListener`, `RulesDecisionEngine`, `ExternalCheckRunner`); System.Text.Json.
+**Storage**: Existing — sealed transactions in the register (source of the instance's accumulated data);
+no new persistence.
+**Testing**: xUnit + FluentAssertions + Moq (unit/integration); the AIAS `demos/AIAS/rehearse.ps1` end-to-end
+harness (valid + invalid application) as the regression witness.
+**Target Platform**: Linux containers (blueprint-service, agent); the agent also runs as a CLI/dotnet tool.
+**Project Type**: Web service (blueprint-service endpoint) + client application (`Sorcha.Agent`).
+**Performance Goals**: The disclosed-data fetch is an on-demand per-decision read; it must not be added to the
+high-frequency `/api/actions/pending` poll. One fetch per pending action the agent decides.
+**Constraints**: MUST respect the DAD disclosure model (agent receives only fields disclosed to its
+participant — FR-006/FR-010); MUST fail closed on unavailable/partial data (FR-005). No new JWT claim; reuse
+the wallet-service caller-wallet resolution `ActionEndpoints` already uses.
+**Scale/Scope**: Small, bounded change — one new endpoint (+ shared resolver extraction) in blueprint-service,
+one fetch-and-populate change + a fail-closed guard in the agent. No schema/disclosure-model changes.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Assessment |
+|---|---|
+| **I. Microservices-First** | PASS. Change is confined to blueprint-service (endpoint + resolver) and the agent client. Dependencies flow downward (agent → blueprint-service via `IBlueprintServiceClient`). No upward/core→app deps introduced. |
+| **II. Security First** | PASS — **security-positive.** Enforces the disclosure model (only disclosed fields reach the agent) and closes a real fail-open hole (decisions on blank data). Endpoint is authenticated; disclosure applied per recipient wallet. |
+| **III. API Documentation** | REQUIRED. The new endpoint MUST have `.WithSummary()`/`.WithDescription()` and XML docs on the response model; surfaces on `/openapi/v1.json` via Scalar. Captured as tasks. |
+| **IV. Testing (>85% new code)** | PASS by plan. Unit tests for the disclosure resolver + the endpoint (disclosed vs. undisclosed fields; caller-wallet resolution) and the agent's fetch-and-fail-closed path; integration test on the endpoint; the AIAS E2E regression (SC-006). |
+| **V. Code Quality** | PASS. async/await, DI (shared resolver injected), nullable, no new warnings; follows service folder structure. |
+| **VI. Blueprint Standards** | N/A — no blueprint authoring changes. |
+| **VII. DDD** | PASS. Disclosure is a domain concept; extracting the resolver puts one authority behind it (removes the private fork in `ActionExecutionService`). |
+| **VIII. Observability** | PASS. Structured logging of evaluated check facts (Story 3 / FR-008), no string interpolation; endpoint under existing telemetry. |
+
+**Result: PASS (no violations).** Re-checked after Phase 1 design — still PASS; the design adds no new
+service, no upward dependency, and strengthens the security posture. No Complexity Tracking entries required.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```
+specs/176-agent-disclosed-payload/
+├── spec.md              # Feature specification (/speckit.specify)
+├── plan.md              # This file (/speckit.plan)
+├── research.md          # Phase 0 — design decision (Design A) + evidence
+├── data-model.md        # Phase 1 — entities & response shapes
+├── quickstart.md        # Phase 1 — how to validate (AIAS E2E)
+├── contracts/           # Phase 1 — endpoint + agent-side contract
+│   └── disclosed-data-endpoint.md
+├── checklists/
+│   └── requirements.md  # Spec quality checklist (all pass)
+└── tasks.md             # Phase 2 — task breakdown (/speckit.tasks)
+```
+
+### Source Code (repository root — files touched)
+
+```
+src/Services/Sorcha.Blueprint.Service/
+├── Endpoints/ActionEndpoints.cs                 # + GET disclosures route (or a new WorkflowDisclosureEndpoints.cs)
+├── Services/
+│   ├── Interfaces/IActionDisclosureResolver.cs  # NEW — shared disclosure resolver seam
+│   └── Implementation/
+│       ├── ActionDisclosureResolver.cs          # NEW — extracted from ApplyDisclosuresAsync
+│       └── ActionExecutionService.cs            # refactor to use the shared resolver
+└── Models/DisclosedActionData*.cs               # response model (align to IBlueprintServiceClient contract)
+
+src/Common/Sorcha.ServiceClients.Http/Blueprint/
+├── IBlueprintServiceClient.cs                   # confirm GetDisclosedDataAsync signature/shape
+└── BlueprintServiceClient.cs                    # confirm route + deserialization
+
+src/Apps/Sorcha.Agent/
+├── Inbox/PollingInboxListener.cs                # finalise dataSchema mapping; wire disclosed-data fetch
+├── Inbox/(fetch)                                # per-pending-action disclosed-data fetch → PreviousPayload
+└── Decision/RulesDecisionEngine.cs              # fail-closed hold when disclosed payload required but empty; keep check-facts log
+
+tests/
+├── Sorcha.Blueprint.Service.Tests/…             # resolver + endpoint unit/integration tests
+└── Sorcha.Agent.Tests/…                         # fetch + fail-closed + decision-on-real-data tests
+demos/AIAS/rehearse.ps1                          # E2E regression witness (already exists)
+```
+
+**Structure decision**: Web-service + client. Endpoint work lives in blueprint-service (with the resolver
+extracted to a service seam); consumption + fail-closed lives in `Sorcha.Agent`; the shared HTTP client
+(`IBlueprintServiceClient`) is the seam between them.
+
+## Complexity Tracking
+
+No constitution violations — table intentionally omitted. The one refactor (extracting the disclosure
+resolver from `ActionExecutionService`) reduces complexity by removing a private, un-reusable code path and
+is covered by tests to prevent behavioural drift.

--- a/specs/176-agent-disclosed-payload/quickstart.md
+++ b/specs/176-agent-disclosed-payload/quickstart.md
@@ -1,0 +1,64 @@
+# Quickstart: Validate Feature 176 (agent decides on disclosed data)
+
+**Feature**: 176-agent-disclosed-payload | **Date**: 2026-07-07
+
+This is the end-to-end witness for the feature (spec SC-006). It proves the autonomous agent decides on the
+**real** disclosed application: a valid application is approved and a credential delivered; an invalid one
+(non-existent postcode) is rejected with no credential.
+
+## Prerequisites
+
+- A running Sorcha stack (Docker `docker-compose up -d`, or `n1`) with the AIAS demo provisioned:
+  `./demos/AIAS/run-demo.ps1 -Target <docker|n1> -Force`.
+- The Assure-ID agent running against that stack (built from this branch), authenticated as
+  `assure-id-agent@…` with `AGENT_EMAIL`/`AGENT_PASSWORD` set:
+  `dotnet run --project src/Apps/Sorcha.Agent -- run --config demos/AIAS/agent/assure-id.config.json --state demos/AIAS/state.json`
+
+## Automated end-to-end (the regression)
+
+```powershell
+./demos/AIAS/rehearse.ps1 -Target <docker|n1>
+```
+
+**Expected — PASS** (previously FAILED before this feature):
+
+- **Approval case** (valid postcode e.g. `SW1A 1AA`, verified email, portrait): agent records `approved`;
+  an `AssuredIdentityCredential` is delivered to the applicant's wallet.
+- **Rejection case** (postcode `ZZ99 9ZZ`): agent records `rejected` with the on-brand reason; **no credential
+  is issued**.
+
+## Manual spot-checks
+
+1. **Disclosed-data endpoint** returns the applicant's fields to the agent's participant:
+   ```bash
+   # as the agent (assure-id-agent), for a pending verify action's instance/action:
+   curl -sk "$GATEWAY/api/workflows/$INSTANCE/actions/$ACTION/disclosures" -H "Authorization: Bearer $AGENT_TOKEN"
+   # → disclosedFields contains name/address/email/emailVerified/portrait; recipientResolved=true
+   ```
+2. **Agent evaluates real data** — the agent log shows non-empty payload fields:
+   ```
+   External checks evaluated for Verify Assured Identity Application:
+     {"emailVerified":true,"photoPresent":true,"postcodeExists":false,"profane":false}
+     (from payload fields: [name, address, email, emailVerified, portrait])
+   ```
+   (For the bad-postcode case `postcodeExists:false` → the reject rule fires.)
+3. **Fail-closed** — make the disclosed-data endpoint temporarily unreachable for one application and confirm
+   the agent **holds** it (no approve/reject, no credential) and logs the hold reason; restore and confirm it
+   is then decided correctly.
+4. **Disclosure boundary** — confirm the endpoint returns only fields disclosed to the agent's participant
+   (no field the applicant did not disclose to `verification-analyst`).
+
+## Success criteria mapping
+
+| Check | Spec |
+|---|---|
+| `rehearse.ps1` PASS (approve valid, reject invalid) | SC-001, SC-002, SC-003, SC-006 |
+| Fail-closed hold on unavailable data | SC-004 |
+| Agent log shows the evaluated facts from real fields | SC-005 |
+
+## Notes
+
+- Drive the demo from a host without HTTPS interception when targeting `n1` (see the AVG-TLS note); the agent
+  itself can run anywhere that can reach the gateway.
+- This quickstart replaces ad-hoc diagnosis: a red `rehearse.ps1` with `postcodeExists:false` yet an approval
+  is the exact signature this feature fixes.

--- a/specs/176-agent-disclosed-payload/research.md
+++ b/specs/176-agent-disclosed-payload/research.md
@@ -1,0 +1,101 @@
+# Phase 0 Research: Autonomous agent decides on disclosed application data
+
+**Feature**: 176-agent-disclosed-payload | **Date**: 2026-07-07
+
+## Problem restated
+
+The autonomous agent (`Sorcha.Agent`) evaluates its external checks against `PendingAction.PreviousPayload`,
+which it maps from the `/api/actions/pending` response. That response (`PendingActionSummary`) carries
+`PrepopulatedPayload` (a Feature-104 form-prefill seed — empty for the AIAS verify action) and `DataSchema`,
+**not** the disclosed prior-action application data. So the agent decides on an empty payload; every check
+defaults to `false`. Confirmed live (n1, 2026-07-07): a diagnostic log showed
+`External checks evaluated … (from payload fields: [])`, and "ZZ99 9ZZ" was approved.
+
+## Key facts established (codebase, cited)
+
+- **The disclosed-data endpoints are already CONTRACTED but NOT IMPLEMENTED.**
+  `IBlueprintServiceClient.GetDisclosedDataAsync()` → `GET /api/workflows/{instanceId}/actions/{actionId}/disclosures`
+  and `GetActionDetailsAsync()` → `GET /api/actions/{actionInstanceId}`
+  (`src/Common/Sorcha.ServiceClients.Http/Blueprint/BlueprintServiceClient.cs:362-368`,
+  `IBlueprintServiceClient.cs:149-154`). Consumed by the MCP participant tools
+  (`Sorcha.McpServer/Tools/Participant/DisclosedDataTool.cs`, `ActionDetailsTool.cs`). The blueprint-service
+  has **no handler** for these routes yet.
+- **Disclosure resolution exists but is private.** `ActionExecutionService.ApplyDisclosuresAsync`
+  (`src/Services/Sorcha.Blueprint.Service/Services/Implementation/ActionExecutionService.cs:1722-1783`) calls
+  `_executionEngine.ApplyDisclosures(data, action)` (JSON-Pointer disclosure rules) and resolves participant →
+  wallet, returning `Dictionary<walletAddress, Dictionary<field, value>>` — the fields disclosed to each
+  recipient wallet.
+- **The pending endpoint already resolves the caller's wallets without a `wallet_address` claim.**
+  `ActionEndpoints` (`ActionEndpoints.cs:27-114, 178-184`) resolves the caller's owned wallets via a Wallet
+  Service fallback when the token omits `wallet_address` (F136 consumer/service tokens omit wallet binding).
+  `EfCoreInstanceStore.GetPendingActionsByWalletAsync(wallet)` runs per resolved wallet.
+- **The agent's wallet IS the disclosure recipient.** At AIAS provisioning the `verification-analyst`
+  participant placeholder is bound to the agent's wallet (provision log: "Patched verification-analyst ->
+  ws11q…"). So "disclosed to `verification-analyst`" == "disclosed to the agent's wallet". Resolving the
+  caller's wallet and applying disclosure for it yields exactly the view the agent needs.
+- **The agent authenticates as a user (email/password), not a bare service token.**
+  `Sorcha.Agent/Auth/AgentAuthService.cs:36-90` — so the same wallet-resolution the pending endpoint uses
+  applies. (A future move to a pure service token would need wallet resolution from `platform_user_id`/`org` —
+  noted as a follow-up, not a blocker here.)
+- **Fail-closed pattern already exists.** `RulesDecisionEngine` (`RulesDecisionEngine.cs:26-31, 80-95`) holds
+  when `_rulesRequireChecks` is true but no check facts are available (#1077). The same shape extends to
+  "hold when the disclosed payload is unavailable".
+
+## Decision: **Design A — implement the already-contracted disclosed-data query endpoint; the agent fetches it per pending action**
+
+Implement the disclosed-data endpoint that `IBlueprintServiceClient.GetDisclosedDataAsync()` and the MCP
+`DisclosedDataTool` already expect, in the blueprint-service. It:
+1. requires authentication (`.RequireAuthorization()`), resolves the **caller's** wallet(s) via the same
+   Wallet-Service fallback `ActionEndpoints` uses;
+2. reconstructs the instance's accumulated data for the target action from its sealed transactions;
+3. applies the blueprint's disclosure rules for the caller's wallet(s) (reusing the `ApplyDisclosures`
+   engine call, extracted into a shared, injectable resolver so it is no longer private to
+   `ActionExecutionService`);
+4. returns the disclosed prior-action payload (keyed by prior action) for that participant.
+
+The agent's inbox/decision layer fetches this per pending action and populates `PendingAction.PreviousPayload`
+before the checks run; if the fetch fails or returns empty when data is required, the agent **holds**.
+
+### Rationale
+
+- **It is the intended contract.** The client interface + MCP tools already target these routes; we are
+  filling an implemented-elsewhere gap, and the human MCP participant surface and the agent share one endpoint
+  and one disclosure code path (no divergence).
+- **Correct disclosure semantics.** Disclosure is keyed by the *recipient* participant's wallet. Design A
+  applies disclosure for the caller's wallet — which is the recipient here — so the agent sees exactly what
+  `verification-analyst` is entitled to and nothing more (FR-006, FR-010).
+- **Separation of concerns.** Disclosed data is an on-demand read query, kept out of the high-frequency
+  `/api/actions/pending` poll and distinct from the Feature-104 `PrepopulatedPayload` form-prefill.
+- **Reuses existing machinery** (`ApplyDisclosures`, wallet-resolution fallback) rather than inventing new
+  disclosure logic — lower risk, DAD-model-faithful.
+
+### Alternatives considered
+
+- **Design B — enrich `/api/actions/pending` with the disclosed payload.** Rejected: (1) conflates
+  Feature-104 form-prefill with disclosed prior-action data in one field; (2) forces disclosure resolution
+  into the hot polling path for every poll even when unused; (3) muddies the "keyed by recipient wallet"
+  semantics by piggy-backing on the "wallets the caller owns" query. The single-round-trip benefit does not
+  outweigh the architectural cost, and it would not be reusable by the MCP participant tools that already
+  expect the dedicated endpoint.
+- **Add a participant/wallet claim to the agent's token.** Rejected as unnecessary and F136-contradicting —
+  the wallet-service fallback already resolves the caller's wallets server-side.
+
+### Consequences / follow-ups
+
+- Extract the disclosure resolution out of `ActionExecutionService` into a shared resolver so both the
+  execution path and the new endpoint use one implementation (no behaviour fork).
+- Finalise the field-name correction already staged on the branch (`PollingInboxListener` read
+  `payload`/`schema`; the API serialises `prepopulatedPayload`/`dataSchema`) — but the agent will now source
+  `PreviousPayload` from the disclosed-data fetch, so the mapping change becomes moot for `PreviousPayload`
+  and remains only for `Schema` (`dataSchema`).
+- Pure-service-token agents (no user login) are out of scope; if adopted later, wallet resolution from
+  `platform_user_id`/`org_id` is the extension point.
+
+## Unknowns resolved
+
+| Unknown | Resolution |
+|---|---|
+| Does a disclosed-projection endpoint exist? | Contracted client-side + MCP, **not implemented** server-side. Implement it. |
+| How is per-participant disclosure computed? | `ApplyDisclosures` engine call + participant→wallet resolution (`ActionExecutionService.ApplyDisclosuresAsync`); extract to a shared resolver. |
+| Can the agent be identified as its participant? | Yes — via the caller's-wallet resolution the pending endpoint already uses; the agent's wallet is the `verification-analyst` recipient. |
+| Where does fail-closed live? | `RulesDecisionEngine` hold path (#1077); extend to "disclosed payload unavailable". |

--- a/specs/176-agent-disclosed-payload/spec.md
+++ b/specs/176-agent-disclosed-payload/spec.md
@@ -1,0 +1,201 @@
+# Feature Specification: Autonomous agent decides on disclosed application data
+
+**Feature Branch**: `176-agent-disclosed-payload`
+
+**Created**: 2026-07-07
+
+**Status**: Draft
+
+**Input**: User description: "Sorcha-agent must evaluate its external checks against the real disclosed application data, not an empty payload."
+
+## Overview
+
+An autonomous Sorcha agent (e.g. the AIAS "Assure-ID" verifier) assesses incoming applications by
+running a set of configured checks (address exists, email verified, photo present, language clean) and
+approving or rejecting based on rules over the results of those checks. For the assessment to mean
+anything, the agent must evaluate the checks against the **actual data the applicant submitted** — the
+data the register has **disclosed to the agent's participant**.
+
+Today the agent decides against an **empty** view of the application: it never receives the disclosed
+prior-action data. Every check therefore resolves to its safe default, the rules are applied to blank
+facts, and the outcome is meaningless. This was found during the first live validation of the AIAS
+Assured-Identity flow on the `n1` network (2026-07-07): a deliberately invalid postcode ("ZZ99 9ZZ")
+was **approved** and a credential issued, and a valid application would be judged on the same blank
+data. This feature makes the agent decide on the disclosed application data so its assessments are
+trustworthy.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Agent decides on the real application (Priority: P1)
+
+An autonomous verification agent, granted disclosure of an application's fields, evaluates its checks
+against those actual fields and approves or rejects accordingly. A citizen who submits a valid
+application is approved and issued their credential; a citizen who submits an invalid one (e.g. a
+non-existent address) is rejected with the configured reason and receives no credential.
+
+**Why this priority**: This is the entire point of an autonomous assessor. Without it the agent's
+approve/reject decision is noise, and — worse than useless — it can issue credentials for applications
+that should be refused, undermining the trust the credential is meant to convey. It is the minimum
+viable slice: implementing only this story restores a working, meaningful autonomous assessment.
+
+**Independent Test**: Submit two applications to a register the agent monitors — one valid, one with a
+disqualifying field (invalid address). Confirm the agent approves the first (credential delivered) and
+rejects the second (no credential, correct reason recorded), with no human involvement.
+
+**Acceptance Scenarios**:
+
+1. **Given** an agent granted disclosure of an application's fields and a rule that rejects a
+   non-existent address, **When** a citizen submits an application with a non-existent address,
+   **Then** the agent records a rejection with the configured reason and **no credential is issued**.
+2. **Given** the same agent and a clean, valid application (address exists, email verified, photo
+   present, language clean), **When** the citizen submits it, **Then** the agent records an approval
+   and the citizen's credential is issued and delivered.
+3. **Given** an application, **When** the agent evaluates it, **Then** each check is evaluated against
+   the applicant's actual submitted value for the relevant field (not a default/blank value).
+
+---
+
+### User Story 2 - The agent never decides on missing data (Priority: P2)
+
+If the agent cannot obtain the disclosed application data it needs — the register is briefly
+unreachable, disclosure has not propagated, or the data is genuinely absent — the agent must **hold**
+the application for manual review rather than guess. It must never approve (or reject) an application on
+the basis of an empty or partial view of the data.
+
+**Why this priority**: A silent "approve on no data" is the exact failure this feature exists to
+prevent; a silent "reject on no data" is equally wrong (it refuses legitimate applicants). Fail-closed
+holding preserves correctness under transient faults and is consistent with the platform's existing
+agent fail-closed policy. P2 because Story 1 delivers the core value, but this guard is what makes it
+safe in production.
+
+**Independent Test**: Make the disclosed data temporarily unavailable for an application the agent must
+decide, and confirm the agent holds it (no approve, no reject, no credential) and logs an actionable
+reason; then restore availability and confirm the same application is decided correctly.
+
+**Acceptance Scenarios**:
+
+1. **Given** an application whose disclosed data cannot be retrieved, **When** the agent processes it,
+   **Then** the agent holds it for manual review and issues no credential.
+2. **Given** an application whose disclosed data is retrieved but is missing a field a rule depends on,
+   **When** the agent processes it, **Then** the agent holds rather than treating the missing field as
+   a pass/fail default.
+3. **Given** a held application, **When** the disclosed data later becomes available, **Then** the
+   agent re-evaluates it and reaches the correct approve/reject decision without manual intervention.
+
+---
+
+### User Story 3 - Every decision is explainable (Priority: P3)
+
+An operator or demo-runner can see, for any application the agent decided, which check results drove the
+decision — so a surprising outcome can be diagnosed without guesswork.
+
+**Why this priority**: The original defect was invisible for weeks precisely because the agent gave no
+insight into what it evaluated. Explainability turns a future recurrence into a two-minute diagnosis
+rather than a multi-hour investigation. P3 because it improves operability rather than the decision
+itself.
+
+**Independent Test**: After the agent decides an application, retrieve the record of the check results
+that produced the decision and confirm they reflect the applicant's actual data.
+
+**Acceptance Scenarios**:
+
+1. **Given** the agent has decided an application, **When** an operator inspects the agent's record,
+   **Then** the check results (and which fields they were derived from) that drove the decision are
+   visible.
+2. **Given** a rejection, **When** an operator inspects the record, **Then** the specific failing
+   check(s) are identifiable.
+
+### Edge Cases
+
+- **Nothing disclosed to the agent**: the agent's participant is not granted disclosure of any field
+  the checks need → the agent must hold (Story 2), not approve on blanks.
+- **Partial disclosure**: the agent is granted some fields but not one a rule depends on → hold.
+- **Encrypted vs. plaintext register**: the agent receives the same disclosed view regardless of whether
+  the register stores payloads encrypted or in plaintext (dev mode).
+- **Application resubmitted / superseded**: the agent decides against the current disclosed data for the
+  action it is assessing, not a stale earlier version.
+- **Multiple monitored registers / applications in flight**: each decision uses the disclosed data for
+  its own application; data from one application never bleeds into another's assessment.
+- **Non-agent consumers unaffected**: existing human-facing surfaces that already show applicants'
+  disclosed data continue to work unchanged.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The agent MUST obtain, for each action it is assigned to decide, the data of the prior
+  action(s) **as disclosed to the agent's own participant** under the register's disclosure model.
+- **FR-002**: The agent MUST evaluate each configured check against the applicant's actual submitted
+  value for the field that check inspects, sourced from the disclosed data in FR-001.
+- **FR-003**: The agent MUST base its approve/reject decision on the results of those checks over the
+  real data, such that an application with a disqualifying field is rejected and a fully-valid
+  application is approved.
+- **FR-004**: The agent MUST NOT issue (or cause the issuance of) a credential for an application it
+  rejects.
+- **FR-005**: When the disclosed data required to evaluate the checks cannot be obtained, or is missing
+  a field a rule depends on, the agent MUST hold the application for manual review and MUST NOT approve
+  or reject it. (Fail-closed, consistent with the platform's agent fail-closed policy.)
+- **FR-006**: The system MUST only expose to the agent the fields that are disclosed to the agent's
+  participant — the agent MUST NOT receive fields the applicant did not disclose to it.
+- **FR-007**: A non-human, service-tier agent identity MUST be able to retrieve the disclosed data it is
+  authorised to see for the applications on the registers it monitors.
+- **FR-008**: The check results that drive a decision MUST be recorded/observable so a decision can be
+  explained after the fact (which checks passed/failed, and which fields they were derived from).
+- **FR-009**: A held application MUST be re-evaluated and decided correctly once the disclosed data
+  becomes available, without manual intervention.
+- **FR-010**: The change MUST NOT alter the disclosed data seen by existing human-facing consumers, and
+  MUST NOT weaken the disclosure model (no field becomes visible to a party not already entitled to it).
+
+### Key Entities *(include if feature involves data)*
+
+- **Disclosed action data**: the subset of an action's submitted payload that the register has disclosed
+  to a given participant, per the disclosure rules of the blueprint. The agent consumes the view
+  disclosed to *its* participant.
+- **Agent decision**: the outcome (approve / reject / hold) for an application, the human-readable
+  reason, and the check results that produced it.
+- **Verification agent identity**: the non-human, service-tier identity the agent authenticates as,
+  mapped to a workflow participant that has been granted disclosure of the fields its checks need.
+- **Check result**: the boolean (and optional detail) produced by one configured check evaluated against
+  the disclosed data (e.g. "address exists = false").
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 100% of applications with a disqualifying field (e.g. a non-existent address) are rejected;
+  0% are approved.
+- **SC-002**: 100% of fully-valid applications are approved and result in a delivered credential.
+- **SC-003**: 0 credentials are issued for rejected applications.
+- **SC-004**: When required disclosed data is unavailable, 100% of affected applications are held (0 are
+  approved or rejected on incomplete data).
+- **SC-005**: For every decided application, the check results that drove the decision are retrievable
+  and reflect the applicant's actual submitted data.
+- **SC-006**: An automated end-to-end check (one valid + one invalid application) passes with no human
+  involvement, and can be re-run as a regression guard.
+
+## Assumptions
+
+- The blueprint being assessed grants the agent's participant disclosure of the fields its checks
+  require (e.g. the AIAS blueprint already discloses `/*` of the application to the `verification-analyst`
+  participant). This feature consumes existing disclosure; it does not grant new disclosure.
+- The register's disclosure model (the platform's DAD model) is the single authority on what the agent
+  may see; the agent receives exactly the disclosed view, whether the register stores payloads encrypted
+  or in dev-mode plaintext.
+- The existing autonomous agent, its external-check framework, and its rules engine are reused; this
+  feature changes **where the data the checks evaluate comes from**, not the check/rule model itself.
+- The agent authenticates as a service-tier identity mapped to a workflow participant (already true for
+  the AIAS Assure-ID agent).
+- A field-name mismatch already found and provisionally corrected during diagnosis (the agent read a
+  differently-named property than the API returns) is in scope to finalise as part of this feature, but
+  is not by itself sufficient — the disclosed data must actually be made available to the agent.
+- Fixing the source of the disclosed data for the agent will not change the human-facing verifier
+  experience, which already renders the disclosed application correctly.
+
+## Out of Scope
+
+- Changing the disclosure model, or granting the agent visibility of fields not already disclosed to its
+  participant.
+- The human web-verifier experience (already functional).
+- New check types or rule-language changes.
+- The unrelated `n1` validator idle-stall work (issue #814) and the agent fail-closed hardening
+  (#1077), which are prerequisites/relatives, not part of this feature's delivery.

--- a/specs/176-agent-disclosed-payload/tasks.md
+++ b/specs/176-agent-disclosed-payload/tasks.md
@@ -18,16 +18,16 @@ real application (bad postcode rejected, clean approved). US2 (fail-closed) and 
 
 ## Phase 1: Setup
 
-- [ ] T001 [P] Record the authoritative disclosed-data contract: read `GetDisclosedDataAsync` route + return type in `src/Common/Sorcha.ServiceClients.Http/Blueprint/IBlueprintServiceClient.cs` and `src/Common/Sorcha.ServiceClients.Http/Blueprint/BlueprintServiceClient.cs`, and the MCP consumer expectations in `src/Apps/Sorcha.McpServer/Tools/Participant/DisclosedDataTool.cs`; note the exact route + DTO the server MUST match into `specs/176-agent-disclosed-payload/contracts/disclosed-data-endpoint.md`.
-- [ ] T002 [P] Define/align the `DisclosedActionData` response model (reuse the existing client DTO if present) in `src/Services/Sorcha.Blueprint.Service/Models/` with XML docs on every member (Constitution III).
+- [x] T001 [P] Record the authoritative disclosed-data contract: read `GetDisclosedDataAsync` route + return type in `src/Common/Sorcha.ServiceClients.Http/Blueprint/IBlueprintServiceClient.cs` and `src/Common/Sorcha.ServiceClients.Http/Blueprint/BlueprintServiceClient.cs`, and the MCP consumer expectations in `src/Apps/Sorcha.McpServer/Tools/Participant/DisclosedDataTool.cs`; note the exact route + DTO the server MUST match into `specs/176-agent-disclosed-payload/contracts/disclosed-data-endpoint.md`.
+- [x] T002 [P] Define/align the `DisclosedActionData` response model (reuse the existing client DTO if present) in `src/Services/Sorcha.Blueprint.Service/Models/` with XML docs on every member (Constitution III).
 
 ## Phase 2: Foundational (blocking prerequisites — MUST complete before user stories)
 
-- [ ] T003 Create the resolver seam `IActionDisclosureResolver` in `src/Services/Sorcha.Blueprint.Service/Services/Interfaces/IActionDisclosureResolver.cs` (per contracts §2).
-- [ ] T004 Extract the disclosure logic from `ActionExecutionService.ApplyDisclosuresAsync` (`src/Services/Sorcha.Blueprint.Service/Services/Implementation/ActionExecutionService.cs:1722-1783`) into `src/Services/Sorcha.Blueprint.Service/Services/Implementation/ActionDisclosureResolver.cs` (engine `ApplyDisclosures` + participant→wallet resolution), and register it in DI in the service's Program/extensions.
-- [ ] T005 Refactor `ActionExecutionService` to depend on `IActionDisclosureResolver` (no behaviour change) in `src/Services/Sorcha.Blueprint.Service/Services/Implementation/ActionExecutionService.cs`.
-- [ ] T006 [P] Unit tests for `ActionDisclosureResolver` in `tests/Sorcha.Blueprint.Service.Tests/Services/ActionDisclosureResolverTests.cs`: only-disclosed-fields returned; caller-wallet resolution (incl. multi-wallet); non-recipient → empty/`recipientResolved=false`; identical view for encrypted vs dev-mode payloads.
-- [ ] T007 Regression guard: an existing `ActionExecutionService` disclosure test (or a new one) proves the refactor (T005) did not change disclosure behaviour, in `tests/Sorcha.Blueprint.Service.Tests/Services/ActionExecutionServiceTests.cs`.
+- [x] T003 Create the resolver seam `IActionDisclosureResolver` in `src/Services/Sorcha.Blueprint.Service/Services/Interfaces/IActionDisclosureResolver.cs` (per contracts §2).
+- [x] T004 Extract the disclosure logic from `ActionExecutionService.ApplyDisclosuresAsync` (`src/Services/Sorcha.Blueprint.Service/Services/Implementation/ActionExecutionService.cs:1722-1783`) into `src/Services/Sorcha.Blueprint.Service/Services/Implementation/ActionDisclosureResolver.cs` (engine `ApplyDisclosures` + participant→wallet resolution), and register it in DI in the service's Program/extensions.
+- [x] T005 Refactor `ActionExecutionService` to depend on `IActionDisclosureResolver` (no behaviour change) in `src/Services/Sorcha.Blueprint.Service/Services/Implementation/ActionExecutionService.cs`.
+- [x] T006 [P] Unit tests for `ActionDisclosureResolver` in `tests/Sorcha.Blueprint.Service.Tests/Services/ActionDisclosureResolverTests.cs`: only-disclosed-fields returned; caller-wallet resolution (incl. multi-wallet); non-recipient → empty/`recipientResolved=false`; identical view for encrypted vs dev-mode payloads.
+- [x] T007 Regression guard: an existing `ActionExecutionService` disclosure test (or a new one) proves the refactor (T005) did not change disclosure behaviour, in `tests/Sorcha.Blueprint.Service.Tests/Services/ActionExecutionServiceTests.cs`.
 
 **Checkpoint**: shared disclosure resolver exists, tested, and `ActionExecutionService` uses it with no drift.
 
@@ -43,15 +43,15 @@ rejects the second (no credential), unattended (spec US1 / SC-001/002/003).
 
 ### Tests (write first)
 
-- [ ] T008 [P] [US1] Endpoint integration test in `tests/Sorcha.Blueprint.Service.Tests/Endpoints/WorkflowDisclosureEndpointsTests.cs`: authenticated recipient caller → `disclosedFields` populated with only disclosed fields; non-recipient caller → empty/`recipientResolved=false`; caller-wallet resolved via the Wallet-Service fallback (no `wallet_address` claim).
-- [ ] T009 [P] [US1] Agent inbox test in `tests/Sorcha.Agent.Tests/Inbox/DisclosedPayloadFetchTests.cs`: given a pending action, the inbox fetch calls `GetDisclosedDataAsync(instanceId, actionId)` and sets `PendingAction.PreviousPayload` to the disclosed fields.
-- [ ] T010 [P] [US1] Agent decision test in `tests/Sorcha.Agent.Tests/Decision/DecideOnRealDataTests.cs`: with a real disclosed payload, a non-existent postcode yields a `rejected` decision payload and a clean payload yields `approved` (rules over real `checks.*` facts).
+- [x] T008 [P] [US1] Endpoint integration test in `tests/Sorcha.Blueprint.Service.Tests/Endpoints/WorkflowDisclosureEndpointsTests.cs`: authenticated recipient caller → `disclosedFields` populated with only disclosed fields; non-recipient caller → empty/`recipientResolved=false`; caller-wallet resolved via the Wallet-Service fallback (no `wallet_address` claim).
+- [x] T009 [P] [US1] Agent inbox test in `tests/Sorcha.Agent.Tests/Inbox/DisclosedPayloadFetchTests.cs`: given a pending action, the inbox fetch calls `GetDisclosedDataAsync(instanceId, actionId)` and sets `PendingAction.PreviousPayload` to the disclosed fields.
+- [x] T010 [P] [US1] Agent decision test in `tests/Sorcha.Agent.Tests/Decision/DecideOnRealDataTests.cs`: with a real disclosed payload, a non-existent postcode yields a `rejected` decision payload and a clean payload yields `approved` (rules over real `checks.*` facts).
 
 ### Implementation
 
-- [ ] T011 [US1] Implement `GET /api/workflows/{instanceId}/actions/{actionId}/disclosures` (match the T001 contract) in `src/Services/Sorcha.Blueprint.Service/Endpoints/WorkflowDisclosureEndpoints.cs` (or extend `ActionEndpoints.cs`): `.RequireAuthorization()`, resolve caller wallet(s) via the Wallet-Service fallback used in `ActionEndpoints.cs:178-184`, call `IActionDisclosureResolver`, return `DisclosedActionData`; add `.WithName`/`.WithSummary`/`.WithDescription` (Constitution III).
-- [ ] T012 [US1] Confirm/adjust `IBlueprintServiceClient.GetDisclosedDataAsync` + `BlueprintServiceClient` (`src/Common/Sorcha.ServiceClients.Http/Blueprint/`) so route + deserialization match the implemented endpoint.
-- [ ] T013 [US1] Wire the agent inbox to fetch disclosed data per pending action and populate `PreviousPayload`, and finalise the `dataSchema` mapping, in `src/Apps/Sorcha.Agent/Inbox/PollingInboxListener.cs` (+ a small fetch helper/service using `IBlueprintServiceClient`); ensure `PreviousPayload` is sourced from the fetch, not the pending summary.
+- [x] T011 [US1] Implement `GET /api/workflows/{instanceId}/actions/{actionId}/disclosures` (match the T001 contract) in `src/Services/Sorcha.Blueprint.Service/Endpoints/WorkflowDisclosureEndpoints.cs` (or extend `ActionEndpoints.cs`): `.RequireAuthorization()`, resolve caller wallet(s) via the Wallet-Service fallback used in `ActionEndpoints.cs:178-184`, call `IActionDisclosureResolver`, return `DisclosedActionData`; add `.WithName`/`.WithSummary`/`.WithDescription` (Constitution III).
+- [x] T012 [US1] Confirm/adjust `IBlueprintServiceClient.GetDisclosedDataAsync` + `BlueprintServiceClient` (`src/Common/Sorcha.ServiceClients.Http/Blueprint/`) so route + deserialization match the implemented endpoint.
+- [x] T013 [US1] Wire the agent inbox to fetch disclosed data per pending action and populate `PreviousPayload`, and finalise the `dataSchema` mapping, in `src/Apps/Sorcha.Agent/Inbox/PollingInboxListener.cs` (+ a small fetch helper/service using `IBlueprintServiceClient`); ensure `PreviousPayload` is sourced from the fetch, not the pending summary.
 - [ ] T014 [US1] Run the end-to-end regression `demos/AIAS/rehearse.ps1 -Target docker` (valid → approved + credential; invalid `ZZ99 9ZZ` → rejected + no credential) and confirm PASS (SC-001/002/003/006).
 
 **Checkpoint**: US1 independently delivers a working autonomous assessment. This is the MVP.
@@ -68,13 +68,13 @@ no credential, actionable reason); restore → same application decided correctl
 
 ### Tests (write first)
 
-- [ ] T015 [P] [US2] `RulesDecisionEngine` test in `tests/Sorcha.Agent.Tests/Decision/DisclosedPayloadFailClosedTests.cs`: rules require the application payload but it is empty → `hold` (not approve/reject); when the payload is later present → correct approve/reject.
-- [ ] T016 [P] [US2] Agent inbox test in `tests/Sorcha.Agent.Tests/Inbox/DisclosedPayloadFetchTests.cs`: a disclosed-data fetch failure results in a `hold` outcome and no action submission.
+- [x] T015 [P] [US2] `RulesDecisionEngine` test in `tests/Sorcha.Agent.Tests/Decision/DisclosedPayloadFailClosedTests.cs`: rules require the application payload but it is empty → `hold` (not approve/reject); when the payload is later present → correct approve/reject.
+- [x] T016 [P] [US2] Agent inbox test in `tests/Sorcha.Agent.Tests/Inbox/DisclosedPayloadFetchTests.cs`: a disclosed-data fetch failure results in a `hold` outcome and no action submission.
 
 ### Implementation
 
-- [ ] T017 [US2] Extend fail-closed in `src/Apps/Sorcha.Agent/Decision/RulesDecisionEngine.cs`: mirror the #1077 `_rulesRequireChecks` pattern to also hold when the disclosed payload the rules depend on is empty/unavailable, with a distinct logged reason ("Disclosed application data unavailable; held for manual review").
-- [ ] T018 [US2] In the agent inbox fetch path (`src/Apps/Sorcha.Agent/Inbox/…`): on fetch failure or `recipientResolved=false`, route the action to a hold outcome — never proceed to a decision on an empty payload; retry naturally on the next poll (FR-009).
+- [x] T017 [US2] Extend fail-closed in `src/Apps/Sorcha.Agent/Decision/RulesDecisionEngine.cs`: mirror the #1077 `_rulesRequireChecks` pattern to also hold when the disclosed payload the rules depend on is empty/unavailable, with a distinct logged reason ("Disclosed application data unavailable; held for manual review").
+- [x] T018 [US2] In the agent inbox fetch path (`src/Apps/Sorcha.Agent/Inbox/…`): on fetch failure or `recipientResolved=false`, route the action to a hold outcome — never proceed to a decision on an empty payload; retry naturally on the next poll (FR-009).
 
 **Checkpoint**: transient/permanent unavailability can never produce a wrong decision.
 
@@ -89,11 +89,11 @@ retrievable; for a rejection the failing check is identifiable (spec US3 / SC-00
 
 ### Tests (write first)
 
-- [ ] T019 [P] [US3] Test in `tests/Sorcha.Agent.Tests/Decision/CheckFactsObservabilityTests.cs`: after a decision the evaluated `checks.*` facts and their source payload fields are emitted (structured), and a failing check is identifiable for a rejection.
+- [x] T019 [P] [US3] Test in `tests/Sorcha.Agent.Tests/Decision/CheckFactsObservabilityTests.cs`: after a decision the evaluated `checks.*` facts and their source payload fields are emitted (structured), and a failing check is identifiable for a rejection.
 
 ### Implementation
 
-- [ ] T020 [US3] Finalise the structured check-facts log in `src/Apps/Sorcha.Agent/Decision/RulesDecisionEngine.cs` (the diagnostic staged on the branch): log evaluated facts + source fields at an appropriate level, structured (no string interpolation, Constitution VIII); ensure it reflects the real disclosed fields and identifies failing checks.
+- [x] T020 [US3] Finalise the structured check-facts log in `src/Apps/Sorcha.Agent/Decision/RulesDecisionEngine.cs` (the diagnostic staged on the branch): log evaluated facts + source fields at an appropriate level, structured (no string interpolation, Constitution VIII); ensure it reflects the real disclosed fields and identifies failing checks.
 
 **Checkpoint**: a future recurrence is a two-minute diagnosis, not a multi-hour investigation.
 
@@ -101,9 +101,9 @@ retrievable; for a rejection the failing check is identifiable (spec US3 / SC-00
 
 ## Phase 6: Polish & Cross-Cutting Concerns
 
-- [ ] T021 [P] Docs: add the endpoint to `docs/reference/API-DOCUMENTATION.md` and the blueprint-service `README.md`; update `.claude/skills/sorcha-architecture/SKILL.md` if it catalogs endpoints; note the agent's disclosed-payload consumption.
-- [ ] T022 [P] Verify coverage (>85% new code) for the resolver, endpoint, and agent paths; confirm no new Release warnings (Constitution IV/V).
-- [ ] T023 Reconcile the provisional field-name edit staged on the branch with the new `PreviousPayload` source (the `payload→prepopulatedPayload` change becomes moot for `PreviousPayload`; keep the `schema→dataSchema` correction); remove any purely-diagnostic scaffolding not intended to ship.
+- [x] T021 [P] Docs: add the endpoint to `docs/reference/API-DOCUMENTATION.md` and the blueprint-service `README.md`; update `.claude/skills/sorcha-architecture/SKILL.md` if it catalogs endpoints; note the agent's disclosed-payload consumption.
+- [x] T022 [P] Verify coverage (>85% new code) for the resolver, endpoint, and agent paths; confirm no new Release warnings (Constitution IV/V).
+- [x] T023 Reconcile the provisional field-name edit staged on the branch with the new `PreviousPayload` source (the `payload→prepopulatedPayload` change becomes moot for `PreviousPayload`; keep the `schema→dataSchema` correction); remove any purely-diagnostic scaffolding not intended to ship.
 - [ ] T024 Full suite green: `dotnet test tests/Sorcha.Blueprint.Service.Tests` + `dotnet test tests/Sorcha.Agent.Tests`, and `demos/AIAS/rehearse.ps1` PASS end-to-end.
 
 ---

--- a/specs/176-agent-disclosed-payload/tasks.md
+++ b/specs/176-agent-disclosed-payload/tasks.md
@@ -1,0 +1,147 @@
+# Tasks: Autonomous agent decides on disclosed application data
+
+**Feature**: 176-agent-disclosed-payload | **Branch**: `176-agent-disclosed-payload`
+**Inputs**: [plan.md](./plan.md), [spec.md](./spec.md), [research.md](./research.md),
+[data-model.md](./data-model.md), [contracts/disclosed-data-endpoint.md](./contracts/disclosed-data-endpoint.md),
+[quickstart.md](./quickstart.md)
+
+**Design (from research.md)**: Design A — implement the already-contracted disclosed-data endpoint in the
+blueprint-service, backed by a shared disclosure resolver extracted from `ActionExecutionService`; the agent
+fetches it per pending action and fails closed when it is unavailable.
+
+**MVP scope**: **User Story 1** (Phase 3) is the minimum viable slice — with US1 done the agent decides on the
+real application (bad postcode rejected, clean approved). US2 (fail-closed) and US3 (explainability) harden it.
+
+**Test policy**: TDD — tests precede implementation within each phase (Constitution IV, >85% new code).
+
+---
+
+## Phase 1: Setup
+
+- [ ] T001 [P] Record the authoritative disclosed-data contract: read `GetDisclosedDataAsync` route + return type in `src/Common/Sorcha.ServiceClients.Http/Blueprint/IBlueprintServiceClient.cs` and `src/Common/Sorcha.ServiceClients.Http/Blueprint/BlueprintServiceClient.cs`, and the MCP consumer expectations in `src/Apps/Sorcha.McpServer/Tools/Participant/DisclosedDataTool.cs`; note the exact route + DTO the server MUST match into `specs/176-agent-disclosed-payload/contracts/disclosed-data-endpoint.md`.
+- [ ] T002 [P] Define/align the `DisclosedActionData` response model (reuse the existing client DTO if present) in `src/Services/Sorcha.Blueprint.Service/Models/` with XML docs on every member (Constitution III).
+
+## Phase 2: Foundational (blocking prerequisites — MUST complete before user stories)
+
+- [ ] T003 Create the resolver seam `IActionDisclosureResolver` in `src/Services/Sorcha.Blueprint.Service/Services/Interfaces/IActionDisclosureResolver.cs` (per contracts §2).
+- [ ] T004 Extract the disclosure logic from `ActionExecutionService.ApplyDisclosuresAsync` (`src/Services/Sorcha.Blueprint.Service/Services/Implementation/ActionExecutionService.cs:1722-1783`) into `src/Services/Sorcha.Blueprint.Service/Services/Implementation/ActionDisclosureResolver.cs` (engine `ApplyDisclosures` + participant→wallet resolution), and register it in DI in the service's Program/extensions.
+- [ ] T005 Refactor `ActionExecutionService` to depend on `IActionDisclosureResolver` (no behaviour change) in `src/Services/Sorcha.Blueprint.Service/Services/Implementation/ActionExecutionService.cs`.
+- [ ] T006 [P] Unit tests for `ActionDisclosureResolver` in `tests/Sorcha.Blueprint.Service.Tests/Services/ActionDisclosureResolverTests.cs`: only-disclosed-fields returned; caller-wallet resolution (incl. multi-wallet); non-recipient → empty/`recipientResolved=false`; identical view for encrypted vs dev-mode payloads.
+- [ ] T007 Regression guard: an existing `ActionExecutionService` disclosure test (or a new one) proves the refactor (T005) did not change disclosure behaviour, in `tests/Sorcha.Blueprint.Service.Tests/Services/ActionExecutionServiceTests.cs`.
+
+**Checkpoint**: shared disclosure resolver exists, tested, and `ActionExecutionService` uses it with no drift.
+
+---
+
+## Phase 3: User Story 1 — Agent decides on the real application (Priority: P1) 🎯 MVP
+
+**Goal**: The agent obtains the disclosed prior-action payload and decides on it — invalid application rejected
+(no credential), valid application approved (credential delivered).
+
+**Independent test**: Submit one valid + one invalid application; agent approves the first (credential) and
+rejects the second (no credential), unattended (spec US1 / SC-001/002/003).
+
+### Tests (write first)
+
+- [ ] T008 [P] [US1] Endpoint integration test in `tests/Sorcha.Blueprint.Service.Tests/Endpoints/WorkflowDisclosureEndpointsTests.cs`: authenticated recipient caller → `disclosedFields` populated with only disclosed fields; non-recipient caller → empty/`recipientResolved=false`; caller-wallet resolved via the Wallet-Service fallback (no `wallet_address` claim).
+- [ ] T009 [P] [US1] Agent inbox test in `tests/Sorcha.Agent.Tests/Inbox/DisclosedPayloadFetchTests.cs`: given a pending action, the inbox fetch calls `GetDisclosedDataAsync(instanceId, actionId)` and sets `PendingAction.PreviousPayload` to the disclosed fields.
+- [ ] T010 [P] [US1] Agent decision test in `tests/Sorcha.Agent.Tests/Decision/DecideOnRealDataTests.cs`: with a real disclosed payload, a non-existent postcode yields a `rejected` decision payload and a clean payload yields `approved` (rules over real `checks.*` facts).
+
+### Implementation
+
+- [ ] T011 [US1] Implement `GET /api/workflows/{instanceId}/actions/{actionId}/disclosures` (match the T001 contract) in `src/Services/Sorcha.Blueprint.Service/Endpoints/WorkflowDisclosureEndpoints.cs` (or extend `ActionEndpoints.cs`): `.RequireAuthorization()`, resolve caller wallet(s) via the Wallet-Service fallback used in `ActionEndpoints.cs:178-184`, call `IActionDisclosureResolver`, return `DisclosedActionData`; add `.WithName`/`.WithSummary`/`.WithDescription` (Constitution III).
+- [ ] T012 [US1] Confirm/adjust `IBlueprintServiceClient.GetDisclosedDataAsync` + `BlueprintServiceClient` (`src/Common/Sorcha.ServiceClients.Http/Blueprint/`) so route + deserialization match the implemented endpoint.
+- [ ] T013 [US1] Wire the agent inbox to fetch disclosed data per pending action and populate `PreviousPayload`, and finalise the `dataSchema` mapping, in `src/Apps/Sorcha.Agent/Inbox/PollingInboxListener.cs` (+ a small fetch helper/service using `IBlueprintServiceClient`); ensure `PreviousPayload` is sourced from the fetch, not the pending summary.
+- [ ] T014 [US1] Run the end-to-end regression `demos/AIAS/rehearse.ps1 -Target docker` (valid → approved + credential; invalid `ZZ99 9ZZ` → rejected + no credential) and confirm PASS (SC-001/002/003/006).
+
+**Checkpoint**: US1 independently delivers a working autonomous assessment. This is the MVP.
+
+---
+
+## Phase 4: User Story 2 — The agent never decides on missing data (Priority: P2)
+
+**Goal**: When the disclosed payload cannot be obtained or is missing a required field, the agent holds
+(fail-closed) rather than approving/rejecting on blanks.
+
+**Independent test**: Make the disclosed-data fetch fail for one application → agent holds (no approve/reject,
+no credential, actionable reason); restore → same application decided correctly (spec US2 / SC-004).
+
+### Tests (write first)
+
+- [ ] T015 [P] [US2] `RulesDecisionEngine` test in `tests/Sorcha.Agent.Tests/Decision/DisclosedPayloadFailClosedTests.cs`: rules require the application payload but it is empty → `hold` (not approve/reject); when the payload is later present → correct approve/reject.
+- [ ] T016 [P] [US2] Agent inbox test in `tests/Sorcha.Agent.Tests/Inbox/DisclosedPayloadFetchTests.cs`: a disclosed-data fetch failure results in a `hold` outcome and no action submission.
+
+### Implementation
+
+- [ ] T017 [US2] Extend fail-closed in `src/Apps/Sorcha.Agent/Decision/RulesDecisionEngine.cs`: mirror the #1077 `_rulesRequireChecks` pattern to also hold when the disclosed payload the rules depend on is empty/unavailable, with a distinct logged reason ("Disclosed application data unavailable; held for manual review").
+- [ ] T018 [US2] In the agent inbox fetch path (`src/Apps/Sorcha.Agent/Inbox/…`): on fetch failure or `recipientResolved=false`, route the action to a hold outcome — never proceed to a decision on an empty payload; retry naturally on the next poll (FR-009).
+
+**Checkpoint**: transient/permanent unavailability can never produce a wrong decision.
+
+---
+
+## Phase 5: User Story 3 — Every decision is explainable (Priority: P3)
+
+**Goal**: The check results that drove a decision are recorded/observable so an outcome can be diagnosed.
+
+**Independent test**: After a decision, the evaluated check facts (and the fields they came from) are
+retrievable; for a rejection the failing check is identifiable (spec US3 / SC-005).
+
+### Tests (write first)
+
+- [ ] T019 [P] [US3] Test in `tests/Sorcha.Agent.Tests/Decision/CheckFactsObservabilityTests.cs`: after a decision the evaluated `checks.*` facts and their source payload fields are emitted (structured), and a failing check is identifiable for a rejection.
+
+### Implementation
+
+- [ ] T020 [US3] Finalise the structured check-facts log in `src/Apps/Sorcha.Agent/Decision/RulesDecisionEngine.cs` (the diagnostic staged on the branch): log evaluated facts + source fields at an appropriate level, structured (no string interpolation, Constitution VIII); ensure it reflects the real disclosed fields and identifies failing checks.
+
+**Checkpoint**: a future recurrence is a two-minute diagnosis, not a multi-hour investigation.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+- [ ] T021 [P] Docs: add the endpoint to `docs/reference/API-DOCUMENTATION.md` and the blueprint-service `README.md`; update `.claude/skills/sorcha-architecture/SKILL.md` if it catalogs endpoints; note the agent's disclosed-payload consumption.
+- [ ] T022 [P] Verify coverage (>85% new code) for the resolver, endpoint, and agent paths; confirm no new Release warnings (Constitution IV/V).
+- [ ] T023 Reconcile the provisional field-name edit staged on the branch with the new `PreviousPayload` source (the `payload→prepopulatedPayload` change becomes moot for `PreviousPayload`; keep the `schema→dataSchema` correction); remove any purely-diagnostic scaffolding not intended to ship.
+- [ ] T024 Full suite green: `dotnet test tests/Sorcha.Blueprint.Service.Tests` + `dotnet test tests/Sorcha.Agent.Tests`, and `demos/AIAS/rehearse.ps1` PASS end-to-end.
+
+---
+
+## Dependencies & completion order
+
+```
+Phase 1 (Setup: T001-T002)
+   └─▶ Phase 2 (Foundational: T003-T007)   ← BLOCKS all user stories (resolver + response model)
+         ├─▶ Phase 3 US1 (T008-T014)  🎯 MVP
+         │       └─▶ Phase 4 US2 (T015-T018)   ← builds on US1's fetch + decision path
+         │       └─▶ Phase 5 US3 (T019-T020)   ← builds on US1's decision path (independent of US2)
+         └─────────────▶ Phase 6 Polish (T021-T024)   ← after the stories it documents/hardens
+```
+
+- **US1 depends on** Phase 2 (needs the resolver + endpoint + response model).
+- **US2 and US3 depend on** US1 (they harden the fetch + decision path US1 introduces). US2 and US3 are
+  **independent of each other** and can proceed in parallel once US1 is done.
+- Phase 2's refactor regression guard (T007) must pass before building on `ActionExecutionService`.
+
+## Parallel execution examples
+
+- **Phase 1**: T001 ∥ T002 (different concerns/files).
+- **Phase 2**: T006 (resolver unit tests) ∥ authoring, once T003-T005 land; T004→T005 are sequential (same class).
+- **Phase 3 (US1) tests**: T008 ∥ T009 ∥ T010 (different test files) — write together before T011-T013.
+- **After US1**: Phase 4 (T015-T018) ∥ Phase 5 (T019-T020) — different files, independent stories.
+- **Phase 6**: T021 ∥ T022 (docs vs coverage).
+
+## Implementation strategy
+
+1. **Land the MVP first**: Phases 1→2→3. At the end of Phase 3, `rehearse.ps1` passes and the demo is
+   correct — this is the shippable slice.
+2. **Harden**: Phase 4 (fail-closed) then Phase 5 (explainability), in parallel if resourced.
+3. **Finish**: Phase 6 docs/coverage/cleanup, then the full-suite + E2E green gate (T024).
+
+## Task count summary
+
+- **Total**: 24 tasks
+- Setup: 2 · Foundational: 5 · US1 (MVP): 7 · US2: 4 · US3: 2 · Polish: 4
+- **Parallelizable [P]**: 11 tasks
+- **MVP = Phases 1-3 (T001-T014)**; independently testable via `rehearse.ps1`.

--- a/src/Apps/Sorcha.Agent/Commands/RunCommand.cs
+++ b/src/Apps/Sorcha.Agent/Commands/RunCommand.cs
@@ -133,6 +133,15 @@ public class RunCommand : Command
                 _ => throw new NotSupportedException($"Mode '{definition.Mode}' not supported")
             };
 
+            // Feature 176 — per-action disclosed-data fetch. Only engines that depend on the disclosed
+            // prior-action payload (rules with external checks) use it; others opt out via
+            // RequiresDisclosedPayload and pay nothing. Uses the agent's own HttpClient/bearer so the
+            // endpoint resolves the agent's wallet as the disclosure recipient.
+            var disclosedDataClient = new HttpDisclosedDataClient(
+                httpClient, authService, loggerFactory.CreateLogger<HttpDisclosedDataClient>());
+            var disclosedPayloadEnricher = new DisclosedPayloadEnricher(
+                disclosedDataClient, loggerFactory.CreateLogger<DisclosedPayloadEnricher>());
+
             // Create audit logger
             using var auditLogger = new AuditLogger(definition.Logging?.ActionLog);
 
@@ -214,14 +223,42 @@ public class RunCommand : Command
             if (!quiet) Console.WriteLine($"[{DateTime.Now:HH:mm:ss}] Actor \"{actorName}\" started");
 
             // Main loop
-            await foreach (var action in compositeListener.ListenAsync(cancellationToken))
+            await foreach (var discovered in compositeListener.ListenAsync(cancellationToken))
             {
+                var action = discovered;
+
                 if (!quiet)
                     Console.WriteLine($"[{DateTime.Now:HH:mm:ss}] Action \"{action.ActionName}\" discovered (id: {action.ActionId[..Math.Min(8, action.ActionId.Length)]})");
+
+                // Feature 176: fetch the disclosed prior-action data the decision depends on, and hold
+                // (fail-closed) if it cannot be obtained — never decide on a blank view. Retries naturally
+                // on the next poll. Skipped for engines that don't need the payload.
+                if (decisionEngine.RequiresDisclosedPayload)
+                {
+                    var enriched = await disclosedPayloadEnricher.EnrichAsync(action, cancellationToken);
+                    if (enriched.ShouldHold)
+                    {
+                        if (!quiet)
+                            Console.WriteLine($"[{DateTime.Now:HH:mm:ss}] Action \"{action.ActionName}\" HELD (no data): {enriched.HoldReason}");
+                        continue;
+                    }
+
+                    action = enriched.Action;
+                }
 
                 var decision = await decisionEngine.DecideAsync(action, cancellationToken);
 
                 if (!quiet) Console.WriteLine($"[{DateTime.Now:HH:mm:ss}] Decision: {decision.Decision}");
+
+                // A "hold" is a deliberate no-op: the agent submits nothing (no approve/reject) and the
+                // action is left pending for manual review / re-evaluation on a later poll (Feature 176 /
+                // #1077). "skip" is likewise non-submitting.
+                if (decision.Decision == "hold")
+                {
+                    if (!quiet)
+                        Console.WriteLine($"[{DateTime.Now:HH:mm:ss}] Action \"{action.ActionName}\" HELD: {decision.Reasoning}");
+                    continue;
+                }
 
                 if (decision.Decision != "skip")
                 {

--- a/src/Apps/Sorcha.Agent/Decision/AiDecisionEngine.cs
+++ b/src/Apps/Sorcha.Agent/Decision/AiDecisionEngine.cs
@@ -31,6 +31,12 @@ public partial class AiDecisionEngine : IDecisionEngine
             ?? throw new InvalidOperationException("ANTHROPIC_API_KEY environment variable is not set");
     }
 
+    /// <summary>
+    /// AI persona mode reads the action context it is given and does not depend on the disclosed
+    /// prior-action payload being pre-fetched, so it opts out of the Feature 176 fetch/fail-closed path.
+    /// </summary>
+    public bool RequiresDisclosedPayload => false;
+
     public async Task<ActionDecision> DecideAsync(PendingAction action, CancellationToken cancellationToken = default)
     {
         // Load persona prompt on first use

--- a/src/Apps/Sorcha.Agent/Decision/IDecisionEngine.cs
+++ b/src/Apps/Sorcha.Agent/Decision/IDecisionEngine.cs
@@ -6,5 +6,14 @@ namespace Sorcha.Agent.Decision;
 
 public interface IDecisionEngine
 {
+    /// <summary>
+    /// True when this engine's decisions depend on the disclosed prior-action payload (e.g. rules that
+    /// reference external-check facts derived from it). When true, the host fetches the disclosed data
+    /// for each pending action and holds (fail-closed) if it is unavailable, rather than deciding on a
+    /// blank view (Feature 176). Engines that do not need it (AI persona mode) return false and are
+    /// unaffected — no disclosed-data fetch is performed for them.
+    /// </summary>
+    bool RequiresDisclosedPayload { get; }
+
     Task<ActionDecision> DecideAsync(PendingAction action, CancellationToken cancellationToken = default);
 }

--- a/src/Apps/Sorcha.Agent/Decision/RulesDecisionEngine.cs
+++ b/src/Apps/Sorcha.Agent/Decision/RulesDecisionEngine.cs
@@ -56,8 +56,30 @@ public class RulesDecisionEngine : IDecisionEngine
             && r.Condition.ToJsonString().Contains("checks.", StringComparison.Ordinal));
     }
 
+    /// <summary>
+    /// True when the rules reference external-check facts (which are derived from the disclosed
+    /// prior-action payload). The host uses this to fetch the disclosed data before deciding and to hold
+    /// when it is unavailable (Feature 176) — the same condition that drives the fail-closed guard below.
+    /// </summary>
+    public bool RequiresDisclosedPayload => _rulesRequireChecks;
+
     public async Task<ActionDecision> DecideAsync(PendingAction action, CancellationToken cancellationToken = default)
     {
+        // #176 fail-closed: rules that depend on external checks derive those checks from the disclosed
+        // prior-action payload. If that payload is empty/unavailable, every check evaluates against
+        // nothing (missing fields resolve to their safe default) and the decision is meaningless — the
+        // exact AIAS blank-data defect (fake postcode "ZZ99 9ZZ" approved). Hold for manual review rather
+        // than approve/reject on blanks. Mirrors the #1077 shape; scoped to rules that reference checks.*
+        // so agents whose rules don't depend on the payload are unaffected.
+        if (_rulesRequireChecks && IsPreviousPayloadEmpty(action))
+        {
+            _logger?.LogError(
+                "Rules for action {ActionName} require the disclosed application data but it is empty/unavailable; "
+                + "holding for manual review (fail-closed, #176).", action.ActionName);
+            return new ActionDecision("hold", null,
+                "Disclosed application data unavailable; held for manual review");
+        }
+
         // Run configured external checks once and expose them as the "checks" fact object. Skipped
         // entirely when no runner/checks are configured, so non-AIAS agents pay nothing.
         JsonObject? checksFacts = null;
@@ -163,7 +185,33 @@ public class RulesDecisionEngine : IDecisionEngine
             };
         }
 
+        // Observability: the decision hinges on these facts, so make them visible. Silent checks were
+        // exactly what hid the #1077 fail-open and made the #814/AIAS decisions impossible to diagnose.
+        _logger?.LogInformation(
+            "External checks evaluated for {ActionName}: {Facts} (from payload fields: [{Fields}])",
+            action.ActionName, obj.ToJsonString(), string.Join(", ", payload.Keys));
+
         return obj;
+    }
+
+    /// <summary>
+    /// True when the action carries no usable disclosed prior-action payload — null, a non-object, or an
+    /// object with no properties. Drives the Feature 176 fail-closed hold (the checks would otherwise run
+    /// against nothing).
+    /// </summary>
+    private static bool IsPreviousPayloadEmpty(PendingAction action)
+    {
+        if (action.PreviousPayload is not { } element || element.ValueKind != JsonValueKind.Object)
+        {
+            return true;
+        }
+
+        foreach (var _ in element.EnumerateObject())
+        {
+            return false;
+        }
+
+        return true;
     }
 
     /// <summary>Projects the action's submitted (previous) payload into the top-level dictionary the checks consume.</summary>

--- a/src/Apps/Sorcha.Agent/Inbox/DisclosedDataClient.cs
+++ b/src/Apps/Sorcha.Agent/Inbox/DisclosedDataClient.cs
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+using System.Net.Http.Headers;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using Sorcha.Agent.Auth;
+
+namespace Sorcha.Agent.Inbox;
+
+/// <summary>
+/// The disclosed prior-action data for the calling participant, as returned by the blueprint-service
+/// disclosed-data endpoint (Feature 176).
+/// </summary>
+/// <param name="RecipientResolved">
+/// True when the caller is a disclosure recipient and fields were disclosed to it. False → the caller is
+/// not a recipient (drives a fail-closed hold).
+/// </param>
+/// <param name="DisclosedFields">
+/// The merged disclosed prior-action payload the checks evaluate, or null when nothing was disclosed.
+/// </param>
+public sealed record DisclosedDataResult(bool RecipientResolved, JsonElement? DisclosedFields);
+
+/// <summary>
+/// Fetches the prior-action data disclosed to the agent's participant for a pending action. A seam so the
+/// enrichment logic can be unit-tested without HTTP.
+/// </summary>
+public interface IDisclosedDataClient
+{
+    /// <summary>
+    /// Gets the disclosed prior-action data for <paramref name="actionId"/> of
+    /// <paramref name="instanceId"/>, as the authenticated agent. Returns null on any transport/HTTP
+    /// failure so the caller can fail closed (hold + retry on the next poll).
+    /// </summary>
+    Task<DisclosedDataResult?> GetDisclosedDataAsync(string instanceId, uint actionId, CancellationToken cancellationToken);
+}
+
+/// <summary>
+/// HTTP implementation of <see cref="IDisclosedDataClient"/>. Calls
+/// <c>GET /api/workflows/{instanceId}/actions/{actionId}/disclosures</c> with the agent's own bearer
+/// token, mirroring the raw-<see cref="HttpClient"/> pattern the rest of the agent uses
+/// (<see cref="PollingInboxListener"/>, <c>ActionExecutor</c>). The agent authenticates as its user, so
+/// the endpoint resolves the agent's own wallet as the disclosure recipient — the caller's user token is
+/// required (a service-to-service client would resolve the wrong identity), which is why this does not go
+/// through <c>IBlueprintServiceClient</c> (that client mints a service token). The bearer is also sent as
+/// <c>X-Delegation-Token</c> so disclosure groups can be decrypted on encrypted (non dev-mode) registers.
+/// </summary>
+public sealed class HttpDisclosedDataClient : IDisclosedDataClient
+{
+    private readonly HttpClient _httpClient;
+    private readonly AgentAuthService _authService;
+    private readonly ILogger<HttpDisclosedDataClient> _logger;
+
+    public HttpDisclosedDataClient(
+        HttpClient httpClient, AgentAuthService authService, ILogger<HttpDisclosedDataClient> logger)
+    {
+        _httpClient = httpClient;
+        _authService = authService;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<DisclosedDataResult?> GetDisclosedDataAsync(
+        string instanceId, uint actionId, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var token = await _authService.GetTokenAsync(cancellationToken);
+
+            using var request = new HttpRequestMessage(
+                HttpMethod.Get,
+                $"/api/workflows/{Uri.EscapeDataString(instanceId)}/actions/{actionId}/disclosures");
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+            request.Headers.Add("X-Delegation-Token", token);
+
+            using var response = await _httpClient.SendAsync(request, cancellationToken);
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogWarning(
+                    "Disclosed-data fetch for {InstanceId}/{ActionId} returned {StatusCode}",
+                    instanceId, actionId, (int)response.StatusCode);
+                return null;
+            }
+
+            var json = await response.Content.ReadAsStringAsync(cancellationToken);
+            using var doc = JsonDocument.Parse(json);
+            var root = doc.RootElement;
+
+            var recipientResolved =
+                root.TryGetProperty("recipientResolved", out var rr) && rr.ValueKind == JsonValueKind.True;
+
+            JsonElement? disclosedFields =
+                root.TryGetProperty("disclosedFields", out var df) && df.ValueKind == JsonValueKind.Object
+                    ? df.Clone()
+                    : null;
+
+            return new DisclosedDataResult(recipientResolved, disclosedFields);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException || !cancellationToken.IsCancellationRequested)
+        {
+            _logger.LogWarning(ex, "Disclosed-data fetch failed for {InstanceId}/{ActionId}", instanceId, actionId);
+            return null;
+        }
+    }
+}

--- a/src/Apps/Sorcha.Agent/Inbox/DisclosedPayloadEnricher.cs
+++ b/src/Apps/Sorcha.Agent/Inbox/DisclosedPayloadEnricher.cs
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+using Microsoft.Extensions.Logging;
+using Sorcha.Agent.Models;
+
+namespace Sorcha.Agent.Inbox;
+
+/// <summary>
+/// The outcome of enriching a pending action with its disclosed prior-action data (Feature 176).
+/// </summary>
+/// <param name="Action">
+/// The action, with <see cref="PendingAction.PreviousPayload"/> populated from the disclosed data when
+/// available. Unchanged when <see cref="ShouldHold"/> is true.
+/// </param>
+/// <param name="ShouldHold">
+/// True when the disclosed data could not be obtained or the agent is not a disclosure recipient — the
+/// host must hold the action (no approve/reject, no submission) and retry on the next poll.
+/// </param>
+/// <param name="HoldReason">The actionable reason logged/recorded when <see cref="ShouldHold"/> is true.</param>
+public sealed record EnrichedAction(PendingAction Action, bool ShouldHold, string? HoldReason);
+
+/// <summary>
+/// Populates a pending action's previous payload from the register's disclosed prior-action data, and
+/// signals a fail-closed hold when that data is unavailable (Feature 176, US1/US2).
+/// </summary>
+public interface IDisclosedPayloadEnricher
+{
+    /// <summary>Fetches the disclosed data for <paramref name="action"/> and returns the enrichment outcome.</summary>
+    Task<EnrichedAction> EnrichAsync(PendingAction action, CancellationToken cancellationToken);
+}
+
+/// <summary>
+/// Default enricher over an <see cref="IDisclosedDataClient"/>. On a fetch failure or a non-recipient /
+/// empty response it returns a hold outcome (the agent never decides on a blank view); otherwise it sets
+/// <see cref="PendingAction.PreviousPayload"/> to the disclosed fields so the external checks evaluate the
+/// applicant's real submitted data.
+/// </summary>
+public sealed class DisclosedPayloadEnricher : IDisclosedPayloadEnricher
+{
+    private const string FetchFailedReason = "Disclosed application data unavailable; held for manual review";
+    private const string NotDisclosedReason =
+        "No application data disclosed to the agent's participant; held for manual review";
+
+    private readonly IDisclosedDataClient _client;
+    private readonly ILogger<DisclosedPayloadEnricher>? _logger;
+
+    public DisclosedPayloadEnricher(IDisclosedDataClient client, ILogger<DisclosedPayloadEnricher>? logger = null)
+    {
+        _client = client;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<EnrichedAction> EnrichAsync(PendingAction action, CancellationToken cancellationToken)
+    {
+        var result = await _client.GetDisclosedDataAsync(action.InstanceId, action.ActionIndex, cancellationToken);
+
+        if (result is null)
+        {
+            _logger?.LogError(
+                "Disclosed-data fetch failed for {ActionName} ({InstanceId}/{ActionId}); holding (fail-closed).",
+                action.ActionName, action.InstanceId, action.ActionIndex);
+            return new EnrichedAction(action, ShouldHold: true, FetchFailedReason);
+        }
+
+        if (!result.RecipientResolved || result.DisclosedFields is null)
+        {
+            _logger?.LogError(
+                "No disclosed data for {ActionName} ({InstanceId}/{ActionId}) — caller is not a disclosure recipient; holding (fail-closed).",
+                action.ActionName, action.InstanceId, action.ActionIndex);
+            return new EnrichedAction(action, ShouldHold: true, NotDisclosedReason);
+        }
+
+        _logger?.LogInformation(
+            "Disclosed data fetched for {ActionName} ({InstanceId}/{ActionId})",
+            action.ActionName, action.InstanceId, action.ActionIndex);
+
+        return new EnrichedAction(
+            action with { PreviousPayload = result.DisclosedFields }, ShouldHold: false, HoldReason: null);
+    }
+}

--- a/src/Apps/Sorcha.Agent/Inbox/PollingInboxListener.cs
+++ b/src/Apps/Sorcha.Agent/Inbox/PollingInboxListener.cs
@@ -112,8 +112,14 @@ public class PollingInboxListener : IInboxListener
             RegisterId = GetStringOrToString(item, "registerId") ?? "",
             TransactionId = GetStringOrToString(item, "transactionId") ?? "",
             SenderAddress = GetStringOrToString(item, "senderAddress"),
-            PreviousPayload = item.TryGetProperty("payload", out var payload) ? payload.Clone() : null,
-            Schema = item.TryGetProperty("schema", out var schema) ? schema.Clone() : null
+            // Feature 176: PreviousPayload is NOT sourced from the pending summary. The summary's
+            // "prepopulatedPayload" is a Feature-104 form-prefill seed (empty for the AIAS verify action),
+            // NOT the disclosed prior-action application data — reading it here is what left the agent
+            // deciding on an empty payload (AIAS bad-postcode approved). PreviousPayload is populated
+            // per-action from the disclosed-data endpoint by DisclosedPayloadEnricher before the decision.
+            // The "dataSchema" correction stays (the API serialises the action schema as "dataSchema").
+            PreviousPayload = null,
+            Schema = item.TryGetProperty("dataSchema", out var schema) ? schema.Clone() : null
         };
     }
 

--- a/src/Services/Sorcha.Blueprint.Service/Endpoints/WorkflowDisclosureEndpoints.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Endpoints/WorkflowDisclosureEndpoints.cs
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using Sorcha.Blueprint.Service.Middleware;
+using Sorcha.Blueprint.Service.Models;
+using Sorcha.Blueprint.Service.Services.Interfaces;
+using Sorcha.Blueprint.Service.Storage;
+using Sorcha.ServiceClients.Wallet;
+
+namespace Sorcha.Blueprint.Service.Endpoints;
+
+/// <summary>
+/// Feature 176 — the disclosed prior-action data query surface. Fills the route already targeted by
+/// <c>IBlueprintServiceClient.GetDisclosedDataAsync</c> and the MCP <c>DisclosedDataTool</c>, and is the
+/// source the autonomous agent reads to decide on the applicant's real submitted data (rather than a
+/// blank view). Returns only fields disclosed to the calling participant under the register's DAD
+/// disclosure model (FR-006 / FR-010).
+/// </summary>
+public static class WorkflowDisclosureEndpoints
+{
+    /// <summary>Maps the workflow disclosed-data endpoints to the application.</summary>
+    public static IEndpointRouteBuilder MapWorkflowDisclosureEndpoints(this IEndpointRouteBuilder routes)
+    {
+        var group = routes.MapGroup("/api/workflows")
+            .WithTags("Workflows")
+            .RequireAuthorization();
+
+        group.MapGet("/{instanceId}/actions/{actionId:int}/disclosures", (
+            HttpContext httpContext,
+            string instanceId,
+            int actionId,
+            IActionDisclosureResolver resolver,
+            IWalletServiceClient walletClient,
+            ILogger<WorkflowDisclosureEndpointsLogCategory> logger) =>
+                GetDisclosuresAsync(httpContext, instanceId, actionId, resolver, walletClient, logger))
+        .WithName("GetActionDisclosures")
+        .WithSummary("Get prior-action data disclosed to the calling participant for an action")
+        .WithDescription("Returns the prior-action payload of a workflow instance that the register has "
+            + "disclosed to the calling participant, for the given action being decided. Only fields "
+            + "disclosed to the caller's participant are returned — the disclosure model is never widened. "
+            + "The caller's wallet(s) are resolved from the `wallet_address` JWT claim when present, and via "
+            + "a live Wallet Service lookup keyed by the caller's identity when the claim is absent "
+            + "(consumer/service-tier tokens omit the wallet binding under Feature 136). Include the "
+            + "`X-Delegation-Token` header to enable decryption on encrypted (non dev-mode) registers. "
+            + "`recipientResolved` is false with an empty view when the caller is not a disclosure "
+            + "recipient — the autonomous agent treats that as a fail-closed hold signal.");
+
+        group.MapGet("/{instanceId}/disclosures", async (
+            HttpContext httpContext,
+            string instanceId,
+            IActionDisclosureResolver resolver,
+            IWalletServiceClient walletClient,
+            IInstanceStore instanceStore,
+            ILogger<WorkflowDisclosureEndpointsLogCategory> logger) =>
+        {
+            // Instance-wide variant (the client's action-less overload): anchor the disclosed-data
+            // reconstruction on the instance's current action so the caller sees the accumulated
+            // prior-action data disclosed to them up to the current point.
+            var instance = await instanceStore.GetAsync(instanceId, httpContext.RequestAborted);
+            var actionId = instance?.CurrentActionIds.FirstOrDefault() ?? 0;
+            return await GetDisclosuresAsync(httpContext, instanceId, actionId, resolver, walletClient, logger);
+        })
+        .WithName("GetInstanceDisclosures")
+        .WithSummary("Get prior-action data disclosed to the calling participant for a workflow instance")
+        .WithDescription("Instance-wide form of the disclosed-data query, anchored on the instance's current "
+            + "action. See GetActionDisclosures for the disclosure semantics and caller-wallet resolution.");
+
+        return routes;
+    }
+
+    /// <summary>
+    /// Resolves the caller's wallet(s), then returns the prior-action data disclosed to the caller for
+    /// <paramref name="actionId"/>. Always returns 200 with a <see cref="DisclosedActionData"/> — an
+    /// unresolved recipient is expressed as <c>recipientResolved=false</c> with an empty view (so the
+    /// caller can distinguish "no disclosure" from an auth failure), never a 403.
+    /// </summary>
+    internal static async Task<IResult> GetDisclosuresAsync(
+        HttpContext httpContext,
+        string instanceId,
+        int actionId,
+        IActionDisclosureResolver resolver,
+        IWalletServiceClient walletClient,
+        ILogger logger)
+    {
+        var callerWallets = await ActionEndpoints.ResolveUserWalletAddressesAsync(
+            httpContext, walletClient, logger, httpContext.RequestAborted);
+
+        if (callerWallets.Count == 0)
+        {
+            return Results.Ok(new DisclosedActionData
+            {
+                InstanceId = instanceId,
+                ActionId = actionId,
+                RegisterId = string.Empty,
+                RecipientResolved = false,
+            });
+        }
+
+        // X-Delegation-Token (when supplied) authorises unwrapping the caller's disclosure-group keys on
+        // encrypted registers; dev-mode registers read plaintext and do not require it.
+        var delegationToken = httpContext.GetDelegationToken();
+
+        var data = await resolver.ResolveDisclosedDataAsync(
+            instanceId, actionId, callerWallets, delegationToken, httpContext.RequestAborted);
+
+        return Results.Ok(data);
+    }
+
+    /// <summary>
+    /// Marker type for <see cref="ILogger{T}"/> categorisation, mirroring
+    /// <c>ActionEndpoints.ActionEndpointsLogCategory</c> so the log category is stable and obvious.
+    /// </summary>
+    internal sealed class WorkflowDisclosureEndpointsLogCategory { }
+}

--- a/src/Services/Sorcha.Blueprint.Service/Models/DisclosedActionData.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Models/DisclosedActionData.cs
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+namespace Sorcha.Blueprint.Service.Models;
+
+/// <summary>
+/// The prior-action data of a workflow instance disclosed to the <b>calling participant</b> under the
+/// register's disclosure model (Feature 176). Returned by
+/// <c>GET /api/workflows/{instanceId}/actions/{actionId}/disclosures</c>.
+/// </summary>
+/// <remarks>
+/// The wire shape is aligned to the existing <c>IBlueprintServiceClient.GetDisclosedDataAsync</c>
+/// contract and its MCP consumer (<c>DisclosedDataTool</c>), which reads the <see cref="Disclosures"/>
+/// list. The additional <see cref="DisclosedFields"/> / <see cref="RecipientResolved"/> members serve
+/// the autonomous agent, which feeds <see cref="DisclosedFields"/> to its external checks and treats an
+/// unresolved recipient / empty view as a fail-closed hold signal. Only fields the caller's participant
+/// is entitled to see ever appear here — the disclosure model is never widened (FR-006 / FR-010).
+/// </remarks>
+public sealed record DisclosedActionData
+{
+    /// <summary>The workflow instance the disclosed data belongs to.</summary>
+    public required string InstanceId { get; init; }
+
+    /// <summary>The action being decided (the action whose prior-action data was requested), or null for an instance-wide query.</summary>
+    public int? ActionId { get; init; }
+
+    /// <summary>The register the instance lives on.</summary>
+    public required string RegisterId { get; init; }
+
+    /// <summary>
+    /// True when the caller's wallet was resolved as a disclosure recipient and at least one prior
+    /// action disclosed fields to it. False → the caller is not a recipient (or nothing was disclosed):
+    /// <see cref="DisclosedFields"/> and <see cref="Disclosures"/> are empty and the consuming agent
+    /// must hold rather than decide on a blank view.
+    /// </summary>
+    public bool RecipientResolved { get; init; }
+
+    /// <summary>
+    /// The disclosed prior-action data partitioned by the action it originated from (newest facts win
+    /// on merge into <see cref="DisclosedFields"/>). This is the member the MCP <c>DisclosedDataTool</c>
+    /// consumes.
+    /// </summary>
+    public IReadOnlyList<DisclosedActionEntry> Disclosures { get; init; } = [];
+
+    /// <summary>
+    /// The merged, disclosed prior-action payload as a single field map — the fields the calling
+    /// participant is entitled to see (e.g. <c>name</c>, <c>address</c>, <c>email</c>,
+    /// <c>emailVerified</c>, <c>portrait</c>). This is what the agent feeds to its checks as the
+    /// previous payload. Empty when <see cref="RecipientResolved"/> is false.
+    /// </summary>
+    public IReadOnlyDictionary<string, object> DisclosedFields { get; init; } =
+        new Dictionary<string, object>();
+}
+
+/// <summary>
+/// The subset of a single prior action's payload disclosed to the calling participant (Feature 176).
+/// </summary>
+public sealed record DisclosedActionEntry
+{
+    /// <summary>The prior action id these fields originated from.</summary>
+    public required int ActionId { get; init; }
+
+    /// <summary>The prior action's human-readable title (for provenance / diagnostics).</summary>
+    public required string ActionTitle { get; init; }
+
+    /// <summary>When the prior action was disclosed/sealed, when available; otherwise null.</summary>
+    public DateTimeOffset? DisclosedAt { get; init; }
+
+    /// <summary>The fields of the prior action disclosed to the calling participant.</summary>
+    public IReadOnlyDictionary<string, object> Data { get; init; } =
+        new Dictionary<string, object>();
+}

--- a/src/Services/Sorcha.Blueprint.Service/Program.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Program.cs
@@ -264,6 +264,10 @@ else
 // Add Orchestration services (Sprint 6)
 builder.Services.AddScoped<Sorcha.Blueprint.Service.Services.Interfaces.IStateReconstructionService,
     Sorcha.Blueprint.Service.Services.Implementation.StateReconstructionService>();
+// Feature 176 — shared disclosure authority. Backs the execution path's submit-side disclosure and the
+// disclosed-data query endpoint's read-side reconstruction from one implementation.
+builder.Services.AddScoped<Sorcha.Blueprint.Service.Services.Interfaces.IActionDisclosureResolver,
+    Sorcha.Blueprint.Service.Services.Implementation.ActionDisclosureResolver>();
 builder.Services.AddScoped<Sorcha.Blueprint.Service.Services.Interfaces.IActionExecutionService,
     Sorcha.Blueprint.Service.Services.Implementation.ActionExecutionService>();
 // Feature 145 US6 — ActionExecutionService also builds the signed RoutingDecision a successful
@@ -1048,6 +1052,8 @@ app.MapStatusListEndpoints();
 
 // Map pending action endpoints (Feature 062)
 app.MapActionEndpoints();
+// Feature 176 — disclosed prior-action data query (agent + MCP participant tools consume this).
+app.MapWorkflowDisclosureEndpoints();
 
 // Map file chunk submission endpoints (Feature 085 — Stored Data Transactions)
 app.MapFileChunkEndpoints();

--- a/src/Services/Sorcha.Blueprint.Service/README.md
+++ b/src/Services/Sorcha.Blueprint.Service/README.md
@@ -275,6 +275,24 @@ OPENTELEMETRY__ZIPKINENDPOINT="https://zipkin.yourcompany.com"
 
 **EventsHubNotificationBridge Enhancements:** The bridge now enriches inbound action notifications with summary text, urgency level, and deadline information before delivery. It also persists `ActivityEvent` records for notification history tracking.
 
+### Disclosed Prior-Action Data Query (Feature 176)
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| GET | `/api/workflows/{instanceId}/actions/{actionId}/disclosures` | Prior-action data disclosed to the calling participant, for the action being decided |
+| GET | `/api/workflows/{instanceId}/disclosures` | Instance-wide form (anchored on the instance's current action) |
+
+The read-side of the DAD disclosure model. Reconstructs each required prior action's caller-decryptable
+view from the instance's sealed transactions (identical for encrypted and dev-mode registers) and clamps
+it to exactly the caller participant's entitlement — no undisclosed field is ever returned. Authenticated;
+the caller's wallet(s) are resolved from the `wallet_address` claim or the Wallet Service fallback (the
+same path `/api/actions/pending` uses), and `X-Delegation-Token` (when supplied) unwraps disclosure-group
+keys on encrypted registers. Returns `recipientResolved: false` with an empty view when the caller is not a
+recipient. Backed by the shared `IActionDisclosureResolver` (also used by `ActionExecutionService`), so the
+execution and query paths share one disclosure implementation. Consumed by the autonomous `Sorcha.Agent`
+(it sets each pending action's previous payload from `disclosedFields` before running its checks, and holds
+fail-closed when the fetch is unavailable) and by the MCP `sorcha_disclosed_data` participant tool.
+
 ### File Chunk Submission (Feature 085)
 
 | Method | Endpoint | Description |

--- a/src/Services/Sorcha.Blueprint.Service/Services/Implementation/ActionDisclosureResolver.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Services/Implementation/ActionDisclosureResolver.cs
@@ -1,0 +1,306 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Text.Json;
+using Sorcha.Blueprint.Engine.Interfaces;
+using Sorcha.Blueprint.Service.Models;
+using Sorcha.Blueprint.Service.Services.Interfaces;
+using Sorcha.Blueprint.Service.Storage;
+using Sorcha.ServiceClients.Register;
+using ActionModel = Sorcha.Blueprint.Models.Action;
+using BlueprintModel = Sorcha.Blueprint.Models.Blueprint;
+
+namespace Sorcha.Blueprint.Service.Services.Implementation;
+
+/// <summary>
+/// Shared implementation of the DAD disclosure model (Feature 176). The submit-side
+/// <see cref="ApplyDisclosuresAsync"/> is the logic lifted verbatim from
+/// <c>ActionExecutionService.ApplyDisclosuresAsync</c> (no behaviour change); the read-side
+/// <see cref="ResolveDisclosedDataAsync"/> reconstructs the caller's disclosed prior-action view and
+/// clamps it to the caller participant's entitlement so no undisclosed field is ever returned.
+/// </summary>
+public sealed class ActionDisclosureResolver : IActionDisclosureResolver
+{
+    private readonly IExecutionEngine _executionEngine;
+    private readonly IRegisterServiceClient _registerClient;
+    private readonly ILogger<ActionDisclosureResolver> _logger;
+
+    // Read-side dependencies. Optional so the execution pipeline can construct a resolver for the
+    // submit-side primitive alone; the disclosed-data endpoint resolves the fully-wired singleton from
+    // DI where all three are present.
+    private readonly IStateReconstructionService? _stateReconstruction;
+    private readonly IInstanceStore? _instanceStore;
+    private readonly IBlueprintStore? _blueprintStore;
+
+    /// <summary>Initialises a new instance of the <see cref="ActionDisclosureResolver"/> class.</summary>
+    public ActionDisclosureResolver(
+        IExecutionEngine executionEngine,
+        IRegisterServiceClient registerClient,
+        ILogger<ActionDisclosureResolver> logger,
+        IStateReconstructionService? stateReconstruction = null,
+        IInstanceStore? instanceStore = null,
+        IBlueprintStore? blueprintStore = null)
+    {
+        _executionEngine = executionEngine ?? throw new ArgumentNullException(nameof(executionEngine));
+        _registerClient = registerClient ?? throw new ArgumentNullException(nameof(registerClient));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _stateReconstruction = stateReconstruction;
+        _instanceStore = instanceStore;
+        _blueprintStore = blueprintStore;
+    }
+
+    /// <inheritdoc />
+    public async Task<Dictionary<string, Dictionary<string, object>>> ApplyDisclosuresAsync(
+        ActionModel action,
+        Dictionary<string, object> data,
+        BlueprintModel blueprint,
+        Dictionary<string, string> participantWallets,
+        string registerId,
+        CancellationToken cancellationToken = default)
+    {
+        // Delegate to the Blueprint Engine for JSON Pointer disclosure filtering
+        var engineResults = _executionEngine.ApplyDisclosures(data, action);
+
+        var disclosedPayloads = new Dictionary<string, Dictionary<string, object>>();
+
+        foreach (var result in engineResults)
+        {
+            // Resolve participant ID to wallet address (2-tier: instance bindings → register)
+            var recipientAddress = result.ParticipantId;
+            if (participantWallets.TryGetValue(recipientAddress, out var walletAddress))
+            {
+                recipientAddress = walletAddress;
+            }
+            else
+            {
+                // Tier 2: Try resolving from register participant index
+                var participant = blueprint.Participants.FirstOrDefault(p =>
+                    string.Equals(p.Id, recipientAddress, StringComparison.OrdinalIgnoreCase));
+
+                if (participant != null)
+                {
+                    try
+                    {
+                        var resolvedRecord = await _registerClient.ResolveParticipantAsync(
+                            registerId, participant.Id, participant.Organisation);
+
+                        if (resolvedRecord?.Addresses.Count > 0)
+                        {
+                            var primaryAddr = resolvedRecord.Addresses.FirstOrDefault(a => a.Primary)
+                                              ?? resolvedRecord.Addresses.First();
+                            recipientAddress = primaryAddr.WalletAddress;
+                            _logger.LogDebug(
+                                "Resolved disclosure recipient {ParticipantId} to wallet {Wallet} from register",
+                                result.ParticipantId, recipientAddress);
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogWarning(ex, "Failed to resolve participant {ParticipantId} from register",
+                            result.ParticipantId);
+                    }
+                }
+            }
+
+            if (string.IsNullOrEmpty(recipientAddress))
+            {
+                _logger.LogWarning("No wallet address for disclosure recipient {ParticipantId}", result.ParticipantId);
+                continue;
+            }
+
+            disclosedPayloads[recipientAddress] = result.DisclosedData;
+        }
+
+        return disclosedPayloads;
+    }
+
+    /// <inheritdoc />
+    public async Task<DisclosedActionData> ResolveDisclosedDataAsync(
+        string instanceId,
+        int actionId,
+        IReadOnlyCollection<string> callerWallets,
+        string? delegationToken,
+        CancellationToken cancellationToken = default)
+    {
+        if (_stateReconstruction is null || _instanceStore is null || _blueprintStore is null)
+        {
+            throw new InvalidOperationException(
+                "ActionDisclosureResolver was constructed without its read-side dependencies "
+                + "(state reconstruction / instance store / blueprint store); ResolveDisclosedDataAsync is unavailable.");
+        }
+
+        DisclosedActionData Empty(string registerId) => new()
+        {
+            InstanceId = instanceId,
+            ActionId = actionId,
+            RegisterId = registerId,
+            RecipientResolved = false,
+        };
+
+        if (callerWallets.Count == 0)
+        {
+            return Empty(string.Empty);
+        }
+
+        var instance = await _instanceStore.GetAsync(instanceId, cancellationToken);
+        if (instance is null)
+        {
+            _logger.LogDebug("Disclosed-data resolve: instance {InstanceId} not found", instanceId);
+            return Empty(string.Empty);
+        }
+
+        var registerId = instance.RegisterId;
+
+        var blueprint = await _blueprintStore.GetAsync(instance.BlueprintId);
+        if (blueprint is null)
+        {
+            _logger.LogWarning(
+                "Disclosed-data resolve: blueprint {BlueprintId} not found for instance {InstanceId}",
+                instance.BlueprintId, instanceId);
+            return Empty(registerId);
+        }
+
+        // The deciding action must exist — otherwise reconstruction has no required-prior set to work
+        // from. Absence is treated as "nothing disclosed" (the caller falls back to a hold), not an error.
+        if (blueprint.Actions?.Any(a => a.Id == actionId) != true)
+        {
+            _logger.LogDebug(
+                "Disclosed-data resolve: action {ActionId} not found in blueprint {BlueprintId}",
+                actionId, instance.BlueprintId);
+            return Empty(registerId);
+        }
+
+        var callerSet = new HashSet<string>(callerWallets, StringComparer.OrdinalIgnoreCase);
+
+        // Reconstruct ONLY the caller-decryptable view: pass the caller's wallets as the reconstruction
+        // participant set so that on an encrypted register only groups sealed to the caller unwrap, and
+        // on a dev-mode register only the caller's plaintext entry is read where present. The
+        // per-prior-action clamp below is the belt-and-braces guarantee against the dev-mode
+        // merge-everything fallback ever widening disclosure to a non-recipient.
+        var callerReconstructionWallets = new Dictionary<string, string>(StringComparer.Ordinal);
+        var i = 0;
+        foreach (var w in callerWallets)
+        {
+            if (!string.IsNullOrEmpty(w))
+            {
+                callerReconstructionWallets[$"caller-{i++}"] = w;
+            }
+        }
+
+        Models.AccumulatedState state;
+        try
+        {
+            state = await _stateReconstruction.ReconstructAsync(
+                blueprint,
+                instanceId,
+                actionId,
+                registerId,
+                delegationToken ?? string.Empty,
+                callerReconstructionWallets,
+                cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            // Fail closed: a reconstruction fault surfaces as "no disclosure available" so the agent
+            // holds and retries on the next poll (FR-005 / FR-009) rather than deciding on a blank view.
+            _logger.LogWarning(ex,
+                "Disclosed-data resolve: state reconstruction failed for instance {InstanceId} action {ActionId}; returning empty (fail-closed)",
+                instanceId, actionId);
+            return Empty(registerId);
+        }
+
+        var entries = new List<DisclosedActionEntry>();
+        var merged = new Dictionary<string, object>(StringComparer.Ordinal);
+
+        foreach (var (actionKey, actionElement) in state.ActionData)
+        {
+            if (!int.TryParse(actionKey, out var priorActionId))
+            {
+                continue;
+            }
+
+            var priorAction = blueprint.Actions!.FirstOrDefault(a => a.Id == priorActionId);
+            if (priorAction is null)
+            {
+                continue;
+            }
+
+            var priorData = JsonElementToDictionary(actionElement);
+            if (priorData.Count == 0)
+            {
+                continue;
+            }
+
+            // Clamp the reconstructed prior-action data to exactly what THIS prior action discloses to
+            // the caller's participant. Uses the full instance bindings so recipient participants resolve
+            // to wallets, then keeps only the caller's wallet entry.
+            var disclosedByWallet = await ApplyDisclosuresAsync(
+                priorAction, priorData, blueprint, instance.ParticipantWallets, registerId, cancellationToken);
+
+            var callerFields = new Dictionary<string, object>(StringComparer.Ordinal);
+            foreach (var (wallet, fields) in disclosedByWallet)
+            {
+                if (!callerSet.Contains(wallet))
+                {
+                    continue;
+                }
+
+                foreach (var (key, value) in fields)
+                {
+                    callerFields[key] = value;
+                }
+            }
+
+            if (callerFields.Count == 0)
+            {
+                continue;
+            }
+
+            entries.Add(new DisclosedActionEntry
+            {
+                ActionId = priorActionId,
+                ActionTitle = priorAction.Title ?? string.Empty,
+                DisclosedAt = null,
+                Data = callerFields,
+            });
+
+            foreach (var (key, value) in callerFields)
+            {
+                merged[key] = value;
+            }
+        }
+
+        entries.Sort((a, b) => a.ActionId.CompareTo(b.ActionId));
+
+        return new DisclosedActionData
+        {
+            InstanceId = instanceId,
+            ActionId = actionId,
+            RegisterId = registerId,
+            RecipientResolved = entries.Count > 0,
+            Disclosures = entries,
+            DisclosedFields = merged,
+        };
+    }
+
+    /// <summary>
+    /// Projects a reconstructed action payload (a JSON object) into a
+    /// <see cref="Dictionary{TKey,TValue}"/> the disclosure engine consumes. Non-object elements yield
+    /// an empty map (nothing to disclose).
+    /// </summary>
+    private static Dictionary<string, object> JsonElementToDictionary(JsonElement element)
+    {
+        if (element.ValueKind != JsonValueKind.Object)
+        {
+            return new Dictionary<string, object>(StringComparer.Ordinal);
+        }
+
+        var result = new Dictionary<string, object>(StringComparer.Ordinal);
+        foreach (var property in element.EnumerateObject())
+        {
+            result[property.Name] = property.Value.Clone();
+        }
+
+        return result;
+    }
+}

--- a/src/Services/Sorcha.Blueprint.Service/Services/Implementation/ActionExecutionService.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Services/Implementation/ActionExecutionService.cs
@@ -54,6 +54,7 @@ public class ActionExecutionService : IActionExecutionService, IPresentationRout
     private readonly INotificationService _notificationService;
     private readonly IInstanceStore _instanceStore;
     private readonly IExecutionEngine _executionEngine;
+    private readonly IActionDisclosureResolver _actionDisclosureResolver;
     private readonly ICredentialVerifier? _credentialVerifier;
     private readonly IStatusListManager? _statusListManager;
     private readonly IEncryptionPipelineService? _encryptionPipeline;
@@ -105,7 +106,8 @@ public class ActionExecutionService : IActionExecutionService, IPresentationRout
         IPresentationLifecycleService? presentationLifecycle = null,
         IPresentationRateLimiter? presentationRateLimiter = null,
         PresentationLifecycleMetrics? presentationMetrics = null,
-        IOptions<Configuration.WalletOwnershipSettings>? walletOwnershipSettings = null)
+        IOptions<Configuration.WalletOwnershipSettings>? walletOwnershipSettings = null,
+        IActionDisclosureResolver? actionDisclosureResolver = null)
     {
         _actionResolver = actionResolver ?? throw new ArgumentNullException(nameof(actionResolver));
         _stateReconstruction = stateReconstruction ?? throw new ArgumentNullException(nameof(stateReconstruction));
@@ -142,6 +144,16 @@ public class ActionExecutionService : IActionExecutionService, IPresentationRout
 
         _walletOwnershipSettings = walletOwnershipSettings?.Value
             ?? new Configuration.WalletOwnershipSettings();
+
+        // Feature 176: disclosure resolution is now a shared authority (IActionDisclosureResolver) so the
+        // execution path and the disclosed-data query endpoint use one implementation. Constructed with a
+        // NullLogger fallback for direct (non-DI) test construction; the submit-side primitive needs only
+        // the engine + register client (its read-side deps stay null here).
+        _actionDisclosureResolver = actionDisclosureResolver
+            ?? new ActionDisclosureResolver(
+                executionEngine,
+                registerClient,
+                Microsoft.Extensions.Logging.Abstractions.NullLogger<ActionDisclosureResolver>.Instance);
     }
 
     /// <inheritdoc/>
@@ -1719,68 +1731,17 @@ public class ActionExecutionService : IActionExecutionService, IPresentationRout
         }
     }
 
-    private async Task<Dictionary<string, Dictionary<string, object>>> ApplyDisclosuresAsync(
+    // Feature 176: disclosure resolution moved to the shared IActionDisclosureResolver so the execution
+    // path and the disclosed-data query endpoint share one authority (no behaviour fork). This thin
+    // delegation preserves the original call shape at the single call site (step 9b).
+    private Task<Dictionary<string, Dictionary<string, object>>> ApplyDisclosuresAsync(
         ActionModel action,
         Dictionary<string, object> data,
         BlueprintModel blueprint,
         Dictionary<string, string> participantWallets,
         string registerId)
-    {
-        // Delegate to the Blueprint Engine for JSON Pointer disclosure filtering
-        var engineResults = _executionEngine.ApplyDisclosures(data, action);
-
-        var disclosedPayloads = new Dictionary<string, Dictionary<string, object>>();
-
-        foreach (var result in engineResults)
-        {
-            // Resolve participant ID to wallet address (2-tier: instance bindings → register)
-            var recipientAddress = result.ParticipantId;
-            if (participantWallets.TryGetValue(recipientAddress, out var walletAddress))
-            {
-                recipientAddress = walletAddress;
-            }
-            else
-            {
-                // Tier 2: Try resolving from register participant index
-                var participant = blueprint.Participants.FirstOrDefault(p =>
-                    string.Equals(p.Id, recipientAddress, StringComparison.OrdinalIgnoreCase));
-
-                if (participant != null)
-                {
-                    try
-                    {
-                        var resolvedRecord = await _registerClient.ResolveParticipantAsync(
-                            registerId, participant.Id, participant.Organisation);
-
-                        if (resolvedRecord?.Addresses.Count > 0)
-                        {
-                            var primaryAddr = resolvedRecord.Addresses.FirstOrDefault(a => a.Primary)
-                                              ?? resolvedRecord.Addresses.First();
-                            recipientAddress = primaryAddr.WalletAddress;
-                            _logger.LogDebug(
-                                "Resolved disclosure recipient {ParticipantId} to wallet {Wallet} from register",
-                                result.ParticipantId, recipientAddress);
-                        }
-                    }
-                    catch (Exception ex)
-                    {
-                        _logger.LogWarning(ex, "Failed to resolve participant {ParticipantId} from register",
-                            result.ParticipantId);
-                    }
-                }
-            }
-
-            if (string.IsNullOrEmpty(recipientAddress))
-            {
-                _logger.LogWarning("No wallet address for disclosure recipient {ParticipantId}", result.ParticipantId);
-                continue;
-            }
-
-            disclosedPayloads[recipientAddress] = result.DisclosedData;
-        }
-
-        return disclosedPayloads;
-    }
+        => _actionDisclosureResolver.ApplyDisclosuresAsync(
+            action, data, blueprint, participantWallets, registerId);
 
     private const int MaxConcurrencyRetries = 3;
 

--- a/src/Services/Sorcha.Blueprint.Service/Services/Interfaces/IActionDisclosureResolver.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Services/Interfaces/IActionDisclosureResolver.cs
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using Sorcha.Blueprint.Service.Models;
+using ActionModel = Sorcha.Blueprint.Models.Action;
+using BlueprintModel = Sorcha.Blueprint.Models.Blueprint;
+
+namespace Sorcha.Blueprint.Service.Services.Interfaces;
+
+/// <summary>
+/// Single authority for the DAD disclosure model (Feature 176). Resolves which fields of an action's
+/// data are disclosed to which recipient wallet, and reconstructs the prior-action data disclosed to a
+/// given caller. Extracted from the previously-private
+/// <c>ActionExecutionService.ApplyDisclosuresAsync</c> so the execution path (submit-side) and the
+/// disclosed-data query endpoint (read-side) share one implementation and can never diverge.
+/// </summary>
+public interface IActionDisclosureResolver
+{
+    /// <summary>
+    /// Applies an action's JSON-Pointer disclosure rules to <paramref name="data"/> and resolves each
+    /// recipient participant to a wallet address, returning the fields disclosed to each recipient
+    /// wallet. This is the submit-side primitive used by the execution pipeline when sealing an action;
+    /// behaviour is identical to the former private method (no drift).
+    /// </summary>
+    /// <param name="action">The action whose <c>Disclosures</c> rules govern the filtering.</param>
+    /// <param name="data">The action's payload (already merged with any calculated fields).</param>
+    /// <param name="blueprint">The blueprint (used for participant → register-record resolution).</param>
+    /// <param name="participantWallets">Instance participant-id → wallet-address bindings (tier-1 resolution).</param>
+    /// <param name="registerId">The register the instance lives on (tier-2 participant resolution).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Map of recipient wallet address → the fields disclosed to that wallet.</returns>
+    Task<Dictionary<string, Dictionary<string, object>>> ApplyDisclosuresAsync(
+        ActionModel action,
+        Dictionary<string, object> data,
+        BlueprintModel blueprint,
+        Dictionary<string, string> participantWallets,
+        string registerId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Resolves the prior-action data of a workflow instance disclosed to the caller's wallet(s), for
+    /// the action being decided. Reconstructs each required prior action's caller-decryptable view from
+    /// the instance's sealed transactions (identical whether the register stores payloads encrypted or
+    /// in dev-mode plaintext) and clamps it to exactly the caller participant's disclosure entitlement.
+    /// A field the applicant did not disclose to the caller is never returned (FR-006 / FR-010).
+    /// </summary>
+    /// <param name="instanceId">The workflow instance (the register is resolved from the instance).</param>
+    /// <param name="actionId">The action being decided (its required prior actions are reconstructed).</param>
+    /// <param name="callerWallets">The wallet address(es) owned by the calling participant.</param>
+    /// <param name="delegationToken">
+    /// The caller's delegation token, used to unwrap disclosure-group keys on encrypted registers.
+    /// May be null/empty for dev-mode (plaintext) registers, where decryption is not required.
+    /// </param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>
+    /// The disclosed prior-action view for the caller. <see cref="DisclosedActionData.RecipientResolved"/>
+    /// is false (and the field maps empty) when the caller is not a disclosure recipient.
+    /// </returns>
+    Task<DisclosedActionData> ResolveDisclosedDataAsync(
+        string instanceId,
+        int actionId,
+        IReadOnlyCollection<string> callerWallets,
+        string? delegationToken,
+        CancellationToken cancellationToken = default);
+}

--- a/tests/Sorcha.Agent.Tests/Decision/CheckFactsObservabilityTests.cs
+++ b/tests/Sorcha.Agent.Tests/Decision/CheckFactsObservabilityTests.cs
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Microsoft.Extensions.Logging;
+using Sorcha.Agent.Configuration;
+using Sorcha.Agent.Decision;
+using Sorcha.Agent.Decision.Checks;
+using Sorcha.Agent.Models;
+using Sorcha.Agent.Tests.Decision.Checks;
+
+namespace Sorcha.Agent.Tests.Decision;
+
+/// <summary>
+/// Feature 176 US3 — every decision is explainable. After the agent decides, the evaluated
+/// <c>checks.*</c> facts and the payload fields they were derived from are emitted as a structured log,
+/// and for a rejection the failing check is identifiable from those facts. The original defect was
+/// invisible precisely because the agent surfaced nothing about what it evaluated.
+/// </summary>
+public class CheckFactsObservabilityTests
+{
+    private const string ActionName = "Verify Assured Identity Application";
+
+    private sealed class FactCheck(string name, bool value) : IExternalCheck
+    {
+        public string Name => name;
+        public Task<ExternalCheckResult> EvaluateAsync(IReadOnlyDictionary<string, object?> payload, CancellationToken ct)
+            => Task.FromResult(new ExternalCheckResult(name, value, null));
+    }
+
+    private static ActorRule[] Rules() =>
+    [
+        new()
+        {
+            ActionName = ActionName,
+            Condition = JsonNode.Parse("""{ "==": [ { "var": "checks.postcodeExists" }, false ] }"""),
+            Decision = "reject",
+            Payload = JsonNode.Parse("""{ "decision": "rejected", "verificationNotes": "AIAS could not locate that address on any map." }""")!.AsObject(),
+        },
+        new()
+        {
+            ActionName = ActionName,
+            Condition = JsonNode.Parse("""{ "==": [ true, true ] }"""),
+            Decision = "approve",
+            Payload = JsonNode.Parse("""{ "decision": "approved", "verificationNotes": "Assured by AIAS." }""")!.AsObject(),
+        },
+    ];
+
+    private static PendingAction Action() => new()
+    {
+        ActionId = "a", ActionName = ActionName, ActionIndex = 2,
+        BlueprintId = "bp", InstanceId = "i", RegisterId = "r", TransactionId = "t",
+        PreviousPayload = JsonSerializer.Deserialize<JsonElement>(
+            """{ "name": { "fullName": "Ada Lovelace" }, "address": { "postcode": "SW1A 1AA" } }"""),
+    };
+
+    private static (RulesDecisionEngine engine, List<string> logs) EngineWithCapturedLogs(params IExternalCheck[] checks)
+    {
+        var logs = new List<string>();
+        var factory = LoggerFactory.Create(b =>
+            b.AddProvider(new CapturingLoggerProvider((_, _, message) =>
+            {
+                lock (logs) { logs.Add(message); }
+            })));
+        var engine = new RulesDecisionEngine(Rules(), new ExternalCheckRunner(checks), factory.CreateLogger<RulesDecisionEngine>());
+        return (engine, logs);
+    }
+
+    [Fact]
+    public async Task AfterDecision_EvaluatedFactsAndSourceFields_AreEmittedStructured()
+    {
+        var (engine, logs) = EngineWithCapturedLogs(
+            new FactCheck("postcodeExists", true), new FactCheck("emailVerified", true));
+
+        await engine.DecideAsync(Action());
+
+        var factsLog = logs.Should().ContainSingle(l => l.Contains("External checks evaluated")).Subject;
+        factsLog.Should().Contain("postcodeExists", "the evaluated facts must be visible");
+        factsLog.Should().Contain("address", "the source payload fields must be visible");
+        factsLog.Should().Contain("name");
+    }
+
+    [Fact]
+    public async Task ForRejection_FailingCheckIsIdentifiable()
+    {
+        var (engine, logs) = EngineWithCapturedLogs(
+            new FactCheck("postcodeExists", false), new FactCheck("emailVerified", true));
+
+        var decision = await engine.DecideAsync(Action());
+
+        decision.Decision.Should().Be("reject");
+        logs.Should().Contain(
+            l => l.Contains("External checks evaluated") && l.Contains("\"postcodeExists\":false"),
+            "the specific failing check must be identifiable from the recorded facts");
+    }
+}

--- a/tests/Sorcha.Agent.Tests/Decision/DecideOnRealDataTests.cs
+++ b/tests/Sorcha.Agent.Tests/Decision/DecideOnRealDataTests.cs
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Sorcha.Agent.Configuration;
+using Sorcha.Agent.Decision;
+using Sorcha.Agent.Decision.Checks;
+using Sorcha.Agent.Models;
+
+namespace Sorcha.Agent.Tests.Decision;
+
+/// <summary>
+/// Feature 176 US1 — with a real disclosed payload the agent decides on the applicant's actual submitted
+/// data: a non-existent postcode drives a rejection, a valid one an approval. Uses the real external-check
+/// runner and the real postcode check (offline fixture) over the payload, so the discriminating check is
+/// evaluated against the real <c>/address/postcode</c> field, not a default.
+/// </summary>
+public class DecideOnRealDataTests
+{
+    private const string ActionName = "Verify Assured Identity Application";
+
+    /// <summary>A check that emits a fixed boolean fact (for the non-discriminating checks).</summary>
+    private sealed class FactCheck(string name, bool value) : IExternalCheck
+    {
+        public string Name => name;
+        public Task<ExternalCheckResult> EvaluateAsync(IReadOnlyDictionary<string, object?> payload, CancellationToken ct)
+            => Task.FromResult(new ExternalCheckResult(name, value, null));
+    }
+
+    private static ActorRule Reject(string condition, string notes) => new()
+    {
+        ActionName = ActionName,
+        Condition = JsonNode.Parse(condition),
+        Decision = "reject",
+        Payload = JsonNode.Parse($$"""{ "decision": "rejected", "verificationNotes": {{JsonSerializer.Serialize(notes)}} }""")!.AsObject(),
+    };
+
+    private static ActorRule[] Rules() =>
+    [
+        Reject("""{ "==": [ { "var": "checks.postcodeExists" }, false ] }""", "AIAS could not locate that address on any map."),
+        Reject("""{ "==": [ { "var": "checks.emailVerified" }, false ] }""", "AIAS needs a verified email before it can assure you."),
+        new()
+        {
+            ActionName = ActionName,
+            Condition = JsonNode.Parse("""{ "==": [ true, true ] }"""),
+            Decision = "approve",
+            Payload = JsonNode.Parse("""{ "decision": "approved", "verificationNotes": "Assured by AIAS." }""")!.AsObject(),
+        },
+    ];
+
+    private static RulesDecisionEngine Engine()
+    {
+        // Offline-Always: the postcode check resolves purely against the bundled fixture — no network.
+        var postcode = new PostcodeExistsCheck(
+            "postcodeExists", "/address", new HttpClient(), ["SW1A 1AA"], PostcodeOfflineMode.Always);
+        var runner = new ExternalCheckRunner([postcode, new FactCheck("emailVerified", true)]);
+        return new RulesDecisionEngine(Rules(), runner);
+    }
+
+    private static PendingAction Application(string postcode) => new()
+    {
+        ActionId = "a", ActionName = ActionName, ActionIndex = 2,
+        BlueprintId = "bp", InstanceId = "i", RegisterId = "r", TransactionId = "t",
+        PreviousPayload = JsonSerializer.Deserialize<JsonElement>(
+            $$"""{ "name": { "fullName": "Ada Lovelace" }, "address": { "postcode": {{JsonSerializer.Serialize(postcode)}} } }"""),
+    };
+
+    [Fact]
+    public async Task Decide_RealDisclosedPayload_NonExistentPostcode_Rejects()
+    {
+        var decision = await Engine().DecideAsync(Application("ZZ99 9ZZ"));
+
+        decision.Decision.Should().Be("reject");
+        decision.Payload!["verificationNotes"]!.ToString().Should().Contain("could not locate that address");
+    }
+
+    [Fact]
+    public async Task Decide_RealDisclosedPayload_ValidPostcode_Approves()
+    {
+        var decision = await Engine().DecideAsync(Application("SW1A 1AA"));
+
+        decision.Decision.Should().Be("approve");
+        decision.Payload!["decision"]!.ToString().Should().Be("approved");
+    }
+}

--- a/tests/Sorcha.Agent.Tests/Decision/DisclosedPayloadFailClosedTests.cs
+++ b/tests/Sorcha.Agent.Tests/Decision/DisclosedPayloadFailClosedTests.cs
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Sorcha.Agent.Configuration;
+using Sorcha.Agent.Decision;
+using Sorcha.Agent.Decision.Checks;
+using Sorcha.Agent.Models;
+
+namespace Sorcha.Agent.Tests.Decision;
+
+/// <summary>
+/// Feature 176 US2 — the <see cref="RulesDecisionEngine"/> holds (never approves/rejects) when the rules
+/// depend on the disclosed application payload but it is empty/unavailable, and decides correctly once the
+/// payload is present. This is the fail-closed guard that stops the AIAS blank-data defect (a missing
+/// payload made every check default and the catch-all approve fire).
+/// </summary>
+public class DisclosedPayloadFailClosedTests
+{
+    private const string ActionName = "Verify Assured Identity Application";
+
+    private static ActorRule[] Rules() =>
+    [
+        new()
+        {
+            ActionName = ActionName,
+            Condition = JsonNode.Parse("""{ "==": [ { "var": "checks.postcodeExists" }, false ] }"""),
+            Decision = "reject",
+            Payload = JsonNode.Parse("""{ "decision": "rejected", "verificationNotes": "AIAS could not locate that address on any map." }""")!.AsObject(),
+        },
+        new()
+        {
+            ActionName = ActionName,
+            Condition = JsonNode.Parse("""{ "==": [ true, true ] }"""),
+            Decision = "approve",
+            Payload = JsonNode.Parse("""{ "decision": "approved", "verificationNotes": "Assured by AIAS." }""")!.AsObject(),
+        },
+    ];
+
+    private static RulesDecisionEngine Engine()
+    {
+        var postcode = new PostcodeExistsCheck(
+            "postcodeExists", "/address", new HttpClient(), ["SW1A 1AA"], PostcodeOfflineMode.Always);
+        return new RulesDecisionEngine(Rules(), new ExternalCheckRunner([postcode]));
+    }
+
+    private static PendingAction Action(JsonElement? payload) => new()
+    {
+        ActionId = "a", ActionName = ActionName, ActionIndex = 2,
+        BlueprintId = "bp", InstanceId = "i", RegisterId = "r", TransactionId = "t",
+        PreviousPayload = payload,
+    };
+
+    [Fact]
+    public async Task Decide_RulesRequireChecks_NullPayload_HoldsFailClosed()
+    {
+        var decision = await Engine().DecideAsync(Action(null));
+
+        decision.Decision.Should().Be("hold", "rules requiring the disclosed payload must not decide on a blank view");
+        decision.Payload.Should().BeNull();
+        decision.Reasoning.Should().Contain("Disclosed application data unavailable");
+    }
+
+    [Fact]
+    public async Task Decide_RulesRequireChecks_EmptyObjectPayload_HoldsFailClosed()
+    {
+        var decision = await Engine().DecideAsync(Action(JsonSerializer.Deserialize<JsonElement>("{}")));
+
+        decision.Decision.Should().Be("hold");
+        decision.Payload.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Decide_PayloadPresent_DecidesCorrectly_NotHeld()
+    {
+        var decision = await Engine().DecideAsync(Action(
+            JsonSerializer.Deserialize<JsonElement>("""{ "address": { "postcode": "SW1A 1AA" } }""")));
+
+        decision.Decision.Should().Be("approve", "with the payload present the checks evaluate and the rules decide");
+    }
+}

--- a/tests/Sorcha.Agent.Tests/Inbox/DisclosedPayloadFetchTests.cs
+++ b/tests/Sorcha.Agent.Tests/Inbox/DisclosedPayloadFetchTests.cs
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+using System.Text.Json;
+using Sorcha.Agent.Inbox;
+using Sorcha.Agent.Models;
+
+namespace Sorcha.Agent.Tests.Inbox;
+
+/// <summary>
+/// Feature 176 US1/US2 — the disclosed-data enrichment step. A successful fetch populates the pending
+/// action's previous payload from the fields disclosed to the agent's participant; a fetch failure or a
+/// non-recipient response yields a fail-closed hold (no payload, no decision).
+/// </summary>
+public class DisclosedPayloadFetchTests
+{
+    private static PendingAction Action() => new()
+    {
+        ActionId = "inst-1-2",
+        ActionName = "Verify Assured Identity Application",
+        ActionIndex = 2,
+        BlueprintId = "bp-1",
+        InstanceId = "inst-1",
+        RegisterId = "reg-1",
+        TransactionId = "tx-1",
+    };
+
+    /// <summary>Scriptable <see cref="IDisclosedDataClient"/> that records the arguments it was called with.</summary>
+    private sealed class StubClient(DisclosedDataResult? result) : IDisclosedDataClient
+    {
+        public string? LastInstanceId { get; private set; }
+        public uint LastActionId { get; private set; }
+
+        public Task<DisclosedDataResult?> GetDisclosedDataAsync(string instanceId, uint actionId, CancellationToken ct)
+        {
+            LastInstanceId = instanceId;
+            LastActionId = actionId;
+            return Task.FromResult(result);
+        }
+    }
+
+    [Fact]
+    public async Task EnrichAsync_DisclosedDataAvailable_FetchesByInstanceAndAction_SetsPreviousPayload()
+    {
+        var fields = JsonSerializer.Deserialize<JsonElement>(
+            """{ "name": { "fullName": "Ada Lovelace" }, "address": { "postcode": "SW1A 1AA" } }""");
+        var client = new StubClient(new DisclosedDataResult(RecipientResolved: true, fields));
+
+        var outcome = await new DisclosedPayloadEnricher(client).EnrichAsync(Action(), CancellationToken.None);
+
+        // Fetched keyed by (instanceId, actionId).
+        client.LastInstanceId.Should().Be("inst-1");
+        client.LastActionId.Should().Be(2u);
+
+        outcome.ShouldHold.Should().BeFalse();
+        outcome.Action.PreviousPayload.Should().NotBeNull();
+        outcome.Action.PreviousPayload!.Value.GetProperty("address").GetProperty("postcode").GetString()
+            .Should().Be("SW1A 1AA");
+    }
+
+    [Fact]
+    public async Task EnrichAsync_FetchFails_ReturnsHold_NoPayloadSubmitted()
+    {
+        // Transport failure — the client returns null. Must hold, not decide on a blank view.
+        var outcome = await new DisclosedPayloadEnricher(new StubClient(null)).EnrichAsync(Action(), CancellationToken.None);
+
+        outcome.ShouldHold.Should().BeTrue();
+        outcome.HoldReason.Should().Contain("unavailable");
+        outcome.Action.PreviousPayload.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task EnrichAsync_CallerNotADisclosureRecipient_ReturnsHold()
+    {
+        var client = new StubClient(new DisclosedDataResult(RecipientResolved: false, DisclosedFields: null));
+
+        var outcome = await new DisclosedPayloadEnricher(client).EnrichAsync(Action(), CancellationToken.None);
+
+        outcome.ShouldHold.Should().BeTrue();
+        outcome.Action.PreviousPayload.Should().BeNull();
+    }
+}

--- a/tests/Sorcha.Blueprint.Service.Tests/Endpoints/WorkflowDisclosureEndpointsTests.cs
+++ b/tests/Sorcha.Blueprint.Service.Tests/Endpoints/WorkflowDisclosureEndpointsTests.cs
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Security.Claims;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Sorcha.Blueprint.Service.Endpoints;
+using Sorcha.Blueprint.Service.Middleware;
+using Sorcha.Blueprint.Service.Models;
+using Sorcha.Blueprint.Service.Services.Interfaces;
+using Sorcha.ServiceClients.Wallet;
+
+namespace Sorcha.Blueprint.Service.Tests.Endpoints;
+
+/// <summary>
+/// Feature 176 — the disclosed-data endpoint handler. Focuses on caller-wallet resolution (fast-path
+/// claim + Wallet-Service fallback), forwarding of the resolved wallets and delegation token to the
+/// shared <see cref="IActionDisclosureResolver"/>, and the recipient-resolved semantics that drive the
+/// agent's fail-closed hold. The disclosure filtering itself is covered by ActionDisclosureResolverTests.
+/// </summary>
+public class WorkflowDisclosureEndpointsTests
+{
+    private const string InstanceId = "inst-1";
+    private const string AnalystWallet = "wsAnalyst";
+    private const int ActionId = 2;
+
+    private static HttpContext ContextWith(
+        (string Type, string Value)[] claims, string? delegationToken = null)
+    {
+        var identity = new ClaimsIdentity(claims.Select(c => new Claim(c.Type, c.Value)), "test");
+        var ctx = new DefaultHttpContext { User = new ClaimsPrincipal(identity) };
+        if (delegationToken is not null)
+        {
+            ctx.Items[DelegationTokenMiddleware.DelegationTokenKey] = delegationToken;
+        }
+
+        return ctx;
+    }
+
+    private static WalletInfo Wallet(string address) => new()
+    {
+        Address = address, Name = "w", PublicKey = "pk", Algorithm = "ED25519",
+        Status = "Active", Owner = "owner", Tenant = "tenant",
+    };
+
+    private static DisclosedActionData Resolved(bool recipientResolved) => new()
+    {
+        InstanceId = InstanceId,
+        ActionId = ActionId,
+        RegisterId = "reg-1",
+        RecipientResolved = recipientResolved,
+        DisclosedFields = recipientResolved
+            ? new Dictionary<string, object> { ["address"] = "SW1A 1AA" }
+            : new Dictionary<string, object>(),
+    };
+
+    [Fact]
+    public async Task GetDisclosures_RecipientCaller_FastPathClaim_ReturnsResolverData()
+    {
+        var resolver = new Mock<IActionDisclosureResolver>();
+        resolver.Setup(r => r.ResolveDisclosedDataAsync(
+                InstanceId, ActionId,
+                It.Is<IReadOnlyCollection<string>>(w => w.Contains(AnalystWallet)),
+                "delg", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Resolved(recipientResolved: true));
+
+        var wallet = new Mock<IWalletServiceClient>(MockBehavior.Strict);
+
+        var result = await WorkflowDisclosureEndpoints.GetDisclosuresAsync(
+            ContextWith([("wallet_address", AnalystWallet)], delegationToken: "delg"),
+            InstanceId, ActionId, resolver.Object, wallet.Object, NullLogger.Instance);
+
+        var ok = result.Should().BeOfType<Ok<DisclosedActionData>>().Subject;
+        ok.Value!.RecipientResolved.Should().BeTrue();
+        ok.Value.DisclosedFields.Should().ContainKey("address");
+        // Fast path — no Wallet Service lookup needed.
+        wallet.Verify(c => c.GetWalletsByOwnerAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task GetDisclosures_NonRecipient_ReturnsRecipientNotResolved()
+    {
+        var resolver = new Mock<IActionDisclosureResolver>();
+        resolver.Setup(r => r.ResolveDisclosedDataAsync(
+                InstanceId, ActionId, It.IsAny<IReadOnlyCollection<string>>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Resolved(recipientResolved: false));
+
+        var result = await WorkflowDisclosureEndpoints.GetDisclosuresAsync(
+            ContextWith([("wallet_address", "wsStranger")]),
+            InstanceId, ActionId, resolver.Object, new Mock<IWalletServiceClient>().Object, NullLogger.Instance);
+
+        var ok = result.Should().BeOfType<Ok<DisclosedActionData>>().Subject;
+        ok.Value!.RecipientResolved.Should().BeFalse();
+        ok.Value.DisclosedFields.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetDisclosures_NoWalletClaim_ResolvesCallerViaWalletServiceFallback()
+    {
+        // Consumer-tier token: no wallet_address claim; wallet is owned by platform_user_id (#912).
+        var wallet = new Mock<IWalletServiceClient>();
+        wallet.Setup(c => c.GetWalletsByOwnerAsync("platform-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([Wallet(AnalystWallet)]);
+
+        var resolver = new Mock<IActionDisclosureResolver>();
+        resolver.Setup(r => r.ResolveDisclosedDataAsync(
+                InstanceId, ActionId,
+                It.Is<IReadOnlyCollection<string>>(w => w.Contains(AnalystWallet)),
+                It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Resolved(recipientResolved: true));
+
+        var result = await WorkflowDisclosureEndpoints.GetDisclosuresAsync(
+            ContextWith([("platform_user_id", "platform-1"), (ClaimTypes.NameIdentifier, "sub-1")]),
+            InstanceId, ActionId, resolver.Object, wallet.Object, NullLogger.Instance);
+
+        result.Should().BeOfType<Ok<DisclosedActionData>>()
+            .Which.Value!.RecipientResolved.Should().BeTrue();
+        wallet.Verify(c => c.GetWalletsByOwnerAsync("platform-1", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetDisclosures_NoWalletsResolvable_ShortCircuitsWithoutCallingResolver()
+    {
+        var resolver = new Mock<IActionDisclosureResolver>(MockBehavior.Strict);
+        var wallet = new Mock<IWalletServiceClient>();
+        wallet.Setup(c => c.GetWalletsByOwnerAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+
+        var result = await WorkflowDisclosureEndpoints.GetDisclosuresAsync(
+            ContextWith([("platform_user_id", "nobody")]),
+            InstanceId, ActionId, resolver.Object, wallet.Object, NullLogger.Instance);
+
+        var ok = result.Should().BeOfType<Ok<DisclosedActionData>>().Subject;
+        ok.Value!.RecipientResolved.Should().BeFalse();
+        resolver.Verify(r => r.ResolveDisclosedDataAsync(
+            It.IsAny<string>(), It.IsAny<int>(), It.IsAny<IReadOnlyCollection<string>>(),
+            It.IsAny<string?>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+}

--- a/tests/Sorcha.Blueprint.Service.Tests/Services/ActionDisclosureResolverTests.cs
+++ b/tests/Sorcha.Blueprint.Service.Tests/Services/ActionDisclosureResolverTests.cs
@@ -1,0 +1,235 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Text.Json;
+using Microsoft.Extensions.Logging.Abstractions;
+using Sorcha.Blueprint.Engine.Interfaces;
+using Sorcha.Blueprint.Engine.Models;
+using Sorcha.Blueprint.Service.Models;
+using Sorcha.Blueprint.Service.Services.Implementation;
+using Sorcha.Blueprint.Service.Services.Interfaces;
+using Sorcha.Blueprint.Service.Storage;
+using Sorcha.ServiceClients.Register;
+using ActionModel = Sorcha.Blueprint.Models.Action;
+using BlueprintModel = Sorcha.Blueprint.Models.Blueprint;
+using DisclosureModel = Sorcha.Blueprint.Models.Disclosure;
+using ParticipantModel = Sorcha.Blueprint.Models.Participant;
+
+namespace Sorcha.Blueprint.Service.Tests.Services;
+
+/// <summary>
+/// Feature 176 — unit coverage for the shared <see cref="ActionDisclosureResolver"/>. Proves the
+/// submit-side participant→wallet mapping and the read-side reconstruct-then-clamp: only fields
+/// disclosed to the caller's participant are ever returned (FR-006 / FR-010), the caller wallet is
+/// resolved (including multi-wallet), a non-recipient gets an empty / <c>recipientResolved=false</c>
+/// view (fail-closed driver), and the view is identical regardless of encrypted vs dev-mode storage.
+/// </summary>
+public class ActionDisclosureResolverTests
+{
+    private const string RegisterId = "reg-1";
+    private const string InstanceId = "inst-1";
+    private const string AnalystWallet = "wsAnalyst";
+    private const string CitizenWallet = "wsCitizen";
+
+    private readonly Mock<IExecutionEngine> _engine = new();
+    private readonly Mock<IRegisterServiceClient> _register = new();
+    private readonly Mock<IStateReconstructionService> _reconstruction = new();
+    private readonly Mock<IInstanceStore> _instanceStore = new();
+    private readonly Mock<IBlueprintStore> _blueprintStore = new();
+
+    private ActionDisclosureResolver CreateResolver() =>
+        new(_engine.Object, _register.Object, NullLogger<ActionDisclosureResolver>.Instance,
+            _reconstruction.Object, _instanceStore.Object, _blueprintStore.Object);
+
+    private static BlueprintModel Blueprint() => new()
+    {
+        Id = "bp-1",
+        Title = "AIAS Assured Identity",
+        Participants =
+        [
+            new ParticipantModel { Id = "citizen", Name = "Applicant" },
+            new ParticipantModel { Id = "verification-analyst", Name = "Assure-ID Agent" },
+        ],
+        Actions =
+        [
+            new ActionModel
+            {
+                Id = 1,
+                Title = "Submit Assured Identity Application",
+                Sender = "citizen",
+                Disclosures =
+                [
+                    new DisclosureModel { ParticipantAddress = "citizen", DataPointers = ["/*"] },
+                    new DisclosureModel { ParticipantAddress = "verification-analyst", DataPointers = ["/*"] },
+                ],
+            },
+            new ActionModel { Id = 2, Title = "Verify Assured Identity Application", Sender = "verification-analyst" },
+        ],
+    };
+
+    private static Instance Instance() => new()
+    {
+        Id = InstanceId,
+        BlueprintId = "bp-1",
+        BlueprintVersion = 1,
+        RegisterId = RegisterId,
+        TenantId = "t-1",
+        CurrentActionIds = [2],
+        ParticipantWallets = new Dictionary<string, string>
+        {
+            ["citizen"] = CitizenWallet,
+            ["verification-analyst"] = AnalystWallet,
+        },
+    };
+
+    private static JsonElement Element(string json) => JsonDocument.Parse(json).RootElement.Clone();
+
+    private void SetupReconstruction(JsonElement action1Data) =>
+        _reconstruction
+            .Setup(r => r.ReconstructAsync(
+                It.IsAny<BlueprintModel>(), InstanceId, 2, RegisterId,
+                It.IsAny<string>(), It.IsAny<Dictionary<string, string>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AccumulatedState
+            {
+                ActionData = new Dictionary<string, JsonElement> { ["1"] = action1Data },
+                ActionCount = 1,
+            });
+
+    // ---- Submit-side primitive -------------------------------------------------------------------
+
+    [Fact]
+    public async Task ApplyDisclosuresAsync_ResolvesBoundParticipant_ToWalletKeyedDisclosedData()
+    {
+        var action = Blueprint().Actions!.First(a => a.Id == 1);
+        var disclosed = new Dictionary<string, object> { ["postcode"] = "SW1A 1AA" };
+        _engine.Setup(e => e.ApplyDisclosures(It.IsAny<Dictionary<string, object>>(), action))
+            .Returns([DisclosureResult.Create("verification-analyst", disclosed)]);
+
+        var result = await CreateResolver().ApplyDisclosuresAsync(
+            action, new Dictionary<string, object>(), Blueprint(),
+            new Dictionary<string, string> { ["verification-analyst"] = AnalystWallet }, RegisterId);
+
+        result.Should().ContainKey(AnalystWallet);
+        result[AnalystWallet].Should().BeEquivalentTo(disclosed);
+    }
+
+    // ---- Read-side: reconstruct-then-clamp -------------------------------------------------------
+
+    [Fact]
+    public async Task ResolveDisclosedDataAsync_RecipientCaller_ReturnsOnlyClampedDisclosedFields()
+    {
+        // Reconstruction yields name + address for the caller; the engine clamps action-1's disclosure
+        // to the analyst — here deliberately a SUBSET (address only) — proving no undisclosed field
+        // (the applicant's name) leaks through even though it was in the reconstructed view.
+        _instanceStore.Setup(s => s.GetAsync(InstanceId, It.IsAny<CancellationToken>())).ReturnsAsync(Instance());
+        _blueprintStore.Setup(s => s.GetAsync("bp-1")).ReturnsAsync(Blueprint());
+        SetupReconstruction(Element("""{ "name": { "fullName": "Ada Lovelace" }, "address": { "postcode": "SW1A 1AA" } }"""));
+
+        var addressOnly = new Dictionary<string, object> { ["address"] = Element("""{ "postcode": "SW1A 1AA" }""") };
+        _engine.Setup(e => e.ApplyDisclosures(It.IsAny<Dictionary<string, object>>(), It.IsAny<ActionModel>()))
+            .Returns([DisclosureResult.Create("verification-analyst", addressOnly)]);
+
+        var result = await CreateResolver().ResolveDisclosedDataAsync(
+            InstanceId, 2, [AnalystWallet], delegationToken: "tok");
+
+        result.RecipientResolved.Should().BeTrue();
+        result.DisclosedFields.Should().ContainKey("address");
+        result.DisclosedFields.Should().NotContainKey("name", "an undisclosed field must never be returned");
+        result.Disclosures.Should().ContainSingle();
+        result.Disclosures[0].ActionId.Should().Be(1);
+        result.Disclosures[0].ActionTitle.Should().Be("Submit Assured Identity Application");
+    }
+
+    [Fact]
+    public async Task ResolveDisclosedDataAsync_MultiWalletCaller_ResolvesViaMatchingWallet()
+    {
+        _instanceStore.Setup(s => s.GetAsync(InstanceId, It.IsAny<CancellationToken>())).ReturnsAsync(Instance());
+        _blueprintStore.Setup(s => s.GetAsync("bp-1")).ReturnsAsync(Blueprint());
+        SetupReconstruction(Element("""{ "email": { "email": "ada@example.test" } }"""));
+
+        var disclosed = new Dictionary<string, object> { ["email"] = Element("""{ "email": "ada@example.test" }""") };
+        _engine.Setup(e => e.ApplyDisclosures(It.IsAny<Dictionary<string, object>>(), It.IsAny<ActionModel>()))
+            .Returns([DisclosureResult.Create("verification-analyst", disclosed)]);
+
+        // The agent owns two wallets; only the second is the analyst recipient.
+        var result = await CreateResolver().ResolveDisclosedDataAsync(
+            InstanceId, 2, ["wsOther", AnalystWallet], delegationToken: "tok");
+
+        result.RecipientResolved.Should().BeTrue();
+        result.DisclosedFields.Should().ContainKey("email");
+    }
+
+    [Fact]
+    public async Task ResolveDisclosedDataAsync_NonRecipientCaller_RecipientNotResolved()
+    {
+        _instanceStore.Setup(s => s.GetAsync(InstanceId, It.IsAny<CancellationToken>())).ReturnsAsync(Instance());
+        _blueprintStore.Setup(s => s.GetAsync("bp-1")).ReturnsAsync(Blueprint());
+        SetupReconstruction(Element("""{ "decision": "approved" }"""));
+
+        // Action-1 discloses only to the citizen; the caller wallet is a stranger.
+        var disclosed = new Dictionary<string, object> { ["decision"] = "approved" };
+        _engine.Setup(e => e.ApplyDisclosures(It.IsAny<Dictionary<string, object>>(), It.IsAny<ActionModel>()))
+            .Returns([DisclosureResult.Create("citizen", disclosed)]);
+
+        var result = await CreateResolver().ResolveDisclosedDataAsync(
+            InstanceId, 2, ["wsStranger"], delegationToken: "tok");
+
+        result.RecipientResolved.Should().BeFalse();
+        result.DisclosedFields.Should().BeEmpty();
+        result.Disclosures.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ResolveDisclosedDataAsync_InstanceNotFound_ReturnsEmptyNotResolved()
+    {
+        _instanceStore.Setup(s => s.GetAsync(InstanceId, It.IsAny<CancellationToken>())).ReturnsAsync((Instance?)null);
+
+        var result = await CreateResolver().ResolveDisclosedDataAsync(
+            InstanceId, 2, [AnalystWallet], delegationToken: "tok");
+
+        result.RecipientResolved.Should().BeFalse();
+        result.DisclosedFields.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ResolveDisclosedDataAsync_ReconstructionFaults_FailsClosedEmpty()
+    {
+        _instanceStore.Setup(s => s.GetAsync(InstanceId, It.IsAny<CancellationToken>())).ReturnsAsync(Instance());
+        _blueprintStore.Setup(s => s.GetAsync("bp-1")).ReturnsAsync(Blueprint());
+        _reconstruction
+            .Setup(r => r.ReconstructAsync(
+                It.IsAny<BlueprintModel>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string>(),
+                It.IsAny<string>(), It.IsAny<Dictionary<string, string>>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException("register unreachable"));
+
+        var result = await CreateResolver().ResolveDisclosedDataAsync(
+            InstanceId, 2, [AnalystWallet], delegationToken: "tok");
+
+        result.RecipientResolved.Should().BeFalse("a reconstruction fault must fail closed, not decide on blanks");
+        result.DisclosedFields.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ResolveDisclosedDataAsync_IdenticalReconstruction_YieldsIdenticalView_RegardlessOfPosture()
+    {
+        // Encrypted vs dev-mode is normalised by StateReconstructionService: given identical
+        // reconstructed ActionData, the resolver's disclosed view is byte-for-byte the same. The
+        // resolver never branches on storage posture.
+        _instanceStore.Setup(s => s.GetAsync(InstanceId, It.IsAny<CancellationToken>())).ReturnsAsync(Instance());
+        _blueprintStore.Setup(s => s.GetAsync("bp-1")).ReturnsAsync(Blueprint());
+        SetupReconstruction(Element("""{ "address": { "postcode": "SW1A 1AA" } }"""));
+        var disclosed = new Dictionary<string, object> { ["address"] = Element("""{ "postcode": "SW1A 1AA" }""") };
+        _engine.Setup(e => e.ApplyDisclosures(It.IsAny<Dictionary<string, object>>(), It.IsAny<ActionModel>()))
+            .Returns([DisclosureResult.Create("verification-analyst", disclosed)]);
+
+        var resolver = CreateResolver();
+        var first = await resolver.ResolveDisclosedDataAsync(
+            InstanceId, 2, [AnalystWallet], "tok");
+        var second = await resolver.ResolveDisclosedDataAsync(
+            InstanceId, 2, [AnalystWallet], "tok");
+
+        JsonSerializer.Serialize(first.DisclosedFields)
+            .Should().Be(JsonSerializer.Serialize(second.DisclosedFields));
+        first.RecipientResolved.Should().BeTrue();
+    }
+}


### PR DESCRIPTION
## Summary

Closes a fail-open hole found live on n1 (2026-07-07): the autonomous `Sorcha.Agent` decided on an **empty** payload. It mapped `PendingAction.PreviousPayload` from the `/api/actions/pending` summary's `prepopulatedPayload` — a Feature-104 form-prefill seed that is empty for the AIAS verify action and does **not** carry the disclosed prior-action application data. Every external check defaulted, so a fake postcode `ZZ99 9ZZ` was **approved** and a credential issued. The blueprint grants the agent's `verification-analyst` participant `/*` disclosure, but the agent never fetched the disclosed view.

**Design A** (`research.md`): implement the already-contracted disclosed-data endpoint server-side and have the agent fetch it per pending action, failing closed when unavailable.

## Server (Blueprint.Service)

- **`IActionDisclosureResolver`** — extracted the disclosure logic from the previously-private `ActionExecutionService.ApplyDisclosuresAsync` into a shared authority; `ActionExecutionService` now delegates to it (no behaviour change, guarded by the existing DevMode disclosure test).
- **Read-side `ResolveDisclosedDataAsync`** — **reconstruct-then-clamp**: `IStateReconstructionService` scoped to the caller's wallets yields each required prior action's caller-decryptable view (encrypted **and** dev-mode paths normalised by StateReconstruction), then the submit-side primitive **clamps** each action's data to the caller participant's entitlement. Belt-and-braces so the dev-mode merge-everything fallback can never widen disclosure to a non-recipient.
- **`GET /api/workflows/{instanceId}/actions/{actionId}/disclosures`** (+ instance-wide) in `WorkflowDisclosureEndpoints.cs`, matching the existing `IBlueprintServiceClient.GetDisclosedDataAsync` / MCP `DisclosedDataTool` contract. `.RequireAuthorization()`; caller wallet resolved via the same `ActionEndpoints` Wallet-Service fallback (`platform_user_id`→owner, #912); `X-Delegation-Token` unwraps encrypted groups. **No new JWT claim.** Non-recipient → `200` with `recipientResolved:false` + empty view.

## Agent (Sorcha.Agent)

- **`IDecisionEngine.RequiresDisclosedPayload`** gates the fetch — rules-with-checks only; AI/simple agents opt out (no hold-forever regression).
- **`DisclosedPayloadEnricher`** over `HttpDisclosedDataClient` (the agent's **own user bearer**, not the service-token `BlueprintServiceClient`, which would resolve the wrong identity) sets `PreviousPayload` from `disclosedFields`; holds fail-closed on fetch failure / non-recipient.
- **`RulesDecisionEngine`** also holds when rules require checks but the payload is empty (mirrors #1077); `RunCommand` treats `hold` as no-submission.
- `PollingInboxListener` no longer sources `PreviousPayload` from the summary (kept the `schema`→`dataSchema` correction).
- **US3 explainability**: the structured check-facts log identifies evaluated facts + source fields for any decision.

## Guardrails
Security-positive: the agent receives **only** fields disclosed to its participant; fails closed, never open. No disclosure widening; no new entity/migration; no duplicate service client.

## Tests
`ActionDisclosureResolverTests`, `WorkflowDisclosureEndpointsTests`, `DisclosedPayloadFetchTests`, `DecideOnRealDataTests` (bad postcode → reject, valid → approve over real checks), `DisclosedPayloadFailClosedTests`, `CheckFactsObservabilityTests`.

- ✅ `Sorcha.Blueprint.Service.Tests` — **913 passed**
- ✅ `Sorcha.Agent.Tests` — **170 passed**
- ✅ Release builds clean, no new warnings

## Remaining
- **T014 / T024 `demos/AIAS/rehearse.ps1` E2E** (valid → approved + credential; `ZZ99 9ZZ` → rejected + no credential) — requires a Docker-Publish + blueprint-service redeploy on n1/tiny; pending as the final live witness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)