### PR TITLE
feat: [181] EUDI conformance — foundation (spec + shared DCQL dialect + dc+sd-jwt + CI gate)

### DIFF
--- a/.github/workflows/presentation-dialect-gate.yml
+++ b/.github/workflows/presentation-dialect-gate.yml
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Sorcha Contributors
+#
+# Feature 181 presentation-dialect CI gate. Fails when the legacy OpenID4VP
+# Presentation Exchange dialect (presentation_definition / input_descriptors /
+# presentation_submission) or the legacy SD-JWT typ "vc+sd-jwt" appears in
+# src/ outside the ratchet allowlist (.presentation-dialect-allowlist).
+# DCQL (dcql_query) + typ "dc+sd-jwt" are the replacements.
+#
+# See scripts/check-presentation-dialect.ps1 and specs/181-eudi-conformance/.
+
+name: presentation-dialect-gate
+
+on:
+  pull_request:
+    paths:
+      - "src/**"
+      - "scripts/check-presentation-dialect.ps1"
+      - ".presentation-dialect-allowlist"
+      - ".github/workflows/presentation-dialect-gate.yml"
+  workflow_dispatch:
+
+jobs:
+  presentation-dialect:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run Feature 181 presentation-dialect gate
+        shell: pwsh
+        run: ./scripts/check-presentation-dialect.ps1

--- a/.presentation-dialect-allowlist
+++ b/.presentation-dialect-allowlist
@@ -1,0 +1,23 @@
+# Presentation-dialect allowlist — Feature 181 (EUDI / HAIP conformance).
+#
+# Files still carrying the legacy OpenID4VP Presentation Exchange dialect
+# (presentation_definition / input_descriptors / presentation_submission)
+# or writing the legacy SD-JWT typ "vc+sd-jwt". Enforced by
+# scripts/check-presentation-dialect.ps1 (CI: presentation-dialect-gate).
+#
+# This list is a RATCHET — it may only shrink, never grow. Remove each entry
+# in the same PR that migrates the file to DCQL / dc+sd-jwt. Verify-side
+# ACCEPTANCE of typ "vc+sd-jwt" and legacy-dialect REJECTION guards may stay
+# allowlisted for interop.
+#
+# One relative path per line (forward slashes); trailing # comments allowed.
+
+src/Apps/Sorcha.Agent/Commands/HaipPresentCommand.cs                                          # presentation_submission, "vc+sd-jwt"
+src/Apps/Sorcha.Agent/Commands/HaipReceiveCommand.cs                                          # "vc+sd-jwt"
+src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/Credentials/HaipLocalReceiveService.cs  # "vc+sd-jwt"
+src/Apps/Sorcha.Wallet.Pwa/Services/Presentation/PresentationEngine.cs                        # presentation_definition, input_descriptors
+src/Common/Sorcha.Verifier.Engine/Dcql/DcqlRequestParser.cs                                   # presentation_definition, input_descriptors — REJECTION GUARD (probes the legacy keys to refuse them); permanent
+src/Services/Sorcha.Haip.Service/Endpoints/CredentialEndpoints.cs                             # "vc+sd-jwt"
+src/Services/Sorcha.Haip.Service/Endpoints/MetadataEndpoints.cs                               # "vc+sd-jwt"
+src/Services/Sorcha.Haip.Service/Endpoints/VerifierEndpoints.cs                               # presentation_definition, input_descriptors, presentation_submission, "vc+sd-jwt"
+src/Services/Sorcha.Haip.Service/Models/HaipModels.cs                                         # "vc+sd-jwt"

--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/180-siwe-prove-control"
+  "feature_directory": "specs/181-eudi-conformance"
 }

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -39,6 +39,8 @@
     <!-- Cryptography - CBOR / COSE (ISO mdoc, feature 135). Cose 10.0.0 carries NU1903/GHSA-qvhc-9v3j-5rfw — pin patched 10.0.8; Cbor matched to 10.0.8 (Cose 10.0.8 requires Cbor >= 10.0.8). -->
     <PackageVersion Include="System.Formats.Cbor" Version="10.0.8" />
     <PackageVersion Include="System.Security.Cryptography.Cose" Version="10.0.8" />
+    <!-- Cryptography - XMLDSig (ETSI TS 119 612 trusted-list signing, feature 181) -->
+    <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.8" />
     <!-- Testing - Blazor -->
     <PackageVersion Include="bunit" Version="2.7.2" />
     <!-- Testing - Coverage -->

--- a/scripts/check-presentation-dialect.ps1
+++ b/scripts/check-presentation-dialect.ps1
@@ -1,0 +1,161 @@
+#!/usr/bin/env pwsh
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Sorcha Contributors
+#
+# Presentation-dialect CI gate (Feature 181 — EUDI / HAIP conformance).
+#
+# The platform is migrating off the legacy OpenID4VP Presentation Exchange
+# dialect onto DCQL, and off the legacy SD-JWT media type onto its successor:
+#   - presentation_definition / input_descriptors -> dcql_query (DCQL)
+#   - presentation_submission                     -> retired (DCQL responses
+#     carry vp_token keyed by credential query id — no submission mapping)
+#   - typ "vc+sd-jwt"                             -> "dc+sd-jwt" (writes only;
+#     verify-side ACCEPTANCE of the legacy typ stays allowlisted for interop)
+#
+# To stop the migration regressing while it's in flight, this gate fails the
+# build when any .cs / .razor / .json file under src/ outside the allowlist
+# (.presentation-dialect-allowlist) contains one of the legacy tokens.
+#
+# The allowlist is a ratchet — it may only shrink, never grow. When it
+# reaches zero entries the migration is complete and this script becomes
+# a permanent guard.
+#
+# Usage:
+#   pwsh scripts/check-presentation-dialect.ps1
+#
+# Exit codes:
+#   0 — no violations
+#   1 — legacy dialect token found outside the allowlist
+
+[CmdletBinding()]
+param(
+    [string]$RepoRoot = (Resolve-Path "$PSScriptRoot/..").Path
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repo = $RepoRoot.TrimEnd([IO.Path]::DirectorySeparatorChar)
+$allowlistPath = Join-Path $repo '.presentation-dialect-allowlist'
+
+if (-not (Test-Path -LiteralPath $allowlistPath)) {
+    Write-Error "Allowlist file not found: $allowlistPath"
+    exit 1
+}
+
+# Load the allowlist — strip blank lines, comments, and trailing comments.
+# Normalise to forward slashes so the comparison works on both Windows and
+# Linux runners.
+$allowed = @{}
+foreach ($line in (Get-Content -LiteralPath $allowlistPath)) {
+    $trimmed = $line.Trim()
+    if ($trimmed.Length -eq 0) { continue }
+    if ($trimmed.StartsWith('#')) { continue }
+    # Allow trailing "# which pattern(s)" annotations on entries.
+    $hashIdx = $trimmed.IndexOf('#')
+    if ($hashIdx -ge 0) { $trimmed = $trimmed.Substring(0, $hashIdx).Trim() }
+    if ($trimmed.Length -eq 0) { continue }
+    $allowed[$trimmed.Replace('\', '/')] = $true
+}
+
+# Legacy dialect tokens. The three Presentation Exchange tokens are banned
+# outright once a file leaves the allowlist; the literal "vc+sd-jwt" typ is
+# the same pattern class — writes must move to "dc+sd-jwt", verify-side
+# acceptance sites stay on the allowlist deliberately.
+$patterns = @(
+    'presentation_definition',
+    'input_descriptors',
+    'presentation_submission',
+    '"vc\+sd-jwt"'
+)
+
+# Files to scan: any .cs / .razor / .json under src/. Excludes build output
+# (obj/bin) and worktree checkouts (.worktrees).
+$srcRoot = Join-Path $repo 'src'
+$candidates = Get-ChildItem -Path $srcRoot -Recurse -Include '*.cs', '*.razor', '*.json' -File -ErrorAction SilentlyContinue |
+    Where-Object { $_.FullName -notmatch '[\\/](obj|bin|\.worktrees)[\\/]' }
+
+$violations = @()
+$matchedAllowed = @{}
+
+foreach ($file in $candidates) {
+    $rel = [IO.Path]::GetRelativePath($repo, $file.FullName).Replace('\', '/')
+    $lineNum = 0
+    $fileHasMatch = $false
+
+    foreach ($line in (Get-Content -LiteralPath $file.FullName)) {
+        $lineNum++
+
+        # Skip comment-only lines so XML docs and inline comments that mention
+        # the retired dialect (e.g. "Replaces presentation_submission") don't
+        # trigger the gate. The DCQL migration explicitly documents what it
+        # replaces; narrative references in prose aren't actual usage.
+        # Covered shapes:
+        #   C# // line comment, /// XML doc, /* block, * continuation, */ end
+        #   Razor @* block-comment line
+        $trimmedForCommentCheck = $line.TrimStart()
+        if ($trimmedForCommentCheck -match '^(//|/\*|\*|@\*)') { continue }
+
+        foreach ($p in $patterns) {
+            if ($line -match $p) {
+                $fileHasMatch = $true
+                if (-not $allowed.ContainsKey($rel)) {
+                    $violations += [pscustomobject]@{
+                        File    = $rel
+                        Line    = $lineNum
+                        Pattern = $p
+                        Snippet = $line.Trim()
+                    }
+                }
+                break
+            }
+        }
+    }
+
+    if ($fileHasMatch -and $allowed.ContainsKey($rel)) {
+        $matchedAllowed[$rel] = $true
+    }
+}
+
+# Detect stale allowlist entries — files listed but no longer containing any
+# legacy token. Warn (don't fail): the entry should be removed in the same PR
+# that migrated the file, but a stale line must not block unrelated PRs.
+$stale = @()
+foreach ($entry in $allowed.Keys) {
+    if (-not $matchedAllowed.ContainsKey($entry)) {
+        $stale += $entry
+    }
+}
+
+if ($stale.Count -gt 0) {
+    Write-Host ""
+    Write-Host "WARN: stale allowlist entries — files no longer contain any legacy dialect token:" -ForegroundColor Yellow
+    foreach ($s in $stale) {
+        Write-Host "  - $s" -ForegroundColor Yellow
+    }
+    Write-Host ""
+    Write-Host "Remove these lines from .presentation-dialect-allowlist in the same PR that migrated them."
+    Write-Host "The allowlist is a ratchet — it may only shrink."
+}
+
+if ($violations.Count -gt 0) {
+    Write-Host ""
+    Write-Host "FAIL: legacy presentation dialect token found in files not on the allowlist." -ForegroundColor Red
+    Write-Host ""
+    foreach ($v in $violations) {
+        Write-Host ("  {0}:{1}  [{2}]  {3}" -f $v.File, $v.Line, $v.Pattern, $v.Snippet) -ForegroundColor Yellow
+    }
+    Write-Host ""
+    Write-Host "New code must use DCQL (dcql_query) instead of Presentation Exchange" -ForegroundColor Yellow
+    Write-Host "(presentation_definition / input_descriptors / presentation_submission),"
+    Write-Host "and mint SD-JWTs with typ ""dc+sd-jwt"" instead of ""vc+sd-jwt""."
+    Write-Host "See specs/181-eudi-conformance/ and CLAUDE.md."
+    exit 1
+}
+
+$remaining = $allowed.Count
+Write-Host ("OK: presentation-dialect gate passed. {0} files still on the allowlist." -f $remaining) -ForegroundColor Green
+if ($remaining -eq 0) {
+    Write-Host "  Allowlist is empty — the DCQL / dc+sd-jwt migration is complete." -ForegroundColor Green
+}
+exit 0

--- a/specs/181-eudi-conformance/checklists/requirements.md
+++ b/specs/181-eudi-conformance/checklists/requirements.md
@@ -1,0 +1,43 @@
+# Specification Quality Checklist: EUDI Conformance — Protocol Alignment & External Trust Rail
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-07-10
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All four scope-shaping decisions were resolved interactively with the platform owner before drafting
+  (recorded as D1–D6 in the spec's Overview) — no open clarifications remain.
+- Standards names (DCQL, `dc+sd-jwt`, ETSI TS 119 612, `x509_san_dns`) appear in the spec deliberately:
+  they are the *requirement* (conformance to named external profiles), not implementation choices.
+  Internal component names (`presentation_definition` producers, PWA engine) appear only where they
+  identify the surfaces whose behaviour must change, mirroring the convention in earlier specs (135, 155).
+- SC-002 references the existing walkthrough suite by name as the regression oracle; those walkthroughs
+  are user-visible journeys, not implementation artefacts.
+- FR-004's dual media-type acceptance is the single deliberate deviation from the clean-break policy,
+  justified in Assumptions (credentials already in citizen wallets cannot be recalled).

--- a/specs/181-eudi-conformance/contracts/dcql-presentation.md
+++ b/specs/181-eudi-conformance/contracts/dcql-presentation.md
@@ -1,0 +1,74 @@
+# Contract: DCQL Presentation Dialect (routes unchanged — D1)
+
+**Owner**: `Sorcha.Verifier.Engine/Dcql` (single builder/parser, FR-008). Consumers: HAIP VerifierEndpoints,
+Blueprint SorchaWalletPresentationConsumer, desk/open verifier, Wallet PWA, Sorcha.Agent.
+
+## 1. Request Object (fetched via existing `GET /api/v1/verifier/requests/{id}/request-object`)
+
+Media type `application/oauth-authz-req+jwt` (unchanged, RFC 9101). Signed JWT; **JWS header gains
+`x5c`** (verifier certificate chain, research R12). Payload:
+
+```jsonc
+{
+  "iss": "x509_san_dns:verify.sorcha.example",     // == client_id
+  "aud": "https://self-issued.me/v2",
+  "iat": 1720620000, "exp": 1720620600,
+  "response_type": "vp_token",
+  "response_mode": "direct_post",
+  "response_uri": "https://…/direct-post",          // unchanged route
+  "client_id": "x509_san_dns:verify.sorcha.example",// prefixed final-spec form (was bare URL)
+  "nonce": "…", "state": "…",
+  "dcql_query": {                                   // REPLACES presentation_definition
+    "credentials": [
+      { "id": "identity", "format": "dc+sd-jwt",
+        "meta": { "vct_values": ["https://sorcha.dev/vc/assured-identity/v1"] },
+        "claims": [ { "path": ["givenName"] }, { "path": ["familyName"] } ] }
+    ],
+    "credential_sets": [
+      { "options": [["identity"]], "required": true, "purpose": "Prove your identity" }
+    ]
+  }
+}
+```
+
+Deep link (all internal producers converge on the request_uri form; inline-definition form retired, FR-026):
+`openid4vp://authorize?client_id=x509_san_dns%3A{host}&request_uri={url-encoded request-object URL}`
+
+## 2. direct_post body (existing `POST …/direct-post`, form-encoded)
+
+| Field | Change |
+|---|---|
+| `vp_token` | now ALWAYS a JSON object `{ "<queryId>": ["<presentation>", …] }` for **both** formats. SD-JWT presentation string = `credentialJwt~disc1~…~kbJwt`; mdoc = base64url(DeviceResponse) (already this shape). |
+| `presentation_submission` | **removed**. If present, or if `vp_token` is a bare compact string → `400 { "error": "LEGACY_DIALECT", "expected": "OpenID4VP 1.0 dcql" }` (FR-007). |
+| `state` | unchanged |
+
+KB-JWT `aud` = the full prefixed `client_id` string (mint + verify sides move together or presentations
+self-reject).
+
+## 3. Verification result (existing `GET …/requests/{id}/result`)
+
+`VerificationResult` gains `perQuery: [{ queryId, outcome, credentialType, verifiedClaims }]`;
+existing top-level fields keep their meaning (overall success = every required query/set satisfied,
+FR-005). Unknown query id in vp_token → overall failure, reason `DCQL_UNKNOWN_QUERY_ID`.
+
+## 4. Blueprint credentialRequirements → DCQL mapping
+
+`CredentialRequirement { type, format, requiredClaims, trustPolicy }` maps to one `DcqlCredentialQuery`
+(id = slugified requirement key). Multiple requirements on one action → multiple queries in one request.
+An explicit alternative construct (`credentialRequirements` gaining an optional `anyOf` grouping) rides
+`credential_sets`. Trust remains F135 `TrustPolicy` — DCQL `trusted_authorities` is NOT used (research R2).
+
+## 5. Wallet-side validation order (PWA, FR-026 / research R13)
+
+1. Parse deep link → require `request_uri` (inline `presentation_definition` → refuse `LEGACY_DIALECT`).
+2. Fetch request object; verify JWS via `x5c` leaf (`REQUEST_OBJECT_INVALID` on failure).
+3. Leaf SAN dNSName == host of `x509_san_dns:` client_id (`REQUEST_HOST_MISMATCH`).
+4. Chain→anchor against cached trusted-list anchors ⇒ `VerifierAuthState` (Trusted / AuthenticUntrusted;
+   anchors unavailable never blocks — FR-027).
+5. Parse `dcql_query` → match → consent → build object-keyed `vp_token` → direct_post.
+
+## 6. CI gate
+
+`scripts/check-presentation-dialect.ps1`: fail on `presentation_definition|input_descriptors|presentation_submission`
+under `src/` outside `.presentation-dialect-allowlist`; fail on new `"vc+sd-jwt"` typ **writes**
+(verify-side acceptance list allowed). Wired as a workflow step (FR-009 / SC-008).

--- a/specs/181-eudi-conformance/contracts/org-certificates.openapi.yaml
+++ b/specs/181-eudi-conformance/contracts/org-certificates.openapi.yaml
@@ -1,0 +1,117 @@
+openapi: 3.1.0
+info:
+  title: Sorcha Org Certificate Lifecycle (Feature 181, US4/US5)
+  description: >
+    Org-admin certificate surface hosted by Tenant Service under the existing /api/v1/trust prefix.
+    Existing routes (provision, trust-anchor, enrol, cert-chain, revoke, crl) are preserved; enrol
+    gains server-side key resolution (no caller-supplied key) and the typed Ed25519 exclusion.
+    Admin routes: RequireAdministrator + RequirePlatformAudience. Auto-enrol (FR-022) is a
+    server-side hook on org creation + OrgWalletReconciliationService, not an API.
+  version: 1.0.0
+paths:
+  /api/v1/trust/tenants/{tenantId}/orgs/{orgWalletAddress}/certificates:
+    get:
+      summary: List the org's certificates (internal + imported)
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  eligibility:
+                    type: object
+                    properties:
+                      eligible: { type: boolean }
+                      reason: { type: string, nullable: true, description: CERT_KEY_NOT_ELIGIBLE when no P-256 key resolvable (FR-024) }
+                      boundKeySource: { type: string, enum: [Primary, HaipCoKey], nullable: true }
+                  certificates:
+                    type: array
+                    items: { $ref: '#/components/schemas/OrgCertificateView' }
+  /api/v1/trust/tenants/{tenantId}/orgs/{orgWalletAddress}/csr:
+    post:
+      summary: Generate a CSR bound to the org's P-256 signing key
+      description: >
+        Server resolves the key (primary ES256 else HAIP co-key) and signs the CSR via the Wallet
+        Service remote-signing generator (research R10). Private key never leaves custody (FR-018).
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                subjectDn: { type: string, nullable: true, description: Override CN/O; defaults to org display name }
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  csrPem: { type: string }
+                  boundKeySource: { type: string, enum: [Primary, HaipCoKey] }
+                  boundPublicKeyThumbprint: { type: string }
+        '422': { description: CERT_KEY_NOT_ELIGIBLE }
+  /api/v1/trust/tenants/{tenantId}/orgs/{orgWalletAddress}/certificates/import:
+    post:
+      summary: Import an externally-issued certificate + chain
+      description: >
+        Validates key match / chain consistency / validity / signing suitability (FR-019).
+        Accepts chain-with-root and chain-without-root. Supersedes any prior Active imported cert.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [certificatePem]
+              properties:
+                certificatePem: { type: string, description: Leaf, PEM or base64 DER }
+                chainPem: { type: array, items: { type: string }, description: Intermediates and/or root, any order }
+      responses:
+        '201':
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/OrgCertificateView' }
+        '422':
+          description: CERT_KEY_MISMATCH | CERT_CHAIN_INVALID | CERT_EXPIRED | CERT_UNSUITABLE (problem+json with code)
+  /api/v1/trust/tenants/{tenantId}/orgs/{orgWalletAddress}/certificates/{certificateId}:
+    delete:
+      summary: Retire an imported certificate (Status→Superseded)
+      description: Internal certs use the existing /revoke route (CRL path). Idempotent.
+      responses:
+        '204': { description: Retired }
+  /api/v1/trust/tenants/{tenantId}/orgs/{orgWalletAddress}/enrol:
+    post:
+      summary: (EXISTING route, changed semantics) Issue/re-issue the internal tenant-root certificate
+      description: >
+        Body no longer carries OrgPublicKeyBase64 — the server resolves the org's P-256 key itself
+        (closes the unvalidated-key TODO at TrustEndpoints.cs:228). Re-issue supersedes the prior
+        internal cert with auditable history (FR-023d). Also the backfill action for pre-existing
+        orgs (US5 AS-2).
+      responses:
+        '200':
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/OrgCertificateView' }
+        '422': { description: CERT_KEY_NOT_ELIGIBLE (typed; replaces the ASN1 500 — FR-024) }
+components:
+  schemas:
+    OrgCertificateView:
+      type: object
+      properties:
+        id: { type: string, format: uuid }
+        provenance: { type: string, enum: [Internal, Imported] }
+        status: { type: string, enum: [Active, Superseded, Revoked, KeyMismatch] }
+        serialNumber: { type: string }
+        subjectDn: { type: string }
+        san: { type: string, description: DID URI (internal) or as-issued (imported) }
+        notBefore: { type: string, format: date-time }
+        notAfter: { type: string, format: date-time }
+        boundKeySource: { type: string, enum: [Primary, HaipCoKey] }
+        chainSummary:
+          type: array
+          items: { type: string, description: SubjectDn per chain element, leaf→root }
+        certificateBase64: { type: string, description: DER }
+        createdAt: { type: string, format: date-time }

--- a/specs/181-eudi-conformance/contracts/trustlist-admin.openapi.yaml
+++ b/specs/181-eudi-conformance/contracts/trustlist-admin.openapi.yaml
@@ -1,0 +1,120 @@
+openapi: 3.1.0
+info:
+  title: Sorcha Trusted-List Snapshot Admin (Feature 181, US3)
+  description: >
+    Operator import + lifecycle of ETSI TS 119 612 trusted-list snapshots, and the internal
+    anchor-distribution read used by verifying services. Replaces the Feature 135 placeholder
+    PUT /trustlists/{id} raw-roots route (clean break). All admin routes:
+    RequireAdministrator + RequirePlatformAudience + RateLimitPolicies.Strict, audited.
+  version: 1.0.0
+paths:
+  /api/v1/trust/trustlists/import:
+    post:
+      summary: Import a trusted-list document (upload or URL fetch-once)
+      description: >
+        Verifies the XMLDSig enveloped signature, extracts CA/QC anchors (granted /
+        recognisedatnationallevel), stores a versioned snapshot. Sequence number must exceed the
+        current Active snapshot for the same trustListId.
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [trustListId]
+              properties:
+                trustListId: { type: string, description: Operator-chosen stable list identity (matches TrustSourceRef.trustListId) }
+                document: { type: string, format: binary, description: The trusted-list XML (mutually exclusive with sourceUrl) }
+                sourceUrl: { type: string, format: uri, description: HTTPS URL to fetch once (mutually exclusive with document) }
+      responses:
+        '201':
+          description: Snapshot stored
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/TrustListSnapshotSummary' }
+        '400':
+          description: TRUSTLIST_MALFORMED | TRUSTLIST_SIGNATURE_INVALID (problem+json with code)
+        '409':
+          description: TRUSTLIST_SEQUENCE_REGRESSION — sequence number not newer than current Active snapshot
+  /api/v1/trust/trustlists:
+    get:
+      summary: List snapshots with freshness state
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { $ref: '#/components/schemas/TrustListSnapshotSummary' }
+  /api/v1/trust/trustlists/{trustListId}:
+    get:
+      summary: Snapshot detail incl. anchor set + extraction summary
+      responses:
+        '200':
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/TrustListSnapshotDetail' }
+        '404': { description: Unknown trustListId }
+    delete:
+      summary: Delete a snapshot (all versions of this list identity)
+      description: Subsequent evaluations against this trustListId fail closed TRUSTLIST_UNAVAILABLE (SC-004).
+      responses:
+        '204': { description: Deleted (idempotent) }
+  /api/v1/trust/trustlists/{trustListId}/anchors:
+    get:
+      summary: Anchor distribution read (verifying services)
+      description: >
+        Service-tier (RequireService). Returns the Active snapshot's DER roots + freshness for the
+        caching HTTP ITrustListProvider in Sorcha.ServiceClients.Http (15-min cache). Also consumed
+        (anonymous, cache-control public) by the wallet PWA for verifier-authentication anchors —
+        final auth split decided at implementation (public read exposes only public CA certs).
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  trustListId: { type: string }
+                  sequenceNumber: { type: integer, format: int64 }
+                  freshness: { type: string, enum: [Fresh, Stale] }
+                  nextUpdate: { type: string, format: date-time, nullable: true }
+                  rootsDerBase64: { type: array, items: { type: string } }
+        '404': { description: TRUSTLIST_UNAVAILABLE }
+components:
+  schemas:
+    TrustListSnapshotSummary:
+      type: object
+      properties:
+        trustListId: { type: string }
+        sequenceNumber: { type: integer, format: int64 }
+        schemeTerritory: { type: string, nullable: true }
+        schemeOperatorName: { type: string, nullable: true }
+        listIssueDateTime: { type: string, format: date-time }
+        nextUpdate: { type: string, format: date-time, nullable: true }
+        freshness: { type: string, enum: [Fresh, Stale] }
+        anchorCount: { type: integer }
+        signerCertSubject: { type: string }
+        signerCertThumbprint: { type: string }
+        importedAt: { type: string, format: date-time }
+        importedBy: { type: string, format: uuid }
+        status: { type: string, enum: [Active, Superseded] }
+    TrustListSnapshotDetail:
+      allOf:
+        - $ref: '#/components/schemas/TrustListSnapshotSummary'
+        - type: object
+          properties:
+            anchors:
+              type: array
+              items:
+                type: object
+                properties:
+                  subjectDn: { type: string }
+                  thumbprint: { type: string }
+                  serviceTypeIdentifier: { type: string }
+                  serviceStatus: { type: string }
+                  notBefore: { type: string, format: date-time }
+                  notAfter: { type: string, format: date-time }
+            extractionSummary:
+              type: object
+              description: extracted vs skipped service entries (FR-012)

--- a/specs/181-eudi-conformance/data-model.md
+++ b/specs/181-eudi-conformance/data-model.md
@@ -1,0 +1,169 @@
+# Data Model: EUDI Conformance — Protocol Alignment & External Trust Rail
+
+**Feature**: `181-eudi-conformance` · **Date**: 2026-07-10 · **Source**: spec.md Key Entities + research.md
+
+## 1. DCQL wire model (`Sorcha.Verifier.Engine/Dcql/`)
+
+Immutable records, `System.Text.Json`-serialized with exact spec property names. Builder + parser live in
+the same file pair (FR-008).
+
+### DcqlQuery
+| Field | Type | JSON | Rules |
+|---|---|---|---|
+| Credentials | `IReadOnlyList<DcqlCredentialQuery>` | `credentials` | 1..n; ids unique |
+| CredentialSets | `IReadOnlyList<DcqlCredentialSetQuery>?` | `credential_sets` | optional; every option id must exist in `credentials` |
+
+### DcqlCredentialQuery
+| Field | Type | JSON | Rules |
+|---|---|---|---|
+| Id | `string` | `id` | `^[a-zA-Z0-9_-]+$`, unique per request |
+| Format | `string` | `format` | `dc+sd-jwt` \| `mso_mdoc` (v1) |
+| Meta | `DcqlCredentialMeta` | `meta` | required in v1 |
+| Claims | `IReadOnlyList<DcqlClaimQuery>?` | `claims` | null ⇒ wallet discloses per its own policy |
+| ClaimSets | `IReadOnlyList<IReadOnlyList<string>>?` | `claim_sets` | v1: emitted only by the builder's required/optional mapping (research R2) |
+
+### DcqlCredentialMeta
+| Field | Type | JSON | Rules |
+|---|---|---|---|
+| VctValues | `IReadOnlyList<string>?` | `vct_values` | required when format `dc+sd-jwt` |
+| DoctypeValue | `string?` | `doctype_value` | required when format `mso_mdoc` |
+
+### DcqlClaimQuery
+| Field | Type | JSON | Rules |
+|---|---|---|---|
+| Id | `string?` | `id` | required only when referenced from `claim_sets` |
+| Path | `IReadOnlyList<string>` | `path` | non-empty; string segments only in v1 (no array indices) |
+
+### DcqlCredentialSetQuery
+| Field | Type | JSON | Rules |
+|---|---|---|---|
+| Options | `IReadOnlyList<IReadOnlyList<string>>` | `options` | each inner list = ids that together satisfy the set |
+| Required | `bool` | `required` | default true |
+| Purpose | `string?` | `purpose` | consent-surface display |
+
+### DcqlVpToken (response envelope)
+| Field | Type | JSON | Rules |
+|---|---|---|---|
+| Presentations | `IReadOnlyDictionary<string, IReadOnlyList<string>>` | (root object) | key = credential-query id; value = presentation strings (SD-JWT compact / base64url mdoc DeviceResponse); unknown key ⇒ verification failure `DCQL_UNKNOWN_QUERY_ID` |
+
+### Parsed request (PWA-side, replaces `ParsedPresentationRequest` single-vct shape)
+`ParsedPresentationRequest` (in `Sorcha.UI.Components.User/Models/User/Presentation/PresentationModels.cs`)
+becomes: `ClientId` (prefixed form), `VerifierHost` (derived), `ResponseUri`, `Nonce`, `ResponseMode`,
+`Query: DcqlQuery`, `VerifierAuthentication: VerifierAuthState` (see §5). `CredentialMatch` becomes
+`DcqlQueryMatch { QueryId, Candidates: IReadOnlyList<CredentialMatch> }` with a request-level
+`DcqlMatchResult { Satisfiable: bool, PerQuery, UnsatisfiedRequiredQueryIds, SetChoices }`.
+
+**State transitions (wallet)**: Parsed → Matched (per-query) → Consented (per-query claim approval,
+alternative chosen) → Submitted. No partial submission when any required query/set unsatisfied (FR-006d).
+
+## 2. Trusted-list snapshot (Tenant Service, EF `public` schema)
+
+### TrustedListSnapshot
+| Field | Type | Rules |
+|---|---|---|
+| Id | `Guid` PK | |
+| TrustListId | `string` | operator-chosen stable identity, matches `TrustSourceRef.trustListId`; indexed |
+| SequenceNumber | `long` | from `TSLSequenceNumber`; per-TrustListId monotonic — import of ≤ current sequence rejected `TRUSTLIST_SEQUENCE_REGRESSION` (edge case: concurrent import) |
+| SchemeTerritory | `string?` | e.g. `EU`, `IE` |
+| SchemeOperatorName | `string?` | display |
+| ListIssueDateTime | `DateTimeOffset` | from list |
+| NextUpdate | `DateTimeOffset?` | from list; null ⇒ treated as stale after config default (90 d) |
+| SignerCertSubject / SignerCertThumbprint | `string` | XMLDSig signer identity surfaced at import (research R5) |
+| ImportedAt / ImportedByPlatformUserId | `DateTimeOffset` / `Guid` | provenance |
+| SourceUrl | `string?` | when imported by URL fetch-once |
+| RawDocumentSha256 | `string` | audit tie to the imported bytes |
+| Status | enum `Active \| Superseded` | newest Active per TrustListId is authoritative (FR-013) |
+| Anchors | owned collection → `TrustedListAnchor` | |
+| ExtractionSummary | `string` (json) | extracted vs skipped service entries (FR-012) |
+
+### TrustedListAnchor
+| Field | Type | Rules |
+|---|---|---|
+| Id | `Guid` PK / SnapshotId FK | cascade delete |
+| CertificateDer | `byte[]` | the CA cert |
+| SubjectDn / Thumbprint | `string` | display + dedupe |
+| ServiceTypeIdentifier | `string` | originating `TSPService` type URI |
+| ServiceStatus | `string` | originating status URI |
+| NotBefore / NotAfter | `DateTimeOffset` | from cert |
+
+**Freshness state (computed, never stored)**: `Fresh` (now < NextUpdate) \| `Stale` (past NextUpdate;
+warn-mode evaluates + flags evidence, strict mode `Trust:TrustListStrictFreshness=true` fails closed —
+FR-016). Read seam unchanged: `ITrustListProvider.GetSnapshotAsync` → `TrustListSnapshot` (wire DTO keeps
+its current shape + gains `SequenceNumber`, `NextUpdate`, `FreshnessState`); `TrustAnchorSet.AnchorSetId`
+carries `{trustListId}#{sequenceNumber}` into `TrustEvidence.TrustListId` (FR-015).
+
+## 3. Certificate persistence (Tenant Service, EF `public` schema — research R8)
+
+### TenantRootCa (persists today's in-memory `_roots` + `_rootPrivateKeys`)
+| Field | Type | Rules |
+|---|---|---|
+| TenantId | `string` PK | |
+| CertificateDer | `byte[]` | self-signed root |
+| PrivateKeyCiphertext / Nonce | `byte[]` | AES-256-GCM at rest (constitution II); KMS = existing TODO |
+| Algorithm | `string` | `ES256` only (v1) |
+| CreatedAt / NotAfter | `DateTimeOffset` | |
+| CrlNumber | `int` | monotonic (moves off `_crlCounters`) |
+
+### OrgCertificateRecord (persists `_orgCerts` + adds imported provenance)
+| Field | Type | Rules |
+|---|---|---|
+| Id | `Guid` PK | |
+| TenantId + OrgWalletAddress | `string` | composite index; org identity |
+| Provenance | enum `Internal \| Imported` | D5/D4 |
+| Status | enum `Active \| Superseded \| Revoked \| KeyMismatch` | one Active per (org, provenance); re-issue supersedes (FR-023d); KeyMismatch set when org key rotation invalidates an imported cert (edge case) |
+| CertificateDer | `byte[]` | leaf |
+| ChainDer | `byte[][]` (jsonb) | ordered leaf-exclusive chain; Internal ⇒ [root] |
+| BoundPublicKeySpki | `byte[]` | the P-256 key certified (research R9) |
+| BoundKeySource | enum `Primary \| HaipCoKey` | which org key it binds |
+| SerialNumber / SubjectDn / SanUri-or-Dns | `string` | display/audit |
+| NotBefore / NotAfter | `DateTimeOffset` | expiry surfaced in admin UI (US4 AS-4) |
+| CreatedAt / CreatedByPlatformUserId | provenance | auto-enrol records system principal |
+| RevokedAt? / RevocationReason? | | Internal certs only (CRL path exists); Imported revocation is the external CA's concern |
+
+### CsrRecord (lightweight audit of FR-018)
+| Field | Type | Rules |
+|---|---|---|
+| Id | `Guid` PK; TenantId + OrgWalletAddress | |
+| CsrPem | `string` | returned to admin; stored for audit |
+| BoundPublicKeySpki | `byte[]` | must match at cert import time (`CERT_KEY_MISMATCH` otherwise) |
+| CreatedAt / CreatedByPlatformUserId | | |
+
+**Org eligibility (computed)**: `Eligible(P256Key)` \| `NotEligible(CERT_KEY_NOT_ELIGIBLE)` — resolved
+via Wallet Service (primary ES256, else HAIP co-key derivation); never stored (mirrors F108
+derived-relationship convention).
+
+## 4. Verifier certificate (config, not DB)
+
+`Haip:VerifierCertificate` (PFX path or base64) + `Haip:VerifierCertificatePassword?` +
+`Haip:PublicHost`. Dev fallback: tenant-root-issued cert with SAN dNSName = `Haip:PublicHost`
+(research R12). Validation at startup: SAN dNSName must equal `Haip:PublicHost`, else fail-fast in
+Production/Staging (mirrors `SorchaIssuer` fail-closed posture).
+
+## 5. VerifierAuthState (engine model, carried to PWA consent surface)
+
+enum-ish record per FR-027: `TrustedListVerified(anchorSetId)` \| `AuthenticUntrusted` \|
+`Unverifiable(reason)`. Produced by `RequestObjectValidator` (research R13); rendered by `ConsentSheet`.
+
+## 6. New typed error codes
+
+| Code | Where |
+|---|---|
+| `LEGACY_DIALECT` | 400 on PE-shaped request/response bodies (FR-007) |
+| `DCQL_UNKNOWN_QUERY_ID` | verification failure (FR-003) |
+| `TRUSTLIST_SIGNATURE_INVALID` / `TRUSTLIST_MALFORMED` / `TRUSTLIST_SEQUENCE_REGRESSION` | import (FR-011/FR-013) |
+| `TRUSTLIST_UNAVAILABLE` | trust evaluation with no snapshot (FR-014) |
+| `TRUSTLIST_STALE` | strict-mode fail-closed (FR-016) |
+| `CERT_KEY_NOT_ELIGIBLE` | non-P-256-resolvable org (FR-024) |
+| `CERT_KEY_MISMATCH` / `CERT_CHAIN_INVALID` / `CERT_EXPIRED` / `CERT_UNSUITABLE` | import validation (FR-019) |
+| `CERT_EXTERNAL_ANCHOR_UNAVAILABLE` | issuance fail-closed (FR-020) |
+| `REQUEST_OBJECT_INVALID` / `REQUEST_HOST_MISMATCH` | wallet-side request refusal (FR-026) |
+
+## 7. Metrics (FR-028)
+
+| Instrument | Meter | Tags |
+|---|---|---|
+| `sorcha_trustlist_snapshot_info` (gauge) / `sorcha_trustlist_stale_evaluation_total` (counter) | `Sorcha.Trust` | `trust_list_id`, `sequence` |
+| `sorcha_trust_decision_total` | existing `Sorcha.Trust` | gains real `source=trustlist` traffic (no schema change) |
+| `sorcha_org_cert_issuance_total` | `Sorcha.Trust` | `provenance`, `outcome`, `reason` |
+| `sorcha_dialect_rejection_total` | `Sorcha.Haip` (new meter or existing) | `surface` |
+| `sorcha_request_auth_total` | `Sorcha.Trust` | `state ∈ {trusted, authentic_untrusted, unverifiable}` |

--- a/specs/181-eudi-conformance/plan.md
+++ b/specs/181-eudi-conformance/plan.md
@@ -1,0 +1,188 @@
+# Implementation Plan: EUDI Conformance — Protocol Alignment & External Trust Rail
+
+**Branch**: `181-eudi-conformance` | **Date**: 2026-07-10 | **Spec**: [spec.md](./spec.md)
+
+**Input**: Feature specification from `/specs/181-eudi-conformance/spec.md`
+
+## Summary
+
+Bring Sorcha's presentation dialect up to the final EUDI-aligned profiles (DCQL replaces Presentation
+Exchange, `dc+sd-jwt` replaces `vc+sd-jwt`, prefixed `x509_san_dns:` client identifiers, multibase
+status-list decode) as a clean break with **all OpenID4VP routes preserved**, and make the external
+X.509 trust rail real (ETSI TS 119 612 trusted-list snapshot import backing `x509-lotl`,
+operator-imported external org certificates, persistent internal CA with auto-enrolment, typed
+Ed25519 exclusion, wallet-side verifier authentication). Technical approach: one shared DCQL
+builder/parser in the WASM-safe `Sorcha.Verifier.Engine`; a persistent Tenant-hosted trusted-list
+snapshot store filling the already-wired F135 `trustlist` resolver seam; EF persistence under the
+existing `InternalCaTrustProvider`; a remote-signing CSR generator over the existing Wallet sign seam.
+Full decisions in [research.md](./research.md) (R1–R15).
+
+## Technical Context
+
+**Language/Version**: C# 14 / .NET 10 (net10.0 everywhere; PWA + Components.User are Blazor WASM)
+
+**Primary Dependencies**: existing only — `System.Text.Json`, `System.Security.Cryptography.Xml`
+(TS 119 612 dsig, server-side), `System.Formats.Asn1` + BCL `CertificateRequest`/`X509SignatureGenerator`
+(CSR, server-side), BouncyCastle.Cryptography (already in Verifier.Engine; WASM request-object
+verification), EF Core/Npgsql (Tenant), MudBlazor (admin UI). **No new NuGet packages.**
+
+**Storage**: Tenant Postgres `public` schema — `TrustedListSnapshot(+Anchors)`, `TenantRootCa`,
+`OrgCertificateRecord`, `CsrRecord` (data-model.md §2–3); squashed into Tenant `InitialCreate` per the
+pre-release convention; `IStorageRegistrationLog` registered, warn-tier (not fail-fast audited).
+
+**Testing**: xUnit + FluentAssertions + Moq; reflection-based endpoint-handler tests (repo pattern);
+bUnit for PWA components; fixture-generated signed TS 119 612 XML + test CA; walkthroughs as the SC-002
+regression oracle; deliberate red-test for the CI dialect gate (SC-008).
+
+**Target Platform**: Linux containers (services) + Blazor WASM (wallet PWA, shared components).
+WASM constraint drives R13: request-object crypto via BouncyCastle, never BCL `X509Chain`/`ECDsa`.
+
+**Project Type**: multi-service platform — changes span 2 common libs, 3 services, 2 WASM apps, 1 CLI
+agent, scripts/CI.
+
+**Performance Goals**: no regression on the presentation hot path (dialect swap is shape-for-shape);
+anchor reads served from a 15-min in-process cache (one Tenant HTTP call per service per window);
+trusted-list import is an operator action (seconds-scale acceptable).
+
+**Constraints**: existing OpenID4VP/VCI routes byte-stable (D1/FR-002); verify-side must keep accepting
+already-issued `vc+sd-jwt` credentials (FR-004); org private keys never leave Wallet Service (FR-018);
+fail-closed at every trust boundary; clean break enforced by CI gate.
+
+**Scale/Scope**: ~6 DCQL model types; ~10 touched producer/parser/verifier sites; 4 new EF entities;
+~8 new/changed endpoints; 2 admin UI surfaces (trust-list panel, org-certificates panel); ~12 typed
+error codes; 5 metrics.
+
+## Constitution Check
+
+*GATE evaluated pre-Phase 0 and re-checked post-design — PASS (no violations to justify).*
+
+| Principle | Compliance |
+|---|---|
+| I. Microservices-first | No new services; new common code goes to existing WASM-safe lib; Tenant remains the trust authority; downward deps only (Engine gains no service refs — anchors injected via existing seams). |
+| II. Security first | Fail-closed trust decisions throughout (FR-014/016/020); CA private keys move from **plaintext in-memory** to AES-256-GCM-at-rest EF rows (improves current state); input validation (FluentValidation/DataAnnotations) on import/CSR endpoints per VAL-001 pattern; no secrets in source. |
+| III. API documentation | New/changed Minimal API endpoints get `.WithSummary()`/`.WithDescription()`; OpenAPI contracts authored in `contracts/`; Scalar (no Swashbuckle). |
+| IV. Testing | Unit coverage targets >85% on new code; deterministic fixtures (self-generated signed TL + test CA — no network); integration tests per endpoint; AAA + `MethodName_Scenario_ExpectedBehavior`. |
+| V. Code quality | Nullable enabled, async I/O, DI seams reused (`ITrustListProvider`, `ITenantTrustAnchorProvider`, `IWalletServiceClient`). |
+| VI. Blueprint standards | `credentialRequirements` JSON stays the authoring surface; DCQL is derived wire shape, never authored. |
+| VII. DDD language | "Trusted-list snapshot", "trust anchor", "org certificate", "credential query" adopted consistently; Blueprint/Action/Participant terms untouched. |
+| VIII. Observability | 5 new instruments on existing meters (data-model §7); structured logging; health unaffected. |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/181-eudi-conformance/
+├── plan.md              # This file
+├── research.md          # Phase 0 — R1..R15 decisions
+├── data-model.md        # Phase 1 — DCQL model, EF entities, error codes, metrics
+├── quickstart.md        # Phase 1 — per-US validation recipes
+├── contracts/
+│   ├── dcql-presentation.md          # dialect contract (routes unchanged)
+│   ├── trustlist-admin.openapi.yaml  # snapshot import/lifecycle/anchor read
+│   └── org-certificates.openapi.yaml # CSR / import / list / enrol semantics
+├── checklists/requirements.md
+└── tasks.md             # Phase 2 (/speckit.tasks — NOT created by /speckit.plan)
+```
+
+### Source Code (repository root)
+
+```text
+src/Common/Sorcha.Verifier.Engine/
+├── Dcql/                                  # NEW — shared model + builder + parser (R1/R2, FR-008)
+│   ├── DcqlModels.cs                      #   DcqlQuery/CredentialQuery/CredentialSetQuery/VpToken
+│   ├── DcqlRequestBuilder.cs              #   the ONE producer
+│   └── DcqlRequestParser.cs               #   the ONE parser (same review unit as builder)
+├── RequestObjectValidator.cs              # NEW — JWS x5c verify + SAN binding + anchor check (R13)
+└── VerifiablePresentationValidator.cs     # CHANGED — object-keyed vp_token, per-query, aud=prefixed client_id
+
+src/Common/Sorcha.Cryptography/SdJwt/SdJwtService.cs        # CHANGED — typ dc+sd-jwt (R3)
+src/Core/Sorcha.Blueprint.Engine/Credentials/
+├── BitstringStatusListChecker.cs          # CHANGED — multibase 'u' decode (R7, line 86)
+└── Sources/…                              # unchanged — trustlist seam already wired (F135)
+
+src/Common/Sorcha.ServiceClients.Http/Trust/
+└── TrustListProvider.cs                   # CHANGED — HTTP-backed caching ITrustListProvider (R6)
+
+src/Services/Sorcha.Tenant.Service/
+├── Trust/
+│   ├── X509CertificateBuilder.cs          # CHANGED — eligibility guard (typed CERT_KEY_NOT_ELIGIBLE)
+│   ├── InternalCaTrustProvider.cs         # CHANGED — write-through cache over EF store (R8)
+│   ├── TrustedListImportService.cs        # NEW — TS 119 612 parse + XMLDSig verify + extract (R5)
+│   ├── OrgCertificateService.cs           # NEW — eligibility/CSR/import/auto-enrol logic (R9/R10/R11)
+│   └── WalletBackedSignatureGenerator.cs  # NEW — X509SignatureGenerator over IWalletServiceClient (R10)
+├── Endpoints/TrustEndpoints.cs            # CHANGED — import/list/detail/delete/anchors + cert routes
+├── Services/OrganizationService.cs        # CHANGED — auto-enrol hook post-wallet-provision (FR-022)
+├── Services/OrgWalletReconciliationService.cs  # CHANGED — enrol retry rides reconciliation
+├── Models/ + Data/TenantDbContext.cs      # NEW entities (data-model §2–3), squashed migration
+└── Migrations/…InitialCreate.cs           # CHANGED — squash per pre-release convention
+
+src/Services/Sorcha.Haip.Service/
+├── Endpoints/VerifierEndpoints.cs         # CHANGED — dcql_query, prefixed client_id, object vp_token,
+│                                          #   LEGACY_DIALECT 400, x5c on request object (R4/R12)
+├── Endpoints/{Metadata,Credential}Endpoints.cs  # CHANGED — dc+sd-jwt format identifiers
+└── Services/RequestObjectSigner.cs        # CHANGED — signs with verifier certificate (R12)
+
+src/Services/Sorcha.Blueprint.Service/Services/Implementation/
+└── SorchaWalletPresentationConsumer.cs    # CHANGED — request_uri form + DCQL body (R4)
+
+src/Services/Sorcha.Wallet.Service/…/IssueCredentialChainResolver.cs  # CHANGED — x509-lotl → imported chain (R11)
+
+src/Apps/Sorcha.Wallet.Pwa/
+├── Services/Presentation/PresentationEngine.cs  # CHANGED — request_uri fetch, DCQL parse, query-set Match,
+│                                                #   object vp_token, prefixed aud (R4/R13)
+└── Pages/Present.razor                          # CHANGED — multi-query flow
+
+src/Apps/Sorcha.UI/Sorcha.UI.Components.User/
+├── Components/Presentation/{ConsentSheet,CredentialPickerDialog}.razor  # CHANGED — per-query + alternatives
+└── Models/User/Presentation/PresentationModels.cs                        # CHANGED — query-set shapes
+
+src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Admin/
+├── Settings/OrgSettings.razor             # CHANGED — org certificates panel (US4/US5)
+└── (platform admin)                       # NEW — trusted-lists panel (US3, SC-009)
+
+src/Apps/Sorcha.Agent/Commands/HaipPresentCommand.cs  # CHANGED — drop submission, object vp_token
+
+scripts/check-presentation-dialect.ps1     # NEW — CI ratchet gate (R14, FR-009)
+.github/workflows/…                        # CHANGED — gate step
+walkthroughs/, demos/                      # CHANGED — R15 inventory (fixtures regenerated as DCQL)
+
+tests/  # per-project test additions mirroring every CHANGED/NEW item above; fixtures:
+        # signed TS 119 612 XML generator + test CA under tests/Sorcha.Tenant.Service.Tests/Fixtures/TrustLists/
+```
+
+**Structure Decision**: no new projects, no new services. The single genuinely shared artefact (DCQL
+model) lands in the existing WASM-safe `Sorcha.Verifier.Engine` (R1); all trust-rail state is Tenant-owned
+(it already hosts the CA + trust endpoints); every other change is in-place migration of the surfaces
+inventoried in R4/R15.
+
+## Delivery order (feeds /speckit.tasks)
+
+1. **Foundation (US1 prerequisites)**: DCQL model + builder/parser + tests → `dc+sd-jwt` typ flip +
+   dual-accept → CI gate (lands early with allowlist, ratchets to empty).
+2. **US1 dialect cutover**: HAIP verifier → Blueprint consumer → engine validator → PWA engine/UI →
+   agent → walkthrough/demo/test migration (SC-001/002).
+3. **US2 multi-credential**: query-set Match + consent UI + per-query results (SC-003). Depends on US1.
+4. **US3 trust rail (parallel with US1/US2 after foundation)**: EF snapshot store + import service +
+   endpoints + HTTP anchor provider + admin panel + multibase fix (SC-004/009).
+5. **US4/US5 certificates**: CA persistence (R8) → eligibility + auto-enrol + backfill + typed Ed25519
+   exclusion (SC-006) → CSR + import + chain-attach (SC-005). US4 verification tests lean on US3 fixtures.
+6. **US6 verifier auth (last)**: verifier certificate config + prefixed client_id + x5c request objects +
+   `RequestObjectValidator` + PWA three-state consent (SC-007). Composes US1 + US3.
+
+Independent-test boundaries and acceptance mapping per story are in spec.md; per-US validation recipes in
+quickstart.md.
+
+## Complexity Tracking
+
+*No constitution violations — table intentionally empty.*
+
+## Notes for the tasks phase
+
+- **R9 flag**: certificates bind the org's P-256 key (primary or HAIP co-key). This narrows D6's
+  practical exclusion to "no P-256 key resolvable" — confirmed direction needed from the platform owner
+  before US5 tasks execute (surfaced in the plan report).
+- The Feature 135 placeholder `PUT /api/v1/trust/trustlists/{id}` raw-roots route is replaced by the
+  import route (clean break; it has no production callers).
+- Documentation sync (CLAUDE.md Feature API pointer → sorcha-architecture skill, STANDARDS.md rows,
+  API-DOCUMENTATION.md, service READMEs) is a mandatory tail task per repo policy (FR-029).

--- a/specs/181-eudi-conformance/quickstart.md
+++ b/specs/181-eudi-conformance/quickstart.md
@@ -1,0 +1,83 @@
+# Quickstart: Validating Feature 181 (EUDI Conformance)
+
+Per-user-story validation recipes against the local Docker stack (`docker-compose up -d`).
+
+## US1 — Dialect migration (SC-001, SC-002)
+
+```powershell
+# 1. Create a presentation request via the HAIP verifier API, fetch the request object,
+#    decode the JWT payload and assert dcql_query present / presentation_definition absent.
+$req = Invoke-RestMethod -Method Post http://localhost/api/v1/verifier/requests `
+  -Body (@{ credentialType = "https://sorcha.dev/vc/assured-identity/v1"; requiredClaims = @("givenName") } | ConvertTo-Json) `
+  -ContentType application/json -Headers @{ Authorization = "Bearer $token" }
+$jwt = Invoke-RestMethod $req.requestUri
+# decode middle segment; assert: dcql_query, client_id starts "x509_san_dns:", typ header x5c present
+
+# 2. Regression oracle — the walkthroughs must pass unchanged:
+walkthroughs/AssuredIdentity/run-phase1-identity.ps1   # + phase2 licence (HAIP gate)
+demos/AIAS/rehearse.ps1                                 # approved + rejected paths
+
+# 3. Legacy rejection: POST a PE-shaped direct_post → expect 400 LEGACY_DIALECT.
+
+# 4. CI gate red-test: temporarily add "presentation_definition" to a src/ file,
+#    run scripts/check-presentation-dialect.ps1 → must fail (SC-008), revert.
+```
+
+## US2 — Multi-credential + alternatives (SC-003)
+
+Author a two-query request (`identity` + `address`) and a two-option `credential_sets` request
+(PID-vct OR AssuredIdentity-vct) via the verifier API; walk the PWA wallet (holding only
+AssuredIdentity) through both: first shows "address: no matching credential" and blocks submission;
+second completes via the AssuredIdentity branch. Verify `GET …/result` reports per-query outcomes.
+
+## US3 — Trusted-list snapshot (SC-004, SC-009)
+
+```powershell
+# Fixture: tests generate a signed minimal TS 119 612 XML with a test CA (fixture kept under
+# tests/…/Fixtures/TrustLists/). Import it:
+Invoke-RestMethod -Method Post http://localhost/api/v1/trust/trustlists/import `
+  -Form @{ trustListId = "test-lotl"; document = Get-Item fixture-tl.xml } -Headers $admin
+# → 201 with sequenceNumber, anchorCount, signerCertThumbprint
+
+# Issue a credential under the fixture CA (test helper), present it with a blueprint
+# trustPolicy { sources:[{kind:"trustlist", trustListId:"test-lotl"}] } → verification succeeds,
+# evidence.trustListId == "test-lotl#<seq>".
+# DELETE the snapshot → same presentation now fails TRUSTLIST_UNAVAILABLE.
+# Tamper one byte of the XML → import fails TRUSTLIST_SIGNATURE_INVALID.
+# SC-009: time an operator (admin UI → import → first vouched verification) < 10 min.
+```
+
+## US4 — External issuance identity (SC-005)
+
+```powershell
+# CSR out:
+$csr = Invoke-RestMethod -Method Post "$trust/orgs/$orgWallet/csr" -Headers $admin
+# Sign with a local test CA (openssl or the test fixture CA), then import:
+Invoke-RestMethod -Method Post "$trust/orgs/$orgWallet/certificates/import" `
+  -Body (@{ certificatePem = $leaf; chainPem = @($root) } | ConvertTo-Json) -ContentType application/json -Headers $admin
+# Issue a credential with credentialIssuanceConfig.trustAnchor = "x509-lotl" → decode SD-JWT x5c:
+# chain terminates at the test CA root, NOT the tenant root. Verify with only the test root trusted.
+# Negative: delete the imported cert → issuance fails CERT_EXTERNAL_ANCHOR_UNAVAILABLE (not tenant-root fallback).
+```
+
+## US5 — Lifecycle + Ed25519 exclusion (SC-006)
+
+Create a new org → `GET …/certificates` shows an Active Internal cert with zero manual steps
+(ED25519-primary org: `boundKeySource == "HaipCoKey"`). Pre-existing org → one-action backfill via
+`/enrol`. Simulate a no-P-256-resolvable org (mock co-key derivation failure in tests) → typed 422
+`CERT_KEY_NOT_ELIGIBLE`, zero unhandled-exception log entries.
+
+## US6 — Verifier authentication (SC-007)
+
+Configure `Haip:VerifierCertificate` with SAN dns == `Haip:PublicHost`; PWA scans a request →
+consent sheet shows verifier identity (AuthenticUntrusted without an imported list; Trusted after
+importing a list containing the verifier CA). Tamper the request-object signature (test hook) →
+PWA refuses with `REQUEST_OBJECT_INVALID`; mismatch the SAN host → `REQUEST_HOST_MISMATCH`.
+
+## Cross-cutting
+
+- `dotnet build` warning-free; `dotnet test` green; E2E suites for F155/F164 verdict flows pass.
+- STANDARDS.md rows updated (OpenID4VP/VCI → 1.0/final versions, SD-JWT VC `dc+sd-jwt`, new ETSI TS
+  119 612 partial row) and `scripts/check-discoverability.sh` passes.
+- Metrics visible on the Aspire dashboard: `sorcha_trustlist_*`, `sorcha_org_cert_issuance_total`,
+  `sorcha_dialect_rejection_total`, `sorcha_request_auth_total`.

--- a/specs/181-eudi-conformance/research.md
+++ b/specs/181-eudi-conformance/research.md
@@ -1,0 +1,273 @@
+# Research: EUDI Conformance — Protocol Alignment & External Trust Rail
+
+**Feature**: `181-eudi-conformance` · **Date**: 2026-07-10
+**Method**: three parallel codebase-mapping dives (presentation dialect, F135 trust rail, X.509/CA
+surfaces) + standards research (OpenID4VP 1.0 final / HAIP 1.0 final / SD-JWT VC final / ETSI TS 119 612).
+All file:line citations verified against master at branch time.
+
+---
+
+## R1 — Where the shared DCQL model lives
+
+**Decision**: New folder `src/Common/Sorcha.Verifier.Engine/Dcql/` containing the typed DCQL
+request/response model, the builder, and the parser — one file pair, build and parse side by side so they
+cannot drift (FR-008).
+
+**Rationale**: `Sorcha.Verifier.Engine` is net10.0, WASM-safe (BouncyCastle-managed crypto only, no
+P/Invoke — csproj comment says so explicitly), and is **already referenced by 4 of the 5 consumers**:
+`Sorcha.Wallet.Pwa`, `Sorcha.UI.Components.User`, `Sorcha.Verifier`, `Sorcha.Blueprint.Service`. Only
+`Sorcha.Haip.Service` needs a new ProjectReference. A brand-new common project would add solution noise
+for ~6 types; `Sorcha.CitizenWallet.Abstractions` was considered but is scoped to wallet-device contracts,
+and `Sorcha.Blueprint.Models` is not referenced by the PWA.
+
+**Alternatives considered**: new `Sorcha.OpenId4Vp` common project (rejected: project proliferation for a
+small surface; revisit if the OpenID4VCI leg later needs shared models); `Sorcha.CitizenWallet.Abstractions`
+(rejected: wrong subject — DCQL is verifier/wallet wire dialect, not citizen-wallet device contracts).
+
+**Note**: the architecture review (2026-06-02 §5.1) flags Verifier.Engine as one half of the dual VC-stack
+problem. Placing the *dialect* model here does not deepen that split — the dialect is format-neutral wire
+vocabulary consumed by both stacks, and centralising it removes four hand-rolled builder/parser sites.
+
+## R2 — DCQL wire shape (OpenID4VP 1.0 final)
+
+**Decision**: Implement this subset of DCQL:
+
+```jsonc
+"dcql_query": {
+  "credentials": [                        // 1..n CredentialQuery
+    {
+      "id": "identity",                   // ^[a-zA-Z0-9_-]+$, unique in request
+      "format": "dc+sd-jwt",              // or "mso_mdoc"
+      "meta": {
+        "vct_values": ["https://sorcha.dev/vc/assured-identity/v1"]   // dc+sd-jwt
+        // "doctype_value": "org.iso.18013.5.1.mDL"                   // mso_mdoc
+      },
+      "claims": [
+        { "path": ["givenName"] },
+        { "path": ["address", "street"] }
+      ]
+      // claims[].values (value matching) — OUT OF SCOPE v1 (spec Assumptions)
+    }
+  ],
+  "credential_sets": [                    // optional; alternatives
+    { "options": [["pid"], ["assured_identity"]], "required": true, "purpose": "Prove your identity" }
+  ]
+}
+```
+
+Response: `vp_token` is a JSON **object** keyed by credential-query id, each value an **array** of
+presentation strings (SD-JWT compact form / base64url mdoc DeviceResponse). `presentation_submission` is
+absent. Optional-claim semantics: DCQL final models optionality via `claim_sets`; for v1 we map the
+existing required/optional split onto `claims` (required) + `claim_sets` (one set with all claims, one
+with required-only) — the builder/parser pair owns this mapping so callers keep the simple
+required/optional API they have today.
+
+**Rationale**: matches the final spec's normative shape; the mdoc verify path already parses the
+object-keyed `vp_token` (`VerifierEndpoints.TryExtractMdocDeviceResponse`, `VerifierEndpoints.cs:318-355`),
+so SD-JWT joins an existing envelope rather than inventing one.
+
+**Alternatives considered**: full `claim_sets`/`values`/`trusted_authorities` support (deferred — nothing
+in our flows needs it; `trusted_authorities` overlaps the F135 TrustPolicy which is our authoritative
+mechanism).
+
+## R3 — `dc+sd-jwt` migration mechanics
+
+**Decision**: flip the constant at `SdJwtService.cs:199-203` (`header["typ"] = "dc+sd-jwt"`); accept
+**both** `dc+sd-jwt` and `vc+sd-jwt` wherever typ is checked on the verify side (grep found **no runtime
+typ checks today** — only test assertions — so acceptance is mostly about *not adding* a strict check that
+breaks stored credentials); all DCQL `format` keys and OpenID4VCI issuer-metadata format identifiers move
+to `dc+sd-jwt`. Update the six test files that assert `vc+sd-jwt`.
+
+**Impacted sites** (from the dialect dive): `SdJwtService.cs:203` (write);
+`VerifierEndpoints.cs:163` (PD format key — replaced by DCQL anyway); HAIP issuer metadata
+(`MetadataEndpointTests` asserts `credentials_supported` format); test fixtures
+(`DeviceDelegationIssuerTests:109,142`, `PresentationEngineTests:226`, `TestVpFactory:79,103,185,209`,
+`CredentialEndpointTests:20,28,39`).
+
+## R4 — Presentation dialect surfaces (what actually changes where)
+
+| Surface | Today | Target |
+|---|---|---|
+| `Sorcha.Haip.Service/Endpoints/VerifierEndpoints.cs:141-179` | builds inline PE dict in signed request object | builds `dcql_query` via shared builder; request object keeps route + signing (RFC 9101 `oauth-authz-req+jwt` already correct) |
+| `VerifierEndpoints.cs:190-277` (`HandleDirectPost`) | mdoc = object-keyed, SD-JWT = bare compact string; `presentation_submission` stored raw | one object-keyed `vp_token` for both formats; per-query dispatch; `presentation_submission` param dropped; legacy-shape input → typed 400 `LEGACY_DIALECT` |
+| `SorchaWalletPresentationConsumer.cs:210-215` (Blueprint, F127) | minimal `openid4vp://` URI (client_id + nonce + request_id; **no embedded PD**) | emits `request_uri` form pointing at the F111 request-object endpoint carrying the DCQL body (converges with the desk-verifier form) |
+| Desk verifier / F164 unified surface (`QrPresentationService.cs:71`) | already `openid4vp://authorize?request_uri=…` | unchanged (already the right transport) |
+| `Sorcha.Wallet.Pwa/Services/Presentation/PresentationEngine.cs:33-73,195-245` | parses **inline** `presentation_definition` query param only; single `input_descriptors[0]` | fetches `request_uri`, validates signed request object (US6), parses `dcql_query` via shared parser; `Match()` generalises to query sets + alternatives |
+| `Sorcha.Agent/Commands/HaipPresentCommand.cs:137-145` | hand-builds `presentation_submission` | drops submission; posts object-keyed `vp_token` |
+| PWA consent UI (`Present.razor`, `ConsentSheet.razor`, `CredentialPickerDialog.razor`, `PresentationModels.cs`) | single-credential model (`ParsedPresentationRequest` = one vct) | `ParsedPresentationRequest` becomes a query set; ConsentSheet renders per-query sections; picker handles per-query alternatives |
+| Stale worktree `.worktrees/116-…/Sorcha.Citizen.Verifier/PresentationRequestBuilder.cs` | orphaned PE builder | not in scope (worktree, not master); noted for the housekeeping sweep |
+
+**Discrepancy found & resolved**: the PWA's `PresentationEngine` v1 comment says it parses "the unsigned
+query-parameter form the reference verifier emits", but the main-tree reference verifier now emits the
+`request_uri` form. The inline form only survives for tests and any F127 gate variant. The migration
+retires the inline form entirely (spec FR-026), which also resolves this drift.
+
+## R5 — ETSI TS 119 612 trusted-list parsing & signature verification depth
+
+**Decision**: Parse the `TrustServiceStatusList` XML server-side in **Tenant Service** (which already
+hosts `TrustEndpoints`). Extract: `SchemeInformation` → `TSLSequenceNumber`, `ListIssueDateTime`,
+`NextUpdate`, `SchemeTerritory`, scheme operator name; `TrustServiceProviderList` → per
+`TSPService`: `ServiceTypeIdentifier`, `ServiceStatus`, `ServiceDigitalIdentity/DigitalId/X509Certificate`
+(DER). **Anchor inclusion filter**: service type ∈ { `…/Svctype/CA/QC`, `…/Svctype/CA/PKC` } AND status ∈
+{ `…/Svcstatus/granted`, `…/Svcstatus/recognisedatnationallevel` } (config-extensible list). Everything
+else is skipped and itemised in the import summary (FR-012).
+
+**Signature verification depth (v1)**: verify the enveloped **XMLDSig core signature** using
+`System.Security.Cryptography.Xml.SignedXml` with the signing certificate from `KeyInfo`; reject on
+core-validation failure. Surface the **signer certificate identity** (subject, issuer, thumbprint) in the
+import summary so the operator confirms out-of-band that it is the expected scheme operator. Full XAdES
+qualifying-property validation and LOTL→TL pivot-chain validation are **explicitly deferred** (documented
+in the import UI and ops docs) — the operator-attested import model (spec D3) makes the operator the
+authenticity root for v1.
+
+**Rationale**: `SignedXml` core validation is well-supported on the server and catches tampering; full
+XAdES is a large surface with poor BCL support and is only load-bearing in the *live-fetch* model (the
+deferred follow-up). This matches D3's trust model: the operator vouches for where the document came from;
+the platform proves it wasn't modified and extracts deterministically.
+
+**Alternatives considered**: full XAdES-B/T validation (rejected v1: effort ≫ value under operator-attested
+import); no signature check at all (rejected: cheap tamper protection discarded).
+
+## R6 — Trusted-list snapshot persistence & distribution
+
+**Decision**: Replace the in-memory `OperatorSnapshotTrustListProvider`
+(`Sorcha.ServiceClients.Http/Trust/TrustListProvider.cs:46-66`) as the authoritative store with an
+EF-backed store in **Tenant** (`public` schema): `TrustedListSnapshot` (+ anchors serialized as a child
+collection). The existing seams stay: `ITrustListProvider.GetSnapshotAsync(trustListId)` is the read seam
+the `TrustListSourceResolver` chain already consumes via `ITenantTrustAnchorProvider`/`AnchorId()`
+(`Sources/TrustListSourceResolver.cs:17-25` subclassing `X509TenantTrustSourceResolver`, whose evidence
+already records `TrustListId` + `TrustListFreshness` — `TrustEvidence.cs:28,31`).
+
+**Distribution**: verifying services (Blueprint, HAIP, Verifier) resolve anchors over HTTP from Tenant —
+extend `TrustEndpoints` with `GET /api/v1/trust/trustlists/{id}/anchors` returning the DER root set +
+freshness (service-tier auth), consumed by a caching HTTP-backed `ITrustListProvider` in
+`Sorcha.ServiceClients.Http` (15-min in-process cache; trust decisions tolerate that staleness window
+given lists roll monthly). The existing `PUT /trustlists/{id}` raw-roots route is **subsumed** by the new
+import route (clean break — it was Feature 135's placeholder).
+
+**Storage registration**: `IStorageRegistrationLog.RegisterPersistent/RegisterInMemory` per pattern #10;
+NOT on the fail-fast audited list (trust config, reloadable), mirroring the F114 presentation-store
+precedent. Migration folded per the pre-release squash convention
+([[prerelease-migration-squash]] memory): add to Tenant's `InitialCreate`.
+
+## R7 — Multibase status-list decode
+
+**Decision**: at `BitstringStatusListChecker.cs:86`, accept both encodings:
+`encodedList[0] == 'u'` → `Base64Url.DecodeFromChars(encodedList.AsSpan(1))`; otherwise
+`Convert.FromBase64String` (current). One-line-plus-tests. The IETF checker
+(`IetfTokenStatusListChecker.cs:161`) already uses Base64Url per its spec — no change.
+
+## R8 — Certificate persistence (prerequisite for US4/US5)
+
+**Decision**: `InternalCaTrustProvider` (`Sorcha.Tenant.Service/Trust/InternalCaTrustProvider.cs:17-20`)
+currently holds tenant roots, **plaintext CA private keys**, org certs, and CRLs in
+`ConcurrentDictionary`s — nothing survives restart. Before auto-enrolment is meaningful, persist to Tenant
+Postgres: `TenantRootCa` (root DER + private key **encrypted at rest** with AES-256-GCM under a
+config-derived key, KMS integration flagged as the existing production TODO), `OrgCertificateRecord`
+(both provenances — see data-model), `TenantCrl`. The provider keeps its interface; the dictionaries
+become a write-through cache over the EF store. Registered via `IStorageRegistrationLog`.
+
+**Rationale**: spec US5 auto-enrols every new org; in-memory certs would silently vanish on every deploy,
+breaking issued-credential x5c chain resolution (`IssueCredentialChainResolver` in Wallet Service resolves
+chains from this store at mint time).
+
+## R9 — Which key gets certified (refinement of D6)
+
+**Finding**: org wallets are created with **ED25519 primary** by default
+(`OrganizationService.cs:102`), yet the X.509 rail is P-256-only. The platform already has the answer:
+HAIP-facing wallets carry a **classical ES256 co-key** derived under `sorcha:haip-issuer-signing`
+(`WalletAlgorithmClassification.cs:18-28`, `Wallet.cs:141`), and the enrol endpoint carries a TODO to
+validate the submitted key against exactly that co-key (`TrustEndpoints.cs:228-229`).
+
+**Decision**: the org certificate always binds the org's **P-256 signing key**: the primary key when the
+wallet is ES256-primary, else the derived HAIP-issuer ES256 co-key. Eligibility = "a P-256 key is
+resolvable for this org". The D6 typed exclusion (`CERT_KEY_NOT_ELIGIBLE`) then applies only to orgs where
+no P-256 key can be resolved (co-key derivation unavailable/failed) — and the enrol path additionally
+gains the missing key-match validation (server resolves the key itself via Wallet Service instead of
+trusting a caller-supplied key). This stays within D6's boundary — **no Ed25519 certificate wrapping is
+built** — while making auto-enrolment useful for the default org population. ⚠ Flagged to the platform
+owner in the plan report (it narrows D6's practical exclusion set to a rare failure mode).
+
+**Alternatives considered**: literal D6 (exclude every ED25519-primary org) — rejected: with ED25519 the
+creation default, auto-enrol (US5/FR-022) would no-op for essentially all orgs, gutting SC-006.
+
+## R10 — CSR generation with wallet-custodied keys
+
+**Decision**: the org's private key never leaves Wallet Service, so Tenant builds the CSR with a custom
+`X509SignatureGenerator` that delegates signing to
+`IWalletServiceClient.SignTransactionAsync(walletAddress, digest, derivationPath: "sorcha:haip-issuer-signing", isPreHashed: true)`
+(the existing seam — no new Wallet API). Implementation notes: `CertificateRequest.CreateSigningRequest(X509SignatureGenerator)`
+signs the `CertificationRequestInfo`; the wallet returns a raw `r‖s` ECDSA signature which the generator
+converts to the DER `ECDSA-Sig-Value` encoding CSRs require (`AsnWriter` — both formats are
+well-defined; conversion is ~20 lines and unit-testable with known vectors). P-256/SHA-256 only (R9).
+
+**Alternatives considered**: adding a dedicated `SignCsrAsync` to Wallet Service (rejected: the generic
+pre-hashed sign seam suffices; fewer API surfaces); generating a *new* keypair Tenant-side for the cert
+(rejected: breaks key-continuity — the cert must bind the key credentials are actually signed with).
+
+## R11 — Imported-certificate validation & chain attach
+
+**Decision**: import validation = (a) `leaf.PublicKey` SPKI byte-match against the org's resolved P-256
+key (R9); (b) chain build leaf→root over the uploaded set only (`X509Chain` with `CustomRootTrust` seeded
+from the uploaded root, `RevocationMode = NoCheck` at import; external CRL/OCSP is the CA's concern);
+(c) validity window sanity (leaf + every intermediate currently valid); (d) suitability = if KeyUsage
+present it must include `digitalSignature`, if EKU present it must not exclude signing (absent extensions
+pass — CA profiles vary). Both chain-with-root and chain-without-root uploads normalise to a stored
+ordered chain. Chain-attach: `IssueCredentialChainResolver` (Wallet Service) and
+`MdocFormatHandler.IssueAsync` resolve per `TrustAnchor` setting — `x509-lotl` → imported chain (fail
+closed `CERT_EXTERNAL_ANCHOR_UNAVAILABLE` if none valid, per FR-020), `x509-tenant` → tenant chain
+(unchanged, FR-021).
+
+## R12 — Verifier request-signing certificate & `x509_san_dns` client_id
+
+**Decision**: client_id becomes the **prefixed** final-spec form `x509_san_dns:{public-host}` (the
+`client_id_scheme` parameter was folded into the prefix in the final spec). The HAIP verifier's request
+object JWS gains an `x5c` header carrying an operator-provisioned **verifier certificate** whose SAN
+dNSName equals the installation's public host: config `Haip:VerifierCertificate` (PFX path or base64) +
+`Haip:VerifierCertificatePassword?`; in dev, fall back to a tenant-root-issued cert with SAN dns =
+configured host (self-contained demos keep working; wallets show it as authentic-but-untrusted). KB-JWT
+`aud` = the full prefixed client_id (both mint side, `PresentationEngine.BuildVpTokenAsync:170`, and
+verify side, `VerifiablePresentationValidator` aud check). `RequestObjectSigner` currently signs with an
+ephemeral/issuer key — switches to the verifier certificate key. The existing `TODO(098)` at
+`VerifierEndpoints.cs:100` is exactly this change.
+
+## R13 — PWA-side signed-request verification (WASM constraints)
+
+**Decision**: implement request-object validation inside `Sorcha.Verifier.Engine` (new
+`RequestObjectValidator`) using **BouncyCastle** — already a WASM-safe dependency of the engine — for
+ES256 JWS verification and X.509 parsing/SAN extraction (BCL `ECDsa`/`X509Chain` are unavailable or
+unreliable on browser-wasm; `System.Formats.Asn1` is available but BouncyCastle's cert object model is
+already in the dependency tree). Steps: parse JWS → extract `x5c` → verify signature with leaf key →
+check leaf SAN dNSName == host part of `x509_san_dns:` client_id → chain-to-anchor check against a
+`TrustAnchorSet` supplied by the host app. Anchor supply: the PWA fetches its home installation's
+trusted-list anchor sets via the R6 endpoint (cached in IndexedDB alongside status lists); no anchors ⇒
+verdict caps at *authentic-but-untrusted* (never blocks an otherwise-valid request — spec FR-027's
+three-state model). The desk verifier and Blueprint consumers get the same validator server-side.
+
+## R14 — CI dialect gate
+
+**Decision**: `scripts/check-presentation-dialect.ps1` + workflow step, following the
+`check-no-snackbar.ps1` / `check-trust-clean-break.ps1` ratchet precedent: fail on `presentation_definition`,
+`input_descriptors`, or `presentation_submission` under `src/` outside an allowlist file
+(`.presentation-dialect-allowlist` — expected to be empty at feature completion; the allowlist exists so
+the gate can land before the last consumer migrates). Also greps for `"vc+sd-jwt"` **writes** (the typ
+constant site) while permitting verify-side acceptance constants.
+
+## R15 — Walkthrough / demo / test migration inventory
+
+From the dialect dive (SC-002 regression oracle): `walkthroughs/AssuredIdentity/**` (phase-2 licence
+script exercises the HAIP verifier), `demos/AIAS/rehearse.ps1`, `demos/AssuredIdentity/**`,
+`demos/Membership/presentations/membership-pos.presentation.json` (static PE fixture — regenerate as
+DCQL), `Sorcha.Agent HaipPresentCommand`, plus the six test files in R3 and
+`PresentationEngineTests` / `VerifiablePresentationValidatorTests` / `SorchaWalletPresentationConsumerTests` /
+HAIP endpoint tests. E2E: F164 shared-verdict tests and F155 open-verifier tests ride the request_uri form
+and re-validate via SC-002.
+
+---
+
+## Resolved clarifications
+
+All Technical Context unknowns are resolved above; no NEEDS CLARIFICATION markers remain. The single
+plan-level deviation from a locked decision is **R9** (certificates bind the P-256 co-key for
+ED25519-primary orgs), which preserves D6's "no Ed25519 cert support" boundary while keeping US5's
+auto-enrolment meaningful — flagged for the platform owner's attention in the plan report.

--- a/specs/181-eudi-conformance/spec.md
+++ b/specs/181-eudi-conformance/spec.md
@@ -1,0 +1,468 @@
+# Feature Specification: EUDI Conformance — Protocol Alignment & External Trust Rail
+
+**Feature Branch**: `181-eudi-conformance`
+
+**Created**: 2026-07-10
+
+**Status**: Draft
+
+**Input**: User description: "EUDI conformance — protocol drift sweep (dc+sd-jwt, DCQL, multibase status decode, x509_san_dns client_id) + trust rail (ETSI TS 119 612 LOTL consumption, external X.509 anchors, org cert enrolment)"
+
+## Overview
+
+Sorcha's credential-presentation and credential-trust surfaces were built against draft versions of the
+OpenID4VC specifications and an internal-only X.509 trust model. The final EUDI-aligned profiles (HAIP 1.0
+final, OpenID4VP 1.0 final, SD-JWT VC final) have moved underneath us, and the external trust rail
+(`x509-lotl`) exists as a named anchor kind with no working implementation behind it. This feature closes
+both gaps — the **protocol dialect** and the **trust rail** — so that:
+
+1. A standards-conformant external wallet (an EUDI wallet, or any wallet built against the final profiles)
+   can receive, understand, and answer a Sorcha presentation request.
+2. Sorcha can verify credentials issued by external EUDI-ecosystem issuers, anchored on the official
+   European trusted-list infrastructure.
+3. A Sorcha organisation can carry an externally-issued certificate so that credentials it issues are
+   verifiable by parties outside the Sorcha ecosystem.
+
+Two things this feature is explicitly **not**: it is not the issuance-flow hardening layer (wallet
+attestation, pushed authorization, sender-constrained tokens — a follow-on feature), and it is not the
+EUDI PID credential profile (doctype/namespace/mandatory-claims shape — a follow-on feature). Those tiers
+build on this one.
+
+### Decisions locked during specification (with the platform owner)
+
+| # | Decision | Choice |
+|---|----------|--------|
+| D1 | Query-language migration strategy | **Clean break** to DCQL across every producer and consumer in one move. No dual Presentation-Exchange/DCQL support. **All existing OpenID4VP/OpenID4VCI routes are preserved unchanged** — only the request/response body dialect migrates. |
+| D2 | Multi-credential interactions | **In scope**: a single presentation request may ask for multiple credentials at once, and may express alternatives ("credential A, or credential B if the holder lacks A"). |
+| D3 | Trusted-list consumption mode | **Operator snapshot import**: an administrator imports a trusted-list document; the platform validates it, extracts the certificate-authority anchors, and stores a versioned snapshot with freshness metadata. Live scheduled refresh is a documented follow-up, not v1. |
+| D4 | External issuance identity | **Operator-imported org certificates**: an org admin generates a certificate signing request from the org's existing issuing key, obtains a certificate from an external authority out-of-band, and uploads the certificate + chain. Sorcha never mints externally-trusted certificates itself. |
+| D5 | Enrolment ergonomics | **Auto-enrol + admin surface**: every eligible (P-256) organisation automatically receives its internal tenant-root certificate at creation; an admin surface lists, re-issues, and imports certificates. |
+| D6 | Ed25519 organisations | **Typed exclusion**: organisations whose issuing key is Ed25519 are cleanly reported as not eligible for the X.509 rail (EUDI mandates P-256; the current behaviour is an unhandled server error). No Ed25519 certificate support is built. |
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Standards-conformant presentation dialect (Priority: P1)
+
+A holder using a standards-conformant external wallet (e.g. an EUDI reference wallet) scans a Sorcha
+verifier's QR code. The wallet fetches the signed request, understands the credential query (expressed in
+the final profile's query language, DCQL), selects a matching credential, and submits a presentation that
+Sorcha verifies successfully. Simultaneously, a citizen using the Sorcha wallet PWA completes the same
+flows they can complete today — council-page credential gates, the open verifier, workflow presentation
+gates — with no user-visible change, because the whole platform speaks the new dialect end-to-end.
+
+**Why this priority**: Every other conformance goal is unreachable while our requests use a query language
+final-profile wallets reject. This is also the largest coordinated change (three request producers, two
+wallet consumers, three verification paths), so it must land first and cleanly.
+
+**Independent Test**: Run the existing presentation walkthroughs (council credential gate, open verifier,
+HAIP workflow gate) end-to-end against the migrated stack — all pass. Separately, capture a generated
+presentation request and validate its body against the final OpenID4VP profile's request schema — no
+legacy query-language fields present.
+
+**Acceptance Scenarios**:
+
+1. **Given** a verifier creates a presentation request for one credential type with three required claims,
+   **When** the signed request object is fetched via its request URI, **Then** the request body contains a
+   DCQL credential query (and no Presentation Exchange `presentation_definition`), and the media/type
+   identifiers use the final SD-JWT VC form (`dc+sd-jwt`).
+2. **Given** a citizen holds a matching credential in the Sorcha wallet PWA, **When** they scan the QR and
+   consent, **Then** the wallet submits a response whose token envelope is keyed by the request's
+   credential query identifier, the verifier validates it, and the outcome records success.
+3. **Given** an in-flight workflow uses the F111 presentation gate, **When** the presentation completes,
+   **Then** the workflow advances exactly as before — callback routes, status routes, and lifecycle events
+   are byte-for-byte unchanged in their URLs and semantics.
+4. **Given** newly issued SD-JWT credentials, **When** their type header is inspected, **Then** it carries
+   the final profile's media type (`dc+sd-jwt`), and Sorcha's own verifiers accept **both** the new and
+   previously-issued (`vc+sd-jwt`) credentials it already delivered to wallets.
+5. **Given** the codebase after migration, **When** the CI conformance gate runs, **Then** no producer or
+   parser of the legacy Presentation Exchange dialect remains outside an explicitly allowlisted
+   compatibility note.
+
+---
+
+### User Story 2 - Multi-credential and alternative asks (Priority: P2)
+
+A council service needs two credentials in one interaction ("prove your identity AND your address"), or
+accepts alternatives ("an EUDI PID, or a Sorcha Assured Identity credential"). The verifier expresses this
+in a single presentation request; the citizen sees one consent flow listing each ask; the wallet resolves
+alternatives against what the citizen actually holds; the response carries one presentation per satisfied
+query.
+
+**Why this priority**: This is the concrete payoff of the query-language migration — accepting an external
+EUDI credential *or* a Sorcha credential for the same gate is the working definition of EUDI interop for
+Sorcha's council use cases. It depends on US1's dialect but is separately testable and shippable.
+
+**Independent Test**: Author a presentation request with two credential queries and a two-option
+alternative set; walk a wallet holding only one of the alternatives through it; confirm the consent
+surface shows both asks, the response satisfies the request, and verification reports per-query outcomes.
+
+**Acceptance Scenarios**:
+
+1. **Given** a request asking for credentials A and B, **When** the holder consents to both, **Then** the
+   response contains two presentations, each independently verified, and the overall outcome is success
+   only if every required query is satisfied.
+2. **Given** a request expressing "A or B" alternatives, **When** the holder has only B, **Then** the
+   wallet matches B, the consent surface shows the B option, and verification succeeds against the B
+   branch of the alternative set.
+3. **Given** a request asking for A and B, **When** the holder lacks B, **Then** the wallet clearly shows
+   which ask cannot be satisfied and does not submit a partial response by default.
+4. **Given** a response containing a presentation keyed to an unknown query identifier, **When** the
+   verifier processes it, **Then** verification fails with a specific, diagnosable reason.
+
+---
+
+### User Story 3 - Verify external EUDI credentials via a trusted-list snapshot (Priority: P2)
+
+A platform operator imports the official European trusted-list document (or a member-state trusted list).
+The platform validates the document's signature, extracts the certificate-authority anchors, and stores
+them as a versioned snapshot with freshness metadata. From then on, when a holder presents a credential
+issued by an external issuer whose certificate chains to one of those anchors, Sorcha's verifiers accept
+it under a trust policy that names the trusted-list source — and the verification evidence records which
+list version vouched.
+
+**Why this priority**: This makes the `x509-lotl` trust anchor real. It is the verify-side half of the
+external trust rail and does not depend on US1 (a credential can be verified regardless of which query
+dialect requested it), so it can proceed in parallel.
+
+**Independent Test**: Import a known trusted-list fixture containing a test CA; present a credential
+issued under that CA; verification succeeds with evidence naming the list snapshot. Present the same
+credential with no snapshot imported; verification fails closed.
+
+**Acceptance Scenarios**:
+
+1. **Given** an administrator with a trusted-list XML document, **When** they import it, **Then** the
+   platform verifies the document's own signature, rejects tampered or unsigned documents, extracts only
+   the anchors of the relevant service types, and records a versioned snapshot with the list's sequence
+   number, issue date, and next-update date.
+2. **Given** a stored snapshot, **When** a presented credential's certificate chain terminates at an
+   anchor in that snapshot, **Then** trust evaluation succeeds via the trusted-list source and the
+   verification evidence carries the snapshot identity and freshness.
+3. **Given** a snapshot whose next-update date has passed, **When** a credential is evaluated against it,
+   **Then** the platform still evaluates but flags the staleness in evidence and surfaces an
+   operator-visible warning (metric + log); a configurable strict mode fails closed instead.
+4. **Given** a new version of the same list is imported and a previously-anchored CA is absent from it,
+   **When** a credential chaining to the removed CA is next evaluated, **Then** trust evaluation fails —
+   the newest snapshot version is authoritative.
+5. **Given** no snapshot has ever been imported, **When** a trust policy references the trusted-list
+   source, **Then** evaluation fails closed with a specific "no trusted list available" reason (never an
+   unhandled error, never a silent pass).
+
+---
+
+### User Story 4 - Externally-verifiable issuance identity (Priority: P3)
+
+An organisation administrator wants credentials issued by their org to be verifiable by parties outside
+Sorcha. They generate a certificate signing request bound to the org's existing issuing key, take it to an
+external certificate authority (out-of-band), and upload the resulting certificate + chain. From then on,
+credentials the org issues on the external anchor setting carry a certificate chain that terminates at the
+external authority's root — so any third party that trusts that root (e.g. via the same European
+trusted-list infrastructure) can verify the credential with no knowledge of Sorcha.
+
+**Why this priority**: This is the issue-side half of the external rail. Valuable, but only after the
+verify-side (US3) exists to test against, and only meaningful to orgs that have completed an external
+registration — a smaller initial population.
+
+**Independent Test**: Generate a CSR for a test org; sign it with a test CA; upload the cert + chain;
+issue a credential with the external anchor setting; verify the credential using only the test CA root
+(no Sorcha tenant root in the trust store).
+
+**Acceptance Scenarios**:
+
+1. **Given** an org whose issuing key is P-256, **When** the admin requests a CSR, **Then** the platform
+   produces a standard CSR bound to that key, and the private key never leaves the platform's custody.
+2. **Given** a certificate + chain uploaded by the admin, **When** the platform validates it, **Then** it
+   confirms (a) the certificate's public key matches the org's issuing key, (b) the chain is internally
+   consistent and within validity, and (c) the certificate is suitable for credential signing — rejecting
+   mismatches with specific reasons.
+3. **Given** an org with an imported external certificate, **When** it issues a credential configured for
+   the external trust anchor, **Then** the credential's embedded chain terminates at the external root
+   (not the Sorcha tenant root), and issuance fails closed with a clear error if the external anchor is
+   requested but no imported certificate exists.
+4. **Given** an imported certificate approaching expiry, **When** an admin views the org's certificate
+   surface, **Then** expiry is visible, and issuance under an expired imported certificate fails closed
+   with a specific reason.
+5. **Given** orgs with tenant-root certificates only, **When** they issue on the internal anchor setting,
+   **Then** nothing about their behaviour changes.
+
+---
+
+### User Story 5 - Certificate lifecycle without footguns (Priority: P3)
+
+Every new eligible organisation automatically receives its internal (tenant-root) certificate at creation
+— no manual API call, no walkthrough-only setup path. An administrator surface lists each org's
+certificates (internal and imported), shows validity and chain summary, and offers re-issue (internal) and
+import (external). An organisation whose issuing key is Ed25519 sees a clear "not eligible for the X.509
+rail" state everywhere a certificate would appear — instead of today's unhandled server error.
+
+**Why this priority**: Ergonomics and error-quality work that turns US4's capability into something a
+normal org actually reaches. Depends on the certificate surfaces existing but not on external interop.
+
+**Independent Test**: Create a new P-256 org; observe a tenant-root certificate exists without any manual
+step. Create an Ed25519 org; observe the certificate surface reports ineligibility with a typed reason and
+no server error is logged.
+
+**Acceptance Scenarios**:
+
+1. **Given** a new organisation with a P-256 issuing key, **When** creation completes, **Then** a
+   tenant-root certificate for the org exists and is visible on the admin surface, and a failure to enrol
+   never fails org creation itself (enrolment is retried/reparable, and its failure is operator-visible).
+2. **Given** an existing org created before this feature, **When** the admin opens the certificate
+   surface, **Then** they can enrol it with one action (backfill).
+3. **Given** an organisation with an Ed25519 issuing key, **When** any certificate operation is attempted,
+   **Then** the response is a typed, documented "key type not eligible for X.509" outcome — never an
+   unhandled ASN.1 error.
+4. **Given** the admin surface, **When** a certificate is re-issued, **Then** the previous certificate's
+   status is recorded and the new one becomes active — the history remains auditable.
+
+---
+
+### User Story 6 - Verifier authentication for wallets (Priority: P4)
+
+A wallet (Sorcha's own PWA, or an external one) that receives a presentation request can authenticate the
+verifier: the request's client identifier uses the DNS-based certificate scheme (`x509_san_dns`), the
+signed request object's signature verifies against the certificate presented with it, and — where trust
+anchors are available (US3) — the certificate chains to a trusted root. The citizen's consent surface can
+then display a verified verifier identity rather than a bare URL.
+
+**Why this priority**: Completes the loop: US1 fixes what we say, US3/US4 fix whom to trust, US6 lets the
+*wallet* apply that trust to the *verifier*. It is last because it composes the others — meaningless
+without real anchors — and because the current unsigned deep-link path our own components use must migrate
+to the fetched signed-request form first.
+
+**Independent Test**: Configure a verifier with a certificate whose DNS name matches its public host;
+create a request; confirm the wallet verifies the request signature and displays the verifier identity.
+Tamper with the signature; confirm the wallet refuses the request.
+
+**Acceptance Scenarios**:
+
+1. **Given** a verifier with a suitable certificate, **When** it creates a presentation request, **Then**
+   the client identifier uses the DNS-based certificate scheme and the signed request object carries the
+   certificate chain needed to validate it.
+2. **Given** the Sorcha wallet PWA receiving such a request, **When** it processes the request, **Then**
+   it fetches the signed request object, verifies the signature against the presented certificate, checks
+   the DNS-name binding, and refuses tampered or mismatched requests with a citizen-comprehensible error.
+3. **Given** trust anchors from an imported trusted list (US3), **When** the verifier's chain terminates
+   at one, **Then** the consent surface shows a verified identity; when it does not, the surface clearly
+   distinguishes "request is authentic but verifier is not on a trusted list".
+4. **Given** Sorcha's internal flows (council gate, open verifier, workflow gate), **When** they run after
+   this story, **Then** they use the same signed-request path — the unsigned inline-parameter deep-link
+   form is retired.
+
+---
+
+### Edge Cases
+
+- **Legacy dialect received after the clean break**: a wallet or verifier submits the old Presentation
+  Exchange shape → rejected with a specific, versioned error message (not a parse crash), so external
+  integrators can self-diagnose.
+- **Previously-issued credentials with the old media type**: credentials already delivered to citizen
+  wallets carry `vc+sd-jwt`. Sorcha's own verifiers accept both media types on the verify side
+  (pre-release data is not migrated); only *newly issued* credentials carry the final form.
+- **Trusted-list document that is validly signed but semantically odd**: empty service list, unknown
+  service types, duplicate CA entries → import succeeds where safe, skips irrelevant entries, and reports
+  exactly what was extracted vs skipped.
+- **Snapshot freshness at the boundary**: evaluation exactly at the next-update instant; clock skew
+  between the operator's import time and the list's own dates → freshness comparisons use the platform's
+  clock with the list's stated dates and behave deterministically.
+- **Imported certificate whose chain includes the anchor itself vs chain-without-root**: both common CA
+  delivery formats must import correctly.
+- **Org key rotation after certificate import**: the imported certificate no longer matches the issuing
+  key → issuance on the external anchor fails closed with a "certificate/key mismatch" reason and the
+  admin surface flags it.
+- **Multi-credential consent where the citizen deselects an optional claim** on one credential but not the
+  other → per-query claim approval is independent.
+- **Alternative sets where the citizen holds both options** → the wallet presents a choice, not an
+  arbitrary auto-pick.
+- **Concurrent snapshot import**: two admins import list versions near-simultaneously → last-write-wins on
+  version ordering rules (the list's own sequence number governs), never a corrupted merged snapshot.
+- **Status-list decode strictness**: a third-party status list encoded with multibase (`u`-prefixed
+  base64url) must decode; Sorcha's own lists remain valid.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+**Protocol dialect (US1, US2)**
+
+- **FR-001**: Every presentation request the platform produces (workflow gate, council-page gate, open
+  verifier, HAIP verifier API) MUST express its credential ask in DCQL (the final OpenID4VP profile's
+  query language). No producer may emit a Presentation Exchange `presentation_definition`.
+- **FR-002**: All existing OpenID4VP/OpenID4VCI **routes, URL shapes, and endpoint semantics MUST be
+  preserved unchanged** — request creation, request-object fetch, direct-post response, result polling,
+  presentation-lifecycle callbacks and status. Only request/response body dialects change.
+- **FR-003**: Presentation responses MUST use the final profile's token envelope: one entry per credential
+  query identifier. The legacy `presentation_submission` descriptor-mapping structure MUST be neither
+  produced nor required. A response entry keyed to an unknown query identifier MUST fail verification with
+  a specific reason.
+- **FR-004**: Newly issued SD-JWT credentials MUST carry the final profile media type (`dc+sd-jwt`) in
+  their type header, and all request/query format identifiers MUST use the final form. Sorcha's verifiers
+  MUST continue to accept previously-issued credentials carrying the prior media type (`vc+sd-jwt`).
+- **FR-005**: A single presentation request MUST be able to carry multiple credential queries, and MUST be
+  able to express alternative sets ("satisfy with A, or with B"). Verification MUST report per-query
+  outcomes and succeed overall only when every required query (or a complete alternative branch) is
+  satisfied.
+- **FR-006**: The Sorcha wallet PWA MUST parse DCQL requests, match multiple queries (including
+  alternatives) against the citizen's held credentials, and present a consent surface that (a) lists each
+  ask separately, (b) supports per-query claim approval, (c) lets the citizen choose among alternatives
+  when more than one is satisfiable, and (d) clearly identifies unsatisfiable asks without submitting a
+  partial response by default.
+- **FR-007**: Requests or responses in the legacy dialect received after migration MUST be rejected with a
+  specific, versioned error identifying the expected dialect — never an unhandled parse failure.
+- **FR-008**: The request-building and request-parsing logic for the DCQL dialect MUST exist exactly once,
+  shared by every producer and consumer inside the platform (single-obvious-path: the current
+  independently hand-rolled builder/parser pairs are retired).
+- **FR-009**: A CI gate MUST fail the build if the legacy Presentation Exchange dialect (producer or
+  parser) reappears outside an explicitly allowlisted location.
+- **FR-010**: Status-list decoding MUST accept multibase (`u`-prefixed base64url) encoded status lists in
+  addition to the currently-accepted plain base64 form.
+
+**Trusted-list snapshot rail (US3)**
+
+- **FR-011**: An administrator MUST be able to import a trusted-list document conforming to the European
+  trusted-list format (ETSI TS 119 612 — the LOTL or a member-state trusted list) by upload or by URL
+  fetch-once. Import MUST verify the document's enveloped signature and reject unsigned, tampered, or
+  malformed documents with specific reasons.
+- **FR-012**: Import MUST extract certificate-authority anchors from service entries relevant to
+  credential issuance (qualified/recognised certificate-issuance service types), skipping irrelevant
+  service types, and MUST report a summary of what was extracted vs skipped.
+- **FR-013**: Each import MUST be stored as a **versioned snapshot** carrying the list's own sequence
+  number, issue date, next-update date, territory/scheme identity, the anchor set, and who imported it
+  when. The newest valid snapshot per list identity is authoritative; superseded snapshots remain
+  auditable.
+- **FR-014**: The trust-evaluation source for trusted lists MUST resolve anchors from the authoritative
+  snapshot(s). With no snapshot present, evaluation against a trusted-list trust policy MUST fail closed
+  with a specific "no trusted list available" reason.
+- **FR-015**: Verification evidence for a trusted-list-vouched decision MUST record the snapshot identity
+  (list + sequence number) and its freshness state, so a past decision can be audited against the list
+  version that vouched for it.
+- **FR-016**: Snapshot staleness (past next-update) MUST be evaluated on every use: default behaviour is
+  evaluate-with-warning (evidence flag + operator-visible metric/log); a configuration switch MUST allow
+  strict fail-closed behaviour per installation.
+- **FR-017**: Administrators MUST be able to list snapshots (with freshness state), inspect an anchor set,
+  and delete a snapshot. All snapshot mutations MUST be restricted to platform administrators and audited.
+
+**External issuance identity (US4)**
+
+- **FR-018**: An org administrator MUST be able to generate a certificate signing request bound to the
+  org's existing P-256 issuing key. The private key MUST never be exported or exposed by this flow.
+- **FR-019**: An org administrator MUST be able to upload an externally-issued certificate + chain. Import
+  MUST validate: public-key match against the org's issuing key; chain internal consistency and validity
+  window; suitability for credential signing. Each failure mode MUST produce a distinct, actionable
+  reason. Both chain-with-root and chain-without-root delivery formats MUST import.
+- **FR-020**: When an org issues a credential configured for the external trust anchor, the embedded
+  certificate chain MUST be the imported external chain. If no valid imported certificate exists (absent,
+  expired, or key-mismatched after rotation), issuance MUST fail closed with a specific reason — never
+  fall back silently to the internal tenant root.
+- **FR-021**: Issuance configured for the internal anchor MUST be entirely unaffected by this feature.
+
+**Certificate lifecycle & eligibility (US5)**
+
+- **FR-022**: Every newly created organisation whose issuing key is P-256 MUST automatically receive its
+  internal tenant-root certificate. Enrolment failure MUST NOT fail organisation creation; it MUST be
+  operator-visible and re-triggerable.
+- **FR-023**: An administrator surface MUST list an org's certificates (internal and imported) with
+  status, validity, and chain summary; support one-action enrolment backfill for pre-existing orgs;
+  support internal re-issue with auditable history; and host the CSR/import flows of US4.
+- **FR-024**: Certificate operations against an organisation whose issuing key is not P-256 MUST return a
+  typed, documented "key type not eligible for the X.509 rail" outcome. The current unhandled ASN.1
+  server error MUST be eliminated.
+
+**Verifier authentication (US6)**
+
+- **FR-025**: Platform verifiers MUST identify themselves in presentation requests using the DNS-based
+  certificate client-identifier scheme (`x509_san_dns`), with the signed request object carrying the
+  certificate material a wallet needs to validate it. The verifier's DNS name MUST match its public host.
+- **FR-026**: The Sorcha wallet PWA MUST migrate from the unsigned inline-parameter deep-link form to
+  fetching and validating the signed request object: signature verification against the presented
+  certificate, DNS-name binding check, and refusal of tampered or mismatched requests with a
+  citizen-comprehensible error. The unsigned form MUST be retired from all internal producers.
+- **FR-027**: Where trusted-list anchors are available, the wallet's consent surface MUST distinguish
+  three verifier states: verified against a trusted list; authentic (signature valid) but not on a trusted
+  list; and unverifiable. It MUST never present an unverifiable request as verified.
+
+**Observability & documentation (cross-cutting)**
+
+- **FR-028**: The platform MUST expose operational metrics for: trusted-list snapshot freshness and
+  staleness events; trust decisions by source (existing metric gains the trusted-list source in practice);
+  external-anchor issuance successes/failures by reason; legacy-dialect rejections; and verifier
+  request-authentication outcomes.
+- **FR-029**: STANDARDS.md rows for OpenID4VP, OpenID4VCI, HAIP, and SD-JWT VC MUST be updated to the
+  final-profile versions with honest partial/full status; the discoverability surfaces that cite them
+  follow.
+
+### Key Entities
+
+- **Credential Query (DCQL)**: the unit of ask inside a presentation request — an identifier, a credential
+  format, format-specific matching metadata (e.g. credential type values), and claim paths with
+  required/optional character. Grouped into a query set with optional alternative-set combinators.
+- **Trusted-List Snapshot**: a versioned, immutable record of one imported trusted list — list identity
+  (scheme/territory), sequence number, issue and next-update dates, extracted anchor set, import
+  provenance (who/when/how), and computed freshness state. Supersedes earlier snapshots of the same list
+  identity.
+- **Trust Anchor (external)**: one certificate-authority certificate extracted from a snapshot, with its
+  originating service entry's type and status. Referenced by trust evaluation and by verifier
+  authentication.
+- **Org Issuing Certificate**: a certificate bound to an organisation's issuing key. Two provenances:
+  *internal* (tenant-root, auto-enrolled) and *imported* (externally issued, uploaded with chain). Carries
+  status (active/superseded/expired/mismatched), validity window, chain summary, and audit history.
+- **Certificate Signing Request**: a one-shot artefact generated from the org's issuing key for out-of-band
+  external certification; records when/by whom it was generated.
+- **Presentation Response Entry**: one presented credential keyed by the credential-query identifier it
+  answers; the response envelope holds one entry per satisfied query.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A presentation request generated by each of the three platform request producers validates
+  against the final OpenID4VP profile's request schema (independent schema check), with zero legacy
+  query-language fields.
+- **SC-002**: 100% of the existing presentation walkthroughs (council credential gate, open verifier
+  demo, HAIP workflow gate, AIAS rehearse) pass unchanged in their user-visible behaviour after the
+  migration.
+- **SC-003**: A wallet holding only the second option of a two-option alternative ask completes the
+  presentation successfully; a wallet lacking a required query is told exactly which ask is unsatisfiable.
+- **SC-004**: A credential issued under a test CA whose root is present only via an imported trusted-list
+  snapshot verifies successfully, and the verification evidence names the snapshot; with the snapshot
+  deleted, the same credential fails verification closed.
+- **SC-005**: A credential issued by an org with an imported external certificate verifies successfully
+  using only the external root (Sorcha's tenant root absent from the trust set).
+- **SC-006**: 100% of newly created P-256 organisations hold a tenant-root certificate with zero manual
+  steps; certificate operations on an Ed25519 org produce the typed ineligibility outcome in 100% of
+  cases and zero unhandled server errors.
+- **SC-007**: The Sorcha wallet PWA refuses 100% of presentation requests with tampered signatures or
+  mismatched DNS-name bindings, with a citizen-comprehensible message; authentic requests display the
+  correct verifier state (trusted / authentic-untrusted).
+- **SC-008**: The CI conformance gate blocks any PR reintroducing the legacy dialect; the gate itself is
+  demonstrated by a deliberate red-test during development.
+- **SC-009**: An operator can import a trusted list and see its anchors in use (first vouched
+  verification) in under 10 minutes without reading source code — using only the admin surface and its
+  inline guidance.
+
+## Assumptions
+
+- **Pre-release clean break is acceptable** (established repo policy): no live external integrators depend
+  on the Presentation Exchange dialect today; Sorcha's own wallets/verifiers migrate in lockstep within
+  this feature. The only backwards-compatibility kept is verify-side acceptance of already-issued
+  `vc+sd-jwt` credentials (FR-004), because those live in citizen wallets we don't control.
+- **Trusted-list refresh is manual in v1** (D3): operators re-import when lists roll. The freshness
+  metadata + staleness warnings (FR-016) make the manual cadence safe; scheduled refresh is a named
+  follow-up.
+- **External certification happens out-of-band** (D4): obtaining a certificate from a member-state
+  registrar or commercial CA is an organisational process outside the platform; the platform's job is CSR
+  out, cert in, chain on credentials.
+- **EUDI's cryptographic profile is P-256**, so restricting the X.509 rail to P-256 issuing keys (D6)
+  costs no EUDI capability. Ed25519 remains fully supported on the register/DID-native rail.
+- **Out of scope, deliberately** (later tiers): wallet attestation / pushed authorization / DPoP
+  (issuance-flow hardening); the EUDI PID credential profile (doctype, namespaces, mandatory claims);
+  mdoc proximity transport and MAC device authentication; live LOTL pointer-following; signed request
+  objects for the *issuance* (OpenID4VCI) leg; claim-value matching constraints in DCQL beyond
+  required/optional claim selection; relying-party access/registration certificates.
+- **Dependencies**: builds on the unified trust evaluator and format-handler seam (Feature 135), the
+  presentation lifecycle (F111/F119/F127), the citizen wallet PWA presentation engine (F114/F159), and the
+  existing per-tenant internal certificate authority. The mdoc verify path already consumes the
+  DCQL-shaped response envelope; this feature aligns SD-JWT with it.
+- **Interop validation target**: conformance is asserted against the published final profiles and schema
+  checks plus our own cross-format tests; live interop against an external EUDI reference wallet is a
+  stretch validation activity, not a gate for this feature (it requires the later-tier issuance
+  hardening to be meaningful end-to-end).

--- a/specs/181-eudi-conformance/tasks.md
+++ b/specs/181-eudi-conformance/tasks.md
@@ -1,0 +1,262 @@
+# Tasks: EUDI Conformance — Protocol Alignment & External Trust Rail
+
+**Input**: Design documents from `/specs/181-eudi-conformance/`
+
+**Prerequisites**: plan.md, spec.md, research.md (R1–R15), data-model.md, contracts/, quickstart.md
+
+**Tests**: Included — the constitution mandates tests alongside code (>85% new-code coverage), and the
+spec's SC-008 requires a deliberate red-test of the CI gate.
+
+**Organization**: Phases 3–8 map 1:1 to spec user stories US1–US6. US3 (trust rail) is independent of
+US1/US2 and can run in parallel after Phase 2. US4→US5 share the certificate foundation; US6 composes
+US1+US3 and goes last.
+
+## Format: `[ID] [P?] [Story] Description`
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Wiring changes every story builds on. (No new projects — plan Structure Decision.)
+
+- [X] T001 Add ProjectReference `Sorcha.Verifier.Engine` to `src/Services/Sorcha.Haip.Service/Sorcha.Haip.Service.csproj` (R1 — HAIP is the only DCQL consumer not already referencing the engine)
+- [X] T002 [P] Create CI dialect gate `scripts/check-presentation-dialect.ps1` + `.presentation-dialect-allowlist` seeded with every current PE site from research R4/R15, and wire a step into the CI workflow (`.github/workflows/`) per the `check-trust-clean-break.ps1` precedent (FR-009; the allowlist ratchets to empty in T028)
+- [X] T003 [P] Test fixtures: signed ETSI TS 119 612 XML generator + test CA helper in `tests/Sorcha.Tenant.Service.Tests/Fixtures/TrustLists/TrustListFixture.cs` (generates a minimal `TrustServiceStatusList` with configurable sequence/dates/service entries, XMLDSig-signs it with a fixture cert; also exposes the test CA for US3/US4 credential-issuance tests — R5, quickstart US3/US4)
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: The shared DCQL dialect and media-type flip that US1/US2/US6 all consume.
+
+**⚠️ CRITICAL**: T004–T009 block all presentation-dialect stories. US3 is NOT blocked by this phase
+(only by Setup) — it may start after T003.
+
+- [X] T004 [P] DCQL wire model records (`DcqlQuery`, `DcqlCredentialQuery`, `DcqlCredentialMeta`, `DcqlClaimQuery`, `DcqlCredentialSetQuery`, `DcqlVpToken`) in `src/Common/Sorcha.Verifier.Engine/Dcql/DcqlModels.cs` per data-model.md §1 (exact JSON property names, id-regex + uniqueness validation)
+- [X] T005 `DcqlRequestBuilder` in `src/Common/Sorcha.Verifier.Engine/Dcql/DcqlRequestBuilder.cs` — builds `dcql_query` from (format, vct/doctype, required claims, optional claims, alternative groups); owns the required/optional → `claims`+`claim_sets` mapping (R2); depends on T004
+- [X] T006 `DcqlRequestParser` in `src/Common/Sorcha.Verifier.Engine/Dcql/DcqlRequestParser.cs` — inverse of T005 in the same review unit (FR-008); typed errors for malformed queries; rejects PE shapes with `LEGACY_DIALECT`; depends on T004
+- [X] T007 [P] Unit tests: builder⇄parser round-trip, id validation, credential_sets referential integrity, legacy-shape rejection in `tests/Sorcha.Verifier.Engine.Tests/Dcql/DcqlRoundTripTests.cs` (depends on T005/T006)
+- [X] T008 Flip SD-JWT typ to `dc+sd-jwt` at `src/Common/Sorcha.Cryptography/SdJwt/SdJwtService.cs:199-203`; audit verify paths to confirm no strict typ check breaks stored `vc+sd-jwt` credentials (R3 — grep found none; add an explicit dual-accept test to lock it in) in `tests/Sorcha.Cryptography.Tests/SdJwt/`
+- [X] T009 [P] (HAIP test assertions deliberately deferred to T013 — they assert endpoint behaviour that only changes there) Update the six `vc+sd-jwt`-asserting test files (R3): `tests/Sorcha.Wallet.Service.Tests/Services/DeviceDelegationIssuerTests.cs:109,142`, `tests/Sorcha.Wallet.Pwa.Tests/Services/Presentation/PresentationEngineTests.cs:226`, `tests/Sorcha.Verifier.Tests/Services/TestVpFactory.cs:79,103,185,209`, `tests/Sorcha.Haip.Service.Tests/Endpoints/MetadataEndpointTests.cs:42,60,64`, `tests/Sorcha.Haip.Service.Tests/Endpoints/CredentialEndpointTests.cs:20,28,39` (depends on T008)
+
+**Checkpoint**: shared dialect exists and round-trips; new issuance carries `dc+sd-jwt`; old credentials still verify.
+
+---
+
+## Phase 3: User Story 1 — Standards-conformant presentation dialect (Priority: P1) 🎯 MVP
+
+**Goal**: Every producer emits DCQL in place of Presentation Exchange; responses use the object-keyed
+`vp_token`; all OpenID4VP routes byte-stable (D1/FR-002); legacy shapes rejected with `LEGACY_DIALECT`.
+
+**Independent Test**: quickstart §US1 — decode a live request object (dcql_query present, PD absent);
+run AssuredIdentity walkthroughs + AIAS rehearse unchanged (SC-002); PE-shaped direct_post → 400.
+
+### Implementation for User Story 1
+
+- [ ] T010 [US1] HAIP verifier request objects emit `dcql_query` via `DcqlRequestBuilder`, drop the inline PE dict, keep route/signing unchanged, in `src/Services/Sorcha.Haip.Service/Endpoints/VerifierEndpoints.cs:141-179` (contract §1; client_id value unchanged until US6)
+- [ ] T011 [US1] `HandleDirectPost` accepts the object-keyed `vp_token` for BOTH formats, dispatches per query id, drops `presentation_submission` (present or bare-compact-string vp_token → 400 `LEGACY_DIALECT` problem+json), in `src/Services/Sorcha.Haip.Service/Endpoints/VerifierEndpoints.cs:190-277` + generalise `TryExtractMdocDeviceResponse` into the shared envelope reader (contract §2, FR-003/FR-007); depends on T010
+- [ ] T012 [P] [US1] `VerifiablePresentationValidator` consumes a single presentation entry from the envelope (per-query call shape) in `src/Common/Sorcha.Verifier.Engine/VerifiablePresentationValidator.cs:94-342` — KB-JWT `aud` check stays against the request's client_id value (prefix flip is US6)
+- [ ] T013 [P] [US1] HAIP issuer metadata + credential endpoint format identifiers → `dc+sd-jwt` in `src/Services/Sorcha.Haip.Service/Endpoints/MetadataEndpoints.cs` and `CredentialEndpoints.cs` (FR-004)
+- [ ] T014 [US1] `SorchaWalletPresentationConsumer.BuildInitiationAsync` emits the `request_uri` deep-link form (converging on the F164 transport) with the DCQL body served by the F111 request-object route, in `src/Services/Sorcha.Blueprint.Service/Services/Implementation/SorchaWalletPresentationConsumer.cs:210-215` (R4); update `tests/Sorcha.Blueprint.Service.Tests/Services/SorchaWalletPresentationConsumerTests.cs`
+- [ ] T015 [US1] PWA `PresentationEngine`: `Parse` fetches `request_uri` (unsigned-inline form refused `LEGACY_DIALECT`), decodes the request-object JWT payload WITHOUT signature verification yet (US6 adds it), parses `dcql_query` via `DcqlRequestParser`; `BuildVpTokenAsync` emits the object-keyed envelope; in `src/Apps/Sorcha.Wallet.Pwa/Services/Presentation/PresentationEngine.cs` (single-query flow preserved; multi-query is US2)
+- [ ] T016 [US1] `Present.razor` + `ParsedPresentationRequest` model migration (single-query shape backed by `DcqlQuery`) in `src/Apps/Sorcha.Wallet.Pwa/Pages/Present.razor` and `src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Models/User/Presentation/PresentationModels.cs`; depends on T015
+- [ ] T017 [P] [US1] `Sorcha.Agent` present command drops `presentation_submission`, posts object-keyed `vp_token`, in `src/Apps/Sorcha.Agent/Commands/HaipPresentCommand.cs:137-145`
+- [ ] T018 [P] [US1] Regenerate the static PE fixture as DCQL: `demos/Membership/presentations/membership-pos.presentation.json` (+ any generator script `demos/Membership/Render-MembershipBlueprint.ps1`) per R15
+- [ ] T019 [US1] Unit/handler tests for T010–T012: request-object payload asserts `dcql_query` + no `presentation_definition`; direct_post accepts object envelope, rejects legacy (400 code asserted); in `tests/Sorcha.Haip.Service.Tests/Endpoints/VerifierEndpointTests.cs`, `tests/Sorcha.Verifier.Tests/Services/VerifiablePresentationValidatorTests.cs`, `tests/Sorcha.Wallet.Pwa.Tests/Services/Presentation/PresentationEngineTests.cs`
+- [ ] T020 [US1] SC-001 schema conformance test: validate generated request bodies against a checked-in JSON Schema for the final OpenID4VP request shape in `tests/Sorcha.Haip.Service.Tests/Conformance/DcqlRequestSchemaTests.cs`
+- [ ] T021 [US1] Run walkthrough/demo regression (SC-002): `walkthroughs/AssuredIdentity/run-phase1-identity.ps1` + phase-2 licence + `demos/AIAS/rehearse.ps1` against local Docker; fix fallout; record results in the PR description
+- [ ] T022 [US1] Ratchet `.presentation-dialect-allowlist` to empty and add the deliberate red-test demo (temporarily reintroduce a PE token, assert gate fails, revert — capture in PR per SC-008); depends on T010–T018
+- [ ] T023 [US1] `sorcha_dialect_rejection_total{surface}` counter on the HAIP meter, recorded at every `LEGACY_DIALECT` return (FR-028); depends on T011
+
+**Checkpoint**: whole platform speaks DCQL end-to-end; MVP demonstrable; CI gate live and empty-allowlisted.
+
+---
+
+## Phase 4: User Story 2 — Multi-credential and alternative asks (Priority: P2)
+
+**Goal**: One request carries N credential queries + `credential_sets` alternatives; per-query consent;
+per-query verification outcomes (FR-005/FR-006).
+
+**Independent Test**: quickstart §US2 — two-query request blocks on a missing credential with a clear
+unsatisfiable indicator; two-option alternative completes with the held option; result reports per query.
+
+### Implementation for User Story 2
+
+- [ ] T024 [P] [US2] Query-set matching: `DcqlMatchResult`/`DcqlQueryMatch` model + `Match()` generalisation (per-query candidates, credential_sets solving, unsatisfied-required detection) in `src/Apps/Sorcha.Wallet.Pwa/Services/Presentation/PresentationEngine.cs` + `src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Models/User/Presentation/PresentationModels.cs` (data-model §1); unit tests in `tests/Sorcha.Wallet.Pwa.Tests/Services/Presentation/DcqlMatchTests.cs`
+- [ ] T025 [US2] Consent surface per-query sections (each ask listed separately, per-query claim approval, unsatisfiable asks flagged, no partial submit) in `src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Presentation/ConsentSheet.razor`; bUnit tests in `tests/Sorcha.UI.Components.User.Tests/` (FR-006a/b/d); depends on T024
+- [ ] T026 [US2] `CredentialPickerDialog` alternative choice (citizen picks among satisfiable options; no auto-pick when several match — edge case) in `src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Presentation/CredentialPickerDialog.razor`; depends on T024
+- [ ] T027 [US2] Multi-presentation `vp_token` build (one entry per consented query) + `Present.razor` orchestration in `src/Apps/Sorcha.Wallet.Pwa/Services/Presentation/PresentationEngine.cs` + `Pages/Present.razor`; depends on T024–T026
+- [ ] T028 [US2] Verifier side: per-query verification loop + `VerificationResult.perQuery` + overall-success rule (every required query/set satisfied) + `DCQL_UNKNOWN_QUERY_ID` failure in `src/Services/Sorcha.Haip.Service/Endpoints/VerifierEndpoints.cs` and `src/Services/Sorcha.Haip.Service/Models/VerifierModels.cs` (contract §3, FR-003/FR-005); handler tests in `tests/Sorcha.Haip.Service.Tests/Endpoints/VerifierEndpointTests.cs`
+- [ ] T029 [US2] Blueprint authoring surface: optional `anyOf` grouping on `credentialRequirements` mapped to `credential_sets` (contract §4) in `src/Common/Sorcha.Blueprint.Models/Credentials/CredentialRequirement.cs` + the requirement→DCQL mapping in `SorchaWalletPresentationConsumer`/request creation; tests in `tests/Sorcha.Blueprint.Service.Tests/`
+- [ ] T030 [US2] End-to-end integration test of quickstart §US2 scenarios (two-query AND, two-option OR, missing-credential block) in `tests/Sorcha.Haip.Service.Tests/Integration/MultiCredentialPresentationTests.cs` (SC-003)
+
+**Checkpoint**: multi-credential + alternatives work end-to-end; US1 flows unaffected.
+
+---
+
+## Phase 5: User Story 3 — Trusted-list snapshot rail (Priority: P2)
+
+**Goal**: Operator imports an ETSI TS 119 612 trusted list; anchors back the `x509-lotl`/`trustlist`
+trust source; evidence names the snapshot; fail-closed everywhere (FR-011..FR-017).
+
+**Independent Test**: quickstart §US3 — fixture import → vouched verification with evidence naming the
+snapshot; delete → `TRUSTLIST_UNAVAILABLE`; tampered XML → `TRUSTLIST_SIGNATURE_INVALID`.
+
+**Dependencies**: Setup only (T003 fixture) — runs in parallel with Phases 3–4.
+
+### Implementation for User Story 3
+
+- [ ] T031 [P] [US3] EF entities `TrustedListSnapshot` + `TrustedListAnchor` (data-model §2) in `src/Services/Sorcha.Tenant.Service/Models/TrustedListSnapshot.cs`, DbContext config + squashed into `Migrations/…InitialCreate.cs` per the pre-release convention, `IStorageRegistrationLog` registration (warn-tier) in the Tenant storage block
+- [ ] T032 [P] [US3] Multibase status decode: accept `u`-prefixed base64url at `src/Core/Sorcha.Blueprint.Engine/Credentials/BitstringStatusListChecker.cs:86` (R7, FR-010); unit tests both encodings in `tests/Sorcha.Blueprint.Engine.Tests/Credentials/BitstringStatusListCheckerTests.cs`
+- [ ] T033 [US3] `TrustedListImportService` in `src/Services/Sorcha.Tenant.Service/Trust/TrustedListImportService.cs`: XMLDSig core verification (`SignedXml`), TS 119 612 parse (scheme info, sequence, dates, territory, signer identity), CA/QC+granted anchor extraction with extraction summary, sequence-regression check (R5, FR-011/FR-012/FR-013); depends on T031; unit tests over the T003 fixture (valid / tampered / unsigned / odd-but-valid edge cases) in `tests/Sorcha.Tenant.Service.Tests/Trust/TrustedListImportServiceTests.cs`
+- [ ] T034 [US3] Trust endpoints per `contracts/trustlist-admin.openapi.yaml`: `POST /api/v1/trust/trustlists/import` (multipart upload | sourceUrl fetch-once), `GET /trustlists`, `GET /trustlists/{id}` (detail + anchors + summary), `DELETE /trustlists/{id}`, `GET /trustlists/{id}/anchors` (service-tier anchor read); REPLACE the F135 placeholder `PUT /trustlists/{id}` (clean break); FluentValidation per VAL-001; in `src/Services/Sorcha.Tenant.Service/Endpoints/TrustEndpoints.cs`; depends on T033; handler tests in `tests/Sorcha.Tenant.Service.Tests/Endpoints/TrustEndpointTests.cs`
+- [ ] T035 [US3] HTTP-backed caching `ITrustListProvider` (15-min cache over `GET …/anchors`) replacing the in-memory singleton as the verifying-services read path, in `src/Common/Sorcha.ServiceClients.Http/Trust/TrustListProvider.cs`; wire into Blueprint + HAIP DI; `TrustAnchorSet.AnchorSetId = "{trustListId}#{seq}"` so `TrustEvidence.TrustListId` carries the snapshot identity (FR-014/FR-015); tests with a stub handler in `tests/Sorcha.ServiceClients.Http.Tests/`
+- [ ] T036 [US3] Freshness semantics: computed Fresh/Stale, warn-mode evidence flag + `sorcha_trustlist_stale_evaluation_total` + log, strict mode `Trust:TrustListStrictFreshness` fail-closed `TRUSTLIST_STALE`; no-snapshot → `TRUSTLIST_UNAVAILABLE`; boundary-deterministic via `TimeProvider` (FR-016, edge cases); implemented across T033/T035 seams; unit tests in `tests/Sorcha.Tenant.Service.Tests/Trust/TrustListFreshnessTests.cs`
+- [ ] T037 [US3] Platform-admin trusted-lists panel (import w/ inline guidance, list w/ freshness chips, detail anchors view, delete w/ confirm; `IInlineFeedback` not Snackbar) in `src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Admin/TrustedLists.razor` + client service under `Sorcha.UI.Core/Services/Admin/` (SC-009); depends on T034
+- [ ] T038 [US3] Integration test of SC-004: issue under fixture CA → present under `trustPolicy{kind:trustlist}` → verified with evidence snapshot id; delete snapshot → fail closed; in `tests/Sorcha.Tenant.Service.Tests/Integration/TrustListVerificationTests.cs` (or Blueprint engine test host); depends on T033–T036
+- [ ] T039 [US3] `sorcha_trustlist_snapshot_info` gauge + import/delete audit logging on the `Sorcha.Trust` meter (FR-028, data-model §7); depends on T034
+
+**Checkpoint**: `x509-lotl` is real; external credentials verifiable against imported anchors.
+
+---
+
+## Phase 6: User Story 4 — Externally-verifiable issuance identity (Priority: P3)
+
+**Goal**: CSR out → external cert in → issued credentials chain to the external root; fail-closed when
+absent/expired/mismatched (FR-018..FR-021). Includes the CA-persistence prerequisite (R8).
+
+**Independent Test**: quickstart §US4 — credential issued on `x509-lotl` anchor verifies with ONLY the
+test CA root trusted (SC-005); deleting the imported cert fails issuance closed.
+
+**Dependencies**: T003 (test CA). Benefits from US3 for the verify leg of SC-005 but the issuance-side
+tasks are independent.
+
+### Implementation for User Story 4
+
+- [ ] T040 [US4] CA persistence: `TenantRootCa` (AES-256-GCM-encrypted private key), `OrgCertificateRecord`, `CsrRecord` entities + DbContext + squashed migration + storage-log registration (data-model §3, R8) in `src/Services/Sorcha.Tenant.Service/Models/` + `Data/TenantDbContext.cs`; convert `InternalCaTrustProvider` to a write-through cache over the EF store in `src/Services/Sorcha.Tenant.Service/Trust/InternalCaTrustProvider.cs` (existing behaviour preserved — regression-guard with current trust-endpoint tests)
+- [ ] T041 [P] [US4] `WalletBackedSignatureGenerator : X509SignatureGenerator` delegating to `IWalletServiceClient.SignTransactionAsync(…, isPreHashed: true)` with raw `r‖s` → DER `ECDSA-Sig-Value` conversion (R10) in `src/Services/Sorcha.Tenant.Service/Trust/WalletBackedSignatureGenerator.cs`; unit tests with known vectors + a mocked wallet client in `tests/Sorcha.Tenant.Service.Tests/Trust/WalletBackedSignatureGeneratorTests.cs`
+- [ ] T042 [US4] `OrgCertificateService` in `src/Services/Sorcha.Tenant.Service/Trust/OrgCertificateService.cs`: P-256 key resolution (primary ES256 else HAIP co-key via Wallet Service — R9), eligibility verdict, CSR generation (T041), import validation per R11 (key match / chain build over uploaded set / validity / suitability; chain-with-root and without), supersede semantics, key-rotation `KeyMismatch` flagging; depends on T040/T041; unit tests covering every FR-019 failure mode with distinct codes in `tests/Sorcha.Tenant.Service.Tests/Trust/OrgCertificateServiceTests.cs`
+- [ ] T043 [US4] Endpoints per `contracts/org-certificates.openapi.yaml`: `GET …/certificates`, `POST …/csr`, `POST …/certificates/import`, `DELETE …/certificates/{id}` in `src/Services/Sorcha.Tenant.Service/Endpoints/TrustEndpoints.cs`; FluentValidation; depends on T042; handler tests in `tests/Sorcha.Tenant.Service.Tests/Endpoints/OrgCertificateEndpointTests.cs`
+- [ ] T044 [US4] Chain-attach by anchor: `x509-lotl` → Active imported chain (fail closed `CERT_EXTERNAL_ANCHOR_UNAVAILABLE` when absent/expired/mismatched — never tenant-root fallback), `x509-tenant` unchanged; in the Wallet Service chain resolver (`IssueCredentialChainResolver`) + `src/Core/Sorcha.Blueprint.Engine/Credentials/MdocFormatHandler.cs` issuance path (FR-020/FR-021); depends on T042; tests in `tests/Sorcha.Wallet.Service.Tests/` + `tests/Sorcha.Blueprint.Engine.Tests/`
+- [ ] T045 [US4] SC-005 integration test: CSR → fixture-CA sign → import → issue on `x509-lotl` → verify with only the external root; negative: delete cert → fail closed; in `tests/Sorcha.Tenant.Service.Tests/Integration/ExternalIssuanceIdentityTests.cs`; depends on T042–T044
+- [ ] T046 [P] [US4] `sorcha_org_cert_issuance_total{provenance,outcome,reason}` metric + structured audit logs (FR-028); depends on T042
+
+**Checkpoint**: an org with an imported cert issues externally-verifiable credentials.
+
+---
+
+## Phase 7: User Story 5 — Certificate lifecycle without footguns (Priority: P3)
+
+**Goal**: Auto-enrol on org creation, backfill, admin surface, auditable re-issue, typed Ed25519/no-P-256
+exclusion replacing the ASN.1 500 (FR-022..FR-024).
+
+**Independent Test**: quickstart §US5 — new org has a cert with zero manual steps; ineligible org gets
+typed 422 with zero unhandled errors (SC-006).
+
+**Dependencies**: T040/T042 (persistence + OrgCertificateService).
+
+### Implementation for User Story 5
+
+- [ ] T047 [US5] Eligibility guard replacing the ASN.1 failure: `X509CertificateBuilder`/`TenantCrlBuilder` guarded by the T042 eligibility check; enrol path returns typed 422 `CERT_KEY_NOT_ELIGIBLE` (never an unhandled `CryptographicException`) in `src/Services/Sorcha.Tenant.Service/Trust/X509CertificateBuilder.cs:32-40,77` + `TrustEndpoints.cs` (FR-024); tests: ineligible-org path asserts typed code + no error-level log in `tests/Sorcha.Tenant.Service.Tests/Trust/CertEligibilityTests.cs`
+- [ ] T048 [US5] Rework `POST …/enrol` semantics per contract: server resolves the P-256 key itself (drop caller-supplied `OrgPublicKeyBase64`, closing the unvalidated-key TODO at `TrustEndpoints.cs:228`), re-issue supersedes with history (FR-023d), doubles as backfill; in `src/Services/Sorcha.Tenant.Service/Endpoints/TrustEndpoints.cs`; depends on T042/T047; update the HAIP walkthrough setup script that calls enrol (R15)
+- [ ] T049 [US5] Auto-enrol hook: post-wallet-provision in `src/Services/Sorcha.Tenant.Service/Services/OrganizationService.cs` (non-fatal on failure — org creation never fails, FR-022) + retry ride-along in `Services/OrgWalletReconciliationService.cs`; operator-visible failure log + metric; depends on T048; tests: creation-with-enrol-failure still succeeds, reconciliation retries, in `tests/Sorcha.Tenant.Service.Tests/Services/OrgAutoEnrolTests.cs`
+- [ ] T050 [US5] Org-admin certificates panel (list with status/validity/chain summary + eligibility state, re-issue, CSR download, import upload, expiry warning) as a section of `src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Admin/Settings/OrgSettings.razor` + client service under `Sorcha.UI.Core/Services/Admin/`; depends on T043/T048
+- [ ] T051 [US5] SC-006 integration test: new P-256-resolvable org → Active internal cert zero-touch (`boundKeySource=HaipCoKey` for ED25519-primary); no-P-256 org → typed ineligibility everywhere a cert op is attempted; in `tests/Sorcha.Tenant.Service.Tests/Integration/CertLifecycleTests.cs`
+
+**Checkpoint**: every eligible org reaches an X.509 identity without manual steps; no ASN.1 500 remains.
+
+---
+
+## Phase 8: User Story 6 — Verifier authentication for wallets (Priority: P4)
+
+**Goal**: Prefixed `x509_san_dns:` client_id, x5c-carrying signed request objects, wallet-side signature
++ SAN + anchor verification with the three-state consent verdict; unsigned inline form retired
+(FR-025..FR-027).
+
+**Independent Test**: quickstart §US6 — tampered signature refused; SAN mismatch refused; verifier state
+renders Trusted / AuthenticUntrusted correctly (SC-007).
+
+**Dependencies**: US1 (dialect + request_uri path), US3 (anchors for the Trusted state).
+
+### Implementation for User Story 6
+
+- [ ] T052 [P] [US6] Verifier certificate config (`Haip:VerifierCertificate`(+Password), `Haip:PublicHost`) with startup SAN==host validation (fail-fast Production/Staging, mirrors `SorchaIssuer`) + dev fallback minting a tenant-root cert with SAN dNSName = PublicHost (R12) in `src/Services/Sorcha.Haip.Service/Extensions/` + config; tests in `tests/Sorcha.Haip.Service.Tests/`
+- [ ] T053 [US6] `RequestObjectSigner` signs with the verifier certificate key and embeds the `x5c` chain header; client_id flips to prefixed `x509_san_dns:{PublicHost}` at request creation (retires `TODO(098)` at `VerifierEndpoints.cs:100`); in `src/Services/Sorcha.Haip.Service/Services/RequestObjectSigner.cs` + `Endpoints/VerifierEndpoints.cs`; depends on T052
+- [ ] T054 [US6] KB-JWT `aud` = full prefixed client_id on BOTH sides in the same task (mint: `src/Apps/Sorcha.Wallet.Pwa/Services/Presentation/PresentationEngine.cs:170`; verify: `src/Common/Sorcha.Verifier.Engine/VerifiablePresentationValidator.cs` aud check) so presentations never self-reject; depends on T053; round-trip test in `tests/Sorcha.Verifier.Tests/`
+- [ ] T055 [US6] `RequestObjectValidator` in `src/Common/Sorcha.Verifier.Engine/RequestObjectValidator.cs` (BouncyCastle — WASM-safe, R13): JWS ES256 verify via x5c leaf, SAN dNSName == client_id host (`REQUEST_OBJECT_INVALID`/`REQUEST_HOST_MISMATCH`), chain→anchor check against a supplied `TrustAnchorSet` ⇒ `VerifierAuthState` (Trusted / AuthenticUntrusted / Unverifiable; anchors-absent never blocks — FR-027); unit tests incl. tamper + mismatch vectors in `tests/Sorcha.Verifier.Engine.Tests/RequestObjectValidatorTests.cs`
+- [ ] T056 [US6] PWA integration: `PresentationEngine.Parse` runs T055 validation (refusal with citizen-comprehensible errors), anchors fetched from the home installation's `GET /trustlists/{id}/anchors` and cached in IndexedDB (evict-and-continue on undecryptable rows per the established cache rule); `ConsentSheet` renders the three-state verifier identity; in `src/Apps/Sorcha.Wallet.Pwa/Services/Presentation/` + `src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Presentation/ConsentSheet.razor`; depends on T055 (+US3 anchors endpoint)
+- [ ] T057 [US6] Retire the unsigned inline-parameter deep-link form from all internal producers and the desk/open verifier + Blueprint consumers adopt server-side `RequestObjectValidator` (FR-026 "same signed-request path"); sweep `src/Apps/Sorcha.Verifier/`, `src/Services/Sorcha.Blueprint.Service/`, `Sorcha.UI.Components.User` QR services; depends on T053/T055
+- [ ] T058 [US6] `sorcha_request_auth_total{state}` metric (FR-028) + SC-007 integration test (tampered/mismatched refusal, correct state rendering) in `tests/Sorcha.Wallet.Pwa.Tests/Integration/VerifierAuthTests.cs`; depends on T055–T057
+
+**Checkpoint**: wallets authenticate verifiers; all six stories complete.
+
+---
+
+## Phase 9: Polish & Cross-Cutting Concerns
+
+- [ ] T059 [P] STANDARDS.md rows: OpenID4VP/OpenID4VCI/HAIP → final-profile versions with honest status; SD-JWT VC note `dc+sd-jwt`; NEW ETSI TS 119 612 `partial` row (snapshot import; live LOTL deferred); verify `scripts/check-discoverability.sh` passes (FR-029)
+- [ ] T060 [P] Documentation sync: `docs/reference/API-DOCUMENTATION.md` (trust-list + org-cert + changed verifier surfaces), Tenant/HAIP service READMEs, `.claude/skills/sorcha-architecture/SKILL.md` Feature 181 section, `.claude/skills/verifiable-credentials/SKILL.md` typ/dialect updates, `docs/openid4vc-haip-integration.md`
+- [ ] T061 [P] `.specify/MASTER-TASKS.md` status update + spec checklists closed
+- [ ] T062 Full quickstart.md validation pass against local Docker (all six US sections + cross-cutting checks); record evidence in the final PR
+- [ ] T063 Coverage + warning gate: `dotnet build` warning-free, `dotnet test` green, >85% coverage on new code (`dotnet test --collect:"XPlat Code Coverage"` on the touched test projects)
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 (Setup)**: none.
+- **Phase 2 (Foundational)**: after T001; blocks US1/US2/US6 only — **US3 needs only T003**.
+- **US1 (Phase 3)**: after Phase 2. **US2 (Phase 4)**: after US1 (extends its surfaces).
+- **US3 (Phase 5)**: after T003 — fully parallel with Phases 3–4.
+- **US4 (Phase 6)**: after T003; SC-005 verify leg benefits from US3 (T038 fixtures/anchors).
+- **US5 (Phase 7)**: after US4's T040/T042.
+- **US6 (Phase 8)**: after US1 + US3 (anchors) — last, as planned.
+- **Phase 9**: after all desired stories.
+
+### Story dependency graph
+
+```
+Setup ─┬─ Foundational ── US1 ── US2 ──┐
+       │                        └──────┼── US6 ── Polish
+       └─ (T003) ── US3 ───────────────┤
+       └─ (T003) ── US4 ── US5 ────────┘
+```
+
+### Parallel Opportunities
+
+- **Two independent tracks after Setup**: dialect track (Phase 2→US1→US2→US6-prep) and trust track
+  (US3 ∥ US4→US5). Matches the plan's delivery order.
+- Within phases: all [P]-marked tasks touch disjoint files (e.g. T004∥T008∥T002∥T003; T012∥T013∥T017∥T018;
+  T031∥T032; T041 alongside T040's EF work; T052 alongside US3 tail).
+
+### Parallel Example: kick-off after T001
+
+```
+Track A (dialect):  T004 → T005/T006 → T007 → T010…        (US1)
+Track B (trust):    T003 → T031 ∥ T032 → T033 → T034…      (US3)
+Track C (certs):    T040 ∥ T041 → T042 → …                 (US4, after T003)
+```
+
+---
+
+## Implementation Strategy
+
+**MVP = Phase 1 + Phase 2 + US1** (SC-001/SC-002 demonstrable: the platform speaks the final dialect with
+zero user-visible change). Then incremental, checkpoint-validated delivery: US2 → (US3, US4/US5 in
+parallel) → US6 → Polish. Each phase lands as its own PR(s) per the repo's branch+PR policy, with the CI
+dialect gate ratcheting at US1 completion.
+
+**Per-PR cadence** (user preference): create PR → await review → apply one round of critical fixes → merge
+→ next phase.
+
+---
+
+## Notes
+
+- R9 direction confirmed by the platform owner 2026-07-10: certificates bind the org's P-256 key
+  (primary ES256 else HAIP co-key); typed exclusion applies only when no P-256 key is resolvable.
+- Task count: 63. US1: 14 (T010–T023) · US2: 7 · US3: 9 · US4: 7 · US5: 5 · US6: 7 · Setup/Foundational: 9 · Polish: 5.
+- Every task cites exact file paths from research R4/R15 inventories; where a line number is cited it was
+  verified at branch time — re-grep if drifted.

--- a/src/Apps/Sorcha.Verifier/Endpoints/DemoMintEndpoint.cs
+++ b/src/Apps/Sorcha.Verifier/Endpoints/DemoMintEndpoint.cs
@@ -78,7 +78,7 @@ public static class DemoMintEndpoint
             ["cnf"] = new Dictionary<string, object> { ["jwk"] = holderJwkEl },
         };
         var credentialJwt = SignEs256(
-            new Dictionary<string, object> { ["alg"] = "ES256", ["typ"] = "vc+sd-jwt" },
+            new Dictionary<string, object> { ["alg"] = "ES256", ["typ"] = "dc+sd-jwt" },
             credentialPayload, issuer);
 
         // Register the freshly-generated issuer JWK so the validator can verify
@@ -105,7 +105,7 @@ public static class DemoMintEndpoint
             // returns false anyway, and the validator skips status checks when uri/idx absent.
         };
         var delegationJwt = SignEs256(
-            new Dictionary<string, object> { ["alg"] = "ES256", ["typ"] = "vc+sd-jwt" },
+            new Dictionary<string, object> { ["alg"] = "ES256", ["typ"] = "dc+sd-jwt" },
             delegationPayload, holder);
 
         var response = new DemoMintResponse(

--- a/src/Common/Sorcha.Cryptography/SdJwt/SdJwtService.cs
+++ b/src/Common/Sorcha.Cryptography/SdJwt/SdJwtService.cs
@@ -195,11 +195,13 @@ public class SdJwtService : ISdJwtService
         if (sdDigests.Count > 0)
             payload["_sd"] = sdDigests;
 
-        // Build the JWT header
+        // Build the JWT header. Feature 181 — the final SD-JWT VC profile media type is
+        // dc+sd-jwt; verify paths accept BOTH dc+sd-jwt and the legacy vc+sd-jwt because
+        // already-issued credentials live in citizen wallets we cannot recall (FR-004).
         var header = new Dictionary<string, object>
         {
             ["alg"] = MapAlgorithm(algorithm),
-            ["typ"] = "vc+sd-jwt"
+            ["typ"] = "dc+sd-jwt"
         };
 
         // Feature 120 — kid header for issuer-key resolution. Production callers pass

--- a/src/Common/Sorcha.Verifier.Engine/Dcql/DcqlModels.cs
+++ b/src/Common/Sorcha.Verifier.Engine/Dcql/DcqlModels.cs
@@ -1,0 +1,356 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.RegularExpressions;
+
+namespace Sorcha.Verifier.Engine.Dcql;
+
+/// <summary>
+/// DCQL (Digital Credentials Query Language) wire model per OpenID4VP 1.0 final —
+/// the request-side vocabulary that replaced Presentation Exchange (Feature 181, D1).
+/// Serialized property names are exact spec names; the model is deliberately the
+/// v1 subset Sorcha emits and consumes: <c>credentials</c> + <c>credential_sets</c>,
+/// claim <c>path</c> selection, no value-matching constraints
+/// (<c>claims[].values</c> / <c>trusted_authorities</c> are out of scope — research R2).
+/// </summary>
+public sealed record DcqlQuery
+{
+    /// <summary>Credential queries; at least one, ids unique across the request.</summary>
+    [JsonPropertyName("credentials")]
+    public required IReadOnlyList<DcqlCredentialQuery> Credentials { get; init; }
+
+    /// <summary>
+    /// Optional alternative sets — each entry's <c>options</c> lists id-combinations that
+    /// satisfy the set. Every referenced id must exist in <see cref="Credentials"/>.
+    /// </summary>
+    [JsonPropertyName("credential_sets")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IReadOnlyList<DcqlCredentialSetQuery>? CredentialSets { get; init; }
+
+    /// <summary>
+    /// Validates structural rules (id syntax + uniqueness, per-format meta, referential
+    /// integrity of credential_sets and claim_sets). Returns an empty list when valid.
+    /// </summary>
+    public IReadOnlyList<string> Validate()
+    {
+        var errors = new List<string>();
+        if (Credentials is null || Credentials.Count == 0)
+        {
+            errors.Add("dcql_query.credentials must contain at least one credential query.");
+            return errors;
+        }
+
+        var seenIds = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var credential in Credentials)
+        {
+            credential.Validate(errors);
+            if (credential.Id is not null && !seenIds.Add(credential.Id))
+            {
+                errors.Add($"Duplicate credential query id '{credential.Id}'.");
+            }
+        }
+
+        if (CredentialSets is not null)
+        {
+            foreach (var set in CredentialSets)
+            {
+                if (set.Options is null || set.Options.Count == 0)
+                {
+                    errors.Add("credential_sets entry must declare at least one option.");
+                    continue;
+                }
+
+                foreach (var option in set.Options)
+                {
+                    if (option is null || option.Count == 0)
+                    {
+                        errors.Add("credential_sets option must reference at least one credential query id.");
+                        continue;
+                    }
+
+                    foreach (var id in option)
+                    {
+                        if (!seenIds.Contains(id))
+                        {
+                            errors.Add($"credential_sets references unknown credential query id '{id}'.");
+                        }
+                    }
+                }
+            }
+        }
+
+        return errors;
+    }
+}
+
+/// <summary>One unit of ask inside a <see cref="DcqlQuery"/>.</summary>
+public sealed record DcqlCredentialQuery
+{
+    /// <summary>Spec id charset: alphanumeric, underscore, hyphen.</summary>
+    public static readonly Regex IdPattern = new("^[a-zA-Z0-9_-]+$", RegexOptions.Compiled);
+
+    /// <summary>Query identifier — the key the response envelope is keyed by.</summary>
+    [JsonPropertyName("id")]
+    public required string Id { get; init; }
+
+    /// <summary>Credential format — see <see cref="DcqlFormats"/>.</summary>
+    [JsonPropertyName("format")]
+    public required string Format { get; init; }
+
+    /// <summary>Format-specific matching metadata (required in v1).</summary>
+    [JsonPropertyName("meta")]
+    public required DcqlCredentialMeta Meta { get; init; }
+
+    /// <summary>
+    /// Claims to disclose. Null means the wallet discloses per its own policy.
+    /// </summary>
+    [JsonPropertyName("claims")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IReadOnlyList<DcqlClaimQuery>? Claims { get; init; }
+
+    /// <summary>
+    /// Preference-ordered combinations of claim ids that satisfy this query. In v1 this is
+    /// only emitted by <see cref="DcqlRequestBuilder"/>'s required/optional mapping (research R2):
+    /// first option = required + optional claim ids, second option = required-only.
+    /// </summary>
+    [JsonPropertyName("claim_sets")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IReadOnlyList<IReadOnlyList<string>>? ClaimSets { get; init; }
+
+    internal void Validate(List<string> errors)
+    {
+        if (string.IsNullOrEmpty(Id) || !IdPattern.IsMatch(Id))
+        {
+            errors.Add($"Credential query id '{Id}' must match {IdPattern}.");
+        }
+
+        switch (Format)
+        {
+            case DcqlFormats.SdJwtVc:
+                if (Meta?.VctValues is null || Meta.VctValues.Count == 0)
+                {
+                    errors.Add($"Credential query '{Id}': format '{DcqlFormats.SdJwtVc}' requires meta.vct_values.");
+                }
+                break;
+            case DcqlFormats.MsoMdoc:
+                if (string.IsNullOrEmpty(Meta?.DoctypeValue))
+                {
+                    errors.Add($"Credential query '{Id}': format '{DcqlFormats.MsoMdoc}' requires meta.doctype_value.");
+                }
+                break;
+            default:
+                errors.Add($"Credential query '{Id}': unsupported format '{Format}' (v1 supports '{DcqlFormats.SdJwtVc}', '{DcqlFormats.MsoMdoc}').");
+                break;
+        }
+
+        var claimIds = new HashSet<string>(StringComparer.Ordinal);
+        if (Claims is not null)
+        {
+            foreach (var claim in Claims)
+            {
+                if (claim.Path is null || claim.Path.Count == 0)
+                {
+                    errors.Add($"Credential query '{Id}': claim path must be non-empty.");
+                }
+
+                if (claim.Id is not null && !claimIds.Add(claim.Id))
+                {
+                    errors.Add($"Credential query '{Id}': duplicate claim id '{claim.Id}'.");
+                }
+            }
+        }
+
+        if (ClaimSets is not null)
+        {
+            foreach (var set in ClaimSets)
+            {
+                foreach (var claimId in set)
+                {
+                    if (!claimIds.Contains(claimId))
+                    {
+                        errors.Add($"Credential query '{Id}': claim_sets references unknown claim id '{claimId}'.");
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// <summary>Format-specific matching metadata.</summary>
+public sealed record DcqlCredentialMeta
+{
+    /// <summary>Accepted <c>vct</c> values (dc+sd-jwt).</summary>
+    [JsonPropertyName("vct_values")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IReadOnlyList<string>? VctValues { get; init; }
+
+    /// <summary>Required mdoc doctype (mso_mdoc).</summary>
+    [JsonPropertyName("doctype_value")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? DoctypeValue { get; init; }
+}
+
+/// <summary>A single claim selection inside a credential query.</summary>
+public sealed record DcqlClaimQuery
+{
+    /// <summary>Claim id — required only when referenced from <c>claim_sets</c>.</summary>
+    [JsonPropertyName("id")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Id { get; init; }
+
+    /// <summary>Claim path segments (string segments only in v1 — no array indices).</summary>
+    [JsonPropertyName("path")]
+    public required IReadOnlyList<string> Path { get; init; }
+}
+
+/// <summary>An alternative set — "satisfy with any one of these id-combinations".</summary>
+public sealed record DcqlCredentialSetQuery
+{
+    /// <summary>Preference-ordered options; each option is a list of credential query ids.</summary>
+    [JsonPropertyName("options")]
+    public required IReadOnlyList<IReadOnlyList<string>> Options { get; init; }
+
+    /// <summary>Whether satisfying this set is required (default true per spec).</summary>
+    [JsonPropertyName("required")]
+    public bool Required { get; init; } = true;
+
+    /// <summary>Consent-surface display text.</summary>
+    [JsonPropertyName("purpose")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Purpose { get; init; }
+}
+
+/// <summary>Credential format identifiers (final-profile forms — Feature 181 FR-004).</summary>
+public static class DcqlFormats
+{
+    /// <summary>SD-JWT VC, final media-type form.</summary>
+    public const string SdJwtVc = "dc+sd-jwt";
+
+    /// <summary>ISO 18013-5 mdoc.</summary>
+    public const string MsoMdoc = "mso_mdoc";
+}
+
+/// <summary>
+/// The OpenID4VP 1.0 response envelope: a JSON object keyed by credential-query id, each value
+/// an array of presentation strings (SD-JWT compact form or base64url mdoc DeviceResponse).
+/// Replaces <c>presentation_submission</c> + bare-string <c>vp_token</c> (FR-003).
+/// </summary>
+public sealed record DcqlVpToken
+{
+    /// <summary>Presentations keyed by credential-query id.</summary>
+    public required IReadOnlyDictionary<string, IReadOnlyList<string>> Presentations { get; init; }
+
+    /// <summary>Serialize to the wire object form.</summary>
+    public string ToJson()
+        => JsonSerializer.Serialize(Presentations, DcqlJson.Options);
+
+    /// <summary>
+    /// Parse a <c>vp_token</c> form value. A bare SD-JWT compact string (the legacy
+    /// pre-DCQL shape) is rejected with <see cref="DcqlParseException"/> code
+    /// <see cref="DcqlErrorCodes.LegacyDialect"/>; malformed JSON or wrong shapes reject
+    /// with <see cref="DcqlErrorCodes.Invalid"/>.
+    /// </summary>
+    public static DcqlVpToken Parse(string vpToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(vpToken);
+        var trimmed = vpToken.TrimStart();
+        if (trimmed.Length == 0 || trimmed[0] != '{')
+        {
+            throw new DcqlParseException(
+                DcqlErrorCodes.LegacyDialect,
+                "vp_token must be a JSON object keyed by credential query id (OpenID4VP 1.0); " +
+                "bare compact-form tokens are the retired pre-DCQL dialect.");
+        }
+
+        JsonDocument doc;
+        try
+        {
+            doc = JsonDocument.Parse(vpToken);
+        }
+        catch (JsonException ex)
+        {
+            throw new DcqlParseException(DcqlErrorCodes.Invalid, $"vp_token is not valid JSON: {ex.Message}");
+        }
+
+        using (doc)
+        {
+            var presentations = new Dictionary<string, IReadOnlyList<string>>(StringComparer.Ordinal);
+            foreach (var property in doc.RootElement.EnumerateObject())
+            {
+                switch (property.Value.ValueKind)
+                {
+                    // The spec value is an array; tolerate a single string for robustness.
+                    case JsonValueKind.String:
+                        presentations[property.Name] = [property.Value.GetString()!];
+                        break;
+                    case JsonValueKind.Array:
+                        var list = new List<string>();
+                        foreach (var item in property.Value.EnumerateArray())
+                        {
+                            if (item.ValueKind != JsonValueKind.String)
+                            {
+                                throw new DcqlParseException(
+                                    DcqlErrorCodes.Invalid,
+                                    $"vp_token entry '{property.Name}' must contain presentation strings.");
+                            }
+                            list.Add(item.GetString()!);
+                        }
+                        if (list.Count == 0)
+                        {
+                            throw new DcqlParseException(
+                                DcqlErrorCodes.Invalid,
+                                $"vp_token entry '{property.Name}' must contain at least one presentation.");
+                        }
+                        presentations[property.Name] = list;
+                        break;
+                    default:
+                        throw new DcqlParseException(
+                            DcqlErrorCodes.Invalid,
+                            $"vp_token entry '{property.Name}' has an unsupported value kind '{property.Value.ValueKind}'.");
+                }
+            }
+
+            if (presentations.Count == 0)
+            {
+                throw new DcqlParseException(DcqlErrorCodes.Invalid, "vp_token object carries no presentations.");
+            }
+
+            return new DcqlVpToken { Presentations = presentations };
+        }
+    }
+}
+
+/// <summary>Typed error codes for dialect parsing failures (data-model §6).</summary>
+public static class DcqlErrorCodes
+{
+    /// <summary>The retired Presentation Exchange dialect was received (FR-007).</summary>
+    public const string LegacyDialect = "LEGACY_DIALECT";
+
+    /// <summary>Structurally invalid DCQL.</summary>
+    public const string Invalid = "DCQL_INVALID";
+
+    /// <summary>A vp_token entry is keyed to a query id the request never declared (FR-003).</summary>
+    public const string UnknownQueryId = "DCQL_UNKNOWN_QUERY_ID";
+}
+
+/// <summary>Thrown by the DCQL parser/envelope reader; carries a typed error code.</summary>
+public sealed class DcqlParseException : FormatException
+{
+    /// <summary>Initialises a new instance.</summary>
+    public DcqlParseException(string code, string message) : base(message) => Code = code;
+
+    /// <summary>Typed error code from <see cref="DcqlErrorCodes"/>.</summary>
+    public string Code { get; }
+}
+
+/// <summary>Shared serializer options for the DCQL wire shapes (hoisted — pattern T10).</summary>
+public static class DcqlJson
+{
+    /// <summary>Strict, camel-free options — property names come from attributes.</summary>
+    public static readonly JsonSerializerOptions Options = new(JsonSerializerDefaults.Web)
+    {
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+}

--- a/src/Common/Sorcha.Verifier.Engine/Dcql/DcqlRequestBuilder.cs
+++ b/src/Common/Sorcha.Verifier.Engine/Dcql/DcqlRequestBuilder.cs
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Text.Json;
+
+namespace Sorcha.Verifier.Engine.Dcql;
+
+/// <summary>
+/// Caller-facing description of one credential ask, in the required/optional vocabulary the
+/// platform's blueprint <c>credentialRequirements</c> and verifier APIs already speak. The
+/// builder owns the mapping onto DCQL <c>claims</c> + <c>claim_sets</c> (research R2) so no
+/// caller hand-rolls the wire shape (FR-008).
+/// </summary>
+/// <param name="Id">Credential query id (alphanumeric/underscore/hyphen; unique per request).</param>
+/// <param name="Format">A <see cref="DcqlFormats"/> value.</param>
+/// <param name="VctValues">Accepted vct URIs (required for <see cref="DcqlFormats.SdJwtVc"/>).</param>
+/// <param name="DoctypeValue">Required doctype (required for <see cref="DcqlFormats.MsoMdoc"/>).</param>
+/// <param name="RequiredClaims">Claim names — plain name ("givenName") or slash path ("/address/street").</param>
+/// <param name="OptionalClaims">Claims the holder may withhold.</param>
+public sealed record DcqlCredentialAsk(
+    string Id,
+    string Format,
+    IReadOnlyList<string>? VctValues,
+    string? DoctypeValue,
+    IReadOnlyList<string> RequiredClaims,
+    IReadOnlyList<string>? OptionalClaims = null)
+{
+    /// <summary>Convenience factory for the common single-vct SD-JWT ask.</summary>
+    public static DcqlCredentialAsk SdJwt(string id, string vct, IReadOnlyList<string> requiredClaims, IReadOnlyList<string>? optionalClaims = null)
+        => new(id, DcqlFormats.SdJwtVc, [vct], null, requiredClaims, optionalClaims);
+}
+
+/// <summary>An alternative group — "any one of these id-combinations satisfies the request".</summary>
+/// <param name="Options">Preference-ordered id-combinations.</param>
+/// <param name="Required">Whether the set must be satisfied (default true).</param>
+/// <param name="Purpose">Consent-surface display text.</param>
+public sealed record DcqlAlternativeGroup(
+    IReadOnlyList<IReadOnlyList<string>> Options,
+    bool Required = true,
+    string? Purpose = null);
+
+/// <summary>
+/// THE producer of <c>dcql_query</c> bodies for every Sorcha verifier surface (HAIP verifier
+/// API, Blueprint presentation consumer, desk/open verifier). Lives beside
+/// <see cref="DcqlRequestParser"/> so build and parse sides cannot drift (FR-008).
+/// </summary>
+public static class DcqlRequestBuilder
+{
+    /// <summary>
+    /// Build a <see cref="DcqlQuery"/> from asks + optional alternative groups. When
+    /// <paramref name="purpose"/> is supplied and no explicit alternatives exist, a single
+    /// all-asks credential_set carries it (the consent-display idiom from contract §1).
+    /// Throws <see cref="DcqlParseException"/> (code <see cref="DcqlErrorCodes.Invalid"/>)
+    /// when the resulting query fails structural validation.
+    /// </summary>
+    public static DcqlQuery Build(
+        IReadOnlyList<DcqlCredentialAsk> asks,
+        IReadOnlyList<DcqlAlternativeGroup>? alternatives = null,
+        string? purpose = null)
+    {
+        ArgumentNullException.ThrowIfNull(asks);
+        if (asks.Count == 0)
+        {
+            throw new DcqlParseException(DcqlErrorCodes.Invalid, "At least one credential ask is required.");
+        }
+
+        var credentials = asks.Select(BuildCredentialQuery).ToList();
+
+        IReadOnlyList<DcqlCredentialSetQuery>? sets = null;
+        if (alternatives is { Count: > 0 })
+        {
+            sets = alternatives
+                .Select(g => new DcqlCredentialSetQuery { Options = g.Options, Required = g.Required, Purpose = g.Purpose })
+                .ToList();
+        }
+        else if (purpose is not null)
+        {
+            sets = [new DcqlCredentialSetQuery
+            {
+                Options = [credentials.Select(c => c.Id).ToList()],
+                Required = true,
+                Purpose = purpose,
+            }];
+        }
+
+        var query = new DcqlQuery { Credentials = credentials, CredentialSets = sets };
+        var errors = query.Validate();
+        if (errors.Count > 0)
+        {
+            throw new DcqlParseException(DcqlErrorCodes.Invalid, string.Join(" ", errors));
+        }
+
+        return query;
+    }
+
+    /// <summary>Serialize a query to its wire JSON (for embedding as <c>dcql_query</c>).</summary>
+    public static string ToJson(DcqlQuery query)
+        => JsonSerializer.Serialize(query, DcqlJson.Options);
+
+    private static DcqlCredentialQuery BuildCredentialQuery(DcqlCredentialAsk ask)
+    {
+        var required = ask.RequiredClaims ?? [];
+        var optional = ask.OptionalClaims ?? [];
+
+        List<DcqlClaimQuery>? claims = null;
+        List<IReadOnlyList<string>>? claimSets = null;
+
+        if (required.Count > 0 || optional.Count > 0)
+        {
+            claims = [];
+            var requiredIds = new List<string>();
+            var optionalIds = new List<string>();
+            var index = 0;
+
+            foreach (var name in required)
+            {
+                var id = $"c{index++}";
+                claims.Add(new DcqlClaimQuery { Id = optional.Count > 0 ? id : null, Path = ToPath(name) });
+                requiredIds.Add(id);
+            }
+
+            foreach (var name in optional)
+            {
+                var id = $"c{index++}";
+                claims.Add(new DcqlClaimQuery { Id = id, Path = ToPath(name) });
+                optionalIds.Add(id);
+            }
+
+            // R2 mapping: optionality rides claim_sets — first (preferred) option asks for
+            // everything, second accepts required-only. No optional claims ⇒ plain claims list.
+            if (optional.Count > 0)
+            {
+                claimSets =
+                [
+                    [.. requiredIds, .. optionalIds],
+                    [.. requiredIds],
+                ];
+            }
+        }
+
+        return new DcqlCredentialQuery
+        {
+            Id = ask.Id,
+            Format = ask.Format,
+            Meta = new DcqlCredentialMeta { VctValues = ask.VctValues, DoctypeValue = ask.DoctypeValue },
+            Claims = claims,
+            ClaimSets = claimSets,
+        };
+    }
+
+    /// <summary>
+    /// Claim name → path segments: plain name is a single segment; a slash path
+    /// ("/address/street") splits into nested segments. Mirror of
+    /// <see cref="DcqlRequestParser.FromPath"/>.
+    /// </summary>
+    internal static IReadOnlyList<string> ToPath(string claimName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(claimName);
+        return claimName.StartsWith('/')
+            ? claimName.Split('/', StringSplitOptions.RemoveEmptyEntries)
+            : [claimName];
+    }
+}

--- a/src/Common/Sorcha.Verifier.Engine/Dcql/DcqlRequestParser.cs
+++ b/src/Common/Sorcha.Verifier.Engine/Dcql/DcqlRequestParser.cs
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Text.Json;
+
+namespace Sorcha.Verifier.Engine.Dcql;
+
+/// <summary>
+/// THE parser of <c>dcql_query</c> bodies for every Sorcha wallet/verifier surface (wallet
+/// PWA presentation engine, direct_post verification, desk verifier). Lives beside
+/// <see cref="DcqlRequestBuilder"/> so build and parse sides cannot drift (FR-008).
+/// </summary>
+public static class DcqlRequestParser
+{
+    /// <summary>
+    /// Parse and validate a <c>dcql_query</c> JSON body. The retired Presentation Exchange
+    /// shape (<c>input_descriptors</c>) is refused with code
+    /// <see cref="DcqlErrorCodes.LegacyDialect"/> (FR-007); structural failures with
+    /// <see cref="DcqlErrorCodes.Invalid"/>.
+    /// </summary>
+    public static DcqlQuery Parse(string dcqlQueryJson)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(dcqlQueryJson);
+
+        using var doc = ParseDocument(dcqlQueryJson);
+        RejectLegacyShapes(doc.RootElement);
+
+        DcqlQuery? query;
+        try
+        {
+            query = doc.RootElement.Deserialize<DcqlQuery>(DcqlJson.Options);
+        }
+        catch (JsonException ex)
+        {
+            throw new DcqlParseException(DcqlErrorCodes.Invalid, $"dcql_query does not deserialize: {ex.Message}");
+        }
+
+        if (query is null)
+        {
+            throw new DcqlParseException(DcqlErrorCodes.Invalid, "dcql_query is null.");
+        }
+
+        var errors = query.Validate();
+        if (errors.Count > 0)
+        {
+            throw new DcqlParseException(DcqlErrorCodes.Invalid, string.Join(" ", errors));
+        }
+
+        return query;
+    }
+
+    /// <summary>
+    /// Parse the query out of a full Request Object payload (the decoded JWT claims JSON).
+    /// A payload carrying <c>presentation_definition</c> is the retired dialect (FR-007).
+    /// </summary>
+    public static DcqlQuery ParseFromRequestObjectPayload(JsonElement payload)
+    {
+        if (payload.TryGetProperty("presentation_definition", out _))
+        {
+            throw new DcqlParseException(
+                DcqlErrorCodes.LegacyDialect,
+                "Request object carries presentation_definition — the retired Presentation Exchange dialect. Expected dcql_query (OpenID4VP 1.0).");
+        }
+
+        if (!payload.TryGetProperty("dcql_query", out var dcql))
+        {
+            throw new DcqlParseException(DcqlErrorCodes.Invalid, "Request object carries no dcql_query.");
+        }
+
+        return Parse(dcql.GetRawText());
+    }
+
+    /// <summary>
+    /// Path segments → the platform claim-name convention: single segment is the plain name;
+    /// nested segments render as a slash path. Mirror of <see cref="DcqlRequestBuilder.ToPath"/>.
+    /// </summary>
+    public static string FromPath(IReadOnlyList<string> path)
+    {
+        ArgumentNullException.ThrowIfNull(path);
+        return path.Count switch
+        {
+            0 => throw new DcqlParseException(DcqlErrorCodes.Invalid, "Claim path must be non-empty."),
+            1 => path[0],
+            _ => "/" + string.Join('/', path),
+        };
+    }
+
+    /// <summary>
+    /// Recover the required/optional claim-name split the builder encoded (research R2): with
+    /// claim_sets, the first option is the full ask and the last is the required-only floor;
+    /// without, every listed claim is required.
+    /// </summary>
+    public static (IReadOnlyList<string> Required, IReadOnlyList<string> Optional) SplitClaims(DcqlCredentialQuery query)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        if (query.Claims is null || query.Claims.Count == 0)
+        {
+            return ([], []);
+        }
+
+        if (query.ClaimSets is null || query.ClaimSets.Count == 0)
+        {
+            return (query.Claims.Select(c => FromPath(c.Path)).ToList(), []);
+        }
+
+        var byId = query.Claims.Where(c => c.Id is not null).ToDictionary(c => c.Id!, StringComparer.Ordinal);
+        var floor = new HashSet<string>(query.ClaimSets[^1], StringComparer.Ordinal);
+
+        var required = new List<string>();
+        var optional = new List<string>();
+        foreach (var claim in query.Claims)
+        {
+            var name = FromPath(claim.Path);
+            if (claim.Id is not null && byId.ContainsKey(claim.Id) && !floor.Contains(claim.Id))
+            {
+                optional.Add(name);
+            }
+            else
+            {
+                required.Add(name);
+            }
+        }
+
+        return (required, optional);
+    }
+
+    private static JsonDocument ParseDocument(string json)
+    {
+        try
+        {
+            return JsonDocument.Parse(json);
+        }
+        catch (JsonException ex)
+        {
+            throw new DcqlParseException(DcqlErrorCodes.Invalid, $"dcql_query is not valid JSON: {ex.Message}");
+        }
+    }
+
+    private static void RejectLegacyShapes(JsonElement root)
+    {
+        if (root.ValueKind != JsonValueKind.Object)
+        {
+            throw new DcqlParseException(DcqlErrorCodes.Invalid, "dcql_query must be a JSON object.");
+        }
+
+        if (root.TryGetProperty("input_descriptors", out _) || root.TryGetProperty("presentation_definition", out _))
+        {
+            throw new DcqlParseException(
+                DcqlErrorCodes.LegacyDialect,
+                "Presentation Exchange shape received — the retired pre-DCQL dialect. Expected OpenID4VP 1.0 dcql_query.");
+        }
+    }
+}

--- a/src/Services/Sorcha.Haip.Service/Sorcha.Haip.Service.csproj
+++ b/src/Services/Sorcha.Haip.Service/Sorcha.Haip.Service.csproj
@@ -20,6 +20,8 @@
     <ProjectReference Include="..\..\Common\Sorcha.Tenant.Models\Sorcha.Tenant.Models.csproj" />
     <ProjectReference Include="..\..\Common\Sorcha.PresentationLifecycle.Abstractions\Sorcha.PresentationLifecycle.Abstractions.csproj" />
     <ProjectReference Include="..\..\Common\Sorcha.AtomicCache\Sorcha.AtomicCache.csproj" />
+    <!-- Feature 181 — shared DCQL request builder/parser (Sorcha.Verifier.Engine/Dcql). -->
+    <ProjectReference Include="..\..\Common\Sorcha.Verifier.Engine\Sorcha.Verifier.Engine.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Services/Sorcha.Wallet.Service/Services/Implementation/DeviceDelegationIssuer.cs
+++ b/src/Services/Sorcha.Wallet.Service/Services/Implementation/DeviceDelegationIssuer.cs
@@ -111,7 +111,7 @@ public sealed class DeviceDelegationIssuer : IDeviceDelegationIssuer
         var header = new
         {
             alg = joseAlg,
-            typ = "vc+sd-jwt",
+            typ = "dc+sd-jwt",
             kid = $"did:sorcha:holder:{holderThumbprint}#0"
         };
         var headerJson = JsonSerializer.SerializeToUtf8Bytes(header);

--- a/tests/Sorcha.Cryptography.Tests/SdJwt/SdJwtX5cHeaderTests.cs
+++ b/tests/Sorcha.Cryptography.Tests/SdJwt/SdJwtX5cHeaderTests.cs
@@ -57,7 +57,7 @@ public class SdJwtX5cHeaderTests
 
         // Header still carries the standard JWT claims.
         doc.RootElement.GetProperty("alg").GetString().Should().Be("ES256");
-        doc.RootElement.GetProperty("typ").GetString().Should().Be("vc+sd-jwt");
+        doc.RootElement.GetProperty("typ").GetString().Should().Be("dc+sd-jwt");
     }
 
     [Fact]

--- a/tests/Sorcha.Tenant.Service.Tests/Fixtures/TrustLists/TrustListFixture.cs
+++ b/tests/Sorcha.Tenant.Service.Tests/Fixtures/TrustLists/TrustListFixture.cs
@@ -1,0 +1,379 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using System.Security.Cryptography.Xml;
+using System.Xml;
+using System.Xml.Linq;
+
+namespace Sorcha.Tenant.Service.Tests.Fixtures.TrustLists;
+
+/// <summary>
+/// Options controlling the shape of a generated ETSI TS 119 612 trusted list.
+/// </summary>
+/// <param name="SequenceNumber">Value for <c>TSLSequenceNumber</c>.</param>
+/// <param name="ListIssueDateTime">Value for <c>ListIssueDateTime</c>.</param>
+/// <param name="NextUpdate">Optional value for <c>NextUpdate/dateTime</c>; omitted when null.</param>
+/// <param name="SchemeTerritory">Two-letter scheme territory (e.g. "IE").</param>
+/// <param name="SchemeOperatorName">Human-readable scheme operator name.</param>
+/// <param name="Services">Trust service entries to embed in the list.</param>
+public sealed record TrustListOptions(
+    long SequenceNumber,
+    DateTimeOffset ListIssueDateTime,
+    DateTimeOffset? NextUpdate,
+    string SchemeTerritory,
+    string SchemeOperatorName,
+    IReadOnlyList<TrustListServiceEntry> Services);
+
+/// <summary>
+/// A single trust service entry inside a generated trusted list.
+/// </summary>
+/// <param name="ServiceTypeIdentifier">The <c>ServiceTypeIdentifier</c> URI.</param>
+/// <param name="ServiceStatus">The <c>ServiceStatus</c> URI.</param>
+/// <param name="Certificate">Certificate embedded as DER base64 in <c>ServiceDigitalIdentity/DigitalId/X509Certificate</c>.</param>
+/// <param name="ServiceName">Human-readable service name.</param>
+public sealed record TrustListServiceEntry(
+    string ServiceTypeIdentifier,
+    string ServiceStatus,
+    X509Certificate2 Certificate,
+    string ServiceName = "Sorcha Test Trust Service");
+
+/// <summary>
+/// Test fixture for ETSI TS 119 612 trusted-list scenarios (Feature 181 trust rail).
+/// Provides an in-memory P-256 test CA, leaf issuance, a minimal
+/// <c>TrustServiceStatusList</c> XML builder, enveloped XMLDSig signing with a
+/// distinct scheme-operator certificate, and a tamper helper for negative tests.
+/// </summary>
+public sealed class TrustListFixture : IDisposable
+{
+    /// <summary>The ETSI TS 119 612 v2 XML namespace.</summary>
+    public const string TslNamespace = "http://uri.etsi.org/02231/v2#";
+
+    /// <summary>Default qualified-CA service type identifier.</summary>
+    public const string CaQcServiceType = "http://uri.etsi.org/TrstSvc/Svctype/CA/QC";
+
+    /// <summary>Default "granted" service status URI.</summary>
+    public const string GrantedServiceStatus = "http://uri.etsi.org/TrstSvc/TrustedList/Svcstatus/granted";
+
+    /// <summary>The XMLDSig signature-method URI for ECDSA P-256 / SHA-256 (RFC 4051).</summary>
+    public const string EcdsaSha256SignatureMethod = "http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha256";
+
+    private readonly ECDsa _caKey;
+    private readonly ECDsa _schemeOperatorKey;
+    private bool _disposed;
+
+    static TrustListFixture()
+    {
+        // SignedXml has no built-in SignatureDescription for ECDSA — without this,
+        // ComputeSignature/CheckSignature throw "SignatureDescription could not be created".
+        CryptoConfig.AddAlgorithm(typeof(EcdsaSha256SignatureDescription), EcdsaSha256SignatureMethod);
+    }
+
+    /// <summary>
+    /// Creates a fresh fixture with a new test CA and scheme-operator certificate.
+    /// Certificates are stable for the lifetime of the fixture instance.
+    /// </summary>
+    public TrustListFixture()
+    {
+        _caKey = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        TestCa = CreateCaCertificate(_caKey);
+
+        _schemeOperatorKey = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        SchemeOperatorCert = CreateSchemeOperatorCertificate(_schemeOperatorKey);
+    }
+
+    /// <summary>Self-signed P-256 test CA ("CN=Sorcha Test Trust CA") with private key.</summary>
+    public X509Certificate2 TestCa { get; }
+
+    /// <summary>P-256 scheme-operator signing certificate (distinct from <see cref="TestCa"/>) with private key.</summary>
+    public X509Certificate2 SchemeOperatorCert { get; }
+
+    /// <summary>
+    /// Issues an end-entity leaf certificate signed by <see cref="TestCa"/>.
+    /// </summary>
+    /// <param name="subjectCn">Common name for the leaf subject (without the "CN=" prefix).</param>
+    /// <param name="leafKey">The leaf's P-256 key pair; the returned certificate carries only the public key.</param>
+    public X509Certificate2 IssueLeaf(string subjectCn, ECDsa leafKey)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(subjectCn);
+        ArgumentNullException.ThrowIfNull(leafKey);
+
+        var request = new CertificateRequest(
+            new X500DistinguishedName($"CN={subjectCn}"),
+            leafKey,
+            HashAlgorithmName.SHA256);
+
+        request.CertificateExtensions.Add(
+            new X509BasicConstraintsExtension(certificateAuthority: false, false, 0, critical: true));
+        request.CertificateExtensions.Add(
+            new X509KeyUsageExtension(X509KeyUsageFlags.DigitalSignature, critical: true));
+        request.CertificateExtensions.Add(
+            new X509SubjectKeyIdentifierExtension(request.PublicKey, critical: false));
+
+        var serial = new byte[16];
+        RandomNumberGenerator.Fill(serial);
+        serial[0] &= 0x7F; // keep serial positive
+
+        var notBefore = DateTimeOffset.UtcNow.AddMinutes(-5);
+        return request.Create(TestCa, notBefore, notBefore.AddYears(2), serial);
+    }
+
+    /// <summary>
+    /// Returns default options: one granted CA/QC entry backed by <see cref="TestCa"/>,
+    /// sequence number 1, issued now, next update in 6 months, territory "IE".
+    /// </summary>
+    public TrustListOptions DefaultOptions(long sequenceNumber = 1) => new(
+        SequenceNumber: sequenceNumber,
+        ListIssueDateTime: DateTimeOffset.UtcNow,
+        NextUpdate: DateTimeOffset.UtcNow.AddMonths(6),
+        SchemeTerritory: "IE",
+        SchemeOperatorName: "Sorcha Test Scheme Operator",
+        Services:
+        [
+            new TrustListServiceEntry(CaQcServiceType, GrantedServiceStatus, TestCa, "Sorcha Test Trust CA")
+        ]);
+
+    /// <summary>
+    /// Builds a minimal (unsigned) ETSI TS 119 612 <c>TrustServiceStatusList</c> document.
+    /// </summary>
+    public string BuildTrustListXml(TrustListOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        XNamespace ns = TslNamespace;
+        XNamespace xml = XNamespace.Xml;
+
+        var schemeInformation = new XElement(ns + "SchemeInformation",
+            new XElement(ns + "TSLVersionIdentifier", 5),
+            new XElement(ns + "TSLSequenceNumber", options.SequenceNumber),
+            new XElement(ns + "TSLType", "http://uri.etsi.org/TrstSvc/TrustedList/TSLType/EUgeneric"),
+            new XElement(ns + "SchemeOperatorName",
+                new XElement(ns + "Name", new XAttribute(xml + "lang", "en"), options.SchemeOperatorName)),
+            new XElement(ns + "SchemeTerritory", options.SchemeTerritory),
+            new XElement(ns + "ListIssueDateTime", FormatDateTime(options.ListIssueDateTime)));
+
+        if (options.NextUpdate is { } nextUpdate)
+        {
+            schemeInformation.Add(new XElement(ns + "NextUpdate",
+                new XElement(ns + "dateTime", FormatDateTime(nextUpdate))));
+        }
+
+        var tspServices = new XElement(ns + "TSPServices");
+        foreach (var service in options.Services)
+        {
+            tspServices.Add(new XElement(ns + "TSPService",
+                new XElement(ns + "ServiceInformation",
+                    new XElement(ns + "ServiceTypeIdentifier", service.ServiceTypeIdentifier),
+                    new XElement(ns + "ServiceName",
+                        new XElement(ns + "Name", new XAttribute(xml + "lang", "en"), service.ServiceName)),
+                    new XElement(ns + "ServiceDigitalIdentity",
+                        new XElement(ns + "DigitalId",
+                            new XElement(ns + "X509Certificate",
+                                Convert.ToBase64String(service.Certificate.RawData)))),
+                    new XElement(ns + "ServiceStatus", service.ServiceStatus),
+                    new XElement(ns + "StatusStartingTime", FormatDateTime(options.ListIssueDateTime)))));
+        }
+
+        var root = new XElement(ns + "TrustServiceStatusList",
+            new XAttribute("TSLTag", "http://uri.etsi.org/19612/TSLTag"),
+            new XAttribute("Id", "TrustServiceStatusList"),
+            schemeInformation,
+            new XElement(ns + "TrustServiceProviderList",
+                new XElement(ns + "TrustServiceProvider",
+                    new XElement(ns + "TSPInformation",
+                        new XElement(ns + "TSPName",
+                            new XElement(ns + "Name", new XAttribute(xml + "lang", "en"), options.SchemeOperatorName))),
+                    tspServices)));
+
+        return new XDocument(new XDeclaration("1.0", "utf-8", null), root)
+            .ToString(SaveOptions.DisableFormatting);
+    }
+
+    /// <summary>
+    /// Signs a trusted-list document with an enveloped XMLDSig signature (ECDSA P-256 / SHA-256)
+    /// using <see cref="SchemeOperatorCert"/>, embedding the certificate in KeyInfo (X509Data).
+    /// </summary>
+    public string SignTrustListXml(string xml)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(xml);
+
+        var doc = new XmlDocument { PreserveWhitespace = true };
+        doc.LoadXml(xml);
+
+        var signedXml = new SignedXml(doc)
+        {
+            SigningKey = _schemeOperatorKey,
+        };
+        signedXml.SignedInfo!.SignatureMethod = EcdsaSha256SignatureMethod;
+        signedXml.SignedInfo.CanonicalizationMethod = SignedXml.XmlDsigExcC14NTransformUrl;
+
+        var reference = new Reference("");
+        reference.AddTransform(new XmlDsigEnvelopedSignatureTransform());
+        reference.AddTransform(new XmlDsigExcC14NTransform());
+        signedXml.AddReference(reference);
+
+        var keyInfo = new KeyInfo();
+        keyInfo.AddClause(new KeyInfoX509Data(SchemeOperatorCert));
+        signedXml.KeyInfo = keyInfo;
+
+        signedXml.ComputeSignature();
+
+        var signatureElement = signedXml.GetXml();
+        doc.DocumentElement!.AppendChild(doc.ImportNode(signatureElement, deep: true));
+
+        return doc.OuterXml;
+    }
+
+    /// <summary>Builds and signs a trusted list in one step.</summary>
+    public string BuildSignedTrustList(TrustListOptions options) =>
+        SignTrustListXml(BuildTrustListXml(options));
+
+    /// <summary>
+    /// Verifies the enveloped XMLDSig signature of a signed trusted-list document.
+    /// </summary>
+    public static bool VerifySignature(string signedXml)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(signedXml);
+
+        var doc = new XmlDocument { PreserveWhitespace = true };
+        doc.LoadXml(signedXml);
+
+        var signatureNodes = doc.GetElementsByTagName("Signature", SignedXml.XmlDsigNamespaceUrl);
+        if (signatureNodes.Count == 0 || signatureNodes[0] is not XmlElement signatureElement)
+        {
+            return false;
+        }
+
+        var verifier = new SignedXml(doc);
+        verifier.LoadXml(signatureElement);
+        return verifier.CheckSignature();
+    }
+
+    /// <summary>
+    /// Flips one character of the signed content (the <c>SchemeTerritory</c> value)
+    /// so that signature verification fails. The result remains well-formed XML.
+    /// </summary>
+    public string Tamper(string signedXml)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(signedXml);
+
+        const string marker = "<SchemeTerritory>";
+        var index = signedXml.IndexOf(marker, StringComparison.Ordinal);
+        if (index < 0)
+        {
+            throw new InvalidOperationException("Signed XML does not contain a SchemeTerritory element to tamper with.");
+        }
+
+        var charIndex = index + marker.Length;
+        var original = signedXml[charIndex];
+        var flipped = original == 'X' ? 'Y' : 'X';
+        return signedXml[..charIndex] + flipped + signedXml[(charIndex + 1)..];
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+        TestCa.Dispose();
+        SchemeOperatorCert.Dispose();
+        _caKey.Dispose();
+        _schemeOperatorKey.Dispose();
+    }
+
+    private static string FormatDateTime(DateTimeOffset value) =>
+        value.UtcDateTime.ToString("yyyy-MM-dd'T'HH:mm:ss'Z'", System.Globalization.CultureInfo.InvariantCulture);
+
+    private static X509Certificate2 CreateCaCertificate(ECDsa key)
+    {
+        var request = new CertificateRequest(
+            new X500DistinguishedName("CN=Sorcha Test Trust CA"),
+            key,
+            HashAlgorithmName.SHA256);
+
+        request.CertificateExtensions.Add(
+            new X509BasicConstraintsExtension(certificateAuthority: true, hasPathLengthConstraint: true, pathLengthConstraint: 0, critical: true));
+        request.CertificateExtensions.Add(
+            new X509KeyUsageExtension(X509KeyUsageFlags.KeyCertSign | X509KeyUsageFlags.CrlSign, critical: true));
+        request.CertificateExtensions.Add(
+            new X509SubjectKeyIdentifierExtension(request.PublicKey, critical: false));
+
+        var notBefore = DateTimeOffset.UtcNow.AddMinutes(-5);
+        return request.CreateSelfSigned(notBefore, notBefore.AddYears(10));
+    }
+
+    private static X509Certificate2 CreateSchemeOperatorCertificate(ECDsa key)
+    {
+        var request = new CertificateRequest(
+            new X500DistinguishedName("CN=Sorcha Test Scheme Operator"),
+            key,
+            HashAlgorithmName.SHA256);
+
+        request.CertificateExtensions.Add(
+            new X509BasicConstraintsExtension(certificateAuthority: false, false, 0, critical: true));
+        request.CertificateExtensions.Add(
+            new X509KeyUsageExtension(X509KeyUsageFlags.DigitalSignature, critical: true));
+
+        var notBefore = DateTimeOffset.UtcNow.AddMinutes(-5);
+        return request.CreateSelfSigned(notBefore, notBefore.AddYears(10));
+    }
+}
+
+/// <summary>
+/// XMLDSig signature description mapping the RFC 4051 ecdsa-sha256 URI onto
+/// <see cref="ECDsa"/> sign/verify, since .NET ships no built-in ECDSA description.
+/// Public because <see cref="CryptoConfig.AddAlgorithm(Type, string[])"/> requires a visible type.
+/// </summary>
+public sealed class EcdsaSha256SignatureDescription : SignatureDescription
+{
+    /// <summary>Initialises the description with the ECDsa key algorithm.</summary>
+    public EcdsaSha256SignatureDescription()
+    {
+        KeyAlgorithm = typeof(ECDsa).AssemblyQualifiedName;
+    }
+
+    /// <inheritdoc />
+    public override HashAlgorithm CreateDigest() => SHA256.Create();
+
+    /// <inheritdoc />
+    public override AsymmetricSignatureFormatter CreateFormatter(AsymmetricAlgorithm key) =>
+        new EcdsaSignatureFormatter((ECDsa)key);
+
+    /// <inheritdoc />
+    public override AsymmetricSignatureDeformatter CreateDeformatter(AsymmetricAlgorithm key) =>
+        new EcdsaSignatureDeformatter((ECDsa)key);
+
+    private sealed class EcdsaSignatureFormatter(ECDsa key) : AsymmetricSignatureFormatter
+    {
+        private ECDsa _key = key;
+
+        public override byte[] CreateSignature(byte[] rgbHash) => _key.SignHash(rgbHash);
+
+        public override void SetHashAlgorithm(string strName)
+        {
+            // Hash algorithm is fixed to SHA-256 by the signature description.
+        }
+
+        public override void SetKey(AsymmetricAlgorithm key) => _key = (ECDsa)key;
+    }
+
+    private sealed class EcdsaSignatureDeformatter(ECDsa key) : AsymmetricSignatureDeformatter
+    {
+        private ECDsa _key = key;
+
+        public override bool VerifySignature(byte[] rgbHash, byte[] rgbSignature) =>
+            _key.VerifyHash(rgbHash, rgbSignature);
+
+        public override void SetHashAlgorithm(string strName)
+        {
+            // Hash algorithm is fixed to SHA-256 by the signature description.
+        }
+
+        public override void SetKey(AsymmetricAlgorithm key) => _key = (ECDsa)key;
+    }
+}

--- a/tests/Sorcha.Tenant.Service.Tests/Fixtures/TrustLists/TrustListFixtureTests.cs
+++ b/tests/Sorcha.Tenant.Service.Tests/Fixtures/TrustLists/TrustListFixtureTests.cs
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Security.Cryptography;
+using System.Xml.Linq;
+using FluentAssertions;
+using Xunit;
+
+namespace Sorcha.Tenant.Service.Tests.Fixtures.TrustLists;
+
+/// <summary>
+/// Smoke tests for <see cref="TrustListFixture"/> — the ETSI TS 119 612
+/// trusted-list test infrastructure used by the Feature 181 trust rail.
+/// </summary>
+public sealed class TrustListFixtureTests : IDisposable
+{
+    private static readonly XNamespace Tsl = TrustListFixture.TslNamespace;
+
+    private readonly TrustListFixture _fixture = new();
+
+    public void Dispose() => _fixture.Dispose();
+
+    [Fact]
+    public void BuildSignedTrustList_DefaultOptions_SignatureVerifies()
+    {
+        var signed = _fixture.BuildSignedTrustList(_fixture.DefaultOptions());
+
+        TrustListFixture.VerifySignature(signed).Should().BeTrue(
+            "an untampered enveloped XMLDSig signature must verify via SignedXml.CheckSignature");
+    }
+
+    [Fact]
+    public void Tamper_SignedTrustList_SignatureFails()
+    {
+        var signed = _fixture.BuildSignedTrustList(_fixture.DefaultOptions());
+
+        var tampered = _fixture.Tamper(signed);
+
+        tampered.Should().NotBe(signed);
+        TrustListFixture.VerifySignature(tampered).Should().BeFalse(
+            "flipping a character inside signed content must invalidate the signature");
+    }
+
+    [Fact]
+    public void BuildSignedTrustList_DefaultOptions_ParsesWithExpectedSequenceAndGrantedCaQcEntry()
+    {
+        var signed = _fixture.BuildSignedTrustList(_fixture.DefaultOptions(sequenceNumber: 42));
+
+        var doc = XDocument.Parse(signed);
+        var root = doc.Root!;
+        root.Name.Should().Be(Tsl + "TrustServiceStatusList");
+
+        root.Element(Tsl + "SchemeInformation")!
+            .Element(Tsl + "TSLSequenceNumber")!.Value.Should().Be("42");
+
+        var services = root
+            .Element(Tsl + "TrustServiceProviderList")!
+            .Elements(Tsl + "TrustServiceProvider")
+            .Elements(Tsl + "TSPServices")
+            .Elements(Tsl + "TSPService")
+            .ToList();
+
+        services.Should().HaveCount(1);
+
+        var serviceInformation = services[0].Element(Tsl + "ServiceInformation")!;
+        serviceInformation.Element(Tsl + "ServiceTypeIdentifier")!.Value
+            .Should().Be(TrustListFixture.CaQcServiceType);
+        serviceInformation.Element(Tsl + "ServiceStatus")!.Value
+            .Should().Be(TrustListFixture.GrantedServiceStatus);
+
+        var certBase64 = serviceInformation
+            .Element(Tsl + "ServiceDigitalIdentity")!
+            .Element(Tsl + "DigitalId")!
+            .Element(Tsl + "X509Certificate")!.Value;
+        Convert.FromBase64String(certBase64).Should().Equal(_fixture.TestCa.RawData);
+    }
+
+    [Fact]
+    public void IssueLeaf_SignedByTestCa_ChainsToCa()
+    {
+        using var leafKey = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+
+        using var leaf = _fixture.IssueLeaf("Sorcha Test Leaf", leafKey);
+
+        leaf.Subject.Should().Be("CN=Sorcha Test Leaf");
+        leaf.Issuer.Should().Be(_fixture.TestCa.Subject);
+    }
+}

--- a/tests/Sorcha.Tenant.Service.Tests/Sorcha.Tenant.Service.Tests.csproj
+++ b/tests/Sorcha.Tenant.Service.Tests/Sorcha.Tenant.Service.Tests.csproj
@@ -20,6 +20,7 @@
     <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Moq" />
+    <PackageReference Include="System.Security.Cryptography.Xml" />
     <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/Sorcha.Verifier.Tests/Dcql/DcqlRoundTripTests.cs
+++ b/tests/Sorcha.Verifier.Tests/Dcql/DcqlRoundTripTests.cs
@@ -1,0 +1,180 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using FluentAssertions;
+using Sorcha.Verifier.Engine.Dcql;
+using Xunit;
+
+namespace Sorcha.Verifier.Tests.Dcql;
+
+/// <summary>
+/// Feature 181 T007 — the shared DCQL builder/parser pair round-trips, validates ids and
+/// referential integrity, and refuses the retired Presentation Exchange dialect.
+/// </summary>
+public class DcqlRoundTripTests
+{
+    private static readonly string[] RequiredClaims = ["givenName", "familyName"];
+
+    [Fact]
+    public void Build_SingleSdJwtAsk_EmitsSpecShape()
+    {
+        var query = DcqlRequestBuilder.Build(
+            [DcqlCredentialAsk.SdJwt("identity", "https://sorcha.dev/vc/assured-identity/v1", RequiredClaims)],
+            purpose: "Prove your identity");
+
+        var json = DcqlRequestBuilder.ToJson(query);
+        using var doc = JsonDocument.Parse(json);
+
+        doc.RootElement.GetProperty("credentials")[0].GetProperty("format").GetString()
+            .Should().Be("dc+sd-jwt");
+        doc.RootElement.GetProperty("credentials")[0].GetProperty("meta").GetProperty("vct_values")[0].GetString()
+            .Should().Be("https://sorcha.dev/vc/assured-identity/v1");
+        doc.RootElement.GetProperty("credential_sets")[0].GetProperty("purpose").GetString()
+            .Should().Be("Prove your identity");
+        json.Should().NotContain("input_descriptors").And.NotContain("presentation_definition");
+    }
+
+    [Fact]
+    public void Parse_BuilderOutput_RoundTripsIncludingOptionalSplit()
+    {
+        var built = DcqlRequestBuilder.Build(
+            [DcqlCredentialAsk.SdJwt("identity", "vct:test", RequiredClaims, optionalClaims: ["portrait"])]);
+
+        var parsed = DcqlRequestParser.Parse(DcqlRequestBuilder.ToJson(built));
+
+        parsed.Credentials.Should().HaveCount(1);
+        var (required, optional) = DcqlRequestParser.SplitClaims(parsed.Credentials[0]);
+        required.Should().BeEquivalentTo(RequiredClaims);
+        optional.Should().BeEquivalentTo(["portrait"]);
+    }
+
+    [Fact]
+    public void Build_NestedClaimPath_RoundTripsSlashConvention()
+    {
+        var built = DcqlRequestBuilder.Build(
+            [DcqlCredentialAsk.SdJwt("addr", "vct:test", ["/address/street"])]);
+
+        built.Credentials[0].Claims![0].Path.Should().Equal("address", "street");
+        DcqlRequestParser.FromPath(built.Credentials[0].Claims![0].Path).Should().Be("/address/street");
+    }
+
+    [Fact]
+    public void Build_AlternativeGroups_EmitCredentialSets()
+    {
+        var built = DcqlRequestBuilder.Build(
+            [
+                DcqlCredentialAsk.SdJwt("pid", "vct:pid", ["given_name"]),
+                DcqlCredentialAsk.SdJwt("assured", "vct:assured", ["givenName"]),
+            ],
+            alternatives: [new DcqlAlternativeGroup([["pid"], ["assured"]], Purpose: "Prove your identity")]);
+
+        var parsed = DcqlRequestParser.Parse(DcqlRequestBuilder.ToJson(built));
+        parsed.CredentialSets.Should().HaveCount(1);
+        parsed.CredentialSets![0].Options.Should().HaveCount(2);
+        parsed.CredentialSets[0].Required.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Build_MdocAsk_RequiresDoctype()
+    {
+        var act = () => DcqlRequestBuilder.Build(
+            [new DcqlCredentialAsk("mdl", DcqlFormats.MsoMdoc, null, DoctypeValue: null, ["family_name"])]);
+
+        act.Should().Throw<DcqlParseException>()
+            .Which.Code.Should().Be(DcqlErrorCodes.Invalid);
+    }
+
+    [Theory]
+    [InlineData("bad id!")]
+    [InlineData("")]
+    public void Build_InvalidQueryId_Throws(string id)
+    {
+        var act = () => DcqlRequestBuilder.Build([DcqlCredentialAsk.SdJwt(id, "vct:test", RequiredClaims)]);
+
+        act.Should().Throw<DcqlParseException>().Which.Code.Should().Be(DcqlErrorCodes.Invalid);
+    }
+
+    [Fact]
+    public void Build_DuplicateQueryIds_Throws()
+    {
+        var act = () => DcqlRequestBuilder.Build(
+            [
+                DcqlCredentialAsk.SdJwt("same", "vct:a", RequiredClaims),
+                DcqlCredentialAsk.SdJwt("same", "vct:b", RequiredClaims),
+            ]);
+
+        act.Should().Throw<DcqlParseException>().Which.Message.Should().Contain("Duplicate credential query id");
+    }
+
+    [Fact]
+    public void Parse_CredentialSetsReferencingUnknownId_Throws()
+    {
+        const string json = """
+            { "credentials": [ { "id": "a", "format": "dc+sd-jwt", "meta": { "vct_values": ["vct:a"] } } ],
+              "credential_sets": [ { "options": [["a"], ["missing"]] } ] }
+            """;
+
+        var act = () => DcqlRequestParser.Parse(json);
+
+        act.Should().Throw<DcqlParseException>().Which.Message.Should().Contain("unknown credential query id 'missing'");
+    }
+
+    [Fact]
+    public void Parse_PresentationExchangeShape_RejectedAsLegacyDialect()
+    {
+        const string json = """
+            { "id": "pd-1", "input_descriptors": [ { "id": "x", "constraints": { "fields": [] } } ] }
+            """;
+
+        var act = () => DcqlRequestParser.Parse(json);
+
+        act.Should().Throw<DcqlParseException>().Which.Code.Should().Be(DcqlErrorCodes.LegacyDialect);
+    }
+
+    [Fact]
+    public void ParseFromRequestObjectPayload_LegacyPayload_RejectedAsLegacyDialect()
+    {
+        using var doc = JsonDocument.Parse("""{ "presentation_definition": {}, "nonce": "n" }""");
+
+        var act = () => DcqlRequestParser.ParseFromRequestObjectPayload(doc.RootElement);
+
+        act.Should().Throw<DcqlParseException>().Which.Code.Should().Be(DcqlErrorCodes.LegacyDialect);
+    }
+
+    [Fact]
+    public void VpToken_ObjectEnvelope_RoundTrips()
+    {
+        var token = new DcqlVpToken
+        {
+            Presentations = new Dictionary<string, IReadOnlyList<string>>
+            {
+                ["identity"] = ["jwt~disc1~kb"],
+                ["addr"] = ["jwt2~kb2"],
+            },
+        };
+
+        var parsed = DcqlVpToken.Parse(token.ToJson());
+
+        parsed.Presentations.Should().HaveCount(2);
+        parsed.Presentations["identity"].Should().Equal("jwt~disc1~kb");
+    }
+
+    [Fact]
+    public void VpToken_BareCompactString_RejectedAsLegacyDialect()
+    {
+        var act = () => DcqlVpToken.Parse("eyJhbGciOi.payload.sig~disclosure~kbjwt");
+
+        act.Should().Throw<DcqlParseException>().Which.Code.Should().Be(DcqlErrorCodes.LegacyDialect);
+    }
+
+    [Fact]
+    public void VpToken_EmptyObject_RejectedAsInvalid()
+    {
+        var act = () => DcqlVpToken.Parse("{}");
+
+        act.Should().Throw<DcqlParseException>().Which.Code.Should().Be(DcqlErrorCodes.Invalid);
+    }
+}

--- a/tests/Sorcha.Verifier.Tests/Services/TestVpFactory.cs
+++ b/tests/Sorcha.Verifier.Tests/Services/TestVpFactory.cs
@@ -43,7 +43,8 @@ internal static class TestVpFactory
         int statusListIndex = 7,
         DateTimeOffset? kbJwtIssuedAt = null,
         DateTimeOffset? kbJwtExpiresAt = null,
-        bool omitKbJwtExp = false)
+        bool omitKbJwtExp = false,
+        string credentialTyp = "dc+sd-jwt")
     {
         var issuer = ECDsa.Create(ECCurve.NamedCurves.nistP256);
         var holder = ECDsa.Create(ECCurve.NamedCurves.nistP256);
@@ -76,7 +77,7 @@ internal static class TestVpFactory
             ["cnf"] = new Dictionary<string, object> { ["jwk"] = JsonDocument.Parse(holderJwk).RootElement },
         };
         var credentialJwt = SignEs256(
-            new Dictionary<string, object> { ["alg"] = "ES256", ["typ"] = "vc+sd-jwt" },
+            new Dictionary<string, object> { ["alg"] = "ES256", ["typ"] = credentialTyp },
             credentialPayload, issuer);
 
         // Delegation credential — signed by holder key, cnf=device JWK
@@ -100,7 +101,7 @@ internal static class TestVpFactory
             },
         };
         var delegation = SignEs256(
-            new Dictionary<string, object> { ["alg"] = "ES256", ["typ"] = "vc+sd-jwt" },
+            new Dictionary<string, object> { ["alg"] = "ES256", ["typ"] = "dc+sd-jwt" },
             delegationPayload, holder);
 
         // KB-JWT — signed by device key, audience+nonce binding
@@ -182,7 +183,7 @@ internal static class TestVpFactory
             ["cnf"] = new Dictionary<string, object> { ["jwk"] = JsonDocument.Parse(holderJwk).RootElement },
         };
         var credentialJwt = SignEs256(
-            new Dictionary<string, object> { ["alg"] = "ES256", ["typ"] = "vc+sd-jwt" },
+            new Dictionary<string, object> { ["alg"] = "ES256", ["typ"] = "dc+sd-jwt" },
             credentialPayload, issuer);
 
         var exp = (delegationExpiresAt ?? DateTimeOffset.UtcNow.AddDays(365)).ToUnixTimeSeconds();
@@ -206,7 +207,7 @@ internal static class TestVpFactory
         };
         // Honest EdDSA header — the holder key is Ed25519, so the delegation JWS is an EdDSA signature.
         var delegation = SignEdDsa(
-            new Dictionary<string, object> { ["alg"] = "EdDSA", ["typ"] = "vc+sd-jwt" },
+            new Dictionary<string, object> { ["alg"] = "EdDSA", ["typ"] = "dc+sd-jwt" },
             delegationPayload, holderPriv);
 
         var kbHeader = new Dictionary<string, object>

--- a/tests/Sorcha.Verifier.Tests/Services/VerifiablePresentationValidatorTests.cs
+++ b/tests/Sorcha.Verifier.Tests/Services/VerifiablePresentationValidatorTests.cs
@@ -109,6 +109,26 @@ public sealed class VerifiablePresentationValidatorTests
     }
 
     [Fact]
+    public async Task ValidateAsync_LegacyVcSdJwtTyp_StillAccepted()
+    {
+        // Feature 181 FR-004 lock-in: already-issued credentials carry typ "vc+sd-jwt" and live
+        // in citizen wallets we cannot recall — the verify side must accept both media types.
+        var bundle = TestVpFactory.Mint(Vct, Claims(("givenName", "Stuart")), ClientId, Nonce,
+            credentialTyp: "vc+sd-jwt");
+        var resolver = new JwkRegistryIssuerKeyResolver();
+        resolver.Register(
+            "did:sorcha:org:test",
+            System.Text.Json.JsonDocument.Parse(TestVpFactory.ToJwk(bundle.IssuerKey)).RootElement);
+        var validator = new VerifiablePresentationValidator(
+            _statusList.Object, resolver, TimeProvider.System,
+            NullLogger<VerifiablePresentationValidator>.Instance, requireIssuerSignature: false);
+
+        var outcome = await validator.ValidateAsync(Session(), bundle.VpToken, bundle.Delegation);
+
+        outcome.Accepted.Should().BeTrue(string.Join(", ", outcome.Errors));
+    }
+
+    [Fact]
     public async Task ValidateAsync_IssuerKeyUnresolved_Required_Rejects()
     {
         // Authoritative server-gate posture (F120): require the issuer signature → reject when unresolvable.

--- a/tests/Sorcha.Wallet.Pwa.Tests/Services/Presentation/PresentationEngineTests.cs
+++ b/tests/Sorcha.Wallet.Pwa.Tests/Services/Presentation/PresentationEngineTests.cs
@@ -223,7 +223,7 @@ public sealed class PresentationEngineTests
         var headerSeg = Base64Url.EncodeToString(JsonSerializer.SerializeToUtf8Bytes(new
         {
             alg = "ES256",
-            typ = "vc+sd-jwt"
+            typ = "dc+sd-jwt"
         }));
         var payloadSeg = Base64Url.EncodeToString(JsonSerializer.SerializeToUtf8Bytes(new
         {

--- a/tests/Sorcha.Wallet.Service.Tests/Services/DeviceDelegationIssuerTests.cs
+++ b/tests/Sorcha.Wallet.Service.Tests/Services/DeviceDelegationIssuerTests.cs
@@ -106,7 +106,7 @@ public sealed class DeviceDelegationIssuerTests
         var header = JsonDocument.Parse(Decode(result.CompactJwt.Split('.')[0])).RootElement;
 
         header.GetProperty("alg").GetString().Should().Be("ES256");
-        header.GetProperty("typ").GetString().Should().Be("vc+sd-jwt");
+        header.GetProperty("typ").GetString().Should().Be("dc+sd-jwt");
         header.GetProperty("kid").GetString().Should().StartWith("did:sorcha:holder:");
     }
 
@@ -139,7 +139,7 @@ public sealed class DeviceDelegationIssuerTests
 
         var header = JsonDocument.Parse(Decode(result.CompactJwt.Split('.')[0])).RootElement;
         header.GetProperty("alg").GetString().Should().Be("EdDSA");
-        header.GetProperty("typ").GetString().Should().Be("vc+sd-jwt");
+        header.GetProperty("typ").GetString().Should().Be("dc+sd-jwt");
         header.GetProperty("kid").GetString().Should().StartWith("did:sorcha:holder:");
     }
 


### PR DESCRIPTION
## Summary

PR 1 of the Feature 181 EUDI-conformance series — the full speckit artifact set plus the Phase 1+2 foundation (tasks T001–T009) that the six user stories build on.

**Spec set** (`specs/181-eudi-conformance/`): spec with owner decisions D1–D6 (clean-break DCQL with all OpenID4VP routes preserved; operator trusted-list snapshots; operator-imported org certs; auto-enrol + typed Ed25519 exclusion), research R1–R15, data model, 3 contracts, quickstart, 63-task breakdown.

**Foundation code**:
- `Sorcha.Verifier.Engine/Dcql/` — the ONE shared DCQL builder/parser pair (single-obvious-path, FR-008): wire model with exact spec property names, required/optional → `claims`+`claim_sets` mapping, `credential_sets` alternatives, object-keyed `DcqlVpToken` envelope, typed `LEGACY_DIALECT`/`DCQL_INVALID` errors.
- SD-JWT `typ` → `dc+sd-jwt` at every issuance site; verify side confirmed check-free and legacy-typ acceptance locked in by a new validator test (FR-004 — credentials already in citizen wallets can't be recalled).
- CI ratchet gate (`scripts/check-presentation-dialect.ps1` + 9-entry allowlist + workflow) — allowlist ratchets to empty when US1 lands; self-tested both directions.
- Signed ETSI TS 119 612 trust-list fixture + test CA for the US3/US4 trust rail, incl. the `EcdsaSha256SignatureDescription` CryptoConfig registration `SignedXml` needs for ECDSA lists.

## Test evidence

| Project | Result |
|---|---|
| Sorcha.Verifier.Tests | 92/92 (14 new DCQL + legacy-typ lock-in) |
| Sorcha.Cryptography.Tests | 407/407 |
| Sorcha.Wallet.Pwa.Tests | 326/326 |
| Sorcha.Wallet.Service.Tests | 856/856 |
| Sorcha.Tenant.Service.Tests (fixture filter) | 4/4 non-vacuous |
| Dialect gate | clean → exit 0; seeded violation → exit 1 |

## Standards & discoverability

STANDARDS.md untouched in this PR — rows update in the polish phase (T059) once the dialect actually flips on the wire (US1).

Next PRs: US1 dialect cutover (T010–T023), then US2/US3 in parallel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)