### PR TITLE
fix: [128] device pairing sent anonymous requests — mint through an authed typed client

### DIFF
--- a/samples/strathcarron-portal/Program.cs
+++ b/samples/strathcarron-portal/Program.cs
@@ -9,6 +9,7 @@ using MudBlazor.Services;
 using Sorcha.Sample.StrathcarronPortal;
 using Sorcha.UI.Core.Services;
 using Sorcha.UI.Core.Services.User.Enrolment;
+using Sorcha.UI.Core.Services.User.Pairing;
 using Sorcha.UI.Core.Services.User.Presentation;
 
 var builder = WebAssemblyHostBuilder.CreateDefault(args);
@@ -46,6 +47,15 @@ builder.Services.AddScoped<TenantHubConnection>(sp =>
         inboxApi: null);
 });
 builder.Services.AddHttpClient<IEnrolPairingSignal, EnrolPairingSignal>(client =>
+{
+    client.BaseAddress = new Uri(builder.HostEnvironment.BaseAddress);
+});
+
+// WalletPairingSurface mints the enrol-session through this typed client. A host with its own token
+// store registers it with that host's auth handler (see Sorcha.UI.Web.Client); this sample portal has
+// no user session of its own, so it registers the plain client — the same anonymous shape it used
+// before the seam existed.
+builder.Services.AddHttpClient<IPairingClient, PairingClient>(client =>
 {
     client.BaseAddress = new Uri(builder.HostEnvironment.BaseAddress);
 });

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/EnrolGate/WalletPairingSurface.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/EnrolGate/WalletPairingSurface.razor
@@ -1,8 +1,8 @@
 @namespace Sorcha.UI.Core.Components.EnrolGate
-@using System.Net.Http.Json
 @using Sorcha.UI.Core.Services.User.Enrolment
+@using Sorcha.UI.Core.Services.User.Pairing
 @using Sorcha.UI.Core.Extensions
-@inject HttpClient Http
+@inject IPairingClient Pairing
 @inject IEnrolPairingSignal PairingSignal
 @implements IAsyncDisposable
 
@@ -78,7 +78,7 @@
     /// <summary>Fired when a wallet device for this user has been enrolled.</summary>
     [Parameter] public EventCallback OnPaired { get; set; }
 
-    private MintEnrolSessionResponseShape? _minted;
+    private EnrolSessionMint? _minted;
     private bool _minting = true;
     private string? _mintError;
     private string _statusText = "Waiting for your phone…";
@@ -117,21 +117,16 @@
 
         try
         {
-            using var response = await Http.PostAsJsonAsync("/api/auth/enrol-session", new { });
-            if (!response.IsSuccessStatusCode)
+            // The mint is authenticated — the typed client carries the caller's bearer token,
+            // because the host registers it with the same auth handler its other API clients use.
+            _minted = await Pairing.MintAsync();
+            if (_minted is null)
             {
                 _mintError = "Couldn't generate an enrolment code — try again or refresh the page.";
                 return;
             }
-            _minted = await response.Content.ReadFromJsonAsync<MintEnrolSessionResponseShape>(JsonDefaults.Api);
-            if (_minted is not null)
-            {
-                _ = WatchForExpiryAsync(_minted.ExpiresAt, _expiryWatcher.Token);
-            }
-        }
-        catch (Exception)
-        {
-            _mintError = "Couldn't reach Sorcha — check your connection.";
+
+            _ = WatchForExpiryAsync(_minted.ExpiresAt, _expiryWatcher.Token);
         }
         finally
         {
@@ -206,7 +201,6 @@
     }
 
     /// <summary>Local DTO mirroring <c>MintEnrolSessionResponse</c> on the Tenant Service.</summary>
-    public sealed record MintEnrolSessionResponseShape(string SessionToken, string QrUrl, DateTimeOffset ExpiresAt);
 
     /// <summary>Tier-aware copy mode for the pairing surface.</summary>
     public enum TierMode

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Pairing/PairingHandoffSurface.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Pairing/PairingHandoffSurface.razor
@@ -27,12 +27,11 @@
     without that optimization.
 *@
 
-@using System.Net.Http.Json
 @using Microsoft.Extensions.Logging
 @using Sorcha.UI.Core.Components.EnrolGate
 @using Sorcha.UI.Core.Services.User.Pairing
 @using Sorcha.UI.Core.Extensions
-@inject HttpClient Http
+@inject IPairingClient Pairing
 @inject NavigationManager Nav
 @inject IPwaInstallabilityProbe InstallProbe
 @inject ILogger<PairingHandoffSurface> Logger
@@ -169,61 +168,22 @@
         _minted = null;
         StateHasChanged();
 
-        try
+        var mint = await Pairing.MintAsync("standalone");
+        if (mint is null || string.IsNullOrEmpty(mint.QrUrl))
         {
-            using var response = await Http.PostAsJsonAsync(
-                "/api/auth/enrol-session",
-                new MintRequest("standalone"));
-
-            if (!response.IsSuccessStatusCode)
-            {
-                Logger.LogWarning(
-                    "PairingHandoffSurface enrol-session mint returned {Status}",
-                    response.StatusCode);
-                _error = "Couldn't generate a pairing code. Try again.";
-                return;
-            }
-
-            var body = await response.Content.ReadFromJsonAsync<MintResponseShape>(JsonDefaults.Api);
-            if (body is null || string.IsNullOrEmpty(body.QrUrl))
-            {
-                _error = "Couldn't generate a pairing code. Try again.";
-                return;
-            }
-
-            _minted = new MintedHandoff(body.QrUrl, body.ExpiresAt);
+            _error = "Couldn't generate a pairing code. Try again.";
+            return;
         }
-        catch (Exception ex)
-        {
-            Logger.LogError(ex, "PairingHandoffSurface mint failed");
-            _error = "Couldn't reach Sorcha. Check your connection and try again.";
-        }
+
+        _minted = new MintedHandoff(mint.QrUrl, mint.ExpiresAt);
     }
 
     private async Task MintShortCodeAsync()
     {
-        try
-        {
-            var route = _installVerdict == PwaInstallabilityVerdict.CanInstallManually
-                ? "MobilewebHandoff"
-                : "MobilewebHandoff";
-            using var response = await Http.PostAsJsonAsync(
-                "/api/auth/enrol-session/short-code",
-                new ShortCodeMintRequest(route));
-
-            if (!response.IsSuccessStatusCode)
-            {
-                Logger.LogWarning("Short-code mint returned {Status}", response.StatusCode);
-                return;
-            }
-
-            var body = await response.Content.ReadFromJsonAsync<ShortCodeMintResponseShape>(JsonDefaults.Api);
-            _shortCode = body?.Code;
-        }
-        catch (Exception ex)
-        {
-            Logger.LogWarning(ex, "Short-code mint failed; install variant will lack the fallback");
-        }
+        // The short code is a fallback affordance, so a failed mint degrades quietly — the install
+        // variant simply renders without it.
+        var code = await Pairing.MintShortCodeAsync("MobilewebHandoff");
+        _shortCode = code?.Code;
     }
 
     private RenderFragment RenderShortCodePanel() => __builder =>
@@ -275,19 +235,7 @@
         _emailLinkBusy = true;
         try
         {
-            using var response = await Http.PostAsync("/api/auth/pairing-resumption-email", content: null);
-            if (response.IsSuccessStatusCode)
-            {
-                _emailLinkSent = true;
-            }
-            else
-            {
-                Logger.LogWarning("Pairing-resumption email returned {Status}", response.StatusCode);
-            }
-        }
-        catch (Exception ex)
-        {
-            Logger.LogError(ex, "Pairing-resumption email failed");
+            _emailLinkSent = await Pairing.SendPairingResumptionEmailAsync();
         }
         finally
         {
@@ -295,9 +243,5 @@
         }
     }
 
-    private sealed record MintRequest(string Mode);
-    private sealed record MintResponseShape(string SessionToken, string QrUrl, DateTimeOffset ExpiresAt, string Mode);
     private sealed record MintedHandoff(string QrUrl, DateTimeOffset ExpiresAt);
-    private sealed record ShortCodeMintRequest(string Route);
-    private sealed record ShortCodeMintResponseShape(string Code, DateTimeOffset ExpiresAt);
 }

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/Pairing/IPairingClient.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/Pairing/IPairingClient.cs
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Net.Http.Json;
+using Microsoft.Extensions.Logging;
+using Sorcha.UI.Core.Extensions;
+
+namespace Sorcha.UI.Core.Services.User.Pairing;
+
+/// <summary>
+/// Mints the enrolment-session artefacts the pairing surfaces hand to the citizen's phone
+/// (Features 126 / 128): the QR-bearing enrol-session token, and the 6-digit short code used
+/// when the citizen is already on the device they want to pair.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Both endpoints are <b>authenticated</b> — they mint a session for the calling citizen. This is a
+/// typed client rather than a raw <see cref="HttpClient"/> injection precisely because a host's
+/// ambient <see cref="HttpClient"/> makes no promise about carrying the caller's bearer token: in
+/// <c>Sorcha.UI.Web.Client</c> the ambient client is deliberately <b>anonymous</b> (it is the one
+/// <c>AuthenticationService</c> itself uses, so it cannot depend on the auth handler without a
+/// circular dependency). A component that reached for the ambient client therefore sent these
+/// requests with no <c>Authorization</c> header and got a 401 — which the citizen saw as
+/// "Couldn't generate a pairing code."
+/// </para>
+/// <para>
+/// So the host registers this typed client with whatever auth handler it already uses
+/// (<c>AuthenticatedHttpMessageHandler</c> in the web client, the bearer chain in the PWA) — the
+/// same contract <see cref="Devices.IHasPairedDeviceProbe"/> follows.
+/// </para>
+/// </remarks>
+public interface IPairingClient
+{
+    /// <summary>
+    /// Mints an enrol-session token for the signed-in citizen. Returns null when the mint fails
+    /// (the caller renders its own message — this seam never throws).
+    /// </summary>
+    /// <param name="mode">
+    /// <c>"gated"</c> (the F126 council-page default) or <c>"standalone"</c> (the F128 routes that
+    /// live outside a council page). Null sends no mode, preserving the F126 default.
+    /// </param>
+    /// <param name="ct">Cancellation token.</param>
+    Task<EnrolSessionMint?> MintAsync(string? mode = null, CancellationToken ct = default);
+
+    /// <summary>
+    /// Mints a 6-digit pairing short code wrapping a standalone enrol-session. Returns null when the
+    /// mint fails — the short code is a fallback affordance, so callers degrade rather than error.
+    /// </summary>
+    /// <param name="route">Attribution tag for telemetry (e.g. <c>"MobilewebHandoff"</c>).</param>
+    /// <param name="ct">Cancellation token.</param>
+    Task<PairingShortCode?> MintShortCodeAsync(string route, CancellationToken ct = default);
+
+    /// <summary>
+    /// Sends the citizen a "finish pairing on your phone" magic link, to their account email.
+    /// Returns true when the dispatch was accepted.
+    /// </summary>
+    /// <param name="ct">Cancellation token.</param>
+    Task<bool> SendPairingResumptionEmailAsync(CancellationToken ct = default);
+}
+
+/// <summary>A minted enrol-session: the QR target the phone scans, and when it lapses.</summary>
+public sealed record EnrolSessionMint(string SessionToken, string QrUrl, DateTimeOffset ExpiresAt, string? Mode);
+
+/// <summary>A minted 6-digit pairing short code and its expiry.</summary>
+public sealed record PairingShortCode(string Code, DateTimeOffset ExpiresAt);
+
+/// <inheritdoc cref="IPairingClient"/>
+public sealed class PairingClient : IPairingClient
+{
+    private const string MintEndpoint = "/api/auth/enrol-session";
+    private const string ShortCodeEndpoint = "/api/auth/enrol-session/short-code";
+    private const string ResumptionEmailEndpoint = "/api/auth/pairing-resumption-email";
+
+    private readonly HttpClient _http;
+    private readonly ILogger<PairingClient> _logger;
+
+    /// <summary>Initialises a new <see cref="EnrolSessionClient"/>.</summary>
+    public PairingClient(HttpClient http, ILogger<PairingClient> logger)
+    {
+        _http = http ?? throw new ArgumentNullException(nameof(http));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    public async Task<EnrolSessionMint?> MintAsync(string? mode = null, CancellationToken ct = default)
+    {
+        try
+        {
+            object body = mode is null ? new { } : new { mode };
+            using var response = await _http.PostAsJsonAsync(MintEndpoint, body, ct).ConfigureAwait(false);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogWarning("enrol-session mint returned {Status}", response.StatusCode);
+                return null;
+            }
+
+            return await response.Content
+                .ReadFromJsonAsync<EnrolSessionMint>(JsonDefaults.Api, ct)
+                .ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogWarning(ex, "enrol-session mint failed");
+            return null;
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<PairingShortCode?> MintShortCodeAsync(string route, CancellationToken ct = default)
+    {
+        try
+        {
+            using var response = await _http
+                .PostAsJsonAsync(ShortCodeEndpoint, new { route }, ct)
+                .ConfigureAwait(false);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogWarning("short-code mint returned {Status}", response.StatusCode);
+                return null;
+            }
+
+            return await response.Content
+                .ReadFromJsonAsync<PairingShortCode>(JsonDefaults.Api, ct)
+                .ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogWarning(ex, "short-code mint failed");
+            return null;
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> SendPairingResumptionEmailAsync(CancellationToken ct = default)
+    {
+        try
+        {
+            using var response = await _http
+                .PostAsync(ResumptionEmailEndpoint, content: null, ct)
+                .ConfigureAwait(false);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogWarning("pairing-resumption email returned {Status}", response.StatusCode);
+                return false;
+            }
+
+            return true;
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogWarning(ex, "pairing-resumption email failed");
+            return false;
+        }
+    }
+}

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Program.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Program.cs
@@ -97,14 +97,32 @@ builder.Services.AddScoped<SchemaLibraryService>(sp =>
 // Feature 126 — council enrolment gate services. ITierProbeService hits the
 // API gateway directly via a typed HttpClient; IEnrolPairingSignal layers
 // SignalR (via TenantHubConnection) with a 3-s /me/devices poll as fallback.
+//
+// ITierProbeService is deliberately left ANONYMOUS: its whole job is to classify the visitor, and a
+// 401 from /whoami IS the answer "cold-start visitor, tier 3". Attaching the authenticated handler
+// would turn that expected 401 into a redirect-to-login and break the cold-start gate.
 builder.Services.AddHttpClient<ITierProbeService, HttpTierProbeService>(client =>
 {
     client.BaseAddress = new Uri(builder.HostEnvironment.BaseAddress);
 });
+
+// Everything below calls an endpoint scoped to the SIGNED-IN citizen, so each typed client must
+// carry their bearer token. The host's ambient HttpClient cannot: it is the plain client
+// AuthenticationService itself uses, so it can't depend on the auth handler without a circular
+// dependency. A client registered without the handler here silently sends anonymous requests and
+// gets a 401 — which is exactly how "Couldn't generate a pairing code." reached a signed-in citizen.
 builder.Services.AddHttpClient<IEnrolPairingSignal, EnrolPairingSignal>(client =>
 {
     client.BaseAddress = new Uri(builder.HostEnvironment.BaseAddress);
-});
+}).AddHttpMessageHandler<AuthenticatedHttpMessageHandler>();
+
+// Features 126/128 — mints the enrol-session token (QR) and the 6-digit pairing short code for
+// WalletPairingSurface and PairingHandoffSurface (/setup/add-device).
+builder.Services.AddHttpClient<Sorcha.UI.Core.Services.User.Pairing.IPairingClient,
+                               Sorcha.UI.Core.Services.User.Pairing.PairingClient>(client =>
+{
+    client.BaseAddress = new Uri(builder.HostEnvironment.BaseAddress);
+}).AddHttpMessageHandler<AuthenticatedHttpMessageHandler>();
 
 // Feature 181 US3 (T037) — platform-admin trusted-list snapshot management.
 builder.Services.AddHttpClient<Sorcha.UI.Core.Services.Admin.ITrustedListAdminService,
@@ -128,7 +146,7 @@ builder.Services.AddHttpClient<Sorcha.UI.Core.Services.User.Devices.IHasPairedDe
                                Sorcha.UI.Core.Services.User.Devices.HasPairedDeviceProbe>(client =>
 {
     client.BaseAddress = new Uri(builder.HostEnvironment.BaseAddress);
-});
+}).AddHttpMessageHandler<AuthenticatedHttpMessageHandler>();
 
 // Feature 128 US3 — PWA-installability probe used by PairingHandoffSurface
 // to switch between the QR variant and the install-flavoured variant.

--- a/tests/Sorcha.UI.Components.User.Tests/Services/PairingClientTests.cs
+++ b/tests/Sorcha.UI.Components.User.Tests/Services/PairingClientTests.cs
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Sorcha.UI.Core.Services.User.Pairing;
+using Xunit;
+
+namespace Sorcha.UI.Components.User.Tests.Services;
+
+/// <summary>
+/// Regression for the live n1 bug where a signed-in citizen on <c>/setup/add-device</c> saw
+/// "Couldn't generate a pairing code." The pairing surfaces reached for the host's <b>ambient</b>
+/// <see cref="HttpClient"/>, which in the web client is deliberately anonymous (it is the client
+/// <c>AuthenticationService</c> itself uses, so it cannot carry the auth handler without a circular
+/// dependency). Every mint therefore went out with no <c>Authorization</c> header and the server
+/// correctly answered 401.
+/// <para>
+/// The fix is this seam: a typed client the <b>host</b> registers with its own auth handler. These
+/// tests pin the client's contract — it returns the mint on success and degrades to null (never
+/// throws) on failure, so the surface can render its own message.
+/// </para>
+/// </summary>
+public class PairingClientTests
+{
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        private readonly HttpStatusCode _status;
+        private readonly string _body;
+
+        public StubHandler(HttpStatusCode status, string body = "")
+        {
+            _status = status;
+            _body = body;
+        }
+
+        public HttpRequestMessage? LastRequest { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            LastRequest = request;
+            return Task.FromResult(new HttpResponseMessage(_status)
+            {
+                Content = new StringContent(_body, Encoding.UTF8, "application/json"),
+            });
+        }
+    }
+
+    private static (PairingClient Client, StubHandler Handler) Create(
+        HttpStatusCode status, string body = "")
+    {
+        var handler = new StubHandler(status, body);
+        var http = new HttpClient(handler) { BaseAddress = new Uri("https://n1.sorcha.dev") };
+        return (new PairingClient(http, NullLogger<PairingClient>.Instance), handler);
+    }
+
+    [Fact]
+    public async Task MintAsync_Success_ReturnsTheMintedSession()
+    {
+        var (client, handler) = Create(HttpStatusCode.OK, """
+            {"sessionToken":"eyJhbG.stub","qrUrl":"https://n1.sorcha.dev/wallet/enrol?t=eyJhbG.stub",
+             "expiresAt":"2026-07-13T13:47:52+00:00","mode":"standalone"}
+            """);
+
+        var mint = await client.MintAsync("standalone");
+
+        mint.Should().NotBeNull();
+        mint!.QrUrl.Should().Be("https://n1.sorcha.dev/wallet/enrol?t=eyJhbG.stub");
+        mint.SessionToken.Should().Be("eyJhbG.stub");
+        handler.LastRequest!.RequestUri!.AbsolutePath.Should().Be("/api/auth/enrol-session");
+        handler.LastRequest.Method.Should().Be(HttpMethod.Post);
+    }
+
+    [Fact]
+    public async Task MintAsync_Unauthorized_ReturnsNullRatherThanThrowing()
+    {
+        // The exact live failure. The surface turns null into its own message; it must never see
+        // an exception, and must never mistake a 401 for a successful mint.
+        var (client, _) = Create(HttpStatusCode.Unauthorized);
+
+        var mint = await client.MintAsync("standalone");
+
+        mint.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task MintAsync_NoMode_OmitsTheModeField_PreservingTheGatedDefault()
+    {
+        var (client, handler) = Create(HttpStatusCode.OK, """
+            {"sessionToken":"t","qrUrl":"https://x/e","expiresAt":"2026-07-13T13:47:52+00:00"}
+            """);
+
+        await client.MintAsync(mode: null);
+
+        var body = await handler.LastRequest!.Content!.ReadAsStringAsync();
+        body.Should().NotContain("mode");
+    }
+
+    [Fact]
+    public async Task MintShortCodeAsync_Success_ReturnsTheCode()
+    {
+        var (client, handler) = Create(HttpStatusCode.OK, """
+            {"code":"243806","expiresAt":"2026-07-13T13:47:52+00:00"}
+            """);
+
+        var code = await client.MintShortCodeAsync("MobilewebHandoff");
+
+        code.Should().NotBeNull();
+        code!.Code.Should().Be("243806");
+        handler.LastRequest!.RequestUri!.AbsolutePath.Should().Be("/api/auth/enrol-session/short-code");
+    }
+
+    [Fact]
+    public async Task MintShortCodeAsync_Failure_ReturnsNull_SoTheSurfaceDegradesQuietly()
+    {
+        var (client, _) = Create(HttpStatusCode.Unauthorized);
+
+        var code = await client.MintShortCodeAsync("MobilewebHandoff");
+
+        code.Should().BeNull();
+    }
+}

--- a/tests/Sorcha.UI.Core.Tests/Components/EnrolGate/EnrolGateComponentTests.cs
+++ b/tests/Sorcha.UI.Core.Tests/Components/EnrolGate/EnrolGateComponentTests.cs
@@ -9,6 +9,7 @@ using Moq;
 using Sorcha.UI.Core.Components.EnrolGate;
 using Sorcha.UI.Core.Services;
 using Sorcha.UI.Core.Services.User.Enrolment;
+using Sorcha.UI.Core.Services.User.Pairing;
 using Xunit;
 
 namespace Sorcha.UI.Core.Tests.Components.EnrolGate;
@@ -24,6 +25,7 @@ public sealed class EnrolGateComponentTests : BunitContext
     private readonly Mock<ITierProbeService> _probe = new();
     private readonly Mock<IEnrolPairingSignal> _signal = new();
     private readonly Mock<IQrPresentationService> _qr = new();
+    private readonly Mock<IPairingClient> _pairing = new();
 
     public EnrolGateComponentTests()
     {
@@ -31,6 +33,13 @@ public sealed class EnrolGateComponentTests : BunitContext
         Services.AddSingleton(_probe.Object);
         Services.AddSingleton(_signal.Object);
         Services.AddSingleton(_qr.Object);
+
+        // WalletPairingSurface mints the enrol-session through IPairingClient — a typed client the
+        // HOST registers with its auth handler, so the mint carries the citizen's bearer token.
+        Services.AddSingleton(_pairing.Object);
+        _pairing.Setup(c => c.MintAsync(It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new EnrolSessionMint("jwt", "http://x/?session=jwt",
+                DateTimeOffset.Parse("2030-01-01T00:00:00Z"), null));
         // HttpClient that immediately returns a synthetic whoami payload —
         // EnrolGateComponent.ResolveBoundPlatformUserIdAsync calls
         // GET /api/auth/whoami when tier != ColdStart.
@@ -233,16 +242,15 @@ public sealed class WalletPairingSurfaceCopyTests : BunitContext
 {
     private readonly Mock<IEnrolPairingSignal> _signal = new();
     private readonly Mock<IQrPresentationService> _qr = new();
+    private readonly Mock<IPairingClient> _pairing = new();
 
     public WalletPairingSurfaceCopyTests()
     {
         JSInterop.Mode = JSRuntimeMode.Loose;
         Services.AddSingleton(_signal.Object);
         Services.AddSingleton(_qr.Object);
-        Services.AddSingleton(new HttpClient(new StubHandler())
-        {
-            BaseAddress = new Uri("http://test.local")
-        });
+        Services.AddSingleton(_pairing.Object);
+        MintExpiring(DateTimeOffset.Parse("2030-01-01T00:00:00Z"));
 
         _qr.Setup(q => q.GenerateSvgFromUri(It.IsAny<string>(), It.IsAny<int>()))
             .Returns("<svg/>");
@@ -284,18 +292,9 @@ public sealed class WalletPairingSurfaceCopyTests : BunitContext
     [Fact]
     public void Expired_Token_Surfaces_Regenerate_Affordance()
     {
-        // Mint handler returns a token whose ExpiresAt is in the past.
-        // The component's WatchForExpiryAsync sees delta <= TimeSpan.Zero
-        // and flips _expired immediately. Strip every registered HttpClient
-        // first (bunit's TestContext can register more than one).
-        foreach (var desc in Services.Where(s => s.ServiceType == typeof(HttpClient)).ToList())
-        {
-            Services.Remove(desc);
-        }
-        Services.AddSingleton(new HttpClient(new ExpiredStubHandler())
-        {
-            BaseAddress = new Uri("http://test.local")
-        });
+        // The mint returns a token whose ExpiresAt is already in the past; the component's
+        // WatchForExpiryAsync sees delta <= TimeSpan.Zero and flips _expired immediately.
+        MintExpiring(DateTimeOffset.Parse("2020-01-01T00:00:00Z"));
 
         var cut = Render<WalletPairingSurface>(parameters => parameters
             .Add(p => p.PlatformUserId, Guid.NewGuid())
@@ -309,29 +308,8 @@ public sealed class WalletPairingSurfaceCopyTests : BunitContext
         });
     }
 
-    private sealed class StubHandler : HttpMessageHandler
-    {
-        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
-        {
-            return Task.FromResult(new HttpResponseMessage(System.Net.HttpStatusCode.OK)
-            {
-                Content = new StringContent(
-                    "{\"sessionToken\":\"jwt\",\"qrUrl\":\"http://x/?session=jwt\",\"expiresAt\":\"2030-01-01T00:00:00Z\"}",
-                    System.Text.Encoding.UTF8, "application/json")
-            });
-        }
-    }
-
-    private sealed class ExpiredStubHandler : HttpMessageHandler
-    {
-        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
-        {
-            return Task.FromResult(new HttpResponseMessage(System.Net.HttpStatusCode.OK)
-            {
-                Content = new StringContent(
-                    "{\"sessionToken\":\"jwt\",\"qrUrl\":\"http://x/?session=jwt\",\"expiresAt\":\"2020-01-01T00:00:00Z\"}",
-                    System.Text.Encoding.UTF8, "application/json")
-            });
-        }
-    }
+    /// <summary>Stubs the enrol-session mint with a token expiring at the given instant.</summary>
+    private void MintExpiring(DateTimeOffset expiresAt) =>
+        _pairing.Setup(c => c.MintAsync(It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new EnrolSessionMint("jwt", "http://x/?session=jwt", expiresAt, null));
 }

--- a/tests/Sorcha.UI.Core.Tests/Components/Pairing/PairingHandoffSurfaceTests.cs
+++ b/tests/Sorcha.UI.Core.Tests/Components/Pairing/PairingHandoffSurfaceTests.cs
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using Bunit;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Sorcha.UI.Core.Components.Pairing;
+using Sorcha.UI.Core.Services;
+using Sorcha.UI.Core.Services.User.Pairing;
+using Xunit;
+
+namespace Sorcha.UI.Core.Tests.Components.Pairing;
+
+/// <summary>
+/// Regression for the live n1 bug: a signed-in citizen landing on <c>/setup/add-device</c> saw
+/// "Couldn't generate a pairing code." every time. The surface was minting through the host's
+/// <b>ambient</b> HttpClient, which in the web client is deliberately anonymous — so the mint went
+/// out with no bearer token and the server answered 401.
+/// <para>
+/// The surface now mints through <see cref="IPairingClient"/>, a typed client the host registers
+/// with its own auth handler. These tests pin the two outcomes that matter: a successful mint renders
+/// the QR (never the error), and only a genuinely failed mint renders the error.
+/// </para>
+/// </summary>
+public sealed class PairingHandoffSurfaceTests : BunitContext
+{
+    private readonly Mock<IPairingClient> _pairing = new();
+    private readonly Mock<IPwaInstallabilityProbe> _install = new();
+    private readonly Mock<IQrPresentationService> _qr = new();
+
+    public PairingHandoffSurfaceTests()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        Services.AddSingleton(_pairing.Object);
+        Services.AddSingleton(_install.Object);
+        Services.AddSingleton(_qr.Object);
+
+        _qr.Setup(q => q.GenerateSvgFromUri(It.IsAny<string>(), It.IsAny<int>()))
+            .Returns("<svg data-testid=\"stub-qr\"/>");
+
+        // Desktop: the QR variant, which is the surface the web citizen actually lands on.
+        _install.Setup(p => p.ProbeAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(PwaInstallabilityVerdict.CannotInstall);
+    }
+
+    [Fact]
+    public void SuccessfulMint_RendersTheQr_AndNotTheError()
+    {
+        _pairing.Setup(c => c.MintAsync("standalone", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new EnrolSessionMint(
+                "jwt", "https://n1.sorcha.dev/wallet/enrol?t=jwt",
+                DateTimeOffset.UtcNow.AddMinutes(10), "standalone"));
+
+        var cut = Render<PairingHandoffSurface>();
+
+        cut.WaitForAssertion(() =>
+        {
+            cut.Markup.Should().NotContain("Couldn't generate a pairing code",
+                "a signed-in citizen whose mint succeeded must never see the failure message");
+            cut.Markup.Should().Contain("data-testid=\"stub-qr\"");
+        });
+    }
+
+    [Fact]
+    public void FailedMint_RendersTheErrorAndARetry()
+    {
+        // The client returns null on any non-success (401, 500, network) — it never throws.
+        _pairing.Setup(c => c.MintAsync("standalone", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((EnrolSessionMint?)null);
+
+        var cut = Render<PairingHandoffSurface>();
+
+        cut.WaitForAssertion(() =>
+        {
+            cut.Markup.Should().Contain("Couldn't generate a pairing code");
+            cut.Markup.Should().Contain("data-testid=\"pairing-handoff-retry\"");
+        });
+    }
+
+    [Fact]
+    public void InstallVariant_MintsTheShortCode_AndRendersIt()
+    {
+        _install.Setup(p => p.ProbeAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(PwaInstallabilityVerdict.CanInstallProgrammatically);
+        _pairing.Setup(c => c.MintAsync("standalone", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new EnrolSessionMint(
+                "jwt", "https://n1.sorcha.dev/wallet/enrol?t=jwt",
+                DateTimeOffset.UtcNow.AddMinutes(10), "standalone"));
+        _pairing.Setup(c => c.MintShortCodeAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PairingShortCode("243806", DateTimeOffset.UtcNow.AddMinutes(5)));
+
+        var cut = Render<PairingHandoffSurface>();
+
+        cut.WaitForAssertion(() => cut.Markup.Should().Contain("243806"));
+    }
+}


### PR DESCRIPTION
Found while verifying #1164 on n1: a **signed-in citizen** landing on `/setup/add-device` always saw **"Couldn't generate a pairing code."**

## Root cause (not what it looks like)

This is not an auth-policy or tier problem. On the wire, the failing request carried **no `Authorization` header at all**, while sibling calls on the same page carried a perfectly good consumer-tier bearer:

| Call | Auth header | Result |
|---|---|---|
| `GET /api/auth/me/organizations` | ✅ Bearer (aud `n1.sorcha.dev:consumer`) | 200 |
| `POST /api/auth/enrol-session` | ❌ **none** | 401 |
| `GET /api/v1/me/devices/has-any` | ❌ **none** | 401 |

Replaying the same POST *with* the citizen's own token returns **200** and mints the code (`{"code":"243806",…}`). The server was healthy all along.

**Why:** in `Sorcha.UI.Web.Client` the ambient `HttpClient` is *deliberately* plain — it's the client `AuthenticationService` itself uses, so it can't depend on the auth handler without a circular dependency (`ServiceCollectionExtensions.cs:51`). Every other authenticated service therefore builds its own client wrapped in `AuthenticatedHttpMessageHandler`. But the F126/F128 pairing surfaces `@inject HttpClient` directly, and the F126/F128 typed clients were registered with a `BaseAddress` and **no handler** — the very contract `HasPairedDeviceProbe`'s own XML doc says the host must satisfy.

Four citizen-scoped endpoints were affected: `enrol-session` (the QR), `enrol-session/short-code`, `pairing-resumption-email`, and `me/devices/has-any` — which is also why the `PairingNagBanner` never appeared for anyone.

## The fix (at the seam, not the symptom)

- **New `IPairingClient` / `PairingClient`** in `Sorcha.UI.Components.User` — the pairing endpoints as a typed client the **host** registers with its own auth handler, mirroring the `IHasPairedDeviceProbe` contract. Degrades to `null`/`false`; never throws.
- `PairingHandoffSurface` + `WalletPairingSurface` mint through it instead of reaching for the ambient client.
- Web client registers `IPairingClient`, `IEnrolPairingSignal` and `IHasPairedDeviceProbe` **with** `AuthenticatedHttpMessageHandler`.
- **`ITierProbeService` is deliberately left anonymous** — a 401 from `/whoami` *is* its answer ("cold-start visitor, tier 3"). Attaching the handler would turn that expected 401 into a redirect-to-login and break the cold-start gate.
- The sample council portal registers the plain client (it has no user session of its own) — behaviour unchanged.

## Tests

`PairingClientTests` pins the 401→null contract. `PairingHandoffSurfaceTests` pins the bug itself: a successful mint renders the QR and **never** the error; only a genuinely failed mint renders the error + retry. UI.Core **1465** green, Components.User **65** green, solution builds clean.

## Same defect, not fixed here

The F181 admin clients (`ITrustedListAdminService`, `IOrgCertificateAdminService`) are registered without an auth handler too and will 401 on the admin pages. Left alone — different feature, unverified, and I didn't want to bundle it. Happy to follow up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)