### PR TITLE
fix: [185] the holder device key is an operation, not a key

### DIFF
--- a/src/Apps/Sorcha.Wallet.Pwa/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Extensions/ServiceCollectionExtensions.cs
@@ -47,6 +47,20 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IPresentationEngine, PresentationEngine>();
         services.AddSingleton<IDeviceKeyService, WebCryptoDeviceKeyService>();
         services.AddSingleton<ICredentialCache, IndexedDbCredentialCache>();
+
+        // Feature 185 (in-person / offline presentation).
+        //
+        // A SECOND device key, and deliberately so: ISO 18013-5 derives EMacKey by ECDH between the mdoc's
+        // static device key and the reader's ephemeral key, so that key must be ECDH-capable. WebCrypto fixes
+        // a key's usages at generation and a key CANNOT be both ECDSA and ECDH — so the sign-only key above
+        // structurally cannot produce a deviceMac. The SD-JWT rail keeps that one; the mdoc rail gets this.
+        services.AddSingleton<Sorcha.Wallet.Pwa.Services.Proximity.IMdocDeviceKeyService,
+                              Sorcha.Wallet.Pwa.Services.Proximity.WebCryptoMdocDeviceKeyService>();
+
+        // Transient: a proximity transport is per-exchange, and Disconnected is terminal — a shared instance
+        // would carry a dead channel into the next presentation.
+        services.AddTransient<Sorcha.Proximity.IProximityTransport,
+                              Sorcha.Wallet.Pwa.Services.Proximity.CapacitorProximityTransport>();
         // Feature 152 (offline / field capture) — encrypted device-local store seam + connectivity.
         services.AddSingleton<Sorcha.Wallet.Pwa.Services.Drafts.IEncryptedObjectStore,
                               Sorcha.Wallet.Pwa.Services.Drafts.IndexedDbEncryptedObjectStore>();

--- a/src/Apps/Sorcha.Wallet.Pwa/Services/Proximity/IMdocDeviceKeyService.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Services/Proximity/IMdocDeviceKeyService.cs
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Text.Json;
+using Microsoft.JSInterop;
+using Org.BouncyCastle.Crypto.Parameters;
+using Sorcha.Mdoc.Cose;
+using Sorcha.Proximity;
+
+namespace Sorcha.Wallet.Pwa.Services.Proximity;
+
+/// <summary>
+/// The citizen's <b>second</b> device key: a non-extractable <b>ECDH</b> P-256 key, used only by the mdoc
+/// proximity rail.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Why a second key exists at all.</b> ISO 18013-5 derives <c>EMacKey</c> by ECDH between the mdoc's
+/// <b>static</b> device key (the one published in the MSO) and the reader's <b>ephemeral</b> key — so the
+/// MSO device key must be ECDH-capable. In WebCrypto a key's usages are <b>fixed at generation</b>, and a key
+/// <b>cannot be both ECDSA and ECDH</b>. The wallet's existing device key
+/// (<see cref="IDeviceKeyService"/>) is <c>sign</c>-only, so it structurally cannot produce a
+/// <c>deviceMac</c> — no amount of plumbing changes that.
+/// </para>
+/// <para>
+/// So: the <b>SD-JWT rail</b> keeps the existing ECDSA key for KB-JWT signing, untouched; the <b>mdoc rail</b>
+/// gets this one. Two keys, each fit for its purpose. A credential bound to this key can produce a
+/// <c>deviceMac</c> but not a <c>deviceSignature</c>, which is correct and sufficient: ISO requires exactly
+/// one of the two, and a conformant reader must accept either.
+/// </para>
+/// <para>
+/// <b>The key never leaves WebCrypto.</b> That is why <see cref="AgreeAsync"/> exists rather than a
+/// "get private key" method: the ECDH happens <em>inside</em> the browser's key store, and .NET only ever
+/// sees the resulting shared secret. Anything else would defeat the point of a non-extractable key.
+/// </para>
+/// </remarks>
+public interface IMdocDeviceKeyService
+{
+    /// <summary>The public key, as an EC2 <c>COSE_Key</c> — what an issuer binds <c>MSO.DeviceKey</c> to.</summary>
+    Task<byte[]> GetPublicCoseKeyAsync(CancellationToken ct = default);
+
+    /// <summary>The public key as a JWK.</summary>
+    Task<JsonElement> GetPublicJwkAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Performs the ECDH agreement against the reader's ephemeral public key, inside WebCrypto, and returns
+    /// the raw shared secret.
+    /// </summary>
+    Task<byte[]> AgreeAsync(ECPublicKeyParameters peerPublicKey, CancellationToken ct = default);
+
+    /// <summary>Adapts this key to the seam the proximity holder session expects.</summary>
+    HolderDeviceKey AsHolderDeviceKey();
+}
+
+/// <inheritdoc />
+public sealed class WebCryptoMdocDeviceKeyService : IMdocDeviceKeyService
+{
+    /// <summary>
+    /// Deliberately distinct from the ECDSA key's id (<c>sorcha-wallet-device</c>).
+    /// </summary>
+    /// <remarks>
+    /// Sharing an id would collide in the bridge's key map and hand back a key with the wrong usages — which
+    /// would fail at the ECDH with an opaque WebCrypto error rather than anywhere useful.
+    /// </remarks>
+    private const string KeyId = "sorcha-wallet-mdoc-device";
+
+    private readonly IJSRuntime _js;
+    private readonly SemaphoreSlim _gate = new(1, 1);
+    private bool _generated;
+
+    public WebCryptoMdocDeviceKeyService(IJSRuntime js)
+    {
+        _js = js ?? throw new ArgumentNullException(nameof(js));
+    }
+
+    /// <inheritdoc />
+    public async Task<byte[]> GetPublicCoseKeyAsync(CancellationToken ct = default)
+    {
+        var jwk = await GetPublicJwkAsync(ct).ConfigureAwait(false);
+
+        var x = Base64Url(jwk.GetProperty("x").GetString()!);
+        var y = Base64Url(jwk.GetProperty("y").GetString()!);
+
+        var point = CoseKey.DomainParameters.Curve.CreatePoint(
+            new Org.BouncyCastle.Math.BigInteger(1, x),
+            new Org.BouncyCastle.Math.BigInteger(1, y));
+
+        return CoseKey.EncodeEc2PublicKey(new ECPublicKeyParameters(point, CoseKey.DomainParameters));
+    }
+
+    /// <inheritdoc />
+    public async Task<JsonElement> GetPublicJwkAsync(CancellationToken ct = default)
+    {
+        await EnsureGeneratedAsync(ct).ConfigureAwait(false);
+
+        var json = await _js.InvokeAsync<string>("SorchaWebCrypto.getPublicJwk", ct, KeyId);
+        return JsonSerializer.Deserialize<JsonElement>(json);
+    }
+
+    /// <inheritdoc />
+    public async Task<byte[]> AgreeAsync(ECPublicKeyParameters peerPublicKey, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(peerPublicKey);
+
+        await EnsureGeneratedAsync(ct).ConfigureAwait(false);
+
+        var q = peerPublicKey.Q.Normalize();
+        var peerJwk = JsonSerializer.Serialize(new
+        {
+            kty = "EC",
+            crv = "P-256",
+            x = ToBase64Url(q.AffineXCoord.GetEncoded()),
+            y = ToBase64Url(q.AffineYCoord.GetEncoded())
+        });
+
+        var secretBase64Url = await _js.InvokeAsync<string>(
+            "SorchaWebCrypto.deriveSharedSecret", ct, KeyId, peerJwk);
+
+        return Base64Url(secretBase64Url);
+    }
+
+    /// <inheritdoc />
+    public HolderDeviceKey AsHolderDeviceKey() => new(AgreeAsync);
+
+    private async Task EnsureGeneratedAsync(CancellationToken ct)
+    {
+        if (_generated)
+            return;
+
+        await _gate.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            if (_generated)
+                return;
+
+            await _js.InvokeAsync<string>("SorchaWebCrypto.generateEcdhP256", ct, KeyId);
+            _generated = true;
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    private static byte[] Base64Url(string value)
+    {
+        var s = value.Replace('-', '+').Replace('_', '/');
+        s = (s.Length % 4) switch { 2 => s + "==", 3 => s + "=", _ => s };
+        return Convert.FromBase64String(s);
+    }
+
+    private static string ToBase64Url(byte[] value) =>
+        Convert.ToBase64String(value).TrimEnd('=').Replace('+', '-').Replace('/', '_');
+}

--- a/src/Apps/Sorcha.Wallet.Pwa/wwwroot/js/webcrypto-bridge.js
+++ b/src/Apps/Sorcha.Wallet.Pwa/wwwroot/js/webcrypto-bridge.js
@@ -87,12 +87,77 @@
     return bytesToB64Url(sig);
   }
 
+  // ---------------------------------------------------------------------------
+  // ECDH P-256 — the mdoc proximity device key (Feature 185).
+  //
+  // WHY A SECOND KEY EXISTS. ISO 18013-5 derives EMacKey by ECDH between the mdoc's STATIC device key
+  // (published in the MSO) and the reader's EPHEMERAL key — so the MSO device key must be ECDH-capable.
+  // In WebCrypto a key's usages are FIXED AT GENERATION and a key cannot be both ECDSA and ECDH. The
+  // ECDSA key above is "sign"-only and therefore structurally cannot produce a deviceMac, no matter what
+  // we do to it. Hence a distinct key, with distinct usages.
+  //
+  // Both keys stay NON-EXTRACTABLE. That is why the ECDH itself has to happen here rather than in C#:
+  // the private key never leaves WebCrypto, so .NET can never hold it. deriveBits hands back the raw
+  // shared secret (the P-256 x-coordinate, 32 bytes) — exactly the HKDF input keying material the
+  // standard calls Z — and C# does the HKDF over that.
+
+  async function generateEcdhP256(id) {
+    if (keys.has(id)) return id;
+    const pair = await subtle.generateKey(
+      { name: "ECDH", namedCurve: "P-256" },
+      false /* non-extractable private key */,
+      ["deriveBits"]   // NOT "sign" — an ECDH key cannot sign, and that is fine: mdoc uses one or the other
+    );
+    const publicJwk = await subtle.exportKey("jwk", pair.publicKey);
+    const cleanJwk = { kty: publicJwk.kty, crv: publicJwk.crv, x: publicJwk.x, y: publicJwk.y };
+    const thumbprint = await rfc7638Thumbprint(cleanJwk);
+    keys.set(id, {
+      privateKey: pair.privateKey,
+      publicKey: pair.publicKey,
+      publicJwk: cleanJwk,
+      thumbprint,
+    });
+    return id;
+  }
+
+  /**
+   * Performs the ECDH agreement between this device's private key and a peer's public key.
+   *
+   * @param id            the ECDH key id
+   * @param peerJwkJson   the peer's public key as a JWK (JSON string)
+   * @returns             the raw shared secret (Z), base64url — 32 bytes for P-256
+   */
+  async function deriveSharedSecret(id, peerJwkJson) {
+    const entry = keys.get(id);
+    if (!entry) throw new Error(`No key with id '${id}'`);
+
+    const peerJwk = JSON.parse(peerJwkJson);
+    const peerKey = await subtle.importKey(
+      "jwk",
+      { kty: peerJwk.kty, crv: peerJwk.crv, x: peerJwk.x, y: peerJwk.y },
+      { name: "ECDH", namedCurve: "P-256" },
+      false,
+      []   // a public key needs no usages
+    );
+
+    // 256 bits = the P-256 x-coordinate. This is Z, the HKDF input keying material.
+    const bits = await subtle.deriveBits(
+      { name: "ECDH", public: peerKey },
+      entry.privateKey,
+      256
+    );
+
+    return bytesToB64Url(bits);
+  }
+
   function disposeKey(id) {
     keys.delete(id);
   }
 
   globalThis.SorchaWebCrypto = {
     generateEcdsaP256,
+    generateEcdhP256,
+    deriveSharedSecret,
     getPublicJwk,
     getThumbprint,
     signEs256,

--- a/src/Common/Sorcha.Mdoc/Proximity/MdocSessionCrypto.cs
+++ b/src/Common/Sorcha.Mdoc/Proximity/MdocSessionCrypto.cs
@@ -129,11 +129,12 @@ public static class MdocSessionCrypto
     /// This asymmetry is the whole reason the mdoc device key must be <b>ECDH-capable</b> — and why the
     /// wallet needs a second device key, since a WebCrypto ECDSA key cannot do ECDH (feature 185, design §3).
     /// </param>
-    public static MdocSessionKeys DeriveKeys(
+    public static async Task<MdocSessionKeys> DeriveKeysAsync(
         byte[] sessionTranscriptBytes,
         ECPrivateKeyParameters ownEphemeralPrivate,
         ECPublicKeyParameters peerEphemeralPublic,
-        StaticDeviceKeyMaterial? staticDeviceKey)
+        StaticDeviceKeyMaterial? staticDeviceKey,
+        CancellationToken ct = default)
     {
         ArgumentNullException.ThrowIfNull(sessionTranscriptBytes);
         ArgumentNullException.ThrowIfNull(ownEphemeralPrivate);
@@ -141,6 +142,9 @@ public static class MdocSessionCrypto
 
         var salt = SHA256.HashData(sessionTranscriptBytes);
 
+        // The EPHEMERAL keys are ours, generated per session, and always in memory — there is nothing to
+        // protect in a key that exists for one exchange and is then discarded. Only the STATIC device key is
+        // hardware-held, and that is why only it goes through the agreement seam.
         var sharedSecret = Agree(ownEphemeralPrivate, peerEphemeralPublic);
         try
         {
@@ -150,7 +154,7 @@ public static class MdocSessionCrypto
             byte[] eMacKey = [];
             if (staticDeviceKey is not null)
             {
-                var macSecret = staticDeviceKey.Agree();
+                var macSecret = await staticDeviceKey.AgreeAsync(ct).ConfigureAwait(false);
                 try
                 {
                     eMacKey = Hkdf(macSecret, salt, InfoEMacKey);
@@ -283,32 +287,65 @@ public enum MdocSessionRole
 }
 
 /// <summary>
-/// The half of the <c>EMacKey</c> ECDH each party holds. The holder has the static device <b>private</b> key;
-/// the reader has the static device <b>public</b> key (from the MSO) and its own ephemeral private key.
+/// The half of the <c>EMacKey</c> ECDH that this party can perform.
 /// </summary>
+/// <remarks>
+/// <para>
+/// <b>This is an agreement <em>seam</em>, not a key — and that distinction is load-bearing.</b>
+/// </para>
+/// <para>
+/// On the citizen's phone the mdoc's static device key is a <b>non-extractable WebCrypto key</b>. C# can
+/// never hold its private half — that is the entire point of it. So the ECDH itself has to happen inside
+/// WebCrypto (<c>deriveBits</c> returns exactly the raw shared secret the standard calls <c>Z</c>), and we
+/// take the result. Modelling this as an <c>ECPrivateKeyParameters</c> would have compiled fine and then
+/// been impossible to wire to the one key that actually matters.
+/// </para>
+/// <para>
+/// It is the same shape as the device-<em>signer</em> delegate in <see cref="Cose.CoseSign1Builder"/>, and
+/// for the same reason: a hardware-protected key is reachable only as an operation, never as bytes.
+/// </para>
+/// <para>
+/// The in-process implementations below are for the reader, for tests, and for the server — all places where
+/// the key really is in memory.
+/// </para>
+/// </remarks>
 public abstract class StaticDeviceKeyMaterial
 {
-    /// <summary>Performs this party's half of the EMacKey agreement.</summary>
-    public abstract byte[] Agree();
+    /// <summary>
+    /// Performs this party's half of the <c>EMacKey</c> agreement and returns the raw shared secret
+    /// (the P-256 x-coordinate, 32 bytes).
+    /// </summary>
+    /// <remarks>Async because on a phone this crosses the JS-interop boundary into WebCrypto.</remarks>
+    public abstract Task<byte[]> AgreeAsync(CancellationToken ct = default);
 
-    /// <summary>The holder's half: the mdoc's static device private key, agreed with the reader's ephemeral public key.</summary>
+    /// <summary>
+    /// The <b>holder's</b> half, when the static device private key is genuinely in memory (tests, server).
+    /// </summary>
+    /// <remarks>
+    /// On a real device use the WebCrypto-backed implementation instead — a phone's device key cannot be
+    /// loaded into an <see cref="ECPrivateKeyParameters"/>, and if it could, it would not be worth having.
+    /// </remarks>
     public static StaticDeviceKeyMaterial ForHolder(
         ECPrivateKeyParameters staticDevicePrivate, ECPublicKeyParameters readerEphemeralPublic)
-        => new HolderMaterial(staticDevicePrivate, readerEphemeralPublic);
+        => new InProcessMaterial(staticDevicePrivate, readerEphemeralPublic);
 
-    /// <summary>The reader's half: its own ephemeral private key, agreed with the mdoc's static device public key.</summary>
+    /// <summary>
+    /// The <b>reader's</b> half: its own ephemeral private key, agreed with the mdoc's static device public
+    /// key (read from the MSO).
+    /// </summary>
+    /// <remarks>
+    /// The reader's key is ephemeral and per-session, so it is always in memory — the reader never needs the
+    /// WebCrypto seam.
+    /// </remarks>
     public static StaticDeviceKeyMaterial ForReader(
         ECPrivateKeyParameters readerEphemeralPrivate, ECPublicKeyParameters staticDevicePublic)
-        => new ReaderMaterial(readerEphemeralPrivate, staticDevicePublic);
+        => new InProcessMaterial(readerEphemeralPrivate, staticDevicePublic);
 
-    private sealed class HolderMaterial(ECPrivateKeyParameters priv, ECPublicKeyParameters pub) : StaticDeviceKeyMaterial
+    private sealed class InProcessMaterial(ECPrivateKeyParameters priv, ECPublicKeyParameters pub)
+        : StaticDeviceKeyMaterial
     {
-        public override byte[] Agree() => AgreeCore(priv, pub);
-    }
-
-    private sealed class ReaderMaterial(ECPrivateKeyParameters priv, ECPublicKeyParameters pub) : StaticDeviceKeyMaterial
-    {
-        public override byte[] Agree() => AgreeCore(priv, pub);
+        public override Task<byte[]> AgreeAsync(CancellationToken ct = default)
+            => Task.FromResult(AgreeCore(priv, pub));
     }
 
     private static byte[] AgreeCore(ECPrivateKeyParameters priv, ECPublicKeyParameters pub)

--- a/src/Common/Sorcha.Proximity.Abstractions/ProximityHolderSession.cs
+++ b/src/Common/Sorcha.Proximity.Abstractions/ProximityHolderSession.cs
@@ -36,15 +36,58 @@ public enum HolderSessionState
     Failed
 }
 
-/// <summary>The holder's static, ECDH-capable device key — the one an mdoc's <c>MSO.DeviceKey</c> is bound to.</summary>
+/// <summary>
+/// The holder's static, ECDH-capable device key — the one an mdoc's <c>MSO.DeviceKey</c> is bound to —
+/// expressed as an <b>agreement operation</b> rather than as key bytes.
+/// </summary>
 /// <remarks>
-/// ⚠ This must be an <b>ECDH</b> key, not the ECDSA key the wallet uses for SD-JWT key binding. ISO 18013-5
+/// <para>
+/// ⚠ It must be an <b>ECDH</b> key, not the ECDSA key the wallet uses for SD-JWT key binding. ISO 18013-5
 /// derives <c>EMacKey</c> by ECDH between this key and the reader's ephemeral key, and in WebCrypto a key's
-/// usages are fixed at generation: a key cannot be both ECDSA and ECDH. That is precisely why the wallet
-/// carries two device keys (feature 185, design §3).
+/// usages are fixed at generation: <b>a key cannot be both ECDSA and ECDH</b>. That is why the wallet carries
+/// two device keys (feature 185, design §3).
+/// </para>
+/// <para>
+/// <b>And it is an operation, not a key.</b> On a phone this key is non-extractable — C# can never hold its
+/// private half, which is precisely what makes it worth having. So the caller supplies a function that
+/// performs the agreement (in WebCrypto, on the device) and returns the shared secret. Tests and the server
+/// pass an in-memory implementation. Modelling this as a private key would compile perfectly and then be
+/// impossible to wire to the only key that matters.
+/// </para>
 /// </remarks>
-/// <param name="Private">The static device private key.</param>
-public sealed record HolderDeviceKey(ECPrivateKeyParameters Private);
+/// <param name="AgreeWithReaderEphemeral">
+/// Given the reader's ephemeral public key, performs the ECDH and returns the raw shared secret (32 bytes).
+/// </param>
+public sealed record HolderDeviceKey(
+    Func<ECPublicKeyParameters, CancellationToken, Task<byte[]>> AgreeWithReaderEphemeral)
+{
+    /// <summary>Builds a holder key from an in-memory private key — for tests and the server.</summary>
+    /// <remarks>A real device cannot use this: its key is in hardware and cannot be loaded into one of these.</remarks>
+    public static HolderDeviceKey FromInMemoryKey(ECPrivateKeyParameters staticDevicePrivate)
+    {
+        ArgumentNullException.ThrowIfNull(staticDevicePrivate);
+
+        return new HolderDeviceKey((readerEphemeralPublic, ct) =>
+            StaticDeviceKeyMaterial
+                .ForHolder(staticDevicePrivate, readerEphemeralPublic)
+                .AgreeAsync(ct));
+    }
+}
+
+/// <summary>
+/// Adapts a <see cref="HolderDeviceKey"/> (an agreement <em>operation</em>) to the
+/// <see cref="StaticDeviceKeyMaterial"/> seam the crypto layer expects.
+/// </summary>
+/// <remarks>
+/// The indirection exists so that a hardware-held, non-extractable device key can take part in the ECDH at
+/// all. It is not ceremony — without it, the one key we actually want to use is the one key we cannot use.
+/// </remarks>
+internal sealed class DelegatedStaticDeviceKey(HolderDeviceKey deviceKey, ECPublicKeyParameters readerEphemeral)
+    : StaticDeviceKeyMaterial
+{
+    public override Task<byte[]> AgreeAsync(CancellationToken ct = default)
+        => deviceKey.AgreeWithReaderEphemeral(readerEphemeral, ct);
+}
 
 /// <summary>
 /// The holder's half of an ISO 18013-5 proximity exchange, as a state machine over
@@ -248,12 +291,21 @@ public sealed class ProximityHolderSession : IAsyncDisposable
 
     private void OnReceived(byte[] payload)
     {
+        // The transport's Received event is synchronous, but key agreement is not: on a phone the static
+        // device key lives in WebCrypto and the ECDH crosses the JS-interop boundary. So the work is
+        // continued on a task, with every failure funnelled into Fail() — a faulted task here must never
+        // become an unobserved exception that silently strands the session.
+        _ = HandleReceivedAsync(payload);
+    }
+
+    private async Task HandleReceivedAsync(byte[] payload)
+    {
         try
         {
             switch (State)
             {
                 case HolderSessionState.Engaging:
-                    HandleSessionEstablishment(payload);
+                    await HandleSessionEstablishmentAsync(payload).ConfigureAwait(false);
                     break;
 
                 case HolderSessionState.AwaitingConsent:
@@ -270,7 +322,7 @@ public sealed class ProximityHolderSession : IAsyncDisposable
         }
     }
 
-    private void HandleSessionEstablishment(byte[] payload)
+    private async Task HandleSessionEstablishmentAsync(byte[] payload)
     {
         var establishment = SessionEstablishment.Decode(payload);
 
@@ -285,12 +337,15 @@ public sealed class ProximityHolderSession : IAsyncDisposable
             MdocCbor.WrapTag24(_engagement!.Encode()),
             establishment.EReaderKeyBytes);
 
-        _keys = MdocSessionCrypto.DeriveKeys(
+        _keys = await MdocSessionCrypto.DeriveKeysAsync(
             _transcript.TaggedBytes,
             _ephemeral!.Private,
             readerEphemeral,
-            // EMacKey: OUR static device private key, agreed with THEIR ephemeral public key.
-            StaticDeviceKeyMaterial.ForHolder(_deviceKey.Private, readerEphemeral));
+            // EMacKey: OUR static device key, agreed with THEIR ephemeral public key.
+            //
+            // On a phone the agreement happens inside WebCrypto — we never see the private key, which is the
+            // whole point of it being non-extractable. Hence a delegate rather than a key.
+            new DelegatedStaticDeviceKey(_deviceKey, readerEphemeral)).ConfigureAwait(false);
 
         _readerCounter++;
         var plaintext = MdocSessionCrypto.Decrypt(

--- a/src/Common/Sorcha.Proximity.Abstractions/ProximityReaderSession.cs
+++ b/src/Common/Sorcha.Proximity.Abstractions/ProximityReaderSession.cs
@@ -123,11 +123,12 @@ public sealed class ProximityReaderSession : IAsyncDisposable
         // The reader has no static device key of its own to agree with — EMacKey comes from the holder's
         // static key, which the reader learns from the MSO in the response. So it is derived later, once we
         // can see the credential. (This asymmetry is inherent to the standard, not an artefact of our design.)
-        _keys = MdocSessionCrypto.DeriveKeys(
+        _keys = await MdocSessionCrypto.DeriveKeysAsync(
             _transcript.TaggedBytes,
             _ephemeral.Private,
             holderEphemeral,
-            staticDeviceKey: null);
+            staticDeviceKey: null,
+            ct).ConfigureAwait(false);
 
         await _transport.ConnectCentralAsync(new ProximityTarget(serviceUuid), ct).ConfigureAwait(false);
 
@@ -155,6 +156,14 @@ public sealed class ProximityReaderSession : IAsyncDisposable
 
     private void OnReceived(byte[] payload)
     {
+        // Deriving EMacKey needs an ECDH, which is async for symmetry with the holder (whose key is in
+        // hardware). Continue on a task and funnel every failure into Fail() — a faulted task here must never
+        // become an unobserved exception that strands the verdict.
+        _ = HandleReceivedAsync(payload);
+    }
+
+    private async Task HandleReceivedAsync(byte[] payload)
+    {
         if (State != ReaderSessionState.RequestSent)
             return;
 
@@ -180,7 +189,7 @@ public sealed class ProximityReaderSession : IAsyncDisposable
                 return;
             }
 
-            _verdictReady?.TrySetResult(Verify(responseBytes));
+            _verdictReady?.TrySetResult(await VerifyAsync(responseBytes).ConfigureAwait(false));
             State = ReaderSessionState.Verified;
         }
         catch (Exception ex)
@@ -192,11 +201,11 @@ public sealed class ProximityReaderSession : IAsyncDisposable
     /// <summary>
     /// Verifies the response, deriving <c>EMacKey</c> from the static device key the MSO carries.
     /// </summary>
-    private ProximityVerdict Verify(byte[] responseBytes)
+    private async Task<ProximityVerdict> VerifyAsync(byte[] responseBytes)
     {
         // The holder's static device key is published in the MSO. Only now can the reader complete the
         // EMacKey agreement — its own ephemeral private key against that static public key.
-        var eMacKey = TryDeriveEMacKey(responseBytes);
+        var eMacKey = await TryDeriveEMacKeyAsync(responseBytes).ConfigureAwait(false);
 
         var result = _mdocService.Verify(responseBytes, _transcript!.Encoded, eMacKey);
 
@@ -235,7 +244,7 @@ public sealed class ProximityReaderSession : IAsyncDisposable
             Errors: errors);
     }
 
-    private byte[]? TryDeriveEMacKey(byte[] responseBytes)
+    private async Task<byte[]?> TryDeriveEMacKeyAsync(byte[] responseBytes)
     {
         try
         {
@@ -252,11 +261,11 @@ public sealed class ProximityReaderSession : IAsyncDisposable
             if (staticDevicePublic is null)
                 return null;
 
-            using var macKeys = MdocSessionCrypto.DeriveKeys(
+            using var macKeys = await MdocSessionCrypto.DeriveKeysAsync(
                 _transcript!.TaggedBytes,
                 _ephemeral!.Private,
                 _ephemeral.Public,   // unused for EMacKey; the static agreement below is what matters
-                StaticDeviceKeyMaterial.ForReader(_ephemeral.Private, staticDevicePublic));
+                StaticDeviceKeyMaterial.ForReader(_ephemeral.Private, staticDevicePublic)).ConfigureAwait(false);
 
             return (byte[])macKeys.EMacKey.Clone();
         }

--- a/tests/Sorcha.Mdoc.Tests/Proximity/IsoAnnexDVectorTests.cs
+++ b/tests/Sorcha.Mdoc.Tests/Proximity/IsoAnnexDVectorTests.cs
@@ -44,7 +44,7 @@ public class IsoAnnexDVectorTests
         ProximitySessionTranscript.FromTaggedBytes(
             IsoAnnexDVectors.Hex(IsoAnnexDVectors.SessionTranscriptBytesHex));
 
-    private static MdocSessionKeys DeriveAnnexDKeys() => MdocSessionCrypto.DeriveKeys(
+    private static Task<MdocSessionKeys> DeriveAnnexDKeysAsync() => MdocSessionCrypto.DeriveKeysAsync(
         AnnexDTranscript().TaggedBytes,
         // From the reader's side: its ephemeral private key against the holder's ephemeral public key.
         PrivateKey(IsoAnnexDVectors.EphemeralReaderKeyDHex),
@@ -59,13 +59,13 @@ public class IsoAnnexDVectorTests
     /// this fails, nothing else can work.
     /// </summary>
     [Fact]
-    public void DeriveKeys_FromEitherSide_AgreesOnTheSameSessionKeys()
+    public async Task DeriveKeys_FromEitherSide_AgreesOnTheSameSessionKeys()
     {
         var transcript = AnnexDTranscript();
 
-        using var readerView = DeriveAnnexDKeys();
+        using var readerView = await DeriveAnnexDKeysAsync();
 
-        using var holderView = MdocSessionCrypto.DeriveKeys(
+        using var holderView = await MdocSessionCrypto.DeriveKeysAsync(
             transcript.TaggedBytes,
             PrivateKey(IsoAnnexDVectors.EphemeralDeviceKeyDHex),
             PublicKey(IsoAnnexDVectors.EphemeralReaderKeyXHex, IsoAnnexDVectors.EphemeralReaderKeyYHex),
@@ -91,9 +91,9 @@ public class IsoAnnexDVectorTests
     /// GCM tag does not authenticate.
     /// </remarks>
     [Fact]
-    public void SessionEstablishment_FromTheStandard_DecryptsToTheStandardsDeviceRequest()
+    public async Task SessionEstablishment_FromTheStandard_DecryptsToTheStandardsDeviceRequest()
     {
-        using var keys = DeriveAnnexDKeys();
+        using var keys = await DeriveAnnexDKeysAsync();
 
         var establishment = SessionEstablishment.Decode(
             IsoAnnexDVectors.Hex(IsoAnnexDVectors.SessionEstablishmentHex));
@@ -112,9 +112,9 @@ public class IsoAnnexDVectorTests
     /// <c>DeviceResponse</c> plaintext back — the holder's direction, under <c>SKDevice</c>.
     /// </summary>
     [Fact]
-    public void SessionData_FromTheStandard_DecryptsToTheStandardsDeviceResponse()
+    public async Task SessionData_FromTheStandard_DecryptsToTheStandardsDeviceResponse()
     {
-        using var keys = DeriveAnnexDKeys();
+        using var keys = await DeriveAnnexDKeysAsync();
 
         var sessionData = SessionData.Decode(IsoAnnexDVectors.Hex(IsoAnnexDVectors.SessionDataHex));
         sessionData.Data.Should().NotBeNull();
@@ -136,9 +136,9 @@ public class IsoAnnexDVectorTests
     /// else's ciphertext exactly cannot.
     /// </remarks>
     [Fact]
-    public void Encrypt_ReproducesTheStandardsCiphertext_ByteForByte()
+    public async Task Encrypt_ReproducesTheStandardsCiphertext_ByteForByte()
     {
-        using var keys = DeriveAnnexDKeys();
+        using var keys = await DeriveAnnexDKeysAsync();
 
         var reEncrypted = MdocSessionCrypto.Encrypt(
             keys.SkReader,
@@ -168,9 +168,9 @@ public class IsoAnnexDVectorTests
     /// </para>
     /// </remarks>
     [Fact]
-    public void DeviceMac_FromTheStandardsDeviceResponse_Verifies()
+    public async Task DeviceMac_FromTheStandardsDeviceResponse_Verifies()
     {
-        using var keys = DeriveAnnexDKeys();
+        using var keys = await DeriveAnnexDKeysAsync();
         var transcript = AnnexDTranscript();
 
         var response = MdocCodec.DecodeDeviceResponse(
@@ -193,9 +193,9 @@ public class IsoAnnexDVectorTests
 
     /// <summary>A tampered MAC tag must be rejected — the verifier fails closed.</summary>
     [Fact]
-    public void DeviceMac_Tampered_IsRejected()
+    public async Task DeviceMac_Tampered_IsRejected()
     {
-        using var keys = DeriveAnnexDKeys();
+        using var keys = await DeriveAnnexDKeysAsync();
         var transcript = AnnexDTranscript();
 
         var response = MdocCodec.DecodeDeviceResponse(

--- a/tests/Sorcha.Proximity.Tests/HolderDeviceKeySeamTests.cs
+++ b/tests/Sorcha.Proximity.Tests/HolderDeviceKeySeamTests.cs
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using FluentAssertions;
+using Org.BouncyCastle.Crypto.Parameters;
+using Sorcha.Mdoc.Proximity;
+using Sorcha.Proximity;
+using Sorcha.Proximity.Tests.Support;
+using Xunit;
+
+namespace Sorcha.Proximity.Tests;
+
+/// <summary>
+/// Pins the seam that lets a <b>hardware-held</b> device key take part in the <c>EMacKey</c> ECDH.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Why this seam exists.</b> On a phone the mdoc's static device key is a non-extractable WebCrypto key:
+/// .NET can never hold its private half, and that is precisely what makes it worth having. So
+/// <see cref="HolderDeviceKey"/> is an <em>agreement operation</em>, not a key.
+/// </para>
+/// <para>
+/// The first cut of this modelled it as an <c>ECPrivateKeyParameters</c>. That compiled, passed every test,
+/// and was <b>impossible to wire to the only key that matters</b> — a defect that would not have surfaced
+/// until the wallet tried to use its real device key on a real phone. These tests exist so it cannot come back.
+/// </para>
+/// </remarks>
+public class HolderDeviceKeySeamTests
+{
+    /// <summary>
+    /// A holder whose key is reachable ONLY as an async operation — never as bytes — completes the exchange.
+    /// </summary>
+    /// <remarks>
+    /// This is the WebCrypto shape, simulated: the private key is closed over and never handed to the
+    /// session. If the session ever needs the key itself rather than the agreement, this test fails.
+    /// </remarks>
+    [Fact]
+    public async Task AHolderWhoseKeyNeverLeavesItsKeystore_CanStillCompleteTheExchange()
+    {
+        var (privateKey, publicKey) = TestMdoc.GenerateDeviceKey();
+        var credential = TestMdoc.Issue(publicKey);
+
+        var agreementCalls = 0;
+
+        // The device key as a phone actually presents it: an operation, behind an async boundary, with the
+        // private key sealed away where the session cannot reach it.
+        var hardwareHeldKey = new HolderDeviceKey(async (readerEphemeralPublic, ct) =>
+        {
+            agreementCalls++;
+            await Task.Yield();   // crossing the JS-interop boundary is not synchronous
+            return await StaticDeviceKeyMaterial
+                .ForHolder(privateKey, readerEphemeralPublic)
+                .AgreeAsync(ct);
+        });
+
+        var (holderTransport, readerTransport) = LoopbackProximityTransport.CreatePair();
+        await using var holder = new ProximityHolderSession(holderTransport, [credential], hardwareHeldKey);
+        await using var reader = new ProximityReaderSession(readerTransport);
+
+        var engagement = await holder.StartAsync();
+        await reader.RequestAsync(engagement, ProximityFixture.StandardRequest());
+        await holder.WaitForRequestAsync();
+
+        await holder.ApproveAsync(holder.RequestedElements);
+
+        var verdict = await reader.WaitForVerdictAsync();
+
+        verdict.Accepted.Should().BeTrue(because: string.Join("; ", verdict.Errors));
+        verdict.DeviceBindingValid.Should().BeTrue(because:
+            "the deviceMac was produced by a key the session never held — which is the entire point");
+
+        agreementCalls.Should().Be(1, because:
+            "the ECDH is performed exactly once, by the keystore, and never re-derived from key material we " +
+            "do not have");
+    }
+
+    /// <summary>
+    /// The convenience constructor for in-memory keys is exactly equivalent — so tests and the server are not
+    /// exercising a different code path from the phone.
+    /// </summary>
+    [Fact]
+    public async Task AnInMemoryKeyAndAnOperationBackedKey_ProduceTheSameSharedSecret()
+    {
+        var (privateKey, _) = TestMdoc.GenerateDeviceKey();
+        var (_, readerEphemeralPublic) = TestMdoc.GenerateDeviceKey();
+
+        var fromConvenience = HolderDeviceKey.FromInMemoryKey(privateKey);
+
+        var fromOperation = new HolderDeviceKey((peer, ct) =>
+            StaticDeviceKeyMaterial.ForHolder(privateKey, peer).AgreeAsync(ct));
+
+        var a = await fromConvenience.AgreeWithReaderEphemeral(readerEphemeralPublic, default);
+        var b = await fromOperation.AgreeWithReaderEphemeral(readerEphemeralPublic, default);
+
+        a.Should().Equal(b);
+        a.Should().HaveCount(32, because: "the shared secret is the P-256 x-coordinate");
+    }
+
+    /// <summary>
+    /// A device key that cannot agree (revoked, or a keystore failure) must fail the session — <b>not</b>
+    /// silently fall back to producing an unauthenticated presentation.
+    /// </summary>
+    [Fact]
+    public async Task AKeystoreFailure_FailsTheSession_RatherThanDiscloseWithoutBinding()
+    {
+        var (_, publicKey) = TestMdoc.GenerateDeviceKey();
+        var credential = TestMdoc.Issue(publicKey);
+
+        var brokenKey = new HolderDeviceKey((_, _) =>
+            Task.FromException<byte[]>(new InvalidOperationException("keystore unavailable")));
+
+        var (holderTransport, readerTransport) = LoopbackProximityTransport.CreatePair();
+        await using var holder = new ProximityHolderSession(holderTransport, [credential], brokenKey);
+        await using var reader = new ProximityReaderSession(readerTransport);
+
+        var engagement = await holder.StartAsync();
+        await reader.RequestAsync(engagement, ProximityFixture.StandardRequest());
+
+        var act = () => holder.WaitForRequestAsync();
+        await act.Should().ThrowAsync<InvalidOperationException>();
+
+        holder.State.Should().Be(HolderSessionState.Failed);
+        holderTransport.Sent.Should().BeEmpty(because:
+            "a holder that cannot prove possession of its device key must disclose NOTHING — an unbound " +
+            "presentation is worse than no presentation");
+    }
+}

--- a/tests/Sorcha.Proximity.Tests/Support/ProximityFixture.cs
+++ b/tests/Sorcha.Proximity.Tests/Support/ProximityFixture.cs
@@ -61,7 +61,7 @@ public sealed class ProximityFixture : IAsyncDisposable
 
         var (holderTransport, readerTransport) = LoopbackProximityTransport.CreatePair();
 
-        var holder = new ProximityHolderSession(holderTransport, [mdoc], new HolderDeviceKey(key.Private));
+        var holder = new ProximityHolderSession(holderTransport, [mdoc], HolderDeviceKey.FromInMemoryKey(key.Private));
         var reader = new ProximityReaderSession(readerTransport);
 
         return new ProximityFixture(holderTransport, readerTransport, holder, reader, mdoc, key);


### PR DESCRIPTION
**A design flaw in what I already shipped in #1169** — found the moment I tried to wire the wallet's *real* device key, which is exactly when it should have been found and exactly too late to be comfortable about.

## The flaw

`MdocSessionCrypto.DeriveKeys` took the static device key as a **BouncyCastle private key**.

But on a phone that key is a **non-extractable WebCrypto key**. C# can *never* hold its private half — that is the entire point of it. So the holder **could never have performed the `EMacKey` ECDH with its actual device key**.

It compiled. Every test passed — because tests hand it an in-memory key. It would have failed the first time a real wallet met a real reader, with an opaque WebCrypto error, in the one setting where debugging is hardest.

## The fix

`HolderDeviceKey` is now an **agreement operation**, not a key.

WebCrypto's `deriveBits` returns exactly the raw shared secret the standard calls `Z`; C# does the HKDF over that. The private key never leaves the browser's keystore.

This is the same shape as the device-**signer** delegate already used for `COSE_Sign1`, and for the same reason: **a hardware-protected key is reachable only as an operation, never as bytes.** Having made that call once already, I should have made it here too.

**The ISO Annex D vectors are what prove the refactor is byte-faithful** — they still reproduce the standard's own ciphertexts exactly. If the async rework had disturbed a single byte, they would have caught it. That is the second time those vectors have earned their keep.

## The second device key

Also lands the key itself: `generateEcdhP256` + `deriveSharedSecret` in the WebCrypto bridge, and `IMdocDeviceKeyService`.

It exists because ISO 18013-5 derives `EMacKey` by ECDH between the mdoc's **static** device key and the reader's **ephemeral** key — so the MSO device key must be ECDH-capable. WebCrypto fixes a key's usages at generation and **a key cannot be both ECDSA and ECDH**. The wallet's existing key is `sign`-only and *structurally* cannot produce a `deviceMac`.

So: the **SD-JWT rail** keeps the existing ECDSA key, untouched. The **mdoc rail** gets this one. It has a **distinct key id** — sharing one would collide in the bridge's key map and return a key with the wrong usages, failing at the ECDH rather than anywhere useful.

## Tests

Three new, pinning the seam:

- A holder whose key is reachable **only** as an async operation — never as bytes — completes the exchange. This is the WebCrypto shape, simulated. If the session ever needs the key itself again, it fails.
- The in-memory convenience path and the operation path produce the **same** shared secret, so tests and the server aren't exercising a different code path from the phone.
- **A keystore failure fails the session and discloses nothing** — no fallback to an unbound presentation. An unbound presentation is worse than no presentation.

13/13 proximity · 30/30 mdoc (Annex D intact) · 96/96 HAIP · 346/346 wallet PWA · WASM gate green.

The *why* is written into the test file, so this cannot quietly come back.

Spec: `specs/185-mobile-proximity-sharing/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018rxzAeahjb74xgRxsThTu2
