### PR TITLE
fix: [128] enrolment QR pointed at a fictional council domain

### DIFF
--- a/docker-compose.n1.yml
+++ b/docker-compose.n1.yml
@@ -83,6 +83,11 @@ services:
       # redirect_uri_mismatch errors. Set the public origin explicitly per
       # feature 115 FR-021.
       OAuth__CallbackBaseUrl: https://n1.sorcha.dev
+      # The enrolment QR sends the citizen's phone to THIS installation's wallet PWA
+      # (/wallet/enrol), so it must carry n1's origin. Unset, the service falls back to
+      # Email:BaseUrl — which the smtp override supplies — but pin it here so a standing
+      # `up` without the smtp override can never emit a QR pointing at the demo domain.
+      EnrolSession__CouncilOrigin: https://n1.sorcha.dev
       # Social login providers — feature 115. ClientId/ClientSecret are
       # interpolated from the host's /opt/sorcha/.env file (gitignored).
       # Buttons for unconfigured providers are hidden client-side, so leaving

--- a/src/Services/Sorcha.Tenant.Service/Services/EnrolSessionService.cs
+++ b/src/Services/Sorcha.Tenant.Service/Services/EnrolSessionService.cs
@@ -66,8 +66,26 @@ public sealed class EnrolSessionService : IEnrolSessionService
     private readonly SigningCredentials _signingCreds;
     private readonly SorchaAudiences _audiences;
 
-    /// <summary>Configuration key for the QR-URL council origin template.</summary>
+    /// <summary>
+    /// Configuration key overriding the origin the enrolment QR points at. Rarely needed: the QR opens
+    /// the <b>wallet PWA</b>, which this installation serves at <c>/wallet/enrol</c>, so the platform's
+    /// own public origin (<see cref="PublicOriginFallbackConfigKey"/>) is the right answer almost
+    /// everywhere — including when the citizen scans it from a third-party council page.
+    /// </summary>
     public const string CouncilOriginConfigKey = "EnrolSession:CouncilOrigin";
+
+    /// <summary>
+    /// The installation's public origin, already configured on every real deployment (it is what
+    /// verification and invitation links are built from). Used as the QR origin when
+    /// <see cref="CouncilOriginConfigKey"/> is not set.
+    /// </summary>
+    public const string PublicOriginFallbackConfigKey = "Email:BaseUrl";
+
+    /// <summary>
+    /// Last-resort origin for a dev box that has configured neither key. It is a <b>fictional</b>
+    /// council domain, so a QR built from it goes nowhere — hence the loud warning at startup.
+    /// </summary>
+    private const string DemoOriginOfLastResort = "https://strathcarron.gov";
 
     private readonly string _councilOrigin;
 
@@ -110,8 +128,22 @@ public sealed class EnrolSessionService : IEnrolSessionService
         _signingKey = new SymmetricSecurityKey(keyBytes);
         _signingCreds = new SigningCredentials(_signingKey, SecurityAlgorithms.HmacSha256);
 
+        // The QR sends the citizen's phone to THIS installation's wallet PWA, so default to the
+        // installation's public origin rather than a council's. Falling through to the demo domain
+        // means the deployment configured neither key — the QR would point at a domain the operator
+        // does not own, so say so loudly rather than shipping a dead QR silently.
         _councilOrigin = configuration[CouncilOriginConfigKey]
-            ?? "https://strathcarron.gov";
+            ?? configuration[PublicOriginFallbackConfigKey]
+            ?? DemoOriginOfLastResort;
+
+        if (string.Equals(_councilOrigin, DemoOriginOfLastResort, StringComparison.OrdinalIgnoreCase))
+        {
+            _logger.LogWarning(
+                "Enrolment QR codes will point at {Origin} — a fictional demo domain — because neither "
+                + "{OverrideKey} nor {FallbackKey} is configured. Scanning such a QR will go nowhere. "
+                + "Set {FallbackKey} to this installation's public origin.",
+                DemoOriginOfLastResort, CouncilOriginConfigKey, PublicOriginFallbackConfigKey);
+        }
     }
 
     /// <inheritdoc />

--- a/tests/Sorcha.Tenant.Service.Tests/Services/EnrolSessionQrOriginTests.cs
+++ b/tests/Sorcha.Tenant.Service.Tests/Services/EnrolSessionQrOriginTests.cs
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Sorcha.AtomicCache;
+using Sorcha.Tenant.Service.Extensions;
+using Sorcha.Tenant.Service.Models;
+using Sorcha.Tenant.Service.Services;
+
+namespace Sorcha.Tenant.Service.Tests.Services;
+
+/// <summary>
+/// The enrolment QR sends the citizen's phone to the <b>wallet PWA</b>, which this installation
+/// serves at <c>/wallet/enrol</c> — so the QR must carry this installation's own origin.
+/// <para>
+/// Found live on n1: <c>EnrolSession:CouncilOrigin</c> was unset, so the QR fell back to the
+/// hard-coded <c>https://strathcarron.gov</c> — a fictional demo council — and scanning it went
+/// nowhere. Every real deployment already configures its public origin (it is what verification
+/// links are built from), so that is now the fallback.
+/// </para>
+/// </summary>
+public sealed class EnrolSessionQrOriginTests
+{
+    private static EnrolSessionService CreateService(params (string Key, string Value)[] settings)
+    {
+        var jwt = new JwtConfiguration
+        {
+            SigningKey = "test-signing-key-please-be-at-least-32-bytes-long-aaaaa",
+            Issuer = "sorcha-test",
+            Audiences = ["sorcha:citizen-wallet"],
+            AccessTokenLifetimeMinutes = 60,
+        };
+
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(settings.Select(s =>
+                new KeyValuePair<string, string?>(s.Key, s.Value)))
+            .Build();
+
+        return new EnrolSessionService(
+            Options.Create(jwt),
+            new InMemoryAtomicDistributedCache(),
+            new Mock<IPlatformUserService>().Object,
+            new EnrolSessionMetrics(new TestMeterFactory()),
+            config,
+            new FakeTimeProvider(),
+            NullLogger<EnrolSessionService>.Instance);
+    }
+
+    [Fact]
+    public async Task QrUrl_FallsBackToTheInstallationsPublicOrigin_NotAFictionalCouncil()
+    {
+        // n1's actual configuration: the public origin is set, the council override is not.
+        var service = CreateService((EnrolSessionService.PublicOriginFallbackConfigKey, "https://n1.sorcha.dev"));
+
+        var response = await service.MintAsync(Guid.NewGuid(), EnrolSessionMode.Standalone, CancellationToken.None);
+
+        response.QrUrl.Should().StartWith("https://n1.sorcha.dev/wallet/enrol?session=");
+        response.QrUrl.Should().NotContain("strathcarron.gov");
+    }
+
+    [Fact]
+    public async Task QrUrl_ExplicitCouncilOrigin_WinsOverThePublicOrigin()
+    {
+        var service = CreateService(
+            (EnrolSessionService.CouncilOriginConfigKey, "https://wallet.example.gov"),
+            (EnrolSessionService.PublicOriginFallbackConfigKey, "https://n1.sorcha.dev"));
+
+        var response = await service.MintAsync(Guid.NewGuid(), EnrolSessionMode.Standalone, CancellationToken.None);
+
+        response.QrUrl.Should().StartWith("https://wallet.example.gov/wallet/enrol?session=");
+    }
+
+    [Fact]
+    public async Task QrUrl_TrailingSlashOnTheOrigin_DoesNotDoubleUpTheSeparator()
+    {
+        var service = CreateService((EnrolSessionService.PublicOriginFallbackConfigKey, "https://n1.sorcha.dev/"));
+
+        var response = await service.MintAsync(Guid.NewGuid(), EnrolSessionMode.Standalone, CancellationToken.None);
+
+        response.QrUrl.Should().StartWith("https://n1.sorcha.dev/wallet/enrol?session=");
+    }
+
+    private sealed class TestMeterFactory : System.Diagnostics.Metrics.IMeterFactory
+    {
+        public System.Diagnostics.Metrics.Meter Create(System.Diagnostics.Metrics.MeterOptions options)
+            => new(options);
+
+        public void Dispose() { }
+    }
+
+    private sealed class FakeTimeProvider : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() => DateTimeOffset.UtcNow;
+    }
+}


### PR DESCRIPTION
Follow-on from #1165. With pairing unblocked, the QR renders — but it encodes **`https://strathcarron.gov/wallet/enrol?session=…`**, a fictional demo council. Scanning it goes nowhere, so pairing still couldn't complete on n1.

`EnrolSession:CouncilOrigin` was unset, and the service fell back to that hard-coded default.

## Why the default was wrong

The QR opens the **wallet PWA**, which *this installation* serves at `/wallet/enrol` — never the council's site, even when the citizen scans it from a council page. So the installation's own public origin is the correct answer essentially everywhere. Every real deployment already configures one (`Email:BaseUrl` is what verification and invitation links are built from — n1 sets it, as it does `OAuth__CallbackBaseUrl`).

New fallback chain:

```
EnrolSession:CouncilOrigin  ->  Email:BaseUrl  ->  demo domain (with a loud startup warning)
```

Landing on the demo domain now **logs a warning naming the keys to set**, instead of silently shipping a dead QR. n1's compose also pins the origin explicitly, so a standing `up` without the smtp override can't regress.

## Tests

`EnrolSessionQrOriginTests` — public-origin fallback, explicit override wins, trailing-slash safety. Tenant.Service **1528** green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)