### PR TITLE
feat: [185] wallet mdoc rail + the in-person presentation UI

### DIFF
--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Models/User/Presentation/PresentationModels.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Models/User/Presentation/PresentationModels.cs
@@ -116,26 +116,68 @@ public sealed record DcqlMatchResult
     public required IReadOnlyList<DcqlSetChoice> SetChoices { get; init; }
 }
 
+/// <summary>Which credential format a cached credential is (Feature 185).</summary>
+/// <remarks>
+/// Before feature 185 the wallet held only SD-JWT VCs, so no discriminator was needed. Proximity presentation
+/// is mdoc-shaped, so the cache now carries both — and the matching rules differ per format (see
+/// <see cref="CachedCredential"/>).
+/// </remarks>
+public enum CachedCredentialFormat
+{
+    /// <summary>SD-JWT VC (<c>dc+sd-jwt</c>) — the Sorcha-native rail. Identified by <c>vct</c>.</summary>
+    SdJwtVc = 0,
+
+    /// <summary>ISO 18013-5 mdoc (<c>mso_mdoc</c>) — the proximity/EUDI rail. Identified by <c>docType</c>.</summary>
+    MsoMdoc = 1
+}
+
 /// <summary>
 /// A credential present in the wallet's cache, in the shape the presentation engine needs.
 /// In production this is materialised by <c>ICredentialCache</c> on demand from IndexedDB.
 /// </summary>
+/// <remarks>
+/// <b>Two formats, two identifiers.</b> An SD-JWT VC is identified by its <see cref="Vct"/>; an mdoc by its
+/// <see cref="DocType"/>. They are different strings and are <em>not</em> interchangeable — a request for
+/// <c>org.iso.18013.5.1.mDL</c> must never be satisfied by matching it against a <c>vct</c>. Which field
+/// applies is decided by <see cref="Format"/>, and nothing else.
+/// </remarks>
 public sealed record CachedCredential
 {
     /// <summary>Credential id (UUID assigned by the issuer).</summary>
     public required Guid Id { get; init; }
 
-    /// <summary>Credential type URI.</summary>
-    public required string Vct { get; init; }
+    /// <summary>Which rail this credential is on. Decides how it is matched and how it is presented.</summary>
+    public CachedCredentialFormat Format { get; init; } = CachedCredentialFormat.SdJwtVc;
+
+    /// <summary>Credential type URI. <b>SD-JWT only</b> — empty for an mdoc.</summary>
+    public string Vct { get; init; } = string.Empty;
+
+    /// <summary>
+    /// mdoc document type, e.g. <c>org.iso.18013.5.1.mDL</c>. <b>mdoc only</b> — null for an SD-JWT VC.
+    /// </summary>
+    public string? DocType { get; init; }
 
     /// <summary>
     /// SD-JWT VC compact form: <c>credentialJwt~disclosure1~..~disclosureN</c>.
     /// Trailing tilde is preserved if present. Does NOT include a KB-JWT — that's
-    /// minted at presentation time.
+    /// minted at presentation time. <b>SD-JWT only</b> — empty for an mdoc.
     /// </summary>
-    public required string RawSdJwt { get; init; }
+    public string RawSdJwt { get; init; } = string.Empty;
 
-    /// <summary>Names of every disclosable claim available in this credential.</summary>
+    /// <summary>
+    /// The raw <c>IssuerSigned</c> CBOR, <b>exactly as issued</b>. <b>mdoc only</b> — null for an SD-JWT VC.
+    /// </summary>
+    /// <remarks>
+    /// Stored verbatim, and it must stay that way. Selective disclosure splices the <em>tag-24-wrapped item
+    /// bytes</em> straight out of here; re-encoding an item can change bytes for the same logical value, which
+    /// changes its digest, which invalidates the issuer's signature over data the issuer really did sign.
+    /// </remarks>
+    public byte[]? IssuerSignedCbor { get; init; }
+
+    /// <summary>
+    /// Names of every disclosable claim available in this credential. For an mdoc these are the element
+    /// identifiers (e.g. <c>age_over_18</c>).
+    /// </summary>
     public required IReadOnlyList<string> AvailableClaimNames { get; init; }
 
     /// <summary>Issuer DID — surfaced for the consent sheet.</summary>
@@ -143,6 +185,20 @@ public sealed record CachedCredential
 
     /// <summary>Optional display label (issuer-supplied).</summary>
     public string? DisplayLabel { get; init; }
+
+    /// <summary>
+    /// The identifier this credential is matched on — <see cref="Vct"/> or <see cref="DocType"/> depending on
+    /// <see cref="Format"/>.
+    /// </summary>
+    /// <remarks>
+    /// A single accessor so no call site has to remember the rule, and so a new format cannot be added without
+    /// deciding what it matches on.
+    /// </remarks>
+    public string MatchIdentifier => Format switch
+    {
+        CachedCredentialFormat.MsoMdoc => DocType ?? string.Empty,
+        _ => Vct
+    };
 }
 
 /// <summary>

--- a/src/Apps/Sorcha.Wallet.Pwa/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Extensions/ServiceCollectionExtensions.cs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Sorcha Contributors
 
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Blazored.LocalStorage;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 using Sorcha.Wallet.Pwa.Services;
@@ -58,9 +59,17 @@ public static class ServiceCollectionExtensions
                               Sorcha.Wallet.Pwa.Services.Proximity.WebCryptoMdocDeviceKeyService>();
 
         // Transient: a proximity transport is per-exchange, and Disconnected is terminal — a shared instance
-        // would carry a dead channel into the next presentation.
+        // would carry a dead channel into the next presentation. Same for the presentation service, which
+        // owns one session.
         services.AddTransient<Sorcha.Proximity.IProximityTransport,
                               Sorcha.Wallet.Pwa.Services.Proximity.CapacitorProximityTransport>();
+        services.AddTransient<Sorcha.Wallet.Pwa.Services.Proximity.IProximityPresentationService,
+                              Sorcha.Wallet.Pwa.Services.Proximity.ProximityPresentationService>();
+
+        // QR generation happens ON DEVICE (QRCoder, pure-managed) — an in-person exchange must work with no
+        // signal, so a server-rendered QR would defeat the entire feature.
+        services.TryAddSingleton<Sorcha.UI.Core.Services.IQrPresentationService,
+                                 Sorcha.UI.Core.Services.QrPresentationService>();
         // Feature 152 (offline / field capture) — encrypted device-local store seam + connectivity.
         services.AddSingleton<Sorcha.Wallet.Pwa.Services.Drafts.IEncryptedObjectStore,
                               Sorcha.Wallet.Pwa.Services.Drafts.IndexedDbEncryptedObjectStore>();

--- a/src/Apps/Sorcha.Wallet.Pwa/Pages/Present.razor
+++ b/src/Apps/Sorcha.Wallet.Pwa/Pages/Present.razor
@@ -32,6 +32,8 @@
 @inject HttpClient Http
 @inject IJSRuntime JS
 @inject IPresentationLog PresentationLog
+@inject IServiceProvider Services
+@inject NavigationManager Nav
 @inject IDeviceProfileProbe DeviceProbe
 
 <PageTitle>Present a credential</PageTitle>
@@ -41,6 +43,26 @@
 
     @if (_phase == Phase.AwaitingDeepLink)
     {
+        @* Feature 185 — in-person sharing.
+           Capability-GATED, not merely linked: this build also runs in a plain browser (capacitor.config
+           points the native shell at the hosted PWA), where there is no BLE at all. Offering an affordance
+           that cannot work would be worse than not offering it (FR-020). *@
+        @if (_proximitySupported)
+        {
+            <MudPaper Elevation="1" Class="pa-4 mb-3" data-testid="present-proximity-card">
+                <MudText Typo="Typo.subtitle2">Someone in front of you?</MudText>
+                <MudText Typo="Typo.body2" Color="Color.Secondary" Class="mb-3">
+                    Share a credential directly with their device. Works with no signal.
+                </MudText>
+                <MudButton Variant="Variant.Filled" Color="Color.Primary" FullWidth="true"
+                           StartIcon="@Icons.Material.Filled.Contactless"
+                           data-testid="present-proximity-button"
+                           OnClick="@(() => Nav.NavigateTo("present/proximity"))">
+                    Share in person
+                </MudButton>
+            </MudPaper>
+        }
+
         <MudPaper Elevation="1" Class="pa-4">
             @if (_intakeMode == IntakeMode.CameraFirst && !_showPaste)
             {
@@ -199,6 +221,9 @@
 
     private enum Phase { AwaitingDeepLink, NoMatch, PickCredential, Consent, PickAlternative, PickQueryCredential, MultiConsent, Done }
 
+    // Feature 185. False until proven otherwise — an affordance the device cannot honour must not appear.
+    private bool _proximitySupported;
+
     private Phase _phase = Phase.AwaitingDeepLink;
     private string _deepLink = string.Empty;
     private string? _error;
@@ -244,6 +269,25 @@
 
     protected override async Task OnInitializedAsync()
     {
+        // Feature 185: ask the device what it can do BEFORE offering in-person sharing.
+        //
+        // Resolved through IServiceProvider rather than @inject, deliberately. The online presentation path
+        // must not acquire a hard dependency on a BLE transport it never uses — a host (or a test) that has
+        // no proximity registration should still render this page perfectly. Graceful-skip, the same pattern
+        // F183 used for IClaimSourceSeeder.
+        try
+        {
+            var transport = Services.GetService(typeof(Sorcha.Proximity.IProximityTransport))
+                as Sorcha.Proximity.IProximityTransport;
+
+            _proximitySupported = transport is not null && (await transport.ProbeAsync()).Supported;
+        }
+        catch
+        {
+            // An unsupported device is a normal answer, not an error. Never let it break the online path.
+            _proximitySupported = false;
+        }
+
         try
         {
             var profile = await DeviceProbe.GetProfileAsync();

--- a/src/Apps/Sorcha.Wallet.Pwa/Pages/PresentProximity.razor
+++ b/src/Apps/Sorcha.Wallet.Pwa/Pages/PresentProximity.razor
@@ -1,0 +1,264 @@
+@page "/present/proximity"
+@using Microsoft.AspNetCore.Authorization
+@using Sorcha.Mdoc.Proximity
+@using Sorcha.Proximity
+@using Sorcha.UI.Core.Services
+@using Sorcha.Wallet.Pwa.Services.Proximity
+@attribute [Authorize]
+@implements IAsyncDisposable
+@inject IProximityPresentationService Proximity
+@inject IQrPresentationService Qr
+@inject NavigationManager Navigation
+
+<PageTitle>Share in person</PageTitle>
+
+<div class="proximity">
+
+    @if (_phase == Phase.Checking)
+    {
+        <p class="proximity__status" aria-live="polite">Checking this device…</p>
+    }
+    else if (_phase == Phase.Unsupported)
+    {
+        @* Honest, specific, and actionable. "Unsupported" alone would dead-end a citizen whose Bluetooth is
+           merely switched off, or who has simply never been asked for permission. *@
+        <h1>Can't share in person here</h1>
+        <p class="proximity__status">@UnsupportedMessage()</p>
+        <button class="proximity__secondary" @onclick="GoBack">Back</button>
+    }
+    else if (_phase == Phase.Engaging)
+    {
+        <h1>Show this to the verifier</h1>
+        <p class="proximity__status">
+            Hold your phone up. They'll scan this code, then you'll see exactly what they're asking for
+            <strong>before</strong> anything is shared.
+        </p>
+
+        <div class="proximity__qr" aria-label="Engagement code">
+            @((MarkupString)(_qrSvg ?? string.Empty))
+        </div>
+
+        <p class="proximity__hint">This works with no signal. Nothing is sent over the internet.</p>
+        <button class="proximity__secondary" @onclick="CancelAsync">Cancel</button>
+    }
+    else if (_phase == Phase.Consent)
+    {
+        <h1>They're asking for…</h1>
+
+        @if (_satisfiable.Count == 0)
+        {
+            @* Do not show an empty approval screen — say plainly that we cannot answer. *@
+            <p class="proximity__status">
+                You don't hold a credential that answers this request. Nothing has been shared.
+            </p>
+            <ul class="proximity__asks">
+                @foreach (var element in _requested)
+                {
+                    <li class="proximity__ask proximity__ask--unmet">@Humanise(element.ElementIdentifier)</li>
+                }
+            </ul>
+            <button class="proximity__secondary" @onclick="DeclineAsync">Close</button>
+        }
+        else
+        {
+            <ul class="proximity__asks">
+                @foreach (var element in _satisfiable)
+                {
+                    <li class="proximity__ask">
+                        <label>
+                            <input type="checkbox"
+                                   checked="@_approved.Contains(element)"
+                                   @onchange="e => Toggle(element, e)" />
+                            <span class="proximity__ask-name">@Humanise(element.ElementIdentifier)</span>
+                        </label>
+
+                        @if (element.IntentToRetain)
+                        {
+                            @* The single most under-appreciated disclosure in the whole exchange. "Prove you
+                               are over 18" and "prove you are over 18, and I am keeping a copy" are materially
+                               different asks, and only one of them is what most people think they agreed to. *@
+                            <span class="proximity__retain" title="The verifier intends to keep this">
+                                They'll keep this
+                            </span>
+                        }
+                    </li>
+                }
+            </ul>
+
+            <button class="proximity__primary" disabled="@(_approved.Count == 0 || _sharing)" @onclick="ApproveAsync">
+                @(_sharing ? "Sharing…" : "Share selected")
+            </button>
+            <button class="proximity__secondary" disabled="@_sharing" @onclick="DeclineAsync">
+                Don't share
+            </button>
+        }
+    }
+    else if (_phase == Phase.Done)
+    {
+        <h1>Shared</h1>
+        <p class="proximity__status">You shared @_approved.Count @(_approved.Count == 1 ? "detail" : "details").</p>
+        <button class="proximity__primary" @onclick="GoBack">Done</button>
+    }
+    else if (_phase == Phase.Declined)
+    {
+        <h1>Nothing shared</h1>
+        <p class="proximity__status">The verifier received nothing.</p>
+        <button class="proximity__primary" @onclick="GoBack">Done</button>
+    }
+    else if (_phase == Phase.Failed)
+    {
+        <h1>That didn't work</h1>
+        <p class="proximity__status">@(_failure ?? "The exchange ended before it completed.")</p>
+        <p class="proximity__hint">Nothing was shared.</p>
+        <button class="proximity__primary" @onclick="GoBack">Back</button>
+    }
+
+</div>
+
+@code {
+    private enum Phase { Checking, Unsupported, Engaging, Consent, Done, Declined, Failed }
+
+    private Phase _phase = Phase.Checking;
+    private ProximityCapability _capability;
+    private string? _failure;
+    private bool _sharing;
+
+    private string? _qrSvg;
+    private IReadOnlyList<RequestedElement> _requested = [];
+    private IReadOnlyList<RequestedElement> _satisfiable = [];
+    private readonly HashSet<RequestedElement> _approved = [];
+
+    protected override async Task OnInitializedAsync()
+    {
+        _capability = await Proximity.ProbeAsync();
+
+        if (!_capability.Supported)
+        {
+            _phase = Phase.Unsupported;
+            return;
+        }
+
+        await StartAsync();
+    }
+
+    private async Task StartAsync()
+    {
+        try
+        {
+            var engagement = await Proximity.StartAsync();
+
+            // Rendered in C#, on-device, with no network and no JS. That matters: the whole point of this
+            // feature is that it works with no signal, so a QR that needed a server would defeat it.
+            //
+            // The payload carries an ephemeral key and a random per-session service UUID — nothing about the
+            // citizen — so it is safe to show to anyone who asks.
+            _qrSvg = Qr.GenerateSvgFromUri(EngagementUri(engagement), pixelsPerModule: 6);
+
+            _phase = Phase.Engaging;
+            StateHasChanged();
+
+            await Proximity.WaitForRequestAsync();
+
+            _requested = Proximity.RequestedElements;
+            _satisfiable = Proximity.SatisfiableElements;
+
+            // Nothing is pre-approved. The citizen opts IN to each element — an approval screen that arrives
+            // pre-ticked is not consent.
+            _approved.Clear();
+
+            _phase = Phase.Consent;
+        }
+        catch (Exception ex)
+        {
+            _failure = ex.Message;
+            _phase = Phase.Failed;
+        }
+
+        StateHasChanged();
+    }
+
+    private void Toggle(RequestedElement element, ChangeEventArgs e)
+    {
+        if (e.Value is true)
+            _approved.Add(element);
+        else
+            _approved.Remove(element);
+    }
+
+    private async Task ApproveAsync()
+    {
+        _sharing = true;
+        try
+        {
+            await Proximity.ApproveAsync(_approved.ToList());
+            _phase = Phase.Done;
+        }
+        catch (Exception ex)
+        {
+            _failure = ex.Message;
+            _phase = Phase.Failed;
+        }
+        finally
+        {
+            _sharing = false;
+        }
+    }
+
+    private async Task DeclineAsync()
+    {
+        await Proximity.DeclineAsync();
+        _phase = Phase.Declined;
+    }
+
+    private async Task CancelAsync()
+    {
+        await Proximity.DeclineAsync();
+        GoBack();
+    }
+
+    private void GoBack() => Navigation.NavigateTo("");
+
+    /// <summary>The ISO 18013-5 QR-engagement payload: <c>mdoc:</c> + base64url of the DeviceEngagement.</summary>
+    private static string EngagementUri(byte[] deviceEngagement) =>
+        "mdoc:" + Convert.ToBase64String(deviceEngagement)
+            .TrimEnd('=').Replace('+', '-').Replace('/', '_');
+
+    private string UnsupportedMessage() => _capability.Reason switch
+    {
+        ProximityUnsupportedReason.BluetoothOff =>
+            "Turn Bluetooth on, then try again.",
+        ProximityUnsupportedReason.PermissionNotYetRequested =>
+            "Sorcha needs permission to use Bluetooth. Try again and allow it when asked.",
+        ProximityUnsupportedReason.PermissionDenied =>
+            "Bluetooth permission was refused. You can turn it back on in your phone's settings.",
+        ProximityUnsupportedReason.NoBluetoothHardware =>
+            "This device has no Bluetooth, so it can't share in person.",
+        ProximityUnsupportedReason.NoPlugin =>
+            "In-person sharing needs the Sorcha app — it can't work in a browser tab.",
+        _ =>
+            "In-person sharing isn't available on this device."
+    };
+
+    /// <summary>Turns an mdoc element identifier into something a person would recognise.</summary>
+    private static string Humanise(string elementIdentifier) => elementIdentifier switch
+    {
+        "family_name" => "Your last name",
+        "given_name" => "Your first name",
+        "birth_date" => "Your date of birth",
+        "age_over_18" => "That you're over 18",
+        "age_over_21" => "That you're over 21",
+        "portrait" => "Your photo",
+        "document_number" => "Your document number",
+        "issuing_authority" => "Who issued it",
+        "expiry_date" => "When it expires",
+        // Unknown elements are shown as-is rather than hidden: the citizen must see everything being asked
+        // for, even something we do not have friendly copy for.
+        _ => elementIdentifier.Replace('_', ' ')
+    };
+
+    public async ValueTask DisposeAsync()
+    {
+        // Navigating away mid-exchange abandons it: the reader is told, and nothing is disclosed.
+        await Proximity.DisposeAsync();
+    }
+}

--- a/src/Apps/Sorcha.Wallet.Pwa/Services/Presentation/PresentationEngine.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Services/Presentation/PresentationEngine.cs
@@ -104,9 +104,14 @@ public sealed class PresentationEngine : IPresentationEngine
                 ResponseUri = GetRequiredString(root, "response_uri"),
                 Nonce = GetRequiredString(root, "nonce"),
                 Query = query,
-                RequiredVct = credential.Meta.VctValues is { Count: > 0 }
-                    ? credential.Meta.VctValues[0]
-                    : throw new FormatException("Request object's credential query carries no vct_values."),
+                // Feature 185: an mdoc query carries `doctype_value`, NOT `vct_values` — so demanding vct
+                // here rejected every mso_mdoc request outright, even though F181's DCQL vocabulary has
+                // always been able to express one. The wallet could not so much as PARSE a request for the
+                // credential type that proximity presentation exists to present.
+                //
+                // A query with neither is genuinely malformed and still fails, but it fails at the query, not
+                // at the whole request.
+                RequiredVct = QueryIdentifier(credential),
                 RequiredClaims = required,
                 OptionalClaims = optional,
                 Purpose = purpose,
@@ -150,7 +155,13 @@ public sealed class PresentationEngine : IPresentationEngine
     {
         ArgumentNullException.ThrowIfNull(request);
         ArgumentNullException.ThrowIfNull(credentials);
-        return MatchCandidates(request.RequiredVct, request.RequiredClaims, request.OptionalClaims, credentials);
+
+        var format = request.Query.Credentials.Count > 0
+            ? request.Query.Credentials[0].Format
+            : DcqlFormats.SdJwtVc;
+
+        return MatchCandidates(
+            format, request.RequiredVct, request.RequiredClaims, request.OptionalClaims, credentials);
     }
 
     /// <inheritdoc />
@@ -166,9 +177,9 @@ public sealed class PresentationEngine : IPresentationEngine
         var unsatisfiable = new HashSet<string>(StringComparer.Ordinal);
         foreach (var cq in request.Query.Credentials)
         {
-            var vct = cq.Meta.VctValues is { Count: > 0 } ? cq.Meta.VctValues[0] : string.Empty;
+            var vct = QueryIdentifier(cq);
             var (required, optional) = DcqlRequestParser.SplitClaims(cq);
-            var candidates = MatchCandidates(vct, required, optional, credentials);
+            var candidates = MatchCandidates(cq.Format, vct, required, optional, credentials);
             perQuery.Add(new DcqlQueryMatch
             {
                 QueryId = cq.Id,
@@ -240,16 +251,48 @@ public sealed class PresentationEngine : IPresentationEngine
         };
     }
 
+    /// <summary>
+    /// The identifier a credential query matches on: <c>vct_values</c> for SD-JWT, <c>doctype_value</c> for
+    /// mdoc.
+    /// </summary>
+    /// <remarks>
+    /// One place, so that the two formats' identifiers can never be silently confused for one another — they
+    /// are different strings and a credential must never be matched against the wrong one.
+    /// </remarks>
+    private static string QueryIdentifier(DcqlCredentialQuery query) =>
+        string.Equals(query.Format, DcqlFormats.MsoMdoc, StringComparison.Ordinal)
+            ? query.Meta.DoctypeValue ?? string.Empty
+            : query.Meta.VctValues is { Count: > 0 } vcts ? vcts[0] : string.Empty;
+
+    /// <summary>Maps a DCQL format string to the wallet's cached-credential format.</summary>
+    private static CachedCredentialFormat FormatOf(string dcqlFormat) =>
+        string.Equals(dcqlFormat, DcqlFormats.MsoMdoc, StringComparison.Ordinal)
+            ? CachedCredentialFormat.MsoMdoc
+            : CachedCredentialFormat.SdJwtVc;
+
     private static IReadOnlyList<CredentialMatch> MatchCandidates(
-        string vct,
+        string dcqlFormat,
+        string identifier,
         IReadOnlyList<string> requiredClaims,
         IReadOnlyList<string> optionalClaims,
         IReadOnlyList<CachedCredential> credentials)
     {
+        // A query with no identifier matches nothing. Returning every credential instead would be a
+        // catastrophic default — the citizen would be offered credentials the verifier never asked for.
+        if (string.IsNullOrEmpty(identifier))
+            return [];
+
+        var wantedFormat = FormatOf(dcqlFormat);
+
         var matches = new List<CredentialMatch>();
         foreach (var credential in credentials)
         {
-            if (!string.Equals(credential.Vct, vct, StringComparison.Ordinal)) continue;
+            // The format gate comes FIRST. Without it an mdoc docType could be matched against an SD-JWT's
+            // vct — they are different namespaces of string and a collision, however unlikely, would present
+            // the wrong credential entirely.
+            if (credential.Format != wantedFormat) continue;
+
+            if (!string.Equals(credential.MatchIdentifier, identifier, StringComparison.Ordinal)) continue;
 
             var availableNames = new HashSet<string>(credential.AvailableClaimNames, StringComparer.Ordinal);
             var satisfied = requiredClaims.Where(availableNames.Contains).ToList();

--- a/src/Apps/Sorcha.Wallet.Pwa/Services/Proximity/ProximityPresentationService.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Services/Proximity/ProximityPresentationService.cs
@@ -1,0 +1,199 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using Microsoft.Extensions.Logging;
+using Sorcha.Mdoc;
+using Sorcha.Mdoc.Proximity;
+using Sorcha.Proximity;
+using Sorcha.UI.Core.Models.Presentation;
+using Sorcha.Wallet.Pwa.Services.Presentation;
+
+namespace Sorcha.Wallet.Pwa.Services.Proximity;
+
+/// <summary>Drives one in-person presentation, from the wallet's point of view.</summary>
+public interface IProximityPresentationService : IAsyncDisposable
+{
+    /// <summary>What this device can do. Ask before offering in-person sharing at all.</summary>
+    Task<ProximityCapability> ProbeAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Starts an exchange and returns the <c>DeviceEngagement</c> bytes to render as a QR code.
+    /// </summary>
+    /// <remarks>The QR carries an ephemeral key and a random service UUID — nothing about the citizen.</remarks>
+    Task<byte[]> StartAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Waits for the reader's request. On return, the citizen must be shown
+    /// <see cref="RequestedElements"/> — <b>including each element's <c>IntentToRetain</c></b> — and nothing
+    /// has been disclosed.
+    /// </summary>
+    Task WaitForRequestAsync(CancellationToken ct = default);
+
+    /// <summary>What the reader asked for.</summary>
+    IReadOnlyList<RequestedElement> RequestedElements { get; }
+
+    /// <summary>Which of those this citizen can actually satisfy.</summary>
+    IReadOnlyList<RequestedElement> SatisfiableElements { get; }
+
+    /// <summary>Discloses exactly <paramref name="approved"/> — nothing more — and completes the exchange.</summary>
+    Task ApproveAsync(IReadOnlyCollection<RequestedElement> approved, CancellationToken ct = default);
+
+    /// <summary>The citizen said no. Nothing is disclosed.</summary>
+    Task DeclineAsync(CancellationToken ct = default);
+
+    /// <summary>Where the exchange is.</summary>
+    HolderSessionState State { get; }
+
+    /// <summary>Why it failed, when it did.</summary>
+    string? FailureReason { get; }
+}
+
+/// <inheritdoc />
+/// <remarks>
+/// <para>
+/// A thin composition: the ISO protocol lives in <c>Sorcha.Mdoc</c> / <c>Sorcha.Proximity.Abstractions</c>
+/// and is already proven end-to-end over a loopback transport with no radio. This class only supplies the
+/// three things that are wallet-specific — the citizen's mdocs, the citizen's device key, and the native
+/// transport — and gets out of the way.
+/// </para>
+/// <para>
+/// It deliberately does <b>not</b> re-implement anything the session engine already does. If a rule about
+/// disclosure or consent seems to be missing here, it is because it is enforced structurally in
+/// <see cref="ProximityHolderSession"/>, which is the right place for it.
+/// </para>
+/// </remarks>
+public sealed class ProximityPresentationService : IProximityPresentationService
+{
+    private readonly IProximityTransport _transport;
+    private readonly ICredentialCache _credentials;
+    private readonly IMdocDeviceKeyService _deviceKey;
+    private readonly ILogger<ProximityPresentationService> _logger;
+
+    private ProximityHolderSession? _session;
+
+    public ProximityPresentationService(
+        IProximityTransport transport,
+        ICredentialCache credentials,
+        IMdocDeviceKeyService deviceKey,
+        ILogger<ProximityPresentationService> logger)
+    {
+        _transport = transport ?? throw new ArgumentNullException(nameof(transport));
+        _credentials = credentials ?? throw new ArgumentNullException(nameof(credentials));
+        _deviceKey = deviceKey ?? throw new ArgumentNullException(nameof(deviceKey));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    public HolderSessionState State => _session?.State ?? HolderSessionState.Idle;
+
+    /// <inheritdoc />
+    public string? FailureReason => _session?.FailureReason;
+
+    /// <inheritdoc />
+    public IReadOnlyList<RequestedElement> RequestedElements => _session?.RequestedElements ?? [];
+
+    /// <inheritdoc />
+    public IReadOnlyList<RequestedElement> SatisfiableElements => _session?.SatisfiableElements ?? [];
+
+    /// <inheritdoc />
+    public Task<ProximityCapability> ProbeAsync(CancellationToken ct = default) =>
+        _transport.ProbeAsync(ct);
+
+    /// <inheritdoc />
+    public async Task<byte[]> StartAsync(CancellationToken ct = default)
+    {
+        if (_session is not null)
+            throw new InvalidOperationException("An exchange is already in progress.");
+
+        var held = await LoadHeldMdocsAsync(ct).ConfigureAwait(false);
+        if (held.Count == 0)
+            throw new InvalidOperationException(
+                "This wallet holds no mdoc credentials, so there is nothing to present in person. " +
+                "(SD-JWT credentials are presented online — the proximity rail is mdoc-shaped.)");
+
+        _session = new ProximityHolderSession(_transport, held, _deviceKey.AsHolderDeviceKey());
+
+        return await _session.StartAsync(ct).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task WaitForRequestAsync(CancellationToken ct = default)
+    {
+        var session = _session ?? throw new InvalidOperationException("No exchange has been started.");
+        await session.WaitForRequestAsync(ct).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task ApproveAsync(IReadOnlyCollection<RequestedElement> approved, CancellationToken ct = default)
+    {
+        var session = _session ?? throw new InvalidOperationException("No exchange has been started.");
+        await session.ApproveAsync(approved, ct).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task DeclineAsync(CancellationToken ct = default)
+    {
+        if (_session is null)
+            return;
+
+        await _session.DeclineAsync(ct).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Loads the citizen's mdoc credentials from the cache, in the shape the protocol needs.
+    /// </summary>
+    /// <remarks>
+    /// SD-JWT credentials are skipped: the proximity rail is mdoc-shaped, and offering an SD-JWT here would be
+    /// offering something the reader cannot consume. A credential whose stored CBOR will not decode is skipped
+    /// with a warning rather than thrown on — the cache is a mirror of server state, and one bad row must
+    /// never take the whole exchange down.
+    /// </remarks>
+    private async Task<IReadOnlyList<HeldMdoc>> LoadHeldMdocsAsync(CancellationToken ct)
+    {
+        var cached = await _credentials.ListAsync(ct).ConfigureAwait(false);
+
+        var held = new List<HeldMdoc>();
+
+        foreach (var credential in cached)
+        {
+            if (credential.Format != CachedCredentialFormat.MsoMdoc)
+                continue;
+
+            if (credential.DocType is not { Length: > 0 } docType || credential.IssuerSignedCbor is not { Length: > 0 } cbor)
+            {
+                _logger.LogWarning(
+                    "Skipping mdoc credential {CredentialId}: it carries no docType or no IssuerSigned CBOR.",
+                    credential.Id);
+                continue;
+            }
+
+            try
+            {
+                held.Add(new HeldMdoc(docType, MdocCodec.DecodeIssuerSigned(cbor)));
+            }
+            catch (Exception ex)
+            {
+                // Evict-and-continue, as the credential cache itself does. A row we cannot decode is one
+                // credential the citizen cannot present — not a reason to fail the whole presentation.
+                _logger.LogWarning(ex,
+                    "Skipping mdoc credential {CredentialId}: its stored CBOR does not decode.",
+                    credential.Id);
+            }
+        }
+
+        return held;
+    }
+
+    /// <inheritdoc />
+    public async ValueTask DisposeAsync()
+    {
+        if (_session is not null)
+        {
+            // Abandon rather than just drop: the reader is left waiting otherwise, and the session's own
+            // teardown zeroises the session keys.
+            await _session.AbandonAsync().ConfigureAwait(false);
+            await _session.DisposeAsync().ConfigureAwait(false);
+            _session = null;
+        }
+    }
+}

--- a/src/Apps/Sorcha.Wallet.Pwa/wwwroot/css/proximity.css
+++ b/src/Apps/Sorcha.Wallet.Pwa/wwwroot/css/proximity.css
@@ -1,0 +1,135 @@
+/* SPDX-License-Identifier: MIT
+   Copyright (c) 2026 Sorcha Contributors
+
+   In-person (proximity) presentation — Feature 185.
+   Deliberately plain: this screen is used at a counter or a roadside, often in a hurry, sometimes in bright
+   sun. Legibility and a large tap target beat decoration. */
+
+.proximity {
+    max-width: 32rem;
+    margin: 0 auto;
+    padding: 1.5rem 1.25rem 3rem;
+}
+
+.proximity h1 {
+    font-size: 1.5rem;
+    line-height: 1.25;
+    margin: 0 0 0.75rem;
+}
+
+.proximity__status {
+    font-size: 1rem;
+    line-height: 1.5;
+    margin: 0 0 1.25rem;
+}
+
+.proximity__hint {
+    font-size: 0.875rem;
+    opacity: 0.75;
+    margin: 1rem 0 1.5rem;
+}
+
+/* The engagement code. White plate regardless of theme — a QR on a dark background does not scan. */
+.proximity__qr {
+    background: #fff;
+    padding: 1rem;
+    border-radius: 0.75rem;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    margin: 0 auto 1rem;
+    max-width: 20rem;
+}
+
+.proximity__qr svg {
+    width: 100%;
+    height: auto;
+    display: block;
+}
+
+.proximity__asks {
+    list-style: none;
+    margin: 0 0 1.5rem;
+    padding: 0;
+}
+
+.proximity__ask {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    padding: 0.875rem 0;
+    border-bottom: 1px solid rgba(128, 128, 128, 0.25);
+}
+
+.proximity__ask label {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    cursor: pointer;
+    flex: 1;
+}
+
+.proximity__ask input[type="checkbox"] {
+    width: 1.25rem;
+    height: 1.25rem;
+    flex: 0 0 auto;
+}
+
+.proximity__ask-name {
+    font-size: 1rem;
+}
+
+.proximity__ask--unmet {
+    opacity: 0.6;
+}
+
+/* "They'll keep this" — intentToRetain.
+   Given visual weight ON PURPOSE. It is the disclosure people least expect and most need to see: proving
+   you are over 18 and having a copy of that kept are materially different things. */
+.proximity__retain {
+    flex: 0 0 auto;
+    font-size: 0.75rem;
+    font-weight: 600;
+    padding: 0.25rem 0.5rem;
+    border-radius: 0.375rem;
+    background: rgba(214, 158, 46, 0.18);
+    color: #8a5a00;
+    white-space: nowrap;
+}
+
+@media (prefers-color-scheme: dark) {
+    .proximity__retain {
+        background: rgba(236, 201, 75, 0.2);
+        color: #f6e05e;
+    }
+}
+
+.proximity__primary,
+.proximity__secondary {
+    display: block;
+    width: 100%;
+    padding: 0.875rem 1rem;
+    font-size: 1rem;
+    font-weight: 600;
+    border-radius: 0.5rem;
+    border: 1px solid transparent;
+    cursor: pointer;
+    margin-bottom: 0.75rem;
+}
+
+.proximity__primary {
+    background: #2b6cb0;
+    color: #fff;
+}
+
+.proximity__primary:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
+.proximity__secondary {
+    background: transparent;
+    border-color: rgba(128, 128, 128, 0.4);
+    color: inherit;
+}

--- a/src/Apps/Sorcha.Wallet.Pwa/wwwroot/index.html
+++ b/src/Apps/Sorcha.Wallet.Pwa/wwwroot/index.html
@@ -9,6 +9,7 @@
     <link href="_content/MudBlazor/MudBlazor.min.css" rel="stylesheet" />
     <link href="css/app.css" rel="stylesheet" />
     <link href="css/welcome-takeover.css" rel="stylesheet" />
+    <link href="css/proximity.css" rel="stylesheet" />
     <link href="css/splash.css" rel="stylesheet" />
     <!-- Blazor CSS-isolation bundle — without this, every component .razor.css
          (incl. the Feature 141 wallet chrome + shared Sorcha.UI.Components.User

--- a/tests/Sorcha.Wallet.Pwa.Tests/Pages/ProximityAffordanceTests.cs
+++ b/tests/Sorcha.Wallet.Pwa.Tests/Pages/ProximityAffordanceTests.cs
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System;
+using System.Threading;
+using Bunit;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Sorcha.Proximity;
+using Sorcha.UI.Testing;
+using Sorcha.Wallet.Pwa.Models.Device;
+using Sorcha.Wallet.Pwa.Services;
+using Sorcha.Wallet.Pwa.Services.Device;
+using Sorcha.Wallet.Pwa.Services.Presentation;
+using Xunit;
+
+using PresentPage = Sorcha.Wallet.Pwa.Pages.Present;
+
+namespace Sorcha.Wallet.Pwa.Tests.Pages;
+
+/// <summary>
+/// The in-person sharing affordance must be <b>hidden</b> where the device cannot honour it — not shown and
+/// then broken (FR-020).
+/// </summary>
+/// <remarks>
+/// <para>
+/// This matters more than it looks. The wallet is a PWA and the <em>same build</em> runs in a plain browser
+/// (the native shell points at the hosted app), where there is no BLE at all. An always-visible "Share in
+/// person" button would be dead for a large share of sessions — and a citizen who taps it at a counter and
+/// gets an error is worse off than one who was never offered it.
+/// </para>
+/// <para>
+/// The page resolves the transport through <c>IServiceProvider</c> rather than <c>@inject</c>, so a host with
+/// <b>no</b> proximity registration renders perfectly and simply offers nothing. That is what the first test
+/// pins — and it is why adding this feature did not force every unrelated Present-page test to register a BLE
+/// transport it does not care about.
+/// </para>
+/// </remarks>
+public sealed class ProximityAffordanceTests : ComponentTestFixture
+{
+    private readonly Mock<IPresentationEngine> _engine = new();
+    private readonly Mock<ICredentialCache> _credentials = new();
+    private readonly Mock<IDeviceKeyService> _deviceKey = new();
+    private readonly Mock<IDelegationStore> _delegation = new();
+    private readonly Mock<IStatusListService> _statusList = new();
+    private readonly Mock<IPresentationLog> _log = new();
+
+    public ProximityAffordanceTests()
+    {
+        Services.AddSingleton(_engine.Object);
+        Services.AddSingleton(_credentials.Object);
+        Services.AddSingleton(_deviceKey.Object);
+        Services.AddSingleton(_delegation.Object);
+        Services.AddSingleton(_statusList.Object);
+        Services.AddSingleton(_log.Object);
+        Services.AddSingleton<Microsoft.Extensions.Logging.ILogger<PresentPage>>(
+            Microsoft.Extensions.Logging.Abstractions.NullLogger<PresentPage>.Instance);
+        Services.AddScoped<System.Net.Http.HttpClient>(_ => new System.Net.Http.HttpClient());
+
+        var probe = new Mock<IDeviceProfileProbe>();
+        probe.Setup(p => p.GetProfileAsync(It.IsAny<CancellationToken>()))
+             .ReturnsAsync(new DeviceProfile(DeviceFormFactor.Desktop, CameraAvailability.Unavailable));
+        Services.AddScoped(_ => probe.Object);
+    }
+
+    private void RegisterTransport(ProximityCapability capability)
+    {
+        var transport = new Mock<IProximityTransport>();
+        transport
+            .Setup(t => t.ProbeAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(capability);
+
+        Services.AddSingleton(transport.Object);
+    }
+
+    /// <summary>A host with no proximity registration at all renders fine and offers nothing.</summary>
+    [Fact]
+    public void NoProximityTransportRegistered_TheAffordanceIsAbsent()
+    {
+        var cut = Render<PresentPage>();
+
+        cut.FindAll("[data-testid=present-proximity-button]").Should().BeEmpty(because:
+            "a host with no proximity support must render the online path perfectly and offer nothing it " +
+            "cannot honour");
+    }
+
+    /// <summary>A real device that cannot do it — no radio, or permission refused — is offered nothing.</summary>
+    [Fact]
+    public void TransportReportsUnsupported_TheAffordanceIsAbsent()
+    {
+        RegisterTransport(new ProximityCapability(
+            Supported: false,
+            BluetoothEnabled: false,
+            PermissionGranted: false,
+            ProximityUnsupportedReason.NoBluetoothHardware));
+
+        var cut = Render<PresentPage>();
+
+        cut.FindAll("[data-testid=present-proximity-button]").Should().BeEmpty();
+    }
+
+    /// <summary>A device that can do it is offered it.</summary>
+    [Fact]
+    public void TransportReportsSupported_TheAffordanceIsOffered()
+    {
+        RegisterTransport(new ProximityCapability(
+            Supported: true,
+            BluetoothEnabled: true,
+            PermissionGranted: true));
+
+        var cut = Render<PresentPage>();
+
+        cut.FindAll("[data-testid=present-proximity-button]").Should().ContainSingle();
+    }
+
+    /// <summary>A misbehaving native layer must never take the online presentation path down with it.</summary>
+    [Fact]
+    public void AProbeThatThrows_DoesNotBreakTheOnlinePath()
+    {
+        var transport = new Mock<IProximityTransport>();
+        transport
+            .Setup(t => t.ProbeAsync(It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("the plugin exploded"));
+
+        Services.AddSingleton(transport.Object);
+
+        var cut = Render<PresentPage>();
+
+        cut.FindAll("[data-testid=present-proximity-button]").Should().BeEmpty();
+        cut.Markup.Should().NotBeNullOrWhiteSpace(because: "the online path still renders");
+    }
+}

--- a/tests/Sorcha.Wallet.Pwa.Tests/Presentation/MdocQueryMatchingTests.cs
+++ b/tests/Sorcha.Wallet.Pwa.Tests/Presentation/MdocQueryMatchingTests.cs
@@ -1,0 +1,214 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Sorcha.UI.Core.Models.Presentation;
+using Sorcha.Verifier.Engine.Dcql;
+using Sorcha.Wallet.Pwa.Services.Presentation;
+using Xunit;
+
+namespace Sorcha.Wallet.Pwa.Tests.Presentation;
+
+/// <summary>
+/// The wallet must be able to answer an <c>mso_mdoc</c> credential query (Feature 185).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Before this, it could not. <c>ParseAsync</c> <b>threw</b> when a query carried no <c>vct_values</c>, and
+/// matching compared <c>vct</c> strings only — so the wallet could not so much as <em>parse</em> a request for
+/// the credential type that proximity presentation exists to present. The DCQL vocabulary (F181) has always
+/// been able to express an mdoc query; the wallet simply could not answer one.
+/// </para>
+/// <para>
+/// The load-bearing rule these tests pin: <b>the two formats have different identifiers and must never
+/// cross-match.</b> An SD-JWT is found by <c>vct</c>, an mdoc by <c>docType</c>. Matching an mdoc request
+/// against a <c>vct</c> (or vice versa) would present the wrong credential entirely.
+/// </para>
+/// </remarks>
+public class MdocQueryMatchingTests
+{
+    private const string MdlDocType = "org.iso.18013.5.1.mDL";
+    private const string IdentityVct = "https://sorcha.dev/vc/assured-identity/v1";
+
+    private static PresentationEngine Engine() =>
+        new(TimeProvider.System, NullLogger<PresentationEngine>.Instance);
+
+    private static CachedCredential AnMdoc(string docType = MdlDocType) => new()
+    {
+        Id = Guid.NewGuid(),
+        Format = CachedCredentialFormat.MsoMdoc,
+        DocType = docType,
+        IssuerSignedCbor = [0x01, 0x02, 0x03],
+        AvailableClaimNames = ["family_name", "age_over_18", "birth_date"],
+    };
+
+    private static CachedCredential AnSdJwt(string vct = IdentityVct) => new()
+    {
+        Id = Guid.NewGuid(),
+        Format = CachedCredentialFormat.SdJwtVc,
+        Vct = vct,
+        RawSdJwt = "header.payload.sig~disclosure~",
+        AvailableClaimNames = ["family_name", "age_over_18"],
+    };
+
+    private static ParsedPresentationRequest MdocRequest(
+        string docType = MdlDocType, params string[] claims) => new()
+    {
+        ClientId = "x509_san_dns:verifier.example",
+        ResponseUri = "https://verifier.example/response",
+        Nonce = "n0nce",
+        RequiredVct = docType,
+        RequiredClaims = claims.Length > 0 ? claims : ["age_over_18"],
+        OptionalClaims = [],
+        Query = new DcqlQuery
+        {
+            Credentials =
+            [
+                new DcqlCredentialQuery
+                {
+                    Id = "mdl",
+                    Format = DcqlFormats.MsoMdoc,
+                    Meta = new DcqlCredentialMeta { DoctypeValue = docType },
+                    Claims = (claims.Length > 0 ? claims : ["age_over_18"])
+                        .Select(c => new DcqlClaimQuery { Path = [c] })
+                        .ToList(),
+                }
+            ]
+        },
+    };
+
+    /// <summary>An mdoc query finds the citizen's mdoc — the thing that was previously impossible.</summary>
+    [Fact]
+    public void AnMdocQuery_MatchesAnMdocCredential()
+    {
+        var matches = Engine().Match(MdocRequest(), [AnMdoc()]);
+
+        matches.Should().HaveCount(1);
+        matches[0].Credential.Format.Should().Be(CachedCredentialFormat.MsoMdoc);
+        matches[0].Credential.DocType.Should().Be(MdlDocType);
+        matches[0].SatisfiedRequired.Should().Equal(["age_over_18"]);
+    }
+
+    /// <summary>
+    /// An mdoc query must <b>not</b> match an SD-JWT — even one whose <c>vct</c> happens to equal the docType.
+    /// </summary>
+    /// <remarks>
+    /// This is the collision the format gate exists to prevent. Matching on the identifier alone would let a
+    /// verifier asking for a driving licence be handed a completely different credential that merely shares a
+    /// string.
+    /// </remarks>
+    [Fact]
+    public void AnMdocQuery_DoesNotMatchAnSdJwt_EvenWithTheSameIdentifier()
+    {
+        var colliding = AnSdJwt(vct: MdlDocType);   // same string, different format
+
+        var matches = Engine().Match(MdocRequest(), [colliding]);
+
+        matches.Should().BeEmpty(because:
+            "vct and docType are different namespaces of string — a request for an mdoc must never be " +
+            "satisfied by an SD-JWT that happens to share the identifier");
+    }
+
+    /// <summary>And the converse: an SD-JWT query must not match an mdoc.</summary>
+    [Fact]
+    public void AnSdJwtQuery_DoesNotMatchAnMdoc()
+    {
+        var request = new ParsedPresentationRequest
+        {
+            ClientId = "x509_san_dns:verifier.example",
+            ResponseUri = "https://verifier.example/response",
+            Nonce = "n0nce",
+            RequiredVct = IdentityVct,
+            RequiredClaims = ["age_over_18"],
+            OptionalClaims = [],
+            Query = new DcqlQuery
+            {
+                Credentials =
+                [
+                    new DcqlCredentialQuery
+                    {
+                        Id = "identity",
+                        Format = DcqlFormats.SdJwtVc,
+                        Meta = new DcqlCredentialMeta { VctValues = [IdentityVct] },
+                        Claims = [new DcqlClaimQuery { Path = ["age_over_18"] }],
+                    }
+                ]
+            },
+        };
+
+        var mdocWithTheSameIdentifier = AnMdoc(docType: IdentityVct);
+
+        Engine().Match(request, [mdocWithTheSameIdentifier]).Should().BeEmpty();
+    }
+
+    /// <summary>A wallet holding both rails answers each query with the right credential.</summary>
+    [Fact]
+    public void AWalletHoldingBothFormats_AnswersAnMdocQueryWithTheMdoc()
+    {
+        var wallet = new List<CachedCredential> { AnSdJwt(), AnMdoc() };
+
+        var matches = Engine().Match(MdocRequest(), wallet);
+
+        matches.Should().HaveCount(1);
+        matches[0].Credential.Format.Should().Be(CachedCredentialFormat.MsoMdoc);
+    }
+
+    /// <summary>An mdoc that lacks a requested element is not a match — no partial presentation.</summary>
+    [Fact]
+    public void AnMdocMissingARequiredElement_IsNotAMatch()
+    {
+        var request = MdocRequest(claims: ["age_over_21"]);   // the credential carries age_over_18 only
+
+        Engine().Match(request, [AnMdoc()]).Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// A query with no identifier at all matches <b>nothing</b> — it must never fall through to "everything".
+    /// </summary>
+    /// <remarks>
+    /// A permissive default here would offer the citizen credentials the verifier never asked for, which is
+    /// the opposite of the minimal-disclosure property the whole design exists to provide.
+    /// </remarks>
+    [Fact]
+    public void AQueryWithNoIdentifier_MatchesNothing()
+    {
+        var request = MdocRequest();
+        var malformed = request with
+        {
+            RequiredVct = string.Empty,
+            Query = new DcqlQuery
+            {
+                Credentials =
+                [
+                    new DcqlCredentialQuery
+                    {
+                        Id = "malformed",
+                        Format = DcqlFormats.MsoMdoc,
+                        Meta = new DcqlCredentialMeta(),   // neither doctype_value nor vct_values
+                        Claims = [new DcqlClaimQuery { Path = ["age_over_18"] }],
+                    }
+                ]
+            },
+        };
+
+        Engine().Match(malformed, [AnMdoc(), AnSdJwt()]).Should().BeEmpty(because:
+            "an unidentifiable query must match nothing — never everything");
+    }
+
+    /// <summary>MatchQuery (the multi-credential DCQL path) handles an mdoc query too.</summary>
+    [Fact]
+    public void MatchQuery_SolvesAnMdocQuery()
+    {
+        var result = Engine().MatchQuery(MdocRequest(), [AnMdoc(), AnSdJwt()]);
+
+        result.Satisfiable.Should().BeTrue();
+        result.PerQuery.Should().HaveCount(1);
+        result.PerQuery[0].Candidates.Should().HaveCount(1);
+        result.PerQuery[0].Candidates[0].Credential.Format.Should().Be(CachedCredentialFormat.MsoMdoc);
+        result.UnsatisfiedRequiredQueryIds.Should().BeEmpty();
+    }
+}


### PR DESCRIPTION
The wallet could not so much as **parse** a request for the credential type this whole feature exists to present.

`PresentationEngine.ParseAsync` **threw** when a DCQL query carried no `vct_values`, and matching compared `vct` strings only. F181's DCQL vocabulary has always been able to express an `mso_mdoc` query — the wallet simply could not answer one. This makes it able to.

## Two formats, two identifiers — and they must never cross-match

An SD-JWT VC is found by its **`vct`**. An mdoc is found by its **`docType`**. These are different strings in different namespaces, and matching one against the other would present **the wrong credential entirely**.

So `CachedCredential` gains a `Format` discriminator, and matching **gates on format first**. `MatchIdentifier` is the single accessor that decides which field applies, so no call site has to remember the rule — and a future format cannot be added without deciding what it matches on.

Both directions are tested, including the nasty case: an SD-JWT whose `vct` *happens to equal* an mdoc `docType` must not satisfy an mdoc request.

## A query with no identifier now matches nothing

It previously fell through to comparing against `string.Empty`. A permissive default here is not a small bug: it would offer the citizen credentials **the verifier never asked for** — the exact opposite of the minimal-disclosure property the whole design exists to provide.

## The in-person UI

`/present/proximity` — engagement QR → consent → done.

- **The QR is rendered on-device, in C#** (`QRCoder`, already a dependency, pure-managed). This is load-bearing: the entire point of the feature is that it works **with no signal**, so a server-rendered QR would defeat it.
- **`intentToRetain` is given real visual weight** at consent. Proving you're over 18, and having a copy of that *kept*, are materially different things — and only one of them is what most people think they agreed to. It is the disclosure people least expect and most need to see.
- **Nothing is pre-ticked.** An approval screen that arrives pre-approved is not consent.
- **"You don't hold anything that answers this"** is said plainly, rather than showing an empty approval screen.
- Failure and decline both end with **"Nothing was shared"**, because that is the fact the citizen actually needs.

## Hidden where it can't work, not shown-and-broken (FR-020)

The affordance is **capability-gated**, not merely linked. The same build runs in a plain browser (the native shell points at the hosted PWA), where there is no BLE at all. A citizen who taps a dead "Share in person" button at a counter is worse off than one who was never offered it.

The Present page resolves the transport through `IServiceProvider` rather than `@inject` — the established graceful-skip pattern here. So the **online path acquires no hard dependency** on a BLE transport it never uses, a host with no proximity registration renders perfectly, and adding this feature did not force every unrelated Present-page test to register a transport it doesn't care about.

## Tests

**357/357** wallet (11 new) · 30/30 mdoc · 13/13 proximity · WASM + snackbar gates green.

New coverage: mdoc query matching (incl. both cross-match refusals and the no-identifier case), and the affordance gating (absent with no registration, absent when unsupported, present when supported, and **a probe that throws does not break the online path**).

## Still not true

**No byte has crossed a real radio.** This is the wallet's half, wired end to end and testable — but the two-device run has not happened, and the evidence bar remains our own devices rather than certified-reader interop.

Next: the reader app (a WASM verifier host — which discharges F155's long-deferred "path B"), then two-device validation.

Spec: `specs/185-mobile-proximity-sharing/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018rxzAeahjb74xgRxsThTu2
