### PR TITLE
fix: [181] admin trusted-list + org-cert clients sent anonymous requests

### DIFF
--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/Admin/IOrgCertificateAdminService.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/Admin/IOrgCertificateAdminService.cs
@@ -9,7 +9,8 @@ namespace Sorcha.UI.Core.Services.Admin;
 /// org's internal + imported certificates with status/validity/chain summary and eligibility, and
 /// drives re-issue (enrol), CSR generation, external-cert import, and retire/delete. Mirrors
 /// <see cref="ITrustedListAdminService"/> in shape (typed HttpClient, record DTOs, <c>*Outcome</c>
-/// result types for the 422-carrying calls). Auth rides the browser session (platform tier).
+/// result types for the 422-carrying calls).
+/// The host registers this typed client with <c>AuthenticatedHttpMessageHandler</c>, which attaches the admin's bearer token — there is no browser session to ride: the WASM client sends no cookie, and these endpoints are admin + platform-audience gated. Registered without that handler, every call 401s (and the swallowed failure renders as a plausible "nothing here yet" empty state).
 /// </summary>
 public interface IOrgCertificateAdminService
 {

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/Admin/OrgCertificateAdminService.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/Admin/OrgCertificateAdminService.cs
@@ -12,7 +12,9 @@ namespace Sorcha.UI.Core.Services.Admin;
 /// <summary>
 /// Feature 181 US5 (T050) — HTTP-backed <see cref="IOrgCertificateAdminService"/>. Talks to the
 /// gateway, which routes <c>/api/v1/trust/tenants/{tenantId}/orgs/{orgWalletAddress}</c> to the
-/// Tenant Service. Auth rides the browser session (platform tier). Mirrors
+/// Tenant Service.
+/// The host registers this typed client with <c>AuthenticatedHttpMessageHandler</c>, which attaches the admin's bearer token — there is no browser session to ride: the WASM client sends no cookie, and these endpoints are admin + platform-audience gated. Registered without that handler, every call 401s (and the swallowed failure renders as a plausible "nothing here yet" empty state).
+/// Mirrors
 /// <see cref="TrustedListAdminService"/> in structure and error handling.
 /// </summary>
 public sealed class OrgCertificateAdminService : IOrgCertificateAdminService

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/Admin/TrustedListAdminService.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/Admin/TrustedListAdminService.cs
@@ -12,7 +12,8 @@ namespace Sorcha.UI.Core.Services.Admin;
 
 /// <summary>
 /// Feature 181 US3 (T037) — HTTP-backed <see cref="ITrustedListAdminService"/>. Talks to the gateway,
-/// which routes <c>/api/v1/trust/trustlists</c> to the Tenant Service. Auth rides the browser session.
+/// which routes <c>/api/v1/trust/trustlists</c> to the Tenant Service.
+/// The host registers this typed client with <c>AuthenticatedHttpMessageHandler</c>, which attaches the admin's bearer token — there is no browser session to ride: the WASM client sends no cookie, and these endpoints are admin + platform-audience gated. Registered without that handler, every call 401s (and the swallowed failure renders as a plausible "nothing here yet" empty state).
 /// </summary>
 public sealed class TrustedListAdminService : ITrustedListAdminService
 {

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Program.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Program.cs
@@ -124,19 +124,20 @@ builder.Services.AddHttpClient<Sorcha.UI.Core.Services.User.Pairing.IPairingClie
     client.BaseAddress = new Uri(builder.HostEnvironment.BaseAddress);
 }).AddHttpMessageHandler<AuthenticatedHttpMessageHandler>();
 
-// Feature 181 US3 (T037) — platform-admin trusted-list snapshot management.
+// Feature 181 US3 (T037) — platform-admin trusted-list snapshot management. The endpoints are
+// admin + platform-audience gated, so the client must carry the admin's bearer token.
 builder.Services.AddHttpClient<Sorcha.UI.Core.Services.Admin.ITrustedListAdminService,
     Sorcha.UI.Core.Services.Admin.TrustedListAdminService>(client =>
 {
     client.BaseAddress = new Uri(builder.HostEnvironment.BaseAddress);
-});
+}).AddHttpMessageHandler<AuthenticatedHttpMessageHandler>();
 
 // Feature 181 US5 (T050) — org-admin X.509 certificate lifecycle management.
 builder.Services.AddHttpClient<Sorcha.UI.Core.Services.Admin.IOrgCertificateAdminService,
     Sorcha.UI.Core.Services.Admin.OrgCertificateAdminService>(client =>
 {
     client.BaseAddress = new Uri(builder.HostEnvironment.BaseAddress);
-});
+}).AddHttpMessageHandler<AuthenticatedHttpMessageHandler>();
 
 // Feature 128 — shared has-any-device probe. Drives the PairingNagBanner
 // on every MainLayout render for signed-in citizens with zero paired


### PR DESCRIPTION
The follow-up I flagged in #1165. **Confirmed live on n1 as an administrator**, so it's no longer a suspicion:

`GET /api/v1/trust/trustlists` goes out with **no `Authorization` header** and returns **401** — while every other authed call on the same page (including `me/devices/has-any`, fixed in #1165) returns 200.

## Worse than the pairing bug, because it's silent

`TrustedListAdminService.ListAsync` catches the failure and returns an empty list, so `/app/admin/trusted-lists` renders:

> **No trusted lists imported yet.**

A plausible empty state, not an error. An admin would conclude the feature is simply unused. That's how this went unnoticed.

## Root cause (same as #1165)

The web client's ambient `HttpClient` is deliberately plain — it's the client `AuthenticationService` itself uses — so a typed client registered without `AuthenticatedHttpMessageHandler` silently sends anonymous requests. Both F181 admin clients were registered that way.

The **proximate** cause is a false claim in their own XML docs:

> *"Auth rides the browser session (platform tier)."*

Untrue in a WASM client: it sends no cookie, and these endpoints are admin + platform-audience gated. Corrected across all three files so the next reader isn't misled into the same mistake.

## Change

- `ITrustedListAdminService` and `IOrgCertificateAdminService` registrations get `.AddHttpMessageHandler<AuthenticatedHttpMessageHandler>()`.
- The three misleading doc comments now say what actually carries the token.

UI.Core **1465** green; builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)