### PR TITLE
fix: [176] route /api/workflows through the gateway to blueprint-service

### DIFF
--- a/src/Services/Sorcha.ApiGateway/appsettings.json
+++ b/src/Services/Sorcha.ApiGateway/appsettings.json
@@ -414,6 +414,7 @@
       "blueprint-catalogue-sub":  { "ClusterId": "blueprint-cluster", "AuthorizationPolicy": "RequireAuthenticated", "Match": { "Path": "/api/catalogue/{**catch-all}" } },
       "blueprint-instances-list": { "ClusterId": "blueprint-cluster", "AuthorizationPolicy": "RequireAuthenticated", "Order": 1, "Match": { "Path": "/api/instances" } },
       "blueprint-instances":   { "ClusterId": "blueprint-cluster", "AuthorizationPolicy": "RequireAuthenticated", "Match": { "Path": "/api/instances/{**catch-all}" } },
+      "blueprint-workflows":   { "ClusterId": "blueprint-cluster", "AuthorizationPolicy": "RequireAuthenticated", "Match": { "Path": "/api/workflows/{**catch-all}" } },
       "blueprint-templates":   { "ClusterId": "blueprint-cluster", "AuthorizationPolicy": "RequireAuthenticated", "Match": { "Path": "/api/templates/{**catch-all}" } },
       "blueprint-actions":     { "ClusterId": "blueprint-cluster", "AuthorizationPolicy": "RequireAuthenticated", "Match": { "Path": "/api/actions/{**catch-all}" } },
       "blueprint-operations":  { "ClusterId": "blueprint-cluster", "AuthorizationPolicy": "RequireAuthenticated", "Match": { "Path": "/api/operations/{**catch-all}" } },


### PR DESCRIPTION
## Summary
Follow-up to #1136 (Feature 176), found via the n1 E2E.

The disclosed-data endpoint lives on blueprint-service at `/api/workflows/{instanceId}/actions/{actionId}/disclosures` (the `IBlueprintServiceClient` / MCP `DisclosedDataTool` contract). The MCP tool reaches it via the **direct** service address, but the autonomous agent calls through the **API gateway** — which had **no `/api/workflows` route** to blueprint-cluster (only `/api/actions`, `/api/instances`, `/api/blueprints`, …). So the agent's disclosed-data fetch 404'd at the gateway and it fail-closed **held every application** instead of deciding.

Adds `blueprint-workflows` — a catch-all `/api/workflows/{**catch-all}` route to `blueprint-cluster` (`RequireAuthenticated`, mirroring `blueprint-instances`). Verified on n1: the endpoint returns 401 (auth gate) directly on blueprint-service but 404 via the gateway before this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)