### PR TITLE
fix: [108] node was a "subscriber" to registers it owns — and pulled from itself

### DIFF
--- a/src/Services/Sorcha.Peer.Service/Replication/RegisterSourceAuthority.cs
+++ b/src/Services/Sorcha.Peer.Service/Replication/RegisterSourceAuthority.cs
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using Sorcha.Register.Models.LocalRelationship;
+
+namespace Sorcha.Peer.Service.Replication;
+
+/// <summary>
+/// Decides whether this node already holds a register authoritatively — in which case it is the
+/// <b>source</b> of that register's chain and has nothing to pull from anyone.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is the rule that stops a node pulling from itself. The genesis/seed node subscribes to the
+/// system register so it advertises and serves it, but that also put it on the pull path: the
+/// replication service looked for source peers, found none (there are none — it IS the source),
+/// failed, and left the subscription in <c>Syncing</c> forever. That surfaced to operators as a
+/// permanently "Recovering" system register that was in fact perfectly healthy.
+/// </para>
+/// <para>
+/// The discriminator is deliberately the register's own <b>control record</b> (Feature 108: does this
+/// node own it, or is its docket-signing key on the validator roster?) and NOT "are there any peers?".
+/// A genuine subscriber that momentarily has no reachable peers must keep trying; only the
+/// relationship separates "nobody to pull from" from "nothing to pull".
+/// </para>
+/// </remarks>
+internal static class RegisterSourceAuthority
+{
+    /// <summary>
+    /// True when <paramref name="relationship"/> shows this node owns or validates the register.
+    /// A null / indeterminate relationship answers <b>false</b>: the node then attempts the pull,
+    /// because wrongly pulling costs a round-trip whereas wrongly declining to pull would leave a
+    /// real subscriber permanently stale.
+    /// </summary>
+    internal static bool IsAuthoritativeSource(RegisterLocalRelationship? relationship)
+        => relationship is { } r && (r.IsOwner || r.IsValidator);
+}

--- a/src/Services/Sorcha.Peer.Service/Replication/RegisterSyncBackgroundService.cs
+++ b/src/Services/Sorcha.Peer.Service/Replication/RegisterSyncBackgroundService.cs
@@ -428,6 +428,30 @@ public class RegisterSyncBackgroundService : BackgroundService
                 break;
 
             case RegisterSyncState.Syncing:
+                // A node cannot pull a register it is itself the source of. The genesis/seed node
+                // subscribes to the system register (SystemRegisterBootstrapper) so it ADVERTISES and
+                // SERVES it — but that put it on the pull path too, where PullFullReplicaAsync found
+                // "no source peers" (there are none — it IS the source), never succeeded, and so the
+                // subscription sat in Syncing forever. Register Service maps Syncing → Recovery, so a
+                // perfectly healthy system register reported itself as being in recovery, permanently.
+                //
+                // The honest discriminator is the register's own control record: this node is on its
+                // validator roster (or holds an owning attestation), so it already holds the
+                // authoritative chain. Nothing to pull — go straight to FullyReplicated and start
+                // serving.
+                if (await IsAuthoritativeSourceAsync(subscription.RegisterId, cancellationToken))
+                {
+                    subscription.TransitionToNextState();
+                    _logger.LogInformation(
+                        "Register {RegisterId} is served by this node (owner/validator) — nothing to pull; "
+                        + "marking fully replicated",
+                        subscription.RegisterId);
+                    await PersistSubscriptionAsync(subscription, cancellationToken);
+                    await ReportSyncStatusAsync(subscription.RegisterId, subscription.SyncState, cancellationToken);
+                    _immediateSyncSignal.Set();
+                    break;
+                }
+
                 // Full replica mode: pull docket chain
                 await ReportSyncStatusAsync(subscription.RegisterId, RegisterSyncState.Syncing, cancellationToken);
                 var result = await _replicationService.PullFullReplicaAsync(subscription, cancellationToken);
@@ -750,6 +774,40 @@ public class RegisterSyncBackgroundService : BackgroundService
     {
         CancelOfflineDebounce(registerId);
         await ReportSyncStatusAsync(registerId, RegisterSyncState.Subscribing, cancellationToken);
+    }
+
+    /// <summary>
+    /// True when this node already holds the register authoritatively — it owns it, or its
+    /// docket-signing key is on the register's validator roster — so there is nothing to pull.
+    /// </summary>
+    /// <remarks>
+    /// Derived from the register's control record via the Feature 108 relationship (the same signal
+    /// T017 uses to pick a sealer), NOT from "are there any peers?" — a genuine subscriber with no
+    /// reachable peers must keep trying, and only the relationship distinguishes the two.
+    /// <para>
+    /// Fail-safe: an unavailable or indeterminate relationship answers <c>false</c>, so the node falls
+    /// back to attempting the pull. Wrongly pulling is a wasted round-trip; wrongly declining to pull
+    /// would leave a real subscriber permanently stale.
+    /// </para>
+    /// </remarks>
+    private async Task<bool> IsAuthoritativeSourceAsync(string registerId, CancellationToken cancellationToken)
+    {
+        try
+        {
+            using var scope = _scopeFactory.CreateScope();
+            var registerClient = scope.ServiceProvider.GetRequiredService<IRegisterServiceClient>();
+
+            var relationship = await registerClient.GetLocalRelationshipAsync(registerId, cancellationToken);
+            return RegisterSourceAuthority.IsAuthoritativeSource(relationship);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex,
+                "Could not derive the local relationship for register {RegisterId}; assuming this node is "
+                + "not the source and attempting a pull",
+                registerId);
+            return false;
+        }
     }
 
     /// <summary>

--- a/src/Services/Sorcha.Register.Service/Program.cs
+++ b/src/Services/Sorcha.Register.Service/Program.cs
@@ -149,9 +149,14 @@ builder.Services.Configure<Sorcha.Register.Core.LocalRelationship.LocalIdentityO
     builder.Configuration.GetSection("LocalIdentity"));
 builder.Services.Configure<Sorcha.Register.Core.SyncState.RegisterSyncStateOptions>(
     builder.Configuration.GetSection("RegisterSyncState"));
+// Resolve this node's identity from the system wallet it actually signs with, not from static
+// config. LocalIdentity:* is set on no deployment, so the configured provider resolved an EMPTY
+// identity and every register derived as Subscriber — a node was a "subscriber" to the very
+// registers it owns, validates and seals. Configured values still win when present (dev/test seam);
+// the wallet is the fallback, and an unreachable wallet fails safe to Subscriber.
 builder.Services.AddSingleton<
     Sorcha.Register.Core.LocalRelationship.ILocalIdentityProvider,
-    Sorcha.Register.Core.LocalRelationship.ConfiguredLocalIdentityProvider>();
+    Sorcha.Register.Service.Services.SystemWalletLocalIdentityProvider>();
 builder.Services.AddSingleton<
     Sorcha.Register.Core.LocalRelationship.IRegisterLocalRelationshipService,
     Sorcha.Register.Core.LocalRelationship.RegisterLocalRelationshipService>();
@@ -511,11 +516,12 @@ app.MapPost("/api/internal/register-sync-status", async (
     if (register == null)
         return Results.NotFound(new { error = $"Register '{report.RegisterId}' not found" });
 
-    // Map peer sync state to RegisterStatus
+    // Map peer sync state to RegisterStatus. A replica pulling chain data is CHECKING, not in
+    // RECOVERY — "Recovery" reads as data loss, and this is the ordinary path every joining node
+    // takes. Recovery/Offline stay reserved for a register that is actually unwell.
     var newStatus = report.SyncState switch
     {
-        "Subscribing" => RegisterStatus.Checking,
-        "Syncing" => RegisterStatus.Recovery,
+        "Subscribing" or "Syncing" => RegisterStatus.Checking,
         "FullyReplicated" or "Active" => RegisterStatus.Online,
         "Error" => RegisterStatus.Offline,
         _ when !report.PeerConnectionActive => RegisterStatus.Offline,

--- a/src/Services/Sorcha.Register.Service/Services/SystemWalletLocalIdentityProvider.cs
+++ b/src/Services/Sorcha.Register.Service/Services/SystemWalletLocalIdentityProvider.cs
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using Microsoft.Extensions.Options;
+using Sorcha.Register.Core.LocalRelationship;
+using Sorcha.ServiceClients.SystemWallet;
+
+namespace Sorcha.Register.Service.Services;
+
+/// <summary>
+/// Resolves this node's identity (Feature 108) from the <b>system wallet it actually signs with</b>,
+/// rather than from static configuration.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The static <see cref="ConfiguredLocalIdentityProvider"/> reads <c>LocalIdentity:*</c> from
+/// appsettings — and nothing sets those keys, on any deployment. So every node resolved an
+/// <b>empty</b> identity and therefore derived <i>every</i> register as
+/// <c>IsSubscriber</c>: a node was a mere subscriber to registers it owned, validated and sealed.
+/// Two things fell out of that on n1: the system register sat permanently in "Syncing"/"Recovery"
+/// (the peer service tried to pull a register this node is itself the source of), and the F145/T017
+/// roster-based sealer selection always answered "subscriber" — right outcome on a single node only
+/// because the fan-out found no peers.
+/// </para>
+/// <para>
+/// The node's real claim on a register is <b>Validator</b>: its <c>sorcha:docket-signing</c> key is on
+/// the register's roster and it seals the dockets. That key is already derivable here — it is exactly
+/// how <c>RegisterCreationOrchestrator</c> populates the roster of every register this node creates —
+/// so this provider resolves it from the same source of truth. Deriving it any other way would
+/// invite the two to drift.
+/// </para>
+/// <para>
+/// <b>Fail-safe:</b> if the wallet cannot be reached, this falls back to the configured identity and
+/// ultimately to <see cref="LocalIdentitySnapshot.Empty"/> — i.e. plain subscriber, which claims
+/// nothing. A node must never assert ownership or validator rights it cannot prove.
+/// </para>
+/// </remarks>
+public sealed class SystemWalletLocalIdentityProvider : ILocalIdentityProvider
+{
+    /// <summary>The derivation context whose public key appears on a register's validator roster.</summary>
+    private const string DocketSigningPath = "sorcha:docket-signing";
+
+    /// <summary>
+    /// A zeroed hash. We sign it only to learn the derived public key — the signature is discarded.
+    /// (Same trick as <c>RegisterCreationOrchestrator</c>; both want a "derive public key" call the
+    /// wallet client does not yet expose.)
+    /// </summary>
+    private const string ZeroHash = "0000000000000000000000000000000000000000000000000000000000000000";
+
+    private readonly ISystemWalletSigningService _signingService;
+    private readonly IOptionsMonitor<LocalIdentityOptions> _options;
+    private readonly ILogger<SystemWalletLocalIdentityProvider> _logger;
+
+    private readonly SemaphoreSlim _gate = new(1, 1);
+    private LocalIdentitySnapshot? _cached;
+
+    /// <summary>Initialises a new <see cref="SystemWalletLocalIdentityProvider"/>.</summary>
+    public SystemWalletLocalIdentityProvider(
+        ISystemWalletSigningService signingService,
+        IOptionsMonitor<LocalIdentityOptions> options,
+        ILogger<SystemWalletLocalIdentityProvider> logger)
+    {
+        _signingService = signingService ?? throw new ArgumentNullException(nameof(signingService));
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _options.OnChange(_ => Invalidate());
+    }
+
+    /// <inheritdoc />
+    public async ValueTask<LocalIdentitySnapshot> GetAsync(CancellationToken cancellationToken = default)
+    {
+        if (_cached is { } cached)
+            return cached;
+
+        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            if (_cached is { } again)
+                return again;
+
+            _cached = await ResolveAsync(cancellationToken).ConfigureAwait(false);
+            return _cached;
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    /// <inheritdoc />
+    public void Invalidate() => _cached = null;
+
+    private async Task<LocalIdentitySnapshot> ResolveAsync(CancellationToken ct)
+    {
+        // Configured values are an override / test seam; they win when present.
+        var configured = _options.CurrentValue;
+        var wallets = new List<string>(configured.WalletAddresses ?? []);
+        byte[]? validatorKey = TryDecodeConfiguredValidatorKey(configured);
+
+        if (validatorKey is null || wallets.Count == 0)
+        {
+            try
+            {
+                var derived = await _signingService.SignAsync(
+                    registerId: "local-identity",
+                    txId: "local-identity-key-derivation",
+                    payloadHash: ZeroHash,
+                    derivationPath: DocketSigningPath,
+                    transactionType: "ValidatorKeyDerivation",
+                    ct).ConfigureAwait(false);
+
+                validatorKey ??= derived.PublicKey;
+
+                if (!string.IsNullOrEmpty(derived.WalletAddress) &&
+                    !wallets.Contains(derived.WalletAddress, StringComparer.Ordinal))
+                {
+                    wallets.Add(derived.WalletAddress);
+                }
+            }
+            catch (Exception ex)
+            {
+                // Fail safe: claim nothing. A node that cannot prove its validator key must not
+                // assert validator rights — it simply derives as a subscriber, as it did before.
+                _logger.LogWarning(ex,
+                    "Could not resolve the local validator key from the system wallet. This node will "
+                    + "derive every register relationship as Subscriber, so it will not recognise "
+                    + "registers it owns or validates.");
+            }
+        }
+
+        var snapshot = new LocalIdentitySnapshot(wallets, validatorKey);
+
+        _logger.LogInformation(
+            "LocalIdentity resolved from the system wallet — {WalletCount} wallet(s), validator key {KeyPresent}",
+            snapshot.WalletAddresses.Count,
+            snapshot.ValidatorPublicKey is null ? "absent" : "present");
+
+        return snapshot;
+    }
+
+    private byte[]? TryDecodeConfiguredValidatorKey(LocalIdentityOptions options)
+    {
+        if (string.IsNullOrWhiteSpace(options.ValidatorPublicKeyBase64))
+            return null;
+
+        try
+        {
+            return Convert.FromBase64String(options.ValidatorPublicKeyBase64);
+        }
+        catch (FormatException ex)
+        {
+            _logger.LogWarning(ex,
+                "LocalIdentity:ValidatorPublicKeyBase64 is not valid Base64 — deriving the key from the "
+                + "system wallet instead");
+            return null;
+        }
+    }
+}

--- a/tests/Sorcha.Peer.Service.Tests/Replication/RegisterSourceAuthorityTests.cs
+++ b/tests/Sorcha.Peer.Service.Tests/Replication/RegisterSourceAuthorityTests.cs
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using FluentAssertions;
+using Sorcha.Peer.Service.Replication;
+using Sorcha.Register.Models.LocalRelationship;
+using Xunit;
+
+namespace Sorcha.Peer.Service.Tests.Replication;
+
+/// <summary>
+/// A node must never try to pull a register it is itself the source of.
+/// <para>
+/// Found live on n1: the genesis node subscribes to the system register (so it advertises and serves
+/// it), which also put it on the pull path. Replication looked for source peers, found none — there
+/// are none, it IS the source — failed, and left the subscription in <c>Syncing</c> forever. Register
+/// Service mapped that to "Recovery", so a perfectly healthy system register (height 5, sealing its
+/// own dockets) reported itself as permanently recovering.
+/// </para>
+/// </summary>
+public class RegisterSourceAuthorityTests
+{
+    private static RegisterLocalRelationship Relationship(RegisterRoleSet roles) =>
+        new("reg-1", roles, ControlRecordVersion: 1, DerivedAt: DateTimeOffset.UtcNow);
+
+    [Fact]
+    public void Validator_IsAuthoritativeSource_SoItDoesNotPull()
+    {
+        // The n1 case: this node's docket-signing key is the sole entry on the register's roster and
+        // it seals every docket. It holds the authoritative chain.
+        RegisterSourceAuthority.IsAuthoritativeSource(Relationship(RegisterRoleSet.Validator))
+            .Should().BeTrue();
+    }
+
+    [Fact]
+    public void Owner_IsAuthoritativeSource_SoItDoesNotPull()
+    {
+        RegisterSourceAuthority.IsAuthoritativeSource(Relationship(RegisterRoleSet.Owner))
+            .Should().BeTrue();
+    }
+
+    [Fact]
+    public void Subscriber_IsNotAuthoritative_AndMustKeepPulling()
+    {
+        // The load-bearing negative: a real subscriber that momentarily has no reachable peers must
+        // keep trying. "No peers" must never be mistaken for "nothing to pull".
+        RegisterSourceAuthority.IsAuthoritativeSource(Relationship(RegisterRoleSet.None))
+            .Should().BeFalse();
+    }
+
+    [Fact]
+    public void UnknownRelationship_FailsSafeToPulling()
+    {
+        // Register Service unreachable / relationship indeterminate. Wrongly pulling costs a
+        // round-trip; wrongly declining to pull would strand a subscriber forever.
+        RegisterSourceAuthority.IsAuthoritativeSource(null).Should().BeFalse();
+    }
+
+    [Fact]
+    public void AuditorOrDesigner_AloneIsNotASource()
+    {
+        // Read-only roles on the control record confer no chain authority — such a node still pulls.
+        RegisterSourceAuthority.IsAuthoritativeSource(
+            Relationship(RegisterRoleSet.Auditor | RegisterRoleSet.Designer)).Should().BeFalse();
+    }
+}

--- a/tests/Sorcha.Register.Service.Tests/Unit/SystemWalletLocalIdentityProviderTests.cs
+++ b/tests/Sorcha.Register.Service.Tests/Unit/SystemWalletLocalIdentityProviderTests.cs
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Sorcha.Register.Core.LocalRelationship;
+using Sorcha.Register.Service.Services;
+using Sorcha.ServiceClients.SystemWallet;
+using Xunit;
+
+namespace Sorcha.Register.Service.Tests.Unit;
+
+/// <summary>
+/// Feature 108 — the node's identity must come from the system wallet it actually signs with.
+/// <para>
+/// Found live on n1: <c>LocalIdentity:*</c> is configured on no deployment, so the static provider
+/// resolved an <b>empty</b> identity and every register derived as <c>IsSubscriber</c> — the node was
+/// a "subscriber" to the system register it owns, validates and seals. The peer service then tried to
+/// pull that register from peers that do not exist, leaving it permanently "Syncing" (surfaced as
+/// "Recovery"), and the T017 roster-based sealer selection always answered "subscriber".
+/// </para>
+/// </summary>
+public class SystemWalletLocalIdentityProviderTests
+{
+    private static readonly byte[] DocketSigningKey = [1, 2, 3, 4, 5, 6, 7, 8];
+    private const string SystemWalletAddress = "ws11qsystemwallet";
+
+    private static SystemWalletLocalIdentityProvider Create(
+        Mock<ISystemWalletSigningService> signing,
+        LocalIdentityOptions? configured = null)
+    {
+        var monitor = new Mock<IOptionsMonitor<LocalIdentityOptions>>();
+        monitor.Setup(m => m.CurrentValue).Returns(configured ?? new LocalIdentityOptions());
+
+        return new SystemWalletLocalIdentityProvider(
+            signing.Object, monitor.Object, NullLogger<SystemWalletLocalIdentityProvider>.Instance);
+    }
+
+    private static Mock<ISystemWalletSigningService> SigningWallet()
+    {
+        var signing = new Mock<ISystemWalletSigningService>();
+        signing.Setup(s => s.SignAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                "sorcha:docket-signing", It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SystemSignResult
+            {
+                Signature = [9, 9],
+                PublicKey = DocketSigningKey,
+                Algorithm = "ED25519",
+                WalletAddress = SystemWalletAddress,
+            });
+        return signing;
+    }
+
+    [Fact]
+    public async Task GetAsync_NothingConfigured_ResolvesTheValidatorKeyFromTheSystemWallet()
+    {
+        // The n1 case: no LocalIdentity config at all. The node must still know its own validator key
+        // — it is the key on the roster of every register it seals.
+        var provider = Create(SigningWallet());
+
+        var identity = await provider.GetAsync();
+
+        identity.ValidatorPublicKey.Should().Equal(DocketSigningKey);
+        identity.WalletAddresses.Should().Contain(SystemWalletAddress);
+    }
+
+    [Fact]
+    public async Task GetAsync_DerivesUnderTheDocketSigningContext_SoItMatchesTheRoster()
+    {
+        // The roster entry is populated from the sorcha:docket-signing key (RegisterCreationOrchestrator).
+        // Derive under any other context and the node would fail to recognise its own roster entry.
+        var signing = SigningWallet();
+        var provider = Create(signing);
+
+        await provider.GetAsync();
+
+        signing.Verify(s => s.SignAsync(
+            It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+            "sorcha:docket-signing", It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetAsync_WalletUnreachable_FailsSafeToSubscriber()
+    {
+        // A node that cannot prove its validator key must claim nothing — never assert rights it
+        // cannot demonstrate.
+        var signing = new Mock<ISystemWalletSigningService>();
+        signing.Setup(s => s.SignAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException("wallet service is down"));
+
+        var identity = await Create(signing).GetAsync();
+
+        identity.ValidatorPublicKey.Should().BeNull();
+        identity.WalletAddresses.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetAsync_ConfiguredIdentity_WinsAndSkipsTheWallet()
+    {
+        // The config seam stays authoritative (dev stacks / tests pin a deterministic identity).
+        var signing = SigningWallet();
+        var configured = new LocalIdentityOptions
+        {
+            WalletAddresses = ["ws11qconfigured"],
+            ValidatorPublicKeyBase64 = Convert.ToBase64String(new byte[] { 42 }),
+        };
+
+        var identity = await Create(signing, configured).GetAsync();
+
+        identity.ValidatorPublicKey.Should().Equal([42]);
+        identity.WalletAddresses.Should().ContainSingle().Which.Should().Be("ws11qconfigured");
+        signing.Verify(s => s.SignAsync(
+            It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+            It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task GetAsync_IsCached_SoTheWalletIsHitOnce()
+    {
+        var signing = SigningWallet();
+        var provider = Create(signing);
+
+        await provider.GetAsync();
+        await provider.GetAsync();
+        await provider.GetAsync();
+
+        signing.Verify(s => s.SignAsync(
+            It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+            It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+}


### PR DESCRIPTION
n1's system register has been showing as **Syncing / "Recovery"** while being perfectly healthy — height 5, sealing its own dockets, serving every blueprint and governance read. Two coupled defects, one of which reaches well beyond a status chip.

## 1. The F108 local relationship is inert on every deployment

The relationship endpoint says n1 is a **subscriber** to its own system register:

```json
"isOwner": false, "isValidator": false, "isSubscriber": true, "roles": 0
```

…even though its docket-signing key is the **sole entry on that register's validator roster** and it seals every docket. Register-service says why at startup:

```
LocalIdentity resolved — 0 wallet(s), validator key absent
```

`ConfiguredLocalIdentityProvider` reads `LocalIdentity:WalletAddresses` / `ValidatorPublicKeyBase64` from appsettings — and **nothing sets those keys, anywhere**: not in a compose file, not in an appsettings. Its own XML doc states the consequence: *"Returns an empty identity when no config is provided — nodes then derive all relationships as IsSubscriber == true."*

**This is not just cosmetic.** It's the same primitive F145/T017 uses in the peer service for roster-based sealer selection (`ForwardSubmissionAsync`: "if I'm owner/validator, seal locally, don't fan out"). That check has always answered "subscriber". Single-node n1 still works only because the fan-out finds no peers and the local validator seals anyway — the right outcome for the wrong reason. On a genuinely multi-node network that is exactly the sort of thing that bites.

**Fix:** `SystemWalletLocalIdentityProvider` resolves the node's identity from the system wallet it actually signs with, deriving the `sorcha:docket-signing` key from the *same* source `RegisterCreationOrchestrator` uses to populate a register's roster — so the two cannot drift. Configured values still win (dev/test seam); an unreachable wallet **fails safe to Subscriber**, claiming nothing it cannot prove.

## 2. The node pulled a register it is the source of

`SystemRegisterBootstrapper` subscribes the local peer service to the system register so it *advertises and serves* it — but that also put the genesis/seed node on the **pull** path. Every cycle, the peer log:

```
Starting full replica sync for register aebf… from docket version 4
WRN  No source peers found for register aebf…
```

There are no source peers because **it is the source**. `PullFullReplicaAsync` returns failure, the subscription never leaves `Syncing`, and `LastSyncedDocketVersion` has sat at **−1** since genesis. Register-service maps `Syncing → Recovery`, so a healthy register reports itself as permanently recovering.

The contrast makes it plain — the SSR is the only register with a peer subscription, and the only one not Online:

| Register | Peer subscription | Status |
|---|---|---|
| AIAS (height 26) | none | Online |
| System Register (height 5) | FullReplica, Syncing, `LastSyncedDocketVersion = −1` | **Recovery** |

**Fix:** the sync loop consults the F108 relationship first. Owner/validator ⇒ it already holds the authoritative chain ⇒ nothing to pull ⇒ straight to `FullyReplicated`. The discriminator is deliberately the **control record**, not *"are there any peers?"* — a genuine subscriber that momentarily has no reachable peers must keep trying, and only the relationship separates "nobody to pull from" from "nothing to pull". An indeterminate relationship fails safe to pulling.

## 3. "Recovery" was the wrong word anyway

`Syncing` no longer maps to `RegisterStatus.Recovery`. A replica pulling chain data is **Checking**; "Recovery" reads as data loss and is now reserved for a register that is actually unwell.

## Tests

`SystemWalletLocalIdentityProviderTests` — derives under the docket-signing context *so it matches the roster*, fails safe when the wallet is down, config wins, cached. `RegisterSourceAuthorityTests` — owner/validator don't pull; a subscriber and an unknown relationship still do (the load-bearing negative).

Register **323**, Peer **738**, Validator **998** green; solution builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)