### PR TITLE
fix: two P0s blocking the phone — the citizen can now claim their credential, and the camera works

### DIFF
--- a/.claude/skills/sorcha-architecture/SKILL.md
+++ b/.claude/skills/sorcha-architecture/SKILL.md
@@ -1703,8 +1703,10 @@ agent's `verification-analyst` participant `/*` disclosure, but the agent never 
 (+ instance-wide `GET /api/workflows/{instanceId}/disclosures`) in `WorkflowDisclosureEndpoints.cs`, filling a
 route the client (`IBlueprintServiceClient.GetDisclosedDataAsync`) and MCP `DisclosedDataTool` already targeted
 but no server implemented. `.RequireAuthorization()`; resolves the **caller's** wallet(s) via the same
-Wallet-Service fallback `ActionEndpoints.ResolveUserWalletAddressesAsync` uses (consumer/service tokens omit
-`wallet_address` under F136 — resolved by `platform_user_id`→owner, #912). Returns `DisclosedActionData`
+Wallet-Service fallback `ParticipantWalletResolver.ResolveUserWalletAddressesAsync` uses (consumer/service
+tokens omit `wallet_address` under F136 — resolved by `platform_user_id`→owner, #912; extracted from
+`ActionEndpoints` into `Sorcha.Blueprint.Service.Services.Infrastructure` during the P0 review fix on
+`fix/pwa-p0-claim-and-camera` once `InstanceActionEndpoints` became a fourth caller). Returns `DisclosedActionData`
 (`Models/DisclosedActionData.cs`): `recipientResolved` + merged `disclosedFields` (agent) + a per-prior-action
 `disclosures[]` list `{actionId, actionTitle, disclosedAt, data}` (MCP-compatible wire shape). Non-recipient →
 `200` with `recipientResolved:false` + empty view (distinguishes "no disclosure" from auth failure). No new JWT

--- a/docs/reference/API-DOCUMENTATION.md
+++ b/docs/reference/API-DOCUMENTATION.md
@@ -840,6 +840,47 @@ a candidate is selected.
 
 ### Base Path: `/api/blueprints`
 
+### `GET /api/instances/{instanceId}/actions/{actionId}` — consumer-readable action schema (P0 fix)
+
+Instance-scoped, consumer-readable read of a single action's form-relevant schema. Added to close a P0
+bug: the Wallet PWA previously read the action schema via the authoring endpoint
+`GET /api/blueprints/{id}` (Feature 147), which is deliberately restricted to service/platform-tier
+callers — every consumer-tier citizen 403'd, and the PWA (wrongly) reported this as "offline". This
+endpoint sits on the existing `/api/instances` group (`CanExecuteBlueprints` — any authenticated
+caller) and adds its own **participant gate**: the caller's `wallet_address` claim must appear in the
+instance's `ParticipantWallets`, or the request is refused with `403`.
+
+| Method | Path | Auth |
+|--------|------|------|
+| GET    | `/api/instances/{instanceId}/actions/{actionId}` | Authenticated + caller's wallet must be a participant on the instance |
+
+**Response — 200 OK** (`InstanceActionSchemaResponse`):
+
+```json
+{
+  "actionId": 1,
+  "title": "Claim your Assured Identity credential",
+  "form": { "type": "Layout", "elements": [ ] },
+  "dataSchemas": [ { "type": "object", "properties": { "email": { "type": "string" } } } ],
+  "calculations": null,
+  "credentialRequirements": null,
+  "credentialIssuanceConfig": { "credentialType": "AssuredIdentityCredential", "claimMappings": [ ], "recipientParticipantId": "citizen" }
+}
+```
+
+Deliberately **narrow** — this is not the full `Action` model and not a blueprint wrapper. It carries
+only what `SorchaFormRenderer` reads to render and validate the form for this one action. It does
+**not** return routing rules (`routes`, `condition`), other participants (`participants`, `target`,
+`additionalRecipients`), state-reconstruction internals (`requiredPriorActions`), rejection routing
+(`rejectionConfig`), or disclosure/sender fields (only meaningful when the caller is not the action's
+sender, which this endpoint's caller always is). `404` if the instance, blueprint, or action is not
+found; `403` if the caller is not a recorded participant on the instance.
+
+> **Known gap, not fixed here (flagged, not silently copied):** the sibling `GET /api/instances/{id}`
+> endpoint on the same group performs **no participant check at all** — any authenticated caller can
+> read any instance by id. This endpoint intentionally does not repeat that gap. Tightening
+> `GET /api/instances/{id}` itself is out of scope for this fix and tracked separately.
+
 ### Timebound Presentation Lifecycle (Feature 111)
 
 Three-event on-register lifecycle for timebound credential presentations. When an action carries `credentialRequirements` targeting HaipExternalWallet and the citizen submits without pre-attached presentations, `/execute` returns **`202 Accepted`** with `AwaitingPresentation=true` and a QR code. A `PresentationInitiated` transaction is written to the register immediately. The action does NOT complete until the verifier callback writes a `PresentationOutcome` with `kind=success`. Retry after a decline is first-class; a second attempt after a successful outcome returns **`409 Conflict`**.

--- a/docs/reference/API-DOCUMENTATION.md
+++ b/docs/reference/API-DOCUMENTATION.md
@@ -847,12 +847,17 @@ bug: the Wallet PWA previously read the action schema via the authoring endpoint
 `GET /api/blueprints/{id}` (Feature 147), which is deliberately restricted to service/platform-tier
 callers — every consumer-tier citizen 403'd, and the PWA (wrongly) reported this as "offline". This
 endpoint sits on the existing `/api/instances` group (`CanExecuteBlueprints` — any authenticated
-caller) and adds its own **participant gate**: the caller's `wallet_address` claim must appear in the
-instance's `ParticipantWallets`, or the request is refused with `403`.
+caller) and adds its own **participant gate**: at least one of the caller's resolved wallets must
+appear in the instance's `ParticipantWallets`, or the request is refused with `403`. The caller's
+wallet(s) are resolved via `ParticipantWalletResolver` — the `wallet_address` JWT claim when present
+(platform-tier fast path), else a Wallet-Service lookup by owner (`platform_user_id`, falling back to
+`sub`) — the same resolution `GET /api/actions/pending` and the Feature 176 disclosures endpoint use.
+This was itself a P0-review fix: the original gate read only `wallet_address`, which consumer-tier
+tokens (every real PWA sign-in, Feature 136) never carry, so every genuine citizen 403'd.
 
 | Method | Path | Auth |
 |--------|------|------|
-| GET    | `/api/instances/{instanceId}/actions/{actionId}` | Authenticated + caller's wallet must be a participant on the instance |
+| GET    | `/api/instances/{instanceId}/actions/{actionId}` | Authenticated + at least one of the caller's resolved wallets is a participant on the instance |
 
 **Response — 200 OK** (`InstanceActionSchemaResponse`):
 

--- a/mobile/wallet/android/app/src/main/AndroidManifest.xml
+++ b/mobile/wallet/android/app/src/main/AndroidManifest.xml
@@ -32,4 +32,20 @@
     <!-- Permissions -->
 
     <uses-permission android:name="android.permission.INTERNET" />
+
+    <!--
+      Camera — used ONLY to scan a verifier's QR code when presenting a credential
+      (Present.razor's CameraFirst intake mode). Without this the WebView refuses
+      getUserMedia, IDeviceProfileProbe reports CameraAvailability.Unavailable, and
+      the Present page silently degrades to the paste-a-deep-link fallback — which is
+      unusable on a phone, because you cannot paste a QR code someone is showing you.
+
+      required=false so the app still installs on a camera-less device; the paste
+      fallback is the honest experience there.
+
+      The BLE permissions the proximity plugin needs are declared in the plugin's own
+      manifest (mobile/plugins/sorcha-proximity) and merged in at build time.
+    -->
+    <uses-permission android:name="android.permission.CAMERA" />
+    <uses-feature android:name="android.hardware.camera" android:required="false" />
 </manifest>

--- a/mobile/wallet/ios/App/App/Info.plist
+++ b/mobile/wallet/ios/App/App/Info.plist
@@ -54,5 +54,7 @@
 	<true/>
 	<key>NSBluetoothAlwaysUsageDescription</key>
 	<string>Sorcha uses Bluetooth to show your credential to a verifier standing in front of you, without sending anything over the internet.</string>
+	<key>NSCameraUsageDescription</key>
+	<string>Sorcha uses the camera to scan a verifier's QR code when you present a credential. Nothing is recorded or stored.</string>
 </dict>
 </plist>

--- a/src/Apps/Sorcha.Wallet.Pwa/Pages/ApplicationInstance.razor
+++ b/src/Apps/Sorcha.Wallet.Pwa/Pages/ApplicationInstance.razor
@@ -103,6 +103,12 @@
             </MudAlert>
             break;
 
+        case State.Forbidden:
+            <MudAlert Severity="Severity.Warning" data-testid="application-instance-forbidden">
+                You don't have permission to view this application. If this seems wrong, contact support.
+            </MudAlert>
+            break;
+
         default:
             <MudAlert Severity="Severity.Error" data-testid="application-instance-error">
                 We couldn't load this application. It may not be ready yet — try again shortly.
@@ -115,7 +121,7 @@
     /// <summary>The blueprint instance the form binds to.</summary>
     [Parameter] public Guid InstanceId { get; set; }
 
-    private enum State { Loading, Ready, Submitted, Error, Offline }
+    private enum State { Loading, Ready, Submitted, Error, Offline, Forbidden }
 
     private State _state = State.Loading;
     private ApplicationFormContext? _ctx;
@@ -133,25 +139,42 @@
 
     protected override async Task OnInitializedAsync()
     {
-        // Online: resolve the live form context. On failure (offline / unreachable), fall back to
-        // the locally pre-cached context (Feature 152 US2) so the action still opens in the field.
+        // Online: resolve the live form context. On failure, fall back to the locally pre-cached
+        // context (Feature 152 US2) so the action still opens in the field when genuinely offline.
+        //
+        // P0 fix (fix/pwa-p0-claim-and-camera): LoadFormAsync now returns a discriminated result
+        // instead of a bare null, so a permission failure (403 — the server answered, and said no)
+        // is never mistaken for a connectivity gap. State.Offline is reached ONLY when
+        // Connectivity.IsOnline actually says so; every other failure gets its own honest state.
+        ApplicationFormLoadResult loadResult;
         try
         {
-            _ctx = await ActionClient.LoadFormAsync(InstanceId);
+            loadResult = await ActionClient.LoadFormAsync(InstanceId);
         }
         catch (Exception ex)
         {
             Logger.LogDebug(ex, "Live form load failed for {InstanceId}; trying offline cache.", InstanceId);
-            _ctx = null;
+            loadResult = ApplicationFormLoadResult.NetworkError;
         }
 
-        if (_ctx is null)
+        if (loadResult.Status == ApplicationFormLoadStatus.Loaded && loadResult.Context is { } loaded)
+        {
+            _ctx = loaded;
+        }
+        else
         {
             _ctx = await TryLoadCachedContextAsync();
             if (_ctx is null)
             {
-                // No live context and nothing prepared offline — distinct from a hard error.
-                _state = State.Offline;
+                // No live context and nothing prepared offline. Distinguish WHY:
+                //  - Forbidden: the server gave a real answer — the citizen is online and was refused.
+                //  - Otherwise: offline only if IConnectivity says so; a genuine server-side problem
+                //    while online (e.g. a 5xx) gets the honest Error state, not a fabricated Offline one.
+                _state = loadResult.Status == ApplicationFormLoadStatus.Forbidden
+                    ? State.Forbidden
+                    : !Connectivity.IsOnline
+                        ? State.Offline
+                        : State.Error;
                 return;
             }
         }

--- a/src/Apps/Sorcha.Wallet.Pwa/Services/Applications/IApplicationActionClient.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Services/Applications/IApplicationActionClient.cs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Sorcha Contributors
 
+using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
 using Microsoft.Extensions.Logging;
@@ -20,10 +21,14 @@ public interface IApplicationActionClient
 {
     /// <summary>
     /// Resolves the instance's current action + submission context (blueprint id, register id, and
-    /// the citizen's own wallet address as the open-participant sender). Returns <c>null</c> when the
-    /// instance, blueprint, current action, or the citizen's wallet cannot be resolved.
+    /// the citizen's own wallet address as the open-participant sender). Returns a discriminated
+    /// <see cref="ApplicationFormLoadResult"/> — P0 fix (<c>fix/pwa-p0-claim-and-camera</c>): a
+    /// permission failure (403) and a genuine connectivity failure used to collapse into the same
+    /// <c>null</c>, which the page then always reported as "offline" even when it wasn't. Callers
+    /// MUST branch on <see cref="ApplicationFormLoadResult.Status"/> rather than treating every
+    /// non-<see cref="ApplicationFormLoadStatus.Loaded"/> result as an offline signal.
     /// </summary>
-    Task<ApplicationFormContext?> LoadFormAsync(Guid instanceId, CancellationToken ct = default);
+    Task<ApplicationFormLoadResult> LoadFormAsync(Guid instanceId, CancellationToken ct = default);
 
     /// <summary>
     /// Nests the flat JSON-Pointer-keyed form data and POSTs it to
@@ -53,11 +58,61 @@ public sealed record ApplicationFormContext(
     string Title);
 
 /// <summary>
-/// Default <see cref="IApplicationActionClient"/> — talks to the Blueprint Service through the
-/// gateway-routed, bearer-authed PWA HttpClient. Mirrors the walkthrough's
-/// <c>Invoke-SorchaAction</c> contract: <c>GET /api/instances/{id}</c>,
-/// <c>GET /api/blueprints/{id}</c>, and <c>POST /api/instances/{id}/actions/{actionId}/execute</c>.
+/// Why <see cref="IApplicationActionClient.LoadFormAsync"/> did or didn't return a usable
+/// <see cref="ApplicationFormContext"/>. Distinguishes "the server said no" (<see cref="Forbidden"/>,
+/// <see cref="NotFound"/>) from "we couldn't reach the server" (<see cref="NetworkError"/>) — the two
+/// have very different honest messages, and only the latter is ever an "offline" signal.
 /// </summary>
+public enum ApplicationFormLoadStatus
+{
+    /// <summary>The form context was resolved successfully.</summary>
+    Loaded,
+
+    /// <summary>The instance, blueprint, or action could not be found.</summary>
+    NotFound,
+
+    /// <summary>The server refused the request (401/403) — a real answer, not a connectivity gap.</summary>
+    Forbidden,
+
+    /// <summary>The request could not be completed — timeout, DNS failure, 5xx, or similar.</summary>
+    NetworkError,
+}
+
+/// <summary>Discriminated result of <see cref="IApplicationActionClient.LoadFormAsync"/>.</summary>
+/// <param name="Status">Which outcome occurred.</param>
+/// <param name="Context">The loaded context; only non-null when <paramref name="Status"/> is <see cref="ApplicationFormLoadStatus.Loaded"/>.</param>
+public sealed record ApplicationFormLoadResult(ApplicationFormLoadStatus Status, ApplicationFormContext? Context)
+{
+    /// <summary>Builds a successful result.</summary>
+    public static ApplicationFormLoadResult Success(ApplicationFormContext context) =>
+        new(ApplicationFormLoadStatus.Loaded, context);
+
+    /// <summary>The instance, blueprint, or action could not be found.</summary>
+    public static readonly ApplicationFormLoadResult NotFound = new(ApplicationFormLoadStatus.NotFound, null);
+
+    /// <summary>The server refused the request.</summary>
+    public static readonly ApplicationFormLoadResult Forbidden = new(ApplicationFormLoadStatus.Forbidden, null);
+
+    /// <summary>The request could not be completed.</summary>
+    public static readonly ApplicationFormLoadResult NetworkError = new(ApplicationFormLoadStatus.NetworkError, null);
+}
+
+/// <summary>
+/// Default <see cref="IApplicationActionClient"/> — talks to the Blueprint Service through the
+/// gateway-routed, bearer-authed PWA HttpClient: <c>GET /api/instances/{id}</c>,
+/// <c>GET /api/instances/{id}/actions/{actionId}</c>, and
+/// <c>POST /api/instances/{id}/actions/{actionId}/execute</c>.
+/// </summary>
+/// <remarks>
+/// P0 fix (<c>fix/pwa-p0-claim-and-camera</c>): this client previously read the action schema from
+/// <c>GET /api/blueprints/{id}</c> — the authoring endpoint Feature 147 deliberately locked to
+/// service/platform-tier callers. A consumer-tier citizen token always 403'd there, and the caller
+/// folded that into a bare <c>null</c>, which <c>ApplicationInstance.razor</c> then always reported as
+/// "offline" — even though the citizen was online and the server had genuinely refused the read. This
+/// client now reads the instance-scoped, consumer-readable
+/// <c>GET /api/instances/{id}/actions/{actionId}</c> endpoint instead, and returns a discriminated
+/// <see cref="ApplicationFormLoadResult"/> so a permission failure is never mistaken for a connectivity one.
+/// </remarks>
 public sealed class HttpApplicationActionClient : IApplicationActionClient
 {
     private readonly HttpClient _http;
@@ -81,28 +136,41 @@ public sealed class HttpApplicationActionClient : IApplicationActionClient
     }
 
     /// <inheritdoc />
-    public async Task<ApplicationFormContext?> LoadFormAsync(Guid instanceId, CancellationToken ct = default)
+    public async Task<ApplicationFormLoadResult> LoadFormAsync(Guid instanceId, CancellationToken ct = default)
     {
         try
         {
-            var instance = await _http.GetFromJsonAsync<InstanceDto>(
-                $"api/instances/{instanceId:N}", JsonDefaults.Api, ct);
+            var instanceResponse = await _http.GetAsync($"api/instances/{instanceId:N}", ct);
+            if (!instanceResponse.IsSuccessStatusCode)
+            {
+                return ClassifyFailure(instanceId, "instance", instanceResponse.StatusCode);
+            }
+
+            var instance = await instanceResponse.Content.ReadFromJsonAsync<InstanceDto>(JsonDefaults.Api, ct);
             if (instance is null || string.IsNullOrEmpty(instance.BlueprintId))
             {
-                return null;
+                return ApplicationFormLoadResult.NotFound;
             }
 
             var actionId = instance.CurrentActionIds is { Count: > 0 } ? instance.CurrentActionIds[0] : 1;
 
-            var blueprintJson = await _http.GetStringAsync(
-                $"api/blueprints/{Uri.EscapeDataString(instance.BlueprintId)}", ct);
-            var action = ExtractAction(blueprintJson, actionId);
+            // Instance-scoped, consumer-readable read — NOT GET /api/blueprints/{id} (authoring-only,
+            // Feature 147). See the class remarks for why.
+            var actionResponse = await _http.GetAsync(
+                $"api/instances/{instanceId:N}/actions/{actionId}", ct);
+            if (!actionResponse.IsSuccessStatusCode)
+            {
+                return ClassifyFailure(instanceId, "action", actionResponse.StatusCode);
+            }
+
+            var actionJson = await actionResponse.Content.ReadAsStringAsync(ct);
+            var action = ParseActionSchema(actionJson);
             if (action is null)
             {
                 _logger.LogWarning(
-                    "Blueprint {BlueprintId} has no action {ActionId} to render for instance {InstanceId}",
-                    instance.BlueprintId, actionId, instanceId);
-                return null;
+                    "Action schema for instance {InstanceId} action {ActionId} could not be parsed",
+                    instanceId, actionId);
+                return ApplicationFormLoadResult.NotFound;
             }
 
             // Open-participant sender: the citizen's own wallet address. Resolved from the
@@ -112,10 +180,10 @@ public sealed class HttpApplicationActionClient : IApplicationActionClient
             if (keys is null || string.IsNullOrEmpty(keys.WalletAddress))
             {
                 _logger.LogWarning("Could not resolve the citizen's wallet address for submission.");
-                return null;
+                return ApplicationFormLoadResult.NetworkError;
             }
 
-            return new ApplicationFormContext(
+            var context = new ApplicationFormContext(
                 InstanceId: instanceId,
                 Action: action,
                 BlueprintId: instance.BlueprintId,
@@ -123,16 +191,43 @@ public sealed class HttpApplicationActionClient : IApplicationActionClient
                 SenderWallet: keys.WalletAddress,
                 ActionId: actionId,
                 Title: string.IsNullOrWhiteSpace(instance.Title) ? "Application" : instance.Title!);
+            return ApplicationFormLoadResult.Success(context);
         }
         catch (OperationCanceledException)
         {
             throw;
         }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogWarning(ex, "Failed to load form context for instance {InstanceId}", instanceId);
+            return ex.StatusCode is { } code
+                ? ClassifyFailure(instanceId, "request", code)
+                : ApplicationFormLoadResult.NetworkError;
+        }
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "Failed to load form context for instance {InstanceId}", instanceId);
-            return null;
+            return ApplicationFormLoadResult.NetworkError;
         }
+    }
+
+    /// <summary>
+    /// Maps an unsuccessful HTTP status to the discriminated <see cref="ApplicationFormLoadResult"/>
+    /// status. 401/403 are a real server answer (Forbidden) — never a connectivity signal, which is
+    /// the whole point of the P0 fix. 404 is NotFound. Everything else (5xx, etc.) is treated as a
+    /// network-shaped failure so the page's offline-vs-online branch (driven by
+    /// <c>IConnectivity.IsOnline</c>) decides how to present it.
+    /// </summary>
+    private ApplicationFormLoadResult ClassifyFailure(Guid instanceId, string what, HttpStatusCode statusCode)
+    {
+        _logger.LogWarning(
+            "Loading {What} for instance {InstanceId} failed with {StatusCode}", what, instanceId, statusCode);
+        return statusCode switch
+        {
+            HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden => ApplicationFormLoadResult.Forbidden,
+            HttpStatusCode.NotFound => ApplicationFormLoadResult.NotFound,
+            _ => ApplicationFormLoadResult.NetworkError,
+        };
     }
 
     /// <inheritdoc />
@@ -190,28 +285,39 @@ public sealed class HttpApplicationActionClient : IApplicationActionClient
         try { return await r.Content.ReadAsStringAsync(ct); } catch { return null; }
     }
 
-    private static Sorcha.Blueprint.Models.Action? ExtractAction(string blueprintJson, int actionId)
+    /// <summary>
+    /// Maps the narrow <c>InstanceActionSchemaResponse</c> wire shape (server:
+    /// <c>Sorcha.Blueprint.Service.Models.Responses.InstanceActionSchemaResponse</c>) onto a
+    /// <see cref="Sorcha.Blueprint.Models.Action"/> instance for <c>SorchaFormRenderer</c>. Only the
+    /// fields the renderer actually reads are populated — routing/other-participant fields
+    /// (<c>Routes</c>, <c>Condition</c>, <c>Participants</c>, ...) are never present on the wire and so
+    /// stay at the model's own defaults.
+    /// </summary>
+    private static Sorcha.Blueprint.Models.Action? ParseActionSchema(string actionJson)
     {
-        using var doc = JsonDocument.Parse(blueprintJson);
-        var root = doc.RootElement;
+        try
+        {
+            var dto = JsonSerializer.Deserialize<ActionSchemaDto>(actionJson, JsonOptions);
+            if (dto is null)
+            {
+                return null;
+            }
 
-        // Served blueprints may be the flat Blueprint model ({ actions: [...] }) or wrap the
-        // authored template ({ template: { actions: [...] } }). Tolerate both.
-        var found = root.TryGetProperty("actions", out var actionsEl)
-            || (root.TryGetProperty("template", out var tmpl) && tmpl.TryGetProperty("actions", out actionsEl));
-        if (!found || actionsEl.ValueKind != JsonValueKind.Array)
+            return new Sorcha.Blueprint.Models.Action
+            {
+                Id = dto.ActionId,
+                Title = dto.Title ?? string.Empty,
+                Form = dto.Form,
+                DataSchemas = dto.DataSchemas,
+                Calculations = dto.Calculations,
+                CredentialRequirements = dto.CredentialRequirements,
+                CredentialIssuanceConfig = dto.CredentialIssuanceConfig,
+            };
+        }
+        catch (JsonException)
         {
             return null;
         }
-
-        foreach (var el in actionsEl.EnumerateArray())
-        {
-            if (el.TryGetProperty("id", out var idEl) && idEl.TryGetInt32(out var id) && id == actionId)
-            {
-                return el.Deserialize<Sorcha.Blueprint.Models.Action>(JsonDefaults.Api);
-            }
-        }
-        return null;
     }
 
     private sealed class InstanceDto
@@ -220,6 +326,18 @@ public sealed class HttpApplicationActionClient : IApplicationActionClient
         public string? RegisterId { get; set; }
         public List<int>? CurrentActionIds { get; set; }
         public string? Title { get; set; }
+    }
+
+    /// <summary>Wire shape of <c>GET /api/instances/{id}/actions/{actionId}</c> (server-side: <c>InstanceActionSchemaResponse</c>).</summary>
+    private sealed class ActionSchemaDto
+    {
+        public int ActionId { get; set; }
+        public string? Title { get; set; }
+        public Sorcha.Blueprint.Models.Control? Form { get; set; }
+        public List<JsonDocument>? DataSchemas { get; set; }
+        public Dictionary<string, System.Text.Json.Nodes.JsonNode>? Calculations { get; set; }
+        public List<Sorcha.Blueprint.Models.Credentials.CredentialRequirement>? CredentialRequirements { get; set; }
+        public Sorcha.Blueprint.Models.Credentials.CredentialIssuanceConfig? CredentialIssuanceConfig { get; set; }
     }
 
     private sealed record ActionExecuteBody(

--- a/src/Apps/Sorcha.Wallet.Pwa/Services/Drafts/IActionContextCache.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Services/Drafts/IActionContextCache.cs
@@ -112,8 +112,8 @@ public sealed class ActionContextCache : IActionContextCache
 
             try
             {
-                var formCtx = await _actionClient.LoadFormAsync(instanceGuid, ct).ConfigureAwait(false);
-                if (formCtx is null)
+                var loadResult = await _actionClient.LoadFormAsync(instanceGuid, ct).ConfigureAwait(false);
+                if (loadResult.Status != ApplicationFormLoadStatus.Loaded || loadResult.Context is not { } formCtx)
                 {
                     continue;
                 }

--- a/src/Services/Sorcha.Blueprint.Service/Endpoints/ActionEndpoints.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Endpoints/ActionEndpoints.cs
@@ -3,8 +3,8 @@
 
 #pragma warning disable ASPDEPR002 // WithOpenApi is deprecated; using it for co-located endpoint examples until transformer API stabilizes
 
-using System.Security.Claims;
 using Sorcha.Blueprint.Service.Models;
+using Sorcha.Blueprint.Service.Services.Infrastructure;
 using Sorcha.Blueprint.Service.Storage;
 using Sorcha.ServiceClients.Wallet;
 
@@ -32,7 +32,7 @@ public static class ActionEndpoints
             int page = 1,
             int pageSize = 20) =>
         {
-            var walletAddresses = await ResolveUserWalletAddressesAsync(
+            var walletAddresses = await ParticipantWalletResolver.ResolveUserWalletAddressesAsync(
                 httpContext, walletClient, logger, httpContext.RequestAborted);
 
             if (walletAddresses.Count == 0)
@@ -119,7 +119,7 @@ public static class ActionEndpoints
             IWalletServiceClient walletClient,
             ILogger<ActionEndpointsLogCategory> logger) =>
         {
-            var walletAddresses = await ResolveUserWalletAddressesAsync(
+            var walletAddresses = await ParticipantWalletResolver.ResolveUserWalletAddressesAsync(
                 httpContext, walletClient, logger, httpContext.RequestAborted);
 
             if (walletAddresses.Count == 0)
@@ -143,97 +143,6 @@ public static class ActionEndpoints
             + "urgency-aware counting will be added in a future iteration.");
 
         return routes;
-    }
-
-    /// <summary>
-    /// Resolves the set of wallet addresses the authenticated user owns, in
-    /// priority order:
-    /// <list type="number">
-    /// <item><description>The <c>wallet_address</c> JWT claim (fast path, zero-RTT).</description></item>
-    /// <item><description>Live lookup via <see cref="IWalletServiceClient.GetWalletsByOwnerAsync"/>
-    /// keyed on the <c>sub</c> / <see cref="ClaimTypes.NameIdentifier"/> claim,
-    /// used when the JWT claim is absent (e.g. because the token was issued
-    /// before the user created their first wallet and no refresh has happened
-    /// since).</description></item>
-    /// </list>
-    /// The fallback is what makes the pending-actions query self-healing —
-    /// without it, a consumer who signs up and then creates a wallet in the
-    /// same session would see an empty pending-actions list forever, even
-    /// though the server has the action and knows which wallet it belongs to.
-    /// Returns an empty list when neither path yields a wallet — the caller
-    /// should surface an empty result rather than a 401.
-    /// </summary>
-    internal static async Task<IReadOnlyList<string>> ResolveUserWalletAddressesAsync(
-        HttpContext httpContext,
-        IWalletServiceClient walletClient,
-        ILogger logger,
-        CancellationToken cancellationToken)
-    {
-        var claim = httpContext.User.FindFirst("wallet_address")?.Value;
-        if (!string.IsNullOrEmpty(claim))
-        {
-            return new[] { claim };
-        }
-
-        // Wallet Service fallback (no wallet_address claim — e.g. consumer-tier tokens, which
-        // omit wallet binding by design under Feature 136). Wallets are keyed by their Owner,
-        // and per the Feature 136 / #878 alignment a wallet's Owner is the cross-org
-        // platform_user_id, NOT the per-org sub/UserIdentity.Id. For admin tokens the two are
-        // equal, but for an org-scoped Consumer (e.g. a verification analyst running the rules
-        // agent) they differ — so a sub-keyed lookup silently misses the wallet and the agent
-        // never discovers the action it must approve (#912). Prefer platform_user_id, then fall
-        // back to sub/NameIdentifier so pre-#878 wallets stay discoverable. Both eras coexist.
-        var ownerCandidates = new List<string>();
-        var platformUserId = httpContext.User.FindFirst("platform_user_id")?.Value;
-        if (!string.IsNullOrEmpty(platformUserId))
-        {
-            ownerCandidates.Add(platformUserId);
-        }
-
-        var userId = httpContext.User.FindFirst(ClaimTypes.NameIdentifier)?.Value
-            ?? httpContext.User.FindFirst("sub")?.Value;
-        if (!string.IsNullOrEmpty(userId) && !ownerCandidates.Contains(userId, StringComparer.Ordinal))
-        {
-            ownerCandidates.Add(userId);
-        }
-
-        if (ownerCandidates.Count == 0)
-        {
-            return Array.Empty<string>();
-        }
-
-        try
-        {
-            foreach (var owner in ownerCandidates)
-            {
-                var wallets = await walletClient.GetWalletsByOwnerAsync(owner, cancellationToken);
-                var addresses = wallets
-                    .Select(w => w.Address)
-                    .Where(a => !string.IsNullOrEmpty(a))
-                    .ToArray();
-                if (addresses.Length > 0)
-                {
-                    return addresses;
-                }
-            }
-
-            return Array.Empty<string>();
-        }
-        catch (Exception ex) when (ex is not OperationCanceledException)
-        {
-            // Non-fatal: surface an empty list so the endpoint still returns
-            // a clean 200 rather than cascading a 500 to the user. The user
-            // will see "no pending actions" which is the same visible
-            // outcome as before this fix — the upside is that when the
-            // wallet service IS reachable the list now populates correctly.
-            // Cancellation is explicitly NOT caught here — tab-close / abort
-            // must propagate cleanly so ASP.NET's request pipeline can short
-            // circuit without a bogus 200 response.
-            logger.LogWarning(ex,
-                "Failed to resolve wallet addresses for user (platform_user_id={PlatformUserId}, sub={UserId}) via Wallet Service fallback; returning empty list",
-                platformUserId, userId);
-            return Array.Empty<string>();
-        }
     }
 
     /// <summary>

--- a/src/Services/Sorcha.Blueprint.Service/Endpoints/InstanceActionEndpoints.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Endpoints/InstanceActionEndpoints.cs
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using Sorcha.Blueprint.Service.Models.Responses;
+using Sorcha.Blueprint.Service.Services.Interfaces;
+using Sorcha.Blueprint.Service.Storage;
+
+namespace Sorcha.Blueprint.Service.Endpoints;
+
+/// <summary>
+/// P0 fix (<c>fix/pwa-p0-claim-and-camera</c>) — an instance-scoped, consumer-readable route to a
+/// blueprint instance's current action schema. Feature 147 correctly narrowed
+/// <c>GET /api/blueprints/{id}</c> (authoring) to service/platform-tier callers only; the Wallet PWA
+/// was (mis)using that same door merely to read the form schema for the action a citizen was filling
+/// in, so every consumer-tier citizen 403'd and the PWA folded that into a fabricated "offline" state.
+/// This endpoint gives the citizen a narrow, participant-gated read instead of reopening authoring.
+/// </summary>
+public static class InstanceActionEndpoints
+{
+    /// <summary>
+    /// Maps <c>GET /{instanceId}/actions/{actionId}</c> onto the group it's called on (the existing
+    /// <c>/api/instances</c> group in <c>Program.cs</c>, already gated by <c>CanExecuteBlueprints</c>).
+    /// </summary>
+    public static void MapInstanceActionSchemaEndpoint(this IEndpointRouteBuilder group)
+    {
+        group.MapGet("/{instanceId}/actions/{actionId}", GetInstanceActionSchema)
+            .WithName("GetInstanceActionSchema")
+            .WithSummary("Get the renderable schema for an instance's action")
+            .WithDescription(
+                "Returns the form-relevant subset of a single action definition — schema, layout, "
+                + "calculations, and this action's own credential gate — for a blueprint instance the "
+                + "caller's wallet participates in. Unlike GET /api/blueprints/{id} (authoring, "
+                + "service/platform-tier only), this endpoint is reachable by consumer-tier tokens so a "
+                + "citizen can render the action currently assigned to them. Does not return routing "
+                + "rules, other participants, or any other action's content. 403 if the caller's wallet "
+                + "is not a participant on the instance; 404 if the instance, blueprint, or action is "
+                + "not found.")
+            .Produces<InstanceActionSchemaResponse>(StatusCodes.Status200OK)
+            .Produces(StatusCodes.Status403Forbidden)
+            .Produces(StatusCodes.Status404NotFound);
+    }
+
+    /// <summary>
+    /// Handler for <see cref="MapInstanceActionSchemaEndpoint"/>. Internal (not private) so tests can
+    /// reach it by reflection without a <c>WebApplicationFactory</c> — see
+    /// <c>tests/Sorcha.Blueprint.Service.Tests/Endpoints/InstanceActionEndpointsTests.cs</c>.
+    /// </summary>
+    internal static async Task<IResult> GetInstanceActionSchema(
+        HttpContext httpContext,
+        string instanceId,
+        int actionId,
+        IInstanceStore instanceStore,
+        IActionResolverService actionResolver,
+        CancellationToken cancellationToken)
+    {
+        var instance = await instanceStore.GetAsync(instanceId, cancellationToken);
+        if (instance is null)
+        {
+            return Results.NotFound(new { error = "Instance not found" });
+        }
+
+        // Participant gate — CanExecuteBlueprints only asserts "any authenticated user"; this
+        // endpoint returns action content (form schema, credential config) so it adds its own check
+        // on top, using the same "wallet is a participant on this instance" test the pending-actions
+        // list already relies on (EfCoreInstanceStore.ContainsWalletAddress /
+        // GetPendingActionsByWalletAsync) — a wallet only ever sees this instance as "pending" once it
+        // is recorded as a participant, so this gate does not regress the flow it's fixing.
+        var walletAddress = httpContext.User.FindFirst("wallet_address")?.Value;
+        var isParticipant = !string.IsNullOrEmpty(walletAddress)
+            && instance.ParticipantWallets.Values.Any(w => string.Equals(w, walletAddress, StringComparison.OrdinalIgnoreCase));
+        if (!isParticipant)
+        {
+            return Results.Problem(
+                "You are not a participant on this instance.",
+                statusCode: StatusCodes.Status403Forbidden);
+        }
+
+        var blueprint = await actionResolver.GetBlueprintAsync(instance.BlueprintId, cancellationToken);
+        if (blueprint is null)
+        {
+            return Results.NotFound(new
+            {
+                error = "Blueprint is not available on this node yet.",
+                blueprintId = instance.BlueprintId,
+            });
+        }
+
+        var action = actionResolver.GetActionDefinition(blueprint, actionId.ToString());
+        if (action is null)
+        {
+            return Results.NotFound(new { error = $"Action {actionId} not found in blueprint {instance.BlueprintId}." });
+        }
+
+        var response = new InstanceActionSchemaResponse
+        {
+            ActionId = action.Id,
+            Title = action.Title,
+            Form = action.Form,
+            DataSchemas = action.DataSchemas,
+            Calculations = action.Calculations,
+            CredentialRequirements = action.CredentialRequirements,
+            CredentialIssuanceConfig = action.CredentialIssuanceConfig,
+        };
+
+        return Results.Ok(response);
+    }
+}

--- a/src/Services/Sorcha.Blueprint.Service/Endpoints/InstanceActionEndpoints.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Endpoints/InstanceActionEndpoints.cs
@@ -2,8 +2,10 @@
 // Copyright (c) 2026 Sorcha Contributors
 
 using Sorcha.Blueprint.Service.Models.Responses;
+using Sorcha.Blueprint.Service.Services.Infrastructure;
 using Sorcha.Blueprint.Service.Services.Interfaces;
 using Sorcha.Blueprint.Service.Storage;
+using Sorcha.ServiceClients.Wallet;
 
 namespace Sorcha.Blueprint.Service.Endpoints;
 
@@ -14,6 +16,14 @@ namespace Sorcha.Blueprint.Service.Endpoints;
 /// was (mis)using that same door merely to read the form schema for the action a citizen was filling
 /// in, so every consumer-tier citizen 403'd and the PWA folded that into a fabricated "offline" state.
 /// This endpoint gives the citizen a narrow, participant-gated read instead of reopening authoring.
+///
+/// The participant gate originally read only the <c>wallet_address</c> JWT claim — but under
+/// Feature 136 a consumer-tier token (every real PWA sign-in) deliberately OMITS that claim, so the
+/// gate was unconditionally false for the exact population the endpoint exists to serve. Fixed by
+/// routing through <see cref="ParticipantWalletResolver.ResolveUserWalletAddressesAsync"/> (the same
+/// claim-then-Wallet-Service-fallback seam <c>GetPendingActions</c> / <c>GetPendingActionCount</c> /
+/// <c>WorkflowDisclosureEndpoints</c> already rely on) and checking membership against the full set
+/// of the caller's resolved wallets, not a single claim value.
 /// </summary>
 public static class InstanceActionEndpoints
 {
@@ -32,9 +42,11 @@ public static class InstanceActionEndpoints
                 + "caller's wallet participates in. Unlike GET /api/blueprints/{id} (authoring, "
                 + "service/platform-tier only), this endpoint is reachable by consumer-tier tokens so a "
                 + "citizen can render the action currently assigned to them. Does not return routing "
-                + "rules, other participants, or any other action's content. 403 if the caller's wallet "
-                + "is not a participant on the instance; 404 if the instance, blueprint, or action is "
-                + "not found.")
+                + "rules, other participants, or any other action's content. The caller's wallet(s) are "
+                + "resolved from the wallet_address claim when present, else via a Wallet-Service lookup "
+                + "by owner (consumer-tier tokens carry no wallet_address per Feature 136) — 403 if none "
+                + "of the caller's wallets is a participant on the instance; 404 if the instance, "
+                + "blueprint, or action is not found.")
             .Produces<InstanceActionSchemaResponse>(StatusCodes.Status200OK)
             .Produces(StatusCodes.Status403Forbidden)
             .Produces(StatusCodes.Status404NotFound);
@@ -51,6 +63,8 @@ public static class InstanceActionEndpoints
         int actionId,
         IInstanceStore instanceStore,
         IActionResolverService actionResolver,
+        IWalletServiceClient walletClient,
+        ILogger<InstanceActionEndpointsLogCategory> logger,
         CancellationToken cancellationToken)
     {
         var instance = await instanceStore.GetAsync(instanceId, cancellationToken);
@@ -65,9 +79,19 @@ public static class InstanceActionEndpoints
         // list already relies on (EfCoreInstanceStore.ContainsWalletAddress /
         // GetPendingActionsByWalletAsync) — a wallet only ever sees this instance as "pending" once it
         // is recorded as a participant, so this gate does not regress the flow it's fixing.
-        var walletAddress = httpContext.User.FindFirst("wallet_address")?.Value;
-        var isParticipant = !string.IsNullOrEmpty(walletAddress)
-            && instance.ParticipantWallets.Values.Any(w => string.Equals(w, walletAddress, StringComparison.OrdinalIgnoreCase));
+        //
+        // A consumer-tier token (every real PWA sign-in, Feature 136) never carries wallet_address, so
+        // the caller's wallet(s) must be resolved via ParticipantWalletResolver (claim fast-path, then
+        // Wallet-Service-by-owner fallback) rather than read off a single claim. A caller can hold more
+        // than one wallet, so membership is checked against the FULL resolved set — matching any one of
+        // them is enough. An empty resolved set means "couldn't resolve any wallet for this caller", not
+        // "didn't look" (ParticipantWalletResolver only returns empty after exhausting the claim and the
+        // owner-keyed Wallet Service lookup) — so it fails closed to 403 like any other non-match.
+        var callerWallets = await ParticipantWalletResolver.ResolveUserWalletAddressesAsync(
+            httpContext, walletClient, logger, cancellationToken);
+        var isParticipant = callerWallets.Count > 0
+            && instance.ParticipantWallets.Values.Any(participantWallet =>
+                callerWallets.Any(w => string.Equals(w, participantWallet, StringComparison.OrdinalIgnoreCase)));
         if (!isParticipant)
         {
             return Results.Problem(
@@ -104,4 +128,11 @@ public static class InstanceActionEndpoints
 
         return Results.Ok(response);
     }
+
+    /// <summary>
+    /// Marker type for <see cref="ILogger{T}"/> categorisation — <see cref="InstanceActionEndpoints"/>
+    /// is static, so it cannot itself be used as a generic type argument. Mirrors
+    /// <c>ActionEndpoints.ActionEndpointsLogCategory</c>.
+    /// </summary>
+    internal sealed class InstanceActionEndpointsLogCategory { }
 }

--- a/src/Services/Sorcha.Blueprint.Service/Endpoints/WorkflowDisclosureEndpoints.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Endpoints/WorkflowDisclosureEndpoints.cs
@@ -3,6 +3,7 @@
 
 using Sorcha.Blueprint.Service.Middleware;
 using Sorcha.Blueprint.Service.Models;
+using Sorcha.Blueprint.Service.Services.Infrastructure;
 using Sorcha.Blueprint.Service.Services.Interfaces;
 using Sorcha.Blueprint.Service.Storage;
 using Sorcha.ServiceClients.Wallet;
@@ -82,7 +83,7 @@ public static class WorkflowDisclosureEndpoints
         IWalletServiceClient walletClient,
         ILogger logger)
     {
-        var callerWallets = await ActionEndpoints.ResolveUserWalletAddressesAsync(
+        var callerWallets = await ParticipantWalletResolver.ResolveUserWalletAddressesAsync(
             httpContext, walletClient, logger, httpContext.RequestAborted);
 
         if (callerWallets.Count == 0)

--- a/src/Services/Sorcha.Blueprint.Service/Models/Responses/InstanceActionSchemaResponse.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Models/Responses/InstanceActionSchemaResponse.cs
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Sorcha.Blueprint.Models;
+using Sorcha.Blueprint.Models.Credentials;
+
+namespace Sorcha.Blueprint.Service.Models.Responses;
+
+/// <summary>
+/// Consumer-readable schema for a single action within a blueprint instance (P0 fix,
+/// <c>fix/pwa-p0-claim-and-camera</c>). Backs <c>GET /api/instances/{instanceId}/actions/{actionId}</c> —
+/// the read the Wallet PWA uses to render the form for the action a citizen is currently completing.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Deliberately narrow.</b> This is NOT the full <see cref="Sorcha.Blueprint.Models.Action"/> model
+/// and NOT a wrapper around the blueprint. It carries only the fields
+/// <c>Sorcha.UI.Components.User</c>'s <c>SorchaFormRenderer</c> actually reads to render and validate a
+/// form: the layout (<see cref="Form"/>), the JSON Schemas (<see cref="DataSchemas"/>), calculated-field
+/// definitions (<see cref="Calculations"/>), and the credential gate for this one action
+/// (<see cref="CredentialRequirements"/> / <see cref="CredentialIssuanceConfig"/>).
+/// </para>
+/// <para>
+/// <b>Excluded on purpose</b> — routing/workflow-internal fields that would leak the blueprint's
+/// authoring structure to a citizen filling in one action: <c>Routes</c> and <c>Condition</c> (where the
+/// instance goes next and under what logic), <c>Participants</c> / <c>Target</c> /
+/// <c>AdditionalRecipients</c> (who else is involved), <c>RequiredPriorActions</c> (state-reconstruction
+/// internals), <c>RejectionConfig</c> (reveals the rejection routing target — the PWA does not wire up
+/// <c>OnReject</c> today; add it here if/when it does), <c>Disclosures</c> / <c>Sender</c> (only consumed
+/// by <c>SorchaFormRenderer</c> when the caller is NOT the action's sender — this endpoint's caller always
+/// is, so they are dead weight that would otherwise reveal downstream participant roles), and
+/// <c>PreviousTxId</c> / <c>BlueprintId</c> / <c>JsonLdType</c> / <c>Published</c> /
+/// <c>AdditionalProperties</c> / <c>Notification</c> (authoring/bookkeeping metadata the renderer never
+/// reads).
+/// </para>
+/// </remarks>
+public sealed record InstanceActionSchemaResponse
+{
+    /// <summary>The action's sequence number within the blueprint.</summary>
+    public required int ActionId { get; init; }
+
+    /// <summary>Human-readable title for this action (e.g. "Apply", "Claim credential").</summary>
+    public required string Title { get; init; }
+
+    /// <summary>The UI form layout (JSON Forms-style control tree). Null falls back to schema auto-generation.</summary>
+    public Control? Form { get; init; }
+
+    /// <summary>JSON Schemas describing the data this action collects.</summary>
+    public IEnumerable<JsonDocument>? DataSchemas { get; init; }
+
+    /// <summary>User-defined calculations (JSON Logic) performed on submitted data.</summary>
+    public Dictionary<string, JsonNode>? Calculations { get; init; }
+
+    /// <summary>Credential requirements that must be satisfied before this action can be executed.</summary>
+    public IEnumerable<CredentialRequirement>? CredentialRequirements { get; init; }
+
+    /// <summary>Configuration for a credential minted when this action executes (drives the review UI).</summary>
+    public CredentialIssuanceConfig? CredentialIssuanceConfig { get; init; }
+}

--- a/src/Services/Sorcha.Blueprint.Service/Program.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Program.cs
@@ -2359,6 +2359,10 @@ instancesGroup.MapGet("/{instanceId}", async (
 .WithSummary("Get workflow instance")
 .WithDescription("Retrieve a workflow instance by its ID");
 
+// P0 fix (fix/pwa-p0-claim-and-camera) — GET /{instanceId}/actions/{actionId}: instance-scoped,
+// consumer-readable action schema (see Sorcha.Blueprint.Service.Endpoints.InstanceActionEndpoints).
+instancesGroup.MapInstanceActionSchemaEndpoint();
+
 // <summary>
 // Execute an action in a workflow instance (with orchestration)
 // </summary>

--- a/src/Services/Sorcha.Blueprint.Service/README.md
+++ b/src/Services/Sorcha.Blueprint.Service/README.md
@@ -220,6 +220,31 @@ OPENTELEMETRY__ZIPKINENDPOINT="https://zipkin.yourcompany.com"
 | POST | `/api/actions/` | Submit an action |
 | POST | `/api/actions/reject` | Reject a pending action |
 
+### Workflow Instances
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| GET | `/api/instances/` | List instances for the authenticated user's wallet (paginated, status filter) |
+| POST | `/api/instances/` | Create a new workflow instance |
+| GET | `/api/instances/{instanceId}` | Get a workflow instance by ID |
+| GET | `/api/instances/{instanceId}/actions/{actionId}` | Consumer-readable action schema for one action (P0 fix, `fix/pwa-p0-claim-and-camera`) — see below |
+| POST | `/api/instances/{instanceId}/actions/{actionId}/execute` | Execute an action with full orchestration |
+| POST | `/api/instances/{instanceId}/actions/{actionId}/reject` | Reject a pending action |
+
+**`GET /api/instances/{instanceId}/actions/{actionId}`** is the narrow, instance-scoped read the Wallet
+PWA uses to render the form for a citizen's current action. It exists because the authoring endpoint
+`GET /api/blueprints/{id}` (Feature 147) is deliberately restricted to service/platform-tier callers —
+a consumer-tier citizen token always 403s there. This endpoint sits on the same `CanExecuteBlueprints`
+group but adds its own participant gate (the caller's `wallet_address` must be in the instance's
+`ParticipantWallets`) and returns only the form-relevant subset of the action (`InstanceActionSchemaResponse`:
+title, form layout, data schemas, calculations, and this action's own credential requirements/issuance
+config) — never routing rules, other participants, or any other action's content. See
+`docs/reference/API-DOCUMENTATION.md` for the full response shape and exclusion list.
+
+> **Note:** `GET /api/instances/{instanceId}` performs no participant check at all today — any
+> authenticated caller can read any instance by ID. The new endpoint above does not repeat that gap,
+> but tightening the existing one is a separate, currently-untracked follow-up.
+
 ### Template System
 
 | Method | Endpoint | Description |

--- a/src/Services/Sorcha.Blueprint.Service/README.md
+++ b/src/Services/Sorcha.Blueprint.Service/README.md
@@ -235,8 +235,11 @@ OPENTELEMETRY__ZIPKINENDPOINT="https://zipkin.yourcompany.com"
 PWA uses to render the form for a citizen's current action. It exists because the authoring endpoint
 `GET /api/blueprints/{id}` (Feature 147) is deliberately restricted to service/platform-tier callers —
 a consumer-tier citizen token always 403s there. This endpoint sits on the same `CanExecuteBlueprints`
-group but adds its own participant gate (the caller's `wallet_address` must be in the instance's
-`ParticipantWallets`) and returns only the form-relevant subset of the action (`InstanceActionSchemaResponse`:
+group but adds its own participant gate — at least one of the caller's resolved wallets must be in the
+instance's `ParticipantWallets`, resolved via the shared `ParticipantWalletResolver` (`wallet_address`
+claim fast path, else Wallet-Service-by-owner fallback — the same seam `GET /api/actions/pending` and
+the Feature 176 disclosures endpoint use, since consumer-tier tokens never carry `wallet_address`,
+Feature 136) — and returns only the form-relevant subset of the action (`InstanceActionSchemaResponse`:
 title, form layout, data schemas, calculations, and this action's own credential requirements/issuance
 config) — never routing rules, other participants, or any other action's content. See
 `docs/reference/API-DOCUMENTATION.md` for the full response shape and exclusion list.

--- a/src/Services/Sorcha.Blueprint.Service/Services/Infrastructure/ParticipantWalletResolver.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Services/Infrastructure/ParticipantWalletResolver.cs
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Security.Claims;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Sorcha.ServiceClients.Wallet;
+
+namespace Sorcha.Blueprint.Service.Services.Infrastructure;
+
+/// <summary>
+/// P0 fix (<c>fix/pwa-p0-claim-and-camera</c>) — shared wallet-resolution seam, extracted from
+/// <c>Sorcha.Blueprint.Service.Endpoints.ActionEndpoints.ResolveUserWalletAddressesAsync</c> (its
+/// original home) once a fourth call site (<c>InstanceActionEndpoints</c>) needed the identical
+/// logic. Originally added for <c>GetPendingActions</c> / <c>GetPendingActionCount</c> (#912) and
+/// reused as-is by <c>WorkflowDisclosureEndpoints</c> (Feature 176); every caller that needs "which
+/// wallet(s) does this authenticated caller control" belongs on this one seam rather than a
+/// per-endpoint copy of the claim-then-fallback logic.
+/// </summary>
+public static class ParticipantWalletResolver
+{
+    /// <summary>
+    /// Resolves the set of wallet addresses the authenticated caller owns, in
+    /// priority order:
+    /// <list type="number">
+    /// <item><description>The <c>wallet_address</c> JWT claim (fast path, zero-RTT).</description></item>
+    /// <item><description>Live lookup via <see cref="IWalletServiceClient.GetWalletsByOwnerAsync"/>
+    /// keyed on the <c>sub</c> / <see cref="ClaimTypes.NameIdentifier"/> claim,
+    /// used when the JWT claim is absent (e.g. because the token was issued
+    /// before the user created their first wallet and no refresh has happened
+    /// since — or because it is a consumer-tier token, which omits wallet
+    /// binding by design under Feature 136).</description></item>
+    /// </list>
+    /// The fallback is what makes every caller of this method self-healing —
+    /// without it, a consumer who signs up and then creates a wallet in the
+    /// same session would see empty results forever, even though the server
+    /// has the data and knows which wallet it belongs to.
+    /// Returns an empty list when neither path yields a wallet — this is a
+    /// "couldn't resolve", not a "didn't look"; callers should fail closed
+    /// (403 / empty result) rather than treat an empty list as "any wallet".
+    /// </summary>
+    public static async Task<IReadOnlyList<string>> ResolveUserWalletAddressesAsync(
+        HttpContext httpContext,
+        IWalletServiceClient walletClient,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        var claim = httpContext.User.FindFirst("wallet_address")?.Value;
+        if (!string.IsNullOrEmpty(claim))
+        {
+            return new[] { claim };
+        }
+
+        // Wallet Service fallback (no wallet_address claim — e.g. consumer-tier tokens, which
+        // omit wallet binding by design under Feature 136). Wallets are keyed by their Owner,
+        // and per the Feature 136 / #878 alignment a wallet's Owner is the cross-org
+        // platform_user_id, NOT the per-org sub/UserIdentity.Id. For admin tokens the two are
+        // equal, but for an org-scoped Consumer (e.g. a verification analyst running the rules
+        // agent) they differ — so a sub-keyed lookup silently misses the wallet and the agent
+        // never discovers the action it must approve (#912). Prefer platform_user_id, then fall
+        // back to sub/NameIdentifier so pre-#878 wallets stay discoverable. Both eras coexist.
+        var ownerCandidates = new List<string>();
+        var platformUserId = httpContext.User.FindFirst("platform_user_id")?.Value;
+        if (!string.IsNullOrEmpty(platformUserId))
+        {
+            ownerCandidates.Add(platformUserId);
+        }
+
+        var userId = httpContext.User.FindFirst(ClaimTypes.NameIdentifier)?.Value
+            ?? httpContext.User.FindFirst("sub")?.Value;
+        if (!string.IsNullOrEmpty(userId) && !ownerCandidates.Contains(userId, StringComparer.Ordinal))
+        {
+            ownerCandidates.Add(userId);
+        }
+
+        if (ownerCandidates.Count == 0)
+        {
+            return Array.Empty<string>();
+        }
+
+        try
+        {
+            foreach (var owner in ownerCandidates)
+            {
+                var wallets = await walletClient.GetWalletsByOwnerAsync(owner, cancellationToken);
+                var addresses = wallets
+                    .Select(w => w.Address)
+                    .Where(a => !string.IsNullOrEmpty(a))
+                    .ToArray();
+                if (addresses.Length > 0)
+                {
+                    return addresses;
+                }
+            }
+
+            return Array.Empty<string>();
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            // Non-fatal: surface an empty list so the caller can still return a clean response
+            // (e.g. a 200 with an empty list, or a 403) rather than cascading a 500. Cancellation
+            // is explicitly NOT caught here — tab-close / abort must propagate cleanly so ASP.NET's
+            // request pipeline can short circuit without a bogus success response.
+            logger.LogWarning(ex,
+                "Failed to resolve wallet addresses for user (platform_user_id={PlatformUserId}, sub={UserId}) via Wallet Service fallback; returning empty list",
+                platformUserId, userId);
+            return Array.Empty<string>();
+        }
+    }
+}

--- a/tests/Sorcha.Blueprint.Service.Tests/Endpoints/InstanceActionEndpointsTests.cs
+++ b/tests/Sorcha.Blueprint.Service.Tests/Endpoints/InstanceActionEndpointsTests.cs
@@ -7,6 +7,7 @@ using System.Text.Json;
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Sorcha.Blueprint.Models;
 using Sorcha.Blueprint.Models.Credentials;
@@ -15,6 +16,7 @@ using Sorcha.Blueprint.Service.Models;
 using Sorcha.Blueprint.Service.Models.Responses;
 using Sorcha.Blueprint.Service.Services.Interfaces;
 using Sorcha.Blueprint.Service.Storage;
+using Sorcha.ServiceClients.Wallet;
 using Xunit;
 using BlueprintModel = Sorcha.Blueprint.Models.Blueprint;
 
@@ -22,15 +24,24 @@ namespace Sorcha.Blueprint.Service.Tests.Endpoints;
 
 /// <summary>
 /// P0 fix (<c>fix/pwa-p0-claim-and-camera</c>) — <c>GET /api/instances/{instanceId}/actions/{actionId}</c>
-/// must be readable by a consumer-tier citizen token (the failure mode of the bug: the PWA previously
-/// hit the authoring-only <c>GET /api/blueprints/{id}</c> and got a 403), must gate on the caller's
-/// wallet being a recorded participant on the instance, and must return only the form-relevant subset
-/// of the action — not the whole blueprint and not routing/other-participant internals.
+/// must be readable by a genuine consumer-tier citizen token, must gate on (at least one of) the caller's
+/// resolved wallets being a recorded participant on the instance, and must return only the form-relevant
+/// subset of the action — not the whole blueprint and not routing/other-participant internals.
+///
+/// This test file previously carried a load-bearing defect: <c>GetInstanceActionSchema_ConsumerTierParticipant_ReturnsOk</c>
+/// built its principal with ONLY a <c>wallet_address</c> claim — which, per <c>TokenService.GenerateUserTokenAsync</c>,
+/// is the PLATFORM-tier claim shape (<c>AddWalletAddressClaimAsync</c> only fires for <c>Tier.Platform</c>).
+/// A real consumer-tier token (every PWA sign-in, Feature 136) never carries <c>wallet_address</c> — so the
+/// "consumer" test was actually exercising the platform-tier fast path, the endpoint's participant gate read
+/// a claim citizens never carry, and every genuine citizen 403'd. Fixed by rewiring the gate through
+/// <c>ParticipantWalletResolver</c> (claim fast path, then Wallet-Service-by-owner fallback) and rewriting
+/// the tests below to use a genuine consumer-tier claim set.
 /// </summary>
 public sealed class InstanceActionEndpointsTests
 {
     private const string CitizenWallet = "ws1qcitizen000000000000000000000000000000";
     private const string OtherWallet = "ws1qother00000000000000000000000000000000";
+    private const string PlatformUserId = "platform-user-1";
 
     private static Instance MakeInstance(string participantWallet, string blueprintId = "bp-1", string instanceId = "inst-1") =>
         new()
@@ -63,6 +74,7 @@ public sealed class InstanceActionEndpointsTests
         AdditionalRecipients = ["assessor-wallet"],
     };
 
+    /// <summary>Fast-path context: a caller whose principal carries the <c>wallet_address</c> claim directly.</summary>
     private static HttpContext ContextWithWallet(string? walletAddress)
     {
         var claims = new List<Claim>();
@@ -74,28 +86,80 @@ public sealed class InstanceActionEndpointsTests
         return new DefaultHttpContext { User = new ClaimsPrincipal(identity) };
     }
 
+    /// <summary>
+    /// Genuine consumer-tier claim set per <c>TokenService.GenerateUserTokenAsync</c> — <c>sub</c>,
+    /// <c>email</c>, <c>org_id</c>, <c>platform_user_id</c>; explicitly NO <c>wallet_address</c> and NO
+    /// roles (both are platform-tier-only, FR-014). The caller's wallet must be resolved via the
+    /// Wallet-Service-by-owner fallback, exactly like a real citizen.
+    /// </summary>
+    private static HttpContext ConsumerTierContext(string platformUserId = PlatformUserId)
+    {
+        var identity = new ClaimsIdentity(
+        [
+            new Claim("sub", "user-1"),
+            new Claim("email", "citizen@example.com"),
+            new Claim("org_id", "org-1"),
+            new Claim("platform_user_id", platformUserId),
+        ], "test");
+        return new DefaultHttpContext { User = new ClaimsPrincipal(identity) };
+    }
+
+    private static WalletInfo Wallet(string address) =>
+        new()
+        {
+            Address = address, Name = "w", PublicKey = "pk", Algorithm = "ED25519",
+            Status = "Active", Owner = "owner", Tenant = "tenant",
+        };
+
+    /// <summary>Wallet client mock resolving <paramref name="addresses"/> for <paramref name="owner"/>, empty for anyone else.</summary>
+    private static Mock<IWalletServiceClient> WalletClientReturning(string owner, params string[] addresses)
+    {
+        var mock = new Mock<IWalletServiceClient>();
+        mock.Setup(c => c.GetWalletsByOwnerAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string requestedOwner, CancellationToken _) =>
+                string.Equals(requestedOwner, owner, StringComparison.Ordinal)
+                    ? addresses.Select(Wallet).ToList()
+                    : new List<WalletInfo>());
+        return mock;
+    }
+
+    /// <summary>Wallet client mock that resolves no wallet for any owner (Wallet Service reachable but empty).</summary>
+    private static Mock<IWalletServiceClient> WalletClientReturningNothing()
+    {
+        var mock = new Mock<IWalletServiceClient>();
+        mock.Setup(c => c.GetWalletsByOwnerAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<WalletInfo>());
+        return mock;
+    }
+
     private static Task<IResult> InvokeAsync(
         HttpContext httpContext,
         string instanceId,
         int actionId,
         IInstanceStore instanceStore,
-        IActionResolverService actionResolver)
+        IActionResolverService actionResolver,
+        IWalletServiceClient walletClient)
     {
         var method = typeof(InstanceActionEndpoints).GetMethod(
             "GetInstanceActionSchema",
             BindingFlags.NonPublic | BindingFlags.Static);
         method.Should().NotBeNull("GetInstanceActionSchema should be reachable for reflection-based endpoint testing");
 
-        var result = method!.Invoke(null, [httpContext, instanceId, actionId, instanceStore, actionResolver, CancellationToken.None]);
+        var result = method!.Invoke(null, [
+            httpContext, instanceId, actionId, instanceStore, actionResolver,
+            walletClient, NullLogger<InstanceActionEndpoints.InstanceActionEndpointsLogCategory>.Instance,
+            CancellationToken.None,
+        ]);
         return (Task<IResult>)result!;
     }
 
     [Fact]
     public async Task GetInstanceActionSchema_ConsumerTierParticipant_ReturnsOk()
     {
-        // This is the P0 regression: a consumer-tier citizen token (identified here purely by the
-        // presence of a wallet_address claim and absence of any org/service claim — the endpoint does
-        // not require platform/service tier at all) must be able to read the action it's about to fill in.
+        // The P0 regression, reproduced honestly this time: a genuine consumer-tier citizen token —
+        // sub/email/org_id/platform_user_id, NO wallet_address, NO roles — must be able to read the
+        // action it's about to fill in. The caller's wallet is resolved via the Wallet-Service-by-owner
+        // fallback (ParticipantWalletResolver), exactly as a real PWA sign-in would require.
         var instance = MakeInstance(CitizenWallet);
         var action = MakeAction();
         var blueprint = new BlueprintModel { Id = "bp-1", Title = "AIAS", Description = "desc-desc", Actions = [action] };
@@ -107,12 +171,15 @@ public sealed class InstanceActionEndpointsTests
         resolver.Setup(r => r.GetBlueprintAsync("bp-1", It.IsAny<CancellationToken>())).ReturnsAsync(blueprint);
         resolver.Setup(r => r.GetActionDefinition(blueprint, "1")).Returns(action);
 
+        var walletClient = WalletClientReturning(PlatformUserId, CitizenWallet);
+
         var result = await InvokeAsync(
-            ContextWithWallet(CitizenWallet), "inst-1", 1, instanceStore.Object, resolver.Object);
+            ConsumerTierContext(), "inst-1", 1, instanceStore.Object, resolver.Object, walletClient.Object);
 
         var ok = result.Should().BeOfType<Ok<InstanceActionSchemaResponse>>().Subject;
         ok.Value!.ActionId.Should().Be(1);
         ok.Value.Title.Should().Be("Claim your Assured Identity credential");
+        walletClient.Verify(c => c.GetWalletsByOwnerAsync(PlatformUserId, It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
@@ -129,8 +196,10 @@ public sealed class InstanceActionEndpointsTests
         resolver.Setup(r => r.GetBlueprintAsync("bp-1", It.IsAny<CancellationToken>())).ReturnsAsync(blueprint);
         resolver.Setup(r => r.GetActionDefinition(blueprint, "1")).Returns(action);
 
+        var walletClient = WalletClientReturning(PlatformUserId, CitizenWallet);
+
         var result = await InvokeAsync(
-            ContextWithWallet(CitizenWallet), "inst-1", 1, instanceStore.Object, resolver.Object);
+            ConsumerTierContext(), "inst-1", 1, instanceStore.Object, resolver.Object, walletClient.Object);
 
         var ok = result.Should().BeOfType<Ok<InstanceActionSchemaResponse>>().Subject;
 
@@ -163,35 +232,95 @@ public sealed class InstanceActionEndpointsTests
     [Fact]
     public async Task GetInstanceActionSchema_WalletNotAParticipant_ReturnsForbidden()
     {
+        // Fast-path claim resolves to CitizenWallet, but the instance's recorded participant is a
+        // different wallet — no Wallet Service call needed (claim fast path short-circuits).
         var instance = MakeInstance(OtherWallet);
         var instanceStore = new Mock<IInstanceStore>();
         instanceStore.Setup(s => s.GetAsync("inst-1", It.IsAny<CancellationToken>())).ReturnsAsync(instance);
 
         var resolver = new Mock<IActionResolverService>(MockBehavior.Strict);
+        var walletClient = new Mock<IWalletServiceClient>(MockBehavior.Strict);
 
         var result = await InvokeAsync(
-            ContextWithWallet(CitizenWallet), "inst-1", 1, instanceStore.Object, resolver.Object);
+            ContextWithWallet(CitizenWallet), "inst-1", 1, instanceStore.Object, resolver.Object, walletClient.Object);
 
         result.GetType().Name.Should().Contain("ProblemHttpResult");
         var problem = (ProblemHttpResult)result;
         problem.StatusCode.Should().Be(StatusCodes.Status403Forbidden);
         resolver.VerifyNoOtherCalls();
+        walletClient.VerifyNoOtherCalls();
     }
 
     [Fact]
-    public async Task GetInstanceActionSchema_NoWalletClaim_ReturnsForbidden()
+    public async Task GetInstanceActionSchema_NoWalletClaim_NoResolvableWallet_ReturnsForbidden()
     {
+        // Reframe of the old (bug-asserting) NoWalletClaim test: no wallet_address claim AND the
+        // Wallet Service fallback resolves nothing for this caller — genuinely "couldn't resolve any
+        // wallet", so 403 is correct fail-closed behaviour, not the old "gate reads a claim citizens
+        // never carry" bug.
         var instance = MakeInstance(CitizenWallet);
         var instanceStore = new Mock<IInstanceStore>();
         instanceStore.Setup(s => s.GetAsync("inst-1", It.IsAny<CancellationToken>())).ReturnsAsync(instance);
 
         var resolver = new Mock<IActionResolverService>(MockBehavior.Strict);
+        var walletClient = WalletClientReturningNothing();
 
         var result = await InvokeAsync(
-            ContextWithWallet(null), "inst-1", 1, instanceStore.Object, resolver.Object);
+            ConsumerTierContext(), "inst-1", 1, instanceStore.Object, resolver.Object, walletClient.Object);
 
         var problem = result.Should().BeOfType<ProblemHttpResult>().Subject;
         problem.StatusCode.Should().Be(StatusCodes.Status403Forbidden);
+        walletClient.Verify(c => c.GetWalletsByOwnerAsync(PlatformUserId, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetInstanceActionSchema_NoWalletClaim_ResolvableWalletIsParticipant_ReturnsOk()
+    {
+        // No wallet_address claim, but the Wallet Service fallback resolves a wallet that IS the
+        // instance's recorded participant — this is the exact citizen path the P0 fix restores.
+        var instance = MakeInstance(CitizenWallet);
+        var action = MakeAction();
+        var blueprint = new BlueprintModel { Id = "bp-1", Title = "AIAS", Description = "desc-desc", Actions = [action] };
+
+        var instanceStore = new Mock<IInstanceStore>();
+        instanceStore.Setup(s => s.GetAsync("inst-1", It.IsAny<CancellationToken>())).ReturnsAsync(instance);
+
+        var resolver = new Mock<IActionResolverService>();
+        resolver.Setup(r => r.GetBlueprintAsync("bp-1", It.IsAny<CancellationToken>())).ReturnsAsync(blueprint);
+        resolver.Setup(r => r.GetActionDefinition(blueprint, "1")).Returns(action);
+
+        var walletClient = WalletClientReturning(PlatformUserId, CitizenWallet);
+
+        var result = await InvokeAsync(
+            ConsumerTierContext(), "inst-1", 1, instanceStore.Object, resolver.Object, walletClient.Object);
+
+        var ok = result.Should().BeOfType<Ok<InstanceActionSchemaResponse>>().Subject;
+        ok.Value!.ActionId.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task GetInstanceActionSchema_CallerHasMultipleWallets_ReturnsOkWhenAnyIsParticipant()
+    {
+        // A caller can own more than one wallet; membership must be checked against the FULL resolved
+        // set, not just the first address returned.
+        const string secondWallet = "ws1qsecond000000000000000000000000000000";
+        var instance = MakeInstance(secondWallet);
+        var action = MakeAction();
+        var blueprint = new BlueprintModel { Id = "bp-1", Title = "AIAS", Description = "desc-desc", Actions = [action] };
+
+        var instanceStore = new Mock<IInstanceStore>();
+        instanceStore.Setup(s => s.GetAsync("inst-1", It.IsAny<CancellationToken>())).ReturnsAsync(instance);
+
+        var resolver = new Mock<IActionResolverService>();
+        resolver.Setup(r => r.GetBlueprintAsync("bp-1", It.IsAny<CancellationToken>())).ReturnsAsync(blueprint);
+        resolver.Setup(r => r.GetActionDefinition(blueprint, "1")).Returns(action);
+
+        var walletClient = WalletClientReturning(PlatformUserId, CitizenWallet, secondWallet);
+
+        var result = await InvokeAsync(
+            ConsumerTierContext(), "inst-1", 1, instanceStore.Object, resolver.Object, walletClient.Object);
+
+        result.Should().BeOfType<Ok<InstanceActionSchemaResponse>>();
     }
 
     [Fact]
@@ -200,9 +329,10 @@ public sealed class InstanceActionEndpointsTests
         var instanceStore = new Mock<IInstanceStore>();
         instanceStore.Setup(s => s.GetAsync("missing", It.IsAny<CancellationToken>())).ReturnsAsync((Instance?)null);
         var resolver = new Mock<IActionResolverService>(MockBehavior.Strict);
+        var walletClient = new Mock<IWalletServiceClient>(MockBehavior.Strict);
 
         var result = await InvokeAsync(
-            ContextWithWallet(CitizenWallet), "missing", 1, instanceStore.Object, resolver.Object);
+            ContextWithWallet(CitizenWallet), "missing", 1, instanceStore.Object, resolver.Object, walletClient.Object);
 
         result.GetType().Name.Should().Contain("NotFound");
     }
@@ -220,8 +350,10 @@ public sealed class InstanceActionEndpointsTests
         resolver.Setup(r => r.GetBlueprintAsync("bp-1", It.IsAny<CancellationToken>())).ReturnsAsync(blueprint);
         resolver.Setup(r => r.GetActionDefinition(blueprint, "1")).Returns((Sorcha.Blueprint.Models.Action?)null);
 
+        var walletClient = new Mock<IWalletServiceClient>(MockBehavior.Strict);
+
         var result = await InvokeAsync(
-            ContextWithWallet(CitizenWallet), "inst-1", 1, instanceStore.Object, resolver.Object);
+            ContextWithWallet(CitizenWallet), "inst-1", 1, instanceStore.Object, resolver.Object, walletClient.Object);
 
         result.GetType().Name.Should().Contain("NotFound");
     }

--- a/tests/Sorcha.Blueprint.Service.Tests/Endpoints/InstanceActionEndpointsTests.cs
+++ b/tests/Sorcha.Blueprint.Service.Tests/Endpoints/InstanceActionEndpointsTests.cs
@@ -1,0 +1,228 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Reflection;
+using System.Security.Claims;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Moq;
+using Sorcha.Blueprint.Models;
+using Sorcha.Blueprint.Models.Credentials;
+using Sorcha.Blueprint.Service.Endpoints;
+using Sorcha.Blueprint.Service.Models;
+using Sorcha.Blueprint.Service.Models.Responses;
+using Sorcha.Blueprint.Service.Services.Interfaces;
+using Sorcha.Blueprint.Service.Storage;
+using Xunit;
+using BlueprintModel = Sorcha.Blueprint.Models.Blueprint;
+
+namespace Sorcha.Blueprint.Service.Tests.Endpoints;
+
+/// <summary>
+/// P0 fix (<c>fix/pwa-p0-claim-and-camera</c>) — <c>GET /api/instances/{instanceId}/actions/{actionId}</c>
+/// must be readable by a consumer-tier citizen token (the failure mode of the bug: the PWA previously
+/// hit the authoring-only <c>GET /api/blueprints/{id}</c> and got a 403), must gate on the caller's
+/// wallet being a recorded participant on the instance, and must return only the form-relevant subset
+/// of the action — not the whole blueprint and not routing/other-participant internals.
+/// </summary>
+public sealed class InstanceActionEndpointsTests
+{
+    private const string CitizenWallet = "ws1qcitizen000000000000000000000000000000";
+    private const string OtherWallet = "ws1qother00000000000000000000000000000000";
+
+    private static Instance MakeInstance(string participantWallet, string blueprintId = "bp-1", string instanceId = "inst-1") =>
+        new()
+        {
+            Id = instanceId,
+            BlueprintId = blueprintId,
+            BlueprintVersion = 1,
+            RegisterId = "reg-1",
+            TenantId = "default",
+            CurrentActionIds = [1],
+            ParticipantWallets = new Dictionary<string, string> { ["citizen"] = participantWallet },
+        };
+
+    private static Sorcha.Blueprint.Models.Action MakeAction() => new()
+    {
+        Id = 1,
+        Title = "Claim your Assured Identity credential",
+        Sender = "citizen",
+        Disclosures = [new Disclosure { ParticipantAddress = "assessor", DataPointers = ["/email"] }],
+        DataSchemas = [JsonDocument.Parse("""{"type":"object","properties":{"email":{"type":"string"}}}""")],
+        Calculations = new Dictionary<string, System.Text.Json.Nodes.JsonNode>
+        {
+            ["total"] = System.Text.Json.Nodes.JsonNode.Parse("1"),
+        },
+        CredentialRequirements = [new CredentialRequirement { Type = "SomeCredential" }],
+        CredentialIssuanceConfig = new CredentialIssuanceConfig { CredentialType = "AssuredIdentity" },
+        RejectionConfig = new RejectionConfig { TargetActionId = 0, TargetParticipantId = "reviewer" },
+        Routes = [new Route { Id = "r1", NextActionIds = [2] }],
+        Participants = [new Condition { Principal = "assessor" }],
+        AdditionalRecipients = ["assessor-wallet"],
+    };
+
+    private static HttpContext ContextWithWallet(string? walletAddress)
+    {
+        var claims = new List<Claim>();
+        if (walletAddress is not null)
+        {
+            claims.Add(new Claim("wallet_address", walletAddress));
+        }
+        var identity = new ClaimsIdentity(claims, "test");
+        return new DefaultHttpContext { User = new ClaimsPrincipal(identity) };
+    }
+
+    private static Task<IResult> InvokeAsync(
+        HttpContext httpContext,
+        string instanceId,
+        int actionId,
+        IInstanceStore instanceStore,
+        IActionResolverService actionResolver)
+    {
+        var method = typeof(InstanceActionEndpoints).GetMethod(
+            "GetInstanceActionSchema",
+            BindingFlags.NonPublic | BindingFlags.Static);
+        method.Should().NotBeNull("GetInstanceActionSchema should be reachable for reflection-based endpoint testing");
+
+        var result = method!.Invoke(null, [httpContext, instanceId, actionId, instanceStore, actionResolver, CancellationToken.None]);
+        return (Task<IResult>)result!;
+    }
+
+    [Fact]
+    public async Task GetInstanceActionSchema_ConsumerTierParticipant_ReturnsOk()
+    {
+        // This is the P0 regression: a consumer-tier citizen token (identified here purely by the
+        // presence of a wallet_address claim and absence of any org/service claim — the endpoint does
+        // not require platform/service tier at all) must be able to read the action it's about to fill in.
+        var instance = MakeInstance(CitizenWallet);
+        var action = MakeAction();
+        var blueprint = new BlueprintModel { Id = "bp-1", Title = "AIAS", Description = "desc-desc", Actions = [action] };
+
+        var instanceStore = new Mock<IInstanceStore>();
+        instanceStore.Setup(s => s.GetAsync("inst-1", It.IsAny<CancellationToken>())).ReturnsAsync(instance);
+
+        var resolver = new Mock<IActionResolverService>();
+        resolver.Setup(r => r.GetBlueprintAsync("bp-1", It.IsAny<CancellationToken>())).ReturnsAsync(blueprint);
+        resolver.Setup(r => r.GetActionDefinition(blueprint, "1")).Returns(action);
+
+        var result = await InvokeAsync(
+            ContextWithWallet(CitizenWallet), "inst-1", 1, instanceStore.Object, resolver.Object);
+
+        var ok = result.Should().BeOfType<Ok<InstanceActionSchemaResponse>>().Subject;
+        ok.Value!.ActionId.Should().Be(1);
+        ok.Value.Title.Should().Be("Claim your Assured Identity credential");
+    }
+
+    [Fact]
+    public async Task GetInstanceActionSchema_ConsumerTierParticipant_DoesNotLeakRoutingOrOtherParticipantFields()
+    {
+        var instance = MakeInstance(CitizenWallet);
+        var action = MakeAction();
+        var blueprint = new BlueprintModel { Id = "bp-1", Title = "AIAS", Description = "desc-desc", Actions = [action] };
+
+        var instanceStore = new Mock<IInstanceStore>();
+        instanceStore.Setup(s => s.GetAsync("inst-1", It.IsAny<CancellationToken>())).ReturnsAsync(instance);
+
+        var resolver = new Mock<IActionResolverService>();
+        resolver.Setup(r => r.GetBlueprintAsync("bp-1", It.IsAny<CancellationToken>())).ReturnsAsync(blueprint);
+        resolver.Setup(r => r.GetActionDefinition(blueprint, "1")).Returns(action);
+
+        var result = await InvokeAsync(
+            ContextWithWallet(CitizenWallet), "inst-1", 1, instanceStore.Object, resolver.Object);
+
+        var ok = result.Should().BeOfType<Ok<InstanceActionSchemaResponse>>().Subject;
+
+        // Serialize exactly as the wire response would be and assert the sensitive/internal
+        // fields are structurally absent — not merely null-valued on a type that happens to carry
+        // them (the response DTO has no properties for these at all).
+        var json = JsonSerializer.Serialize(ok.Value);
+        using var doc = JsonDocument.Parse(json);
+        var propertyNames = doc.RootElement.EnumerateObject().Select(p => p.Name).ToList();
+
+        propertyNames.Should().NotContain(new[]
+        {
+            "routes", "condition", "participants", "target", "additionalRecipients",
+            "requiredPriorActions", "rejectionConfig", "disclosures", "sender",
+            "blueprint", "previousTxId", "notification", "additionalProperties",
+        });
+
+        // And confirm the DTO type itself has no such properties (belt-and-braces: this fails even
+        // if a future edit adds one of these fields back with [JsonIgnore(WhenWritingNull)] and a
+        // null value happened to hide it from the serialized JSON above).
+        var dtoProperties = typeof(InstanceActionSchemaResponse).GetProperties().Select(p => p.Name).ToList();
+        dtoProperties.Should().NotContain(new[]
+        {
+            "Routes", "Condition", "Participants", "Target", "AdditionalRecipients",
+            "RequiredPriorActions", "RejectionConfig", "Disclosures", "Sender", "BlueprintId",
+            "PreviousTxId", "Notification", "AdditionalProperties",
+        });
+    }
+
+    [Fact]
+    public async Task GetInstanceActionSchema_WalletNotAParticipant_ReturnsForbidden()
+    {
+        var instance = MakeInstance(OtherWallet);
+        var instanceStore = new Mock<IInstanceStore>();
+        instanceStore.Setup(s => s.GetAsync("inst-1", It.IsAny<CancellationToken>())).ReturnsAsync(instance);
+
+        var resolver = new Mock<IActionResolverService>(MockBehavior.Strict);
+
+        var result = await InvokeAsync(
+            ContextWithWallet(CitizenWallet), "inst-1", 1, instanceStore.Object, resolver.Object);
+
+        result.GetType().Name.Should().Contain("ProblemHttpResult");
+        var problem = (ProblemHttpResult)result;
+        problem.StatusCode.Should().Be(StatusCodes.Status403Forbidden);
+        resolver.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task GetInstanceActionSchema_NoWalletClaim_ReturnsForbidden()
+    {
+        var instance = MakeInstance(CitizenWallet);
+        var instanceStore = new Mock<IInstanceStore>();
+        instanceStore.Setup(s => s.GetAsync("inst-1", It.IsAny<CancellationToken>())).ReturnsAsync(instance);
+
+        var resolver = new Mock<IActionResolverService>(MockBehavior.Strict);
+
+        var result = await InvokeAsync(
+            ContextWithWallet(null), "inst-1", 1, instanceStore.Object, resolver.Object);
+
+        var problem = result.Should().BeOfType<ProblemHttpResult>().Subject;
+        problem.StatusCode.Should().Be(StatusCodes.Status403Forbidden);
+    }
+
+    [Fact]
+    public async Task GetInstanceActionSchema_InstanceNotFound_ReturnsNotFound()
+    {
+        var instanceStore = new Mock<IInstanceStore>();
+        instanceStore.Setup(s => s.GetAsync("missing", It.IsAny<CancellationToken>())).ReturnsAsync((Instance?)null);
+        var resolver = new Mock<IActionResolverService>(MockBehavior.Strict);
+
+        var result = await InvokeAsync(
+            ContextWithWallet(CitizenWallet), "missing", 1, instanceStore.Object, resolver.Object);
+
+        result.GetType().Name.Should().Contain("NotFound");
+    }
+
+    [Fact]
+    public async Task GetInstanceActionSchema_ActionNotInBlueprint_ReturnsNotFound()
+    {
+        var instance = MakeInstance(CitizenWallet);
+        var blueprint = new BlueprintModel { Id = "bp-1", Title = "AIAS", Description = "desc-desc", Actions = [] };
+
+        var instanceStore = new Mock<IInstanceStore>();
+        instanceStore.Setup(s => s.GetAsync("inst-1", It.IsAny<CancellationToken>())).ReturnsAsync(instance);
+
+        var resolver = new Mock<IActionResolverService>();
+        resolver.Setup(r => r.GetBlueprintAsync("bp-1", It.IsAny<CancellationToken>())).ReturnsAsync(blueprint);
+        resolver.Setup(r => r.GetActionDefinition(blueprint, "1")).Returns((Sorcha.Blueprint.Models.Action?)null);
+
+        var result = await InvokeAsync(
+            ContextWithWallet(CitizenWallet), "inst-1", 1, instanceStore.Object, resolver.Object);
+
+        result.GetType().Name.Should().Contain("NotFound");
+    }
+}

--- a/tests/Sorcha.Blueprint.Service.Tests/Services/Infrastructure/ParticipantWalletResolverTests.cs
+++ b/tests/Sorcha.Blueprint.Service.Tests/Services/Infrastructure/ParticipantWalletResolverTests.cs
@@ -6,20 +6,24 @@ using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
-using Sorcha.Blueprint.Service.Endpoints;
+using Sorcha.Blueprint.Service.Services.Infrastructure;
 using Sorcha.ServiceClients.Wallet;
 
-namespace Sorcha.Blueprint.Service.Tests.Endpoints;
+namespace Sorcha.Blueprint.Service.Tests.Services.Infrastructure;
 
 /// <summary>
-/// Feature 145 / #912 — the pending-actions endpoint must resolve the caller's wallet by
-/// <c>platform_user_id</c> (the cross-org Owner key per #878), not just <c>sub</c>. A consumer-tier
-/// token (e.g. the verification analyst running the rules agent) carries no <c>wallet_address</c>
-/// claim and its wallet is owned by <c>platform_user_id</c>, which differs from <c>sub</c> for an
-/// org-scoped user — so a sub-only lookup silently misses the wallet and the agent never discovers
-/// the action it must approve.
+/// P0 fix (<c>fix/pwa-p0-claim-and-camera</c>) — <see cref="ParticipantWalletResolver"/> was extracted
+/// from <c>ActionEndpoints.ResolveUserWalletAddressesAsync</c> once a fourth call site
+/// (<c>InstanceActionEndpoints</c>) needed the identical claim-then-Wallet-Service-fallback logic.
+/// These tests were originally <c>ActionEndpointsTests</c> and moved verbatim onto the shared seam.
+///
+/// Feature 145 / #912 — the resolver must resolve the caller's wallet by <c>platform_user_id</c> (the
+/// cross-org Owner key per #878), not just <c>sub</c>. A consumer-tier token (e.g. the verification
+/// analyst running the rules agent, or any real citizen under Feature 136) carries no
+/// <c>wallet_address</c> claim and its wallet is owned by <c>platform_user_id</c>, which differs from
+/// <c>sub</c> for an org-scoped user — so a sub-only lookup silently misses the wallet.
 /// </summary>
-public class ActionEndpointsTests
+public class ParticipantWalletResolverTests
 {
     private static HttpContext ContextWith(params (string Type, string Value)[] claims)
     {
@@ -52,7 +56,7 @@ public class ActionEndpointsTests
     {
         var wallet = new Mock<IWalletServiceClient>(MockBehavior.Strict);
 
-        var result = await ActionEndpoints.ResolveUserWalletAddressesAsync(
+        var result = await ParticipantWalletResolver.ResolveUserWalletAddressesAsync(
             ContextWith(("wallet_address", "ws1-fast"), ("sub", "sub-1")),
             wallet.Object, NullLogger.Instance, CancellationToken.None);
 
@@ -69,7 +73,7 @@ public class ActionEndpointsTests
             ("platform-1", new[] { "ws1-analyst" }),
             ("sub-1", Array.Empty<string>()));
 
-        var result = await ActionEndpoints.ResolveUserWalletAddressesAsync(
+        var result = await ParticipantWalletResolver.ResolveUserWalletAddressesAsync(
             ContextWith(("platform_user_id", "platform-1"), (ClaimTypes.NameIdentifier, "sub-1")),
             wallet.Object, NullLogger.Instance, CancellationToken.None);
 
@@ -85,7 +89,7 @@ public class ActionEndpointsTests
             ("platform-1", Array.Empty<string>()),
             ("sub-1", new[] { "ws1-legacy" }));
 
-        var result = await ActionEndpoints.ResolveUserWalletAddressesAsync(
+        var result = await ParticipantWalletResolver.ResolveUserWalletAddressesAsync(
             ContextWith(("platform_user_id", "platform-1"), (ClaimTypes.NameIdentifier, "sub-1")),
             wallet.Object, NullLogger.Instance, CancellationToken.None);
 
@@ -99,7 +103,7 @@ public class ActionEndpointsTests
     {
         var wallet = new Mock<IWalletServiceClient>(MockBehavior.Strict);
 
-        var result = await ActionEndpoints.ResolveUserWalletAddressesAsync(
+        var result = await ParticipantWalletResolver.ResolveUserWalletAddressesAsync(
             ContextWith(("some-other-claim", "x")),
             wallet.Object, NullLogger.Instance, CancellationToken.None);
 

--- a/tests/Sorcha.Wallet.Pwa.Tests/Drafts/ActionContextCacheTests.cs
+++ b/tests/Sorcha.Wallet.Pwa.Tests/Drafts/ActionContextCacheTests.cs
@@ -45,7 +45,7 @@ public sealed class ActionContextCacheTests
         _actions.Setup(a => a.GetPendingAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<PendingActionItem> { Pending(id1.ToString()), Pending(id2.ToString()) });
         _actionClient.Setup(c => c.LoadFormAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((Guid g, CancellationToken _) => FormCtx(g));
+            .ReturnsAsync((Guid g, CancellationToken _) => ApplicationFormLoadResult.Success(FormCtx(g)));
 
         var cached = await Create().RefreshFromPendingAsync();
 
@@ -64,7 +64,7 @@ public sealed class ActionContextCacheTests
         _actionClient.Setup(c => c.LoadFormAsync(bad, It.IsAny<CancellationToken>()))
             .ThrowsAsync(new InvalidOperationException("boom"));
         _actionClient.Setup(c => c.LoadFormAsync(ok, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(FormCtx(ok));
+            .ReturnsAsync(ApplicationFormLoadResult.Success(FormCtx(ok)));
 
         var cached = await Create().RefreshFromPendingAsync();
 

--- a/tests/Sorcha.Wallet.Pwa.Tests/Pages/ApplicationInstanceLoadFailureTests.cs
+++ b/tests/Sorcha.Wallet.Pwa.Tests/Pages/ApplicationInstanceLoadFailureTests.cs
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Bunit;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Sorcha.UI.Testing;
+using Sorcha.Wallet.Pwa.Services;
+using Sorcha.Wallet.Pwa.Services.Applications;
+using Sorcha.Wallet.Pwa.Services.Drafts;
+using Xunit;
+using ApplicationInstancePage = Sorcha.Wallet.Pwa.Pages.ApplicationInstance;
+
+namespace Sorcha.Wallet.Pwa.Tests.Pages;
+
+/// <summary>
+/// P0 fix (<c>fix/pwa-p0-claim-and-camera</c>) — <c>ApplicationInstance.razor</c> must only report
+/// "offline" when the device is genuinely offline. Before this fix, <c>LoadFormAsync</c> collapsed
+/// every failure (including a 403 from the citizen's own permission gate) into a bare <c>null</c>,
+/// and the page treated any such failure as "offline" unconditionally — never consulting the
+/// already-injected <see cref="IConnectivity"/>. These tests drive the page through the discriminated
+/// <see cref="ApplicationFormLoadResult"/> outcomes and assert each lands on its own honest state.
+/// </summary>
+public sealed class ApplicationInstanceLoadFailureTests : ComponentTestFixture
+{
+    private readonly Mock<IApplicationActionClient> _actionClient = new();
+    private readonly Mock<IPendingApplicationClient> _pendingApplications = new();
+    private readonly Mock<IActionContextCache> _actionContextCache = new();
+    private readonly Mock<IDraftStore> _draftStore = new();
+    private readonly Mock<ISubmitQueue> _submitQueue = new();
+    private readonly Mock<IFileChunkUploader> _fileUploader = new();
+    private readonly Mock<IConnectivity> _connectivity = new();
+
+    public ApplicationInstanceLoadFailureTests()
+    {
+        Services.AddSingleton(_actionClient.Object);
+        Services.AddSingleton(_pendingApplications.Object);
+        Services.AddSingleton(_actionContextCache.Object);
+        Services.AddSingleton(_draftStore.Object);
+        Services.AddSingleton(_submitQueue.Object);
+        Services.AddSingleton(_fileUploader.Object);
+        Services.AddSingleton(_connectivity.Object);
+        Services.AddSingleton<Microsoft.Extensions.Logging.ILogger<ApplicationInstancePage>>(
+            NullLogger<ApplicationInstancePage>.Instance);
+
+        // No offline cache prepared for any of these scenarios — forces the page onto its
+        // failure-state branch instead of a silently-successful cache hit.
+        _actionContextCache
+            .Setup(c => c.GetForInstanceAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Sorcha.Wallet.Pwa.Services.Drafts.Models.CachedActionContext?)null);
+    }
+
+    [Fact]
+    public void Forbidden_WhileOnline_RendersForbidden_NotOffline()
+    {
+        _actionClient.Setup(c => c.LoadFormAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ApplicationFormLoadResult.Forbidden);
+        _connectivity.SetupGet(c => c.IsOnline).Returns(true);
+
+        var cut = Render<ApplicationInstancePage>(ps => ps.Add(p => p.InstanceId, Guid.NewGuid()));
+
+        cut.FindAll("[data-testid=application-instance-forbidden]").Should().ContainSingle();
+        cut.FindAll("[data-testid=application-instance-offline]").Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Forbidden_WhileOffline_StillRendersForbidden_NotOffline()
+    {
+        // A 403 is a real server answer — the request reached the server. Even if the connectivity
+        // flag is stale/false, the honest state is "forbidden", not "offline" (P0 fix's core claim).
+        _actionClient.Setup(c => c.LoadFormAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ApplicationFormLoadResult.Forbidden);
+        _connectivity.SetupGet(c => c.IsOnline).Returns(false);
+
+        var cut = Render<ApplicationInstancePage>(ps => ps.Add(p => p.InstanceId, Guid.NewGuid()));
+
+        cut.FindAll("[data-testid=application-instance-forbidden]").Should().ContainSingle();
+        cut.FindAll("[data-testid=application-instance-offline]").Should().BeEmpty();
+    }
+
+    [Fact]
+    public void NetworkError_WhileOffline_RendersOffline()
+    {
+        _actionClient.Setup(c => c.LoadFormAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ApplicationFormLoadResult.NetworkError);
+        _connectivity.SetupGet(c => c.IsOnline).Returns(false);
+
+        var cut = Render<ApplicationInstancePage>(ps => ps.Add(p => p.InstanceId, Guid.NewGuid()));
+
+        cut.FindAll("[data-testid=application-instance-offline]").Should().ContainSingle();
+    }
+
+    [Fact]
+    public void NetworkError_WhileOnline_RendersError_NotOffline()
+    {
+        // The deeper defect this fix closes: a genuine server-side problem (5xx, etc.) while the
+        // device is online must never be fabricated into "you're offline".
+        _actionClient.Setup(c => c.LoadFormAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ApplicationFormLoadResult.NetworkError);
+        _connectivity.SetupGet(c => c.IsOnline).Returns(true);
+
+        var cut = Render<ApplicationInstancePage>(ps => ps.Add(p => p.InstanceId, Guid.NewGuid()));
+
+        cut.FindAll("[data-testid=application-instance-error]").Should().ContainSingle();
+        cut.FindAll("[data-testid=application-instance-offline]").Should().BeEmpty();
+    }
+
+    [Fact]
+    public void NotFound_WhileOnline_RendersError_NotOffline()
+    {
+        _actionClient.Setup(c => c.LoadFormAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ApplicationFormLoadResult.NotFound);
+        _connectivity.SetupGet(c => c.IsOnline).Returns(true);
+
+        var cut = Render<ApplicationInstancePage>(ps => ps.Add(p => p.InstanceId, Guid.NewGuid()));
+
+        cut.FindAll("[data-testid=application-instance-error]").Should().ContainSingle();
+        cut.FindAll("[data-testid=application-instance-offline]").Should().BeEmpty();
+    }
+}

--- a/tests/Sorcha.Wallet.Pwa.Tests/Services/Applications/HttpApplicationActionClientTests.cs
+++ b/tests/Sorcha.Wallet.Pwa.Tests/Services/Applications/HttpApplicationActionClientTests.cs
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Sorcha.UI.Core.Services.HolderKeys;
+using Sorcha.Wallet.Pwa.Services.Applications;
+using Xunit;
+
+namespace Sorcha.Wallet.Pwa.Tests.Services.Applications;
+
+/// <summary>
+/// P0 fix (<c>fix/pwa-p0-claim-and-camera</c>) — <c>HttpApplicationActionClient.LoadFormAsync</c> must
+/// read the instance-scoped <c>GET /api/instances/{id}/actions/{actionId}</c> endpoint (not the
+/// authoring-only <c>GET /api/blueprints/{id}</c>, which 403s for a consumer-tier citizen token) and
+/// must surface a 403 as <see cref="ApplicationFormLoadStatus.Forbidden"/> — never collapse it into a
+/// bare failure that the caller could mistake for "offline".
+/// </summary>
+public sealed class HttpApplicationActionClientTests
+{
+    private static readonly Guid InstanceId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+
+    private const string InstanceJson = """
+        { "blueprintId": "bp-1", "registerId": "reg-1", "currentActionIds": [1], "title": "Claim your Assured Identity credential" }
+        """;
+
+    private const string ActionSchemaJson = """
+        { "actionId": 1, "title": "Claim your Assured Identity credential",
+          "form": { "type": "Layout", "title": "", "scope": "" },
+          "dataSchemas": [ { "type": "object", "properties": { "email": { "type": "string" } } } ] }
+        """;
+
+    [Fact]
+    public async Task LoadFormAsync_ActionEndpointReturns403_ReturnsForbidden_NotNullOrOffline()
+    {
+        // This is the exact P0 regression: the server refuses (403) and the caller must be told
+        // "forbidden", never asked to guess that it means "you must be offline".
+        var client = Create(req =>
+        {
+            if (req.RequestUri!.AbsolutePath.EndsWith($"/api/instances/{InstanceId:N}", StringComparison.Ordinal))
+            {
+                return Ok(InstanceJson);
+            }
+            return new HttpResponseMessage(HttpStatusCode.Forbidden);
+        }, keys: Keys());
+
+        var result = await client.LoadFormAsync(InstanceId);
+
+        result.Status.Should().Be(ApplicationFormLoadStatus.Forbidden);
+        result.Context.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task LoadFormAsync_ActionEndpointReturns401_ReturnsForbidden()
+    {
+        var client = Create(req =>
+        {
+            if (req.RequestUri!.AbsolutePath.EndsWith($"/api/instances/{InstanceId:N}", StringComparison.Ordinal))
+            {
+                return Ok(InstanceJson);
+            }
+            return new HttpResponseMessage(HttpStatusCode.Unauthorized);
+        }, keys: Keys());
+
+        var result = await client.LoadFormAsync(InstanceId);
+
+        result.Status.Should().Be(ApplicationFormLoadStatus.Forbidden);
+    }
+
+    [Fact]
+    public async Task LoadFormAsync_ServerError500_ReturnsNetworkError_NotForbidden()
+    {
+        var client = Create(req =>
+        {
+            if (req.RequestUri!.AbsolutePath.EndsWith($"/api/instances/{InstanceId:N}", StringComparison.Ordinal))
+            {
+                return Ok(InstanceJson);
+            }
+            return new HttpResponseMessage(HttpStatusCode.InternalServerError);
+        }, keys: Keys());
+
+        var result = await client.LoadFormAsync(InstanceId);
+
+        result.Status.Should().Be(ApplicationFormLoadStatus.NetworkError);
+    }
+
+    [Fact]
+    public async Task LoadFormAsync_ActionEndpointReturns404_ReturnsNotFound()
+    {
+        var client = Create(req =>
+        {
+            if (req.RequestUri!.AbsolutePath.EndsWith($"/api/instances/{InstanceId:N}", StringComparison.Ordinal))
+            {
+                return Ok(InstanceJson);
+            }
+            return new HttpResponseMessage(HttpStatusCode.NotFound);
+        }, keys: Keys());
+
+        var result = await client.LoadFormAsync(InstanceId);
+
+        result.Status.Should().Be(ApplicationFormLoadStatus.NotFound);
+    }
+
+    [Fact]
+    public async Task LoadFormAsync_Success_ReadsFromInstanceScopedActionEndpoint_NotBlueprintEndpoint()
+    {
+        var hitBlueprintEndpoint = false;
+        var client = Create(req =>
+        {
+            if (req.RequestUri!.AbsolutePath.Contains("/api/blueprints/", StringComparison.Ordinal))
+            {
+                hitBlueprintEndpoint = true;
+                return new HttpResponseMessage(HttpStatusCode.Forbidden);
+            }
+            if (req.RequestUri!.AbsolutePath.EndsWith($"/api/instances/{InstanceId:N}", StringComparison.Ordinal))
+            {
+                return Ok(InstanceJson);
+            }
+            if (req.RequestUri!.AbsolutePath.EndsWith($"/api/instances/{InstanceId:N}/actions/1", StringComparison.Ordinal))
+            {
+                return Ok(ActionSchemaJson);
+            }
+            return new HttpResponseMessage(HttpStatusCode.NotFound);
+        }, keys: Keys());
+
+        var result = await client.LoadFormAsync(InstanceId);
+
+        hitBlueprintEndpoint.Should().BeFalse("the authoring-only blueprint endpoint must never be called from this client");
+        result.Status.Should().Be(ApplicationFormLoadStatus.Loaded);
+        result.Context.Should().NotBeNull();
+        result.Context!.Action.Title.Should().Be("Claim your Assured Identity credential");
+        result.Context.Action.Id.Should().Be(1);
+        result.Context.SenderWallet.Should().Be("ws1qcitizen");
+    }
+
+    [Fact]
+    public async Task LoadFormAsync_InstanceEndpointReturns403_ReturnsForbidden()
+    {
+        var client = Create(_ => new HttpResponseMessage(HttpStatusCode.Forbidden), keys: Keys());
+
+        var result = await client.LoadFormAsync(InstanceId);
+
+        result.Status.Should().Be(ApplicationFormLoadStatus.Forbidden);
+    }
+
+    private static HolderKeysView Keys() => new() { WalletAddress = "ws1qcitizen" };
+
+    private static HttpResponseMessage Ok(string json) =>
+        new(HttpStatusCode.OK) { Content = new StringContent(json, Encoding.UTF8, "application/json") };
+
+    private static HttpApplicationActionClient Create(
+        Func<HttpRequestMessage, HttpResponseMessage> respond,
+        HolderKeysView? keys)
+    {
+        var http = new HttpClient(new StubHandler(respond)) { BaseAddress = new Uri("https://test.example.com") };
+        var holderKeys = new Mock<IHolderKeyClient>();
+        holderKeys.Setup(h => h.GetHolderKeysAsync(It.IsAny<CancellationToken>())).ReturnsAsync(keys);
+        return new HttpApplicationActionClient(http, holderKeys.Object, NullLogger<HttpApplicationActionClient>.Instance);
+    }
+
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, HttpResponseMessage> _respond;
+        public StubHandler(Func<HttpRequestMessage, HttpResponseMessage> respond) => _respond = respond;
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct) =>
+            Task.FromResult(_respond(request));
+    }
+}


### PR DESCRIPTION
## Why

Screenshots from a real phone (iOS TestFlight build) showed two things that stop a citizen dead. Neither was visible to the test suite.

## P0 #1 — the citizen could not claim their credential

The wallet showed a to-do: **"Claim your Assured Identity credential"**. Tapping it said:

> *"This application isn't available offline yet. Open it once while you're connected and it'll be ready to fill in the field next time."*

**The phone was online.** The message was a lie, and the citizen could never claim their credential — so the to-do never cleared, the badge stuck at 1, and (relevant to the proximity work) there was no *accepted* credential to present.

**Root cause:** `HttpApplicationActionClient.LoadFormAsync` read the action schema from `GET /api/blueprints/{id}` — an **authoring** endpoint gated by `CanManageBlueprints`, which **deliberately refuses consumer-tier tokens**. Feature 147 locked citizens out of blueprint authoring on purpose; the PWA was using that same door merely to *read a form schema*. The 403 was swallowed by a blanket `catch` into `return null`, and the page rendered `State.Offline` for **any** null — never consulting the `IConnectivity` it already had injected.

The offline cache couldn't rescue it either: `ActionContextCache.RefreshFromPendingAsync` populates itself by calling the same method, so it 403'd too and stored nothing.

**Fix:**
- **Server** — new `GET /api/instances/{instanceId}/actions/{actionId}` on the existing `CanExecuteBlueprints` group, returning a **narrow** `InstanceActionSchemaResponse` (only what the renderer reads). It deliberately does **not** return `Routes`, `Condition`, `Participants`, `RejectionConfig`, `Disclosures`, `Sender`, or credential-issuance internals. `GET /api/blueprints/{id}` was **not** widened — F147's narrowing stands.
- **Client** — `LoadFormAsync` returns a discriminated `ApplicationFormLoadResult` (Loaded / NotFound / Forbidden / NetworkError). The page only shows Offline when **actually offline**. That closes the deeper defect: as written, *any* server-side problem on that page would have claimed the user was offline forever.

### The first attempt was wrong, and the review caught it

The participant gate initially read the `wallet_address` JWT claim — which, **under Feature 136, consumer-tier tokens never carry**. It would have 403'd *every* genuine citizen: a false "you're offline" swapped for an authoritative-sounding "you don't have permission".

It passed its tests because the test meant to prove "a consumer-tier citizen can read this" fabricated a principal carrying **only** a `wallet_address` claim — the *platform*-tier shape. It asserted the opposite of what it claimed.

Fixed by extracting the existing, correct `ActionEndpoints.ResolveUserWalletAddressesAsync` (JWT claim **+ Wallet-Service owner lookup by `platform_user_id`**, added after incident #912) into a shared `ParticipantWalletResolver`, now used by **all four** call sites so the next person cannot repeat the copy-paste. Membership is checked against **all** the caller's wallets, failing closed on an empty set.

Red-then-green proof: reverting just the gate body to claim-only makes **5 tests fail** — all the consumer-tier cases.

## P0 #2 — the QR scanner never had camera permission

The Present screen offered *"Paste the `openid4vp://` link from the verifier"* — unusable on a phone, because you cannot paste a QR code someone is showing you.

The camera-first design was already built and correct (`Present.razor` has a `CameraFirst` mode that auto-starts a viewfinder on a handheld). It never fired because the **native app never asked for the camera**:

- iOS `Info.plist` had `NSBluetoothAlwaysUsageDescription` (added for F185 proximity) but **no `NSCameraUsageDescription`** → WKWebView refuses `getUserMedia`.
- The Android manifest declared only `INTERNET`.

Without `getUserMedia`, `IDeviceProfileProbe` reports `CameraAvailability.Unavailable` and `(anything, Unavailable) → IntakeMode.PasteOnly`. The probe was doing exactly what it was designed to do — it degraded because the phone genuinely could not open a camera.

(The proximity **BLE** permissions are *not* missing — they are declared in the `sorcha-proximity` plugin's own manifest and merged at build time.)

## Verification

- `dotnet build Sorcha.sln` — 0 errors
- `Sorcha.Blueprint.Service.Tests` **964 / 0**, `Sorcha.Wallet.Pwa.Tests` **368 / 0**
- No EF migration

**The camera fix needs on-device confirmation and the test suite structurally cannot give it.** Everything runs in a browser or over a loopback transport; nothing exercises the native permission surface. That blind spot is why this reached a real phone.

## Follow-ups raised

- **#1182 — SECURITY, pre-existing and more serious than either P0 here.** `GET /api/instances/{id}` has **no** participant check: any authenticated caller, any tier, any org, who has or guesses an instance GUID can read the full instance — including `AccumulatedData` (name, date of birth, address, portrait tokens in plaintext on an identity workflow) and `ParticipantWallets` (de-anonymising every participant).
- **#1183** — open-participant *starting* actions will 403 on the new endpoint (latent; AIAS's claim action is unaffected, and no PWA route currently reaches a starting action).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018rxzAeahjb74xgRxsThTu2