### PR TITLE
fix: [vct] decouple credential vct from display + type; convert every blueprint

### DIFF
--- a/.claude/skills/blueprint-builder/SKILL.md
+++ b/.claude/skills/blueprint-builder/SKILL.md
@@ -159,7 +159,7 @@ Sorcha blueprints define multi-participant workflows as JSON documents. Each blu
       "sender": "applicant",
       "credentialRequirements": [
         {
-          "type": "AssuredIdentityCredential",
+          "type": "https://sorcha.dev/vc/assured-identity/v1",
           "presentationSource": "HaipExternalWallet",
           "requiredClaims": [ { "claimName": "givenName" }, { "claimName": "dateOfBirth" } ]
         }
@@ -604,7 +604,7 @@ Watermark states (Draft/Pending/Issued/None), stacked-cards behaviour for `crede
 ```jsonc
 "credentialRequirements": [
   {
-    "type": "AssuredIdentityCredential",
+    "type": "https://sorcha.dev/vc/assured-identity/v1",
     "presentationSource": "HaipExternalWallet",
     "trustPolicy": {
       "sources": [
@@ -625,12 +625,15 @@ Watermark states (Draft/Pending/Issued/None), stacked-cards behaviour for `crede
 - `presentationSource: "HaipExternalWallet"` runs the OpenID4VP `direct_post` flow (Feature 098) — required for citizen-facing services that accept external wallets and for credential-bootstrapped open submissions.
 - `trustPolicy` replaced the removed `acceptedIssuers` field (F135). A null/empty `trustPolicy` accepts any issuer (`OPEN_CREDENTIAL_ISSUER` warning at publish time); a `did-allowlist` source is the direct equivalent of the old issuer list, and a `register` source trusts register-resolved issuers. Full shape: the F135 section of the `sorcha-architecture` skill. **Do not write `acceptedIssuers`** — it is silently ignored.
 - Multiple requirements are AND-combined.
+- `type` above is the canonical, **case-sensitive** VCT URI (`Sorcha.CitizenWallet.Abstractions.Constants.VctUris`, e.g. `VctUris.AssuredIdentityV1`) — for a platform-catalogued credential type it must match the issuer's `vct` exactly (`Ordinal` comparison). A missed URI/casing means the requirement silently never matches.
 
 ### Issuing a credential on action completion
 
 ```jsonc
 "credentialIssuanceConfig": {
-  "credentialType": "PlanningPermit",
+  "credentialType": "PlanningPermissionCredential",
+  "vct": "https://sorcha.dev/vc/planning-permission/v1",
+  "displayName": "Planning Permission",
   "claimMappings": [
     { "claimName": "applicantName", "sourceField": "/applicantName" },
     { "claimName": "siteAddress",   "sourceField": "/siteAddress"   }
@@ -644,6 +647,9 @@ Watermark states (Draft/Pending/Issued/None), stacked-cards behaviour for `crede
 }
 ```
 
+- `vct` (new) is the canonical, case-sensitive absolute URI written to `claims["vct"]` — the SD-JWT VC's **sole** type identifier (SD-JWT VC §3.2.2.1; Sorcha no longer emits a `type` claim). Always set it from `VctUris` for a platform-catalogued type — don't hand-write the URI.
+- `displayName` (new) is the authored human card label (e.g. "Planning Permission"). When omitted, the card falls back to `Humanize(vct)` — which reads badly for a URI (`Humanize("https://.../planning-permission/v1")` → "V1"), so set it explicitly for any URI-`vct` credential.
+- `credentialType` is now a short-name/fallback/readable id, written only when `vct` is omitted. It is no longer the matching identity.
 - `targetAudience: "SorchaLocalWallet"` (Feature 106): the engine seals an X25519-wrapped, AEAD-encrypted SD-JWT VC into the action transaction; the credential peer-replicates and is detected by the holder's Wallet Service regardless of node. Default for on-platform issuance.
 - `targetAudience: "HaipExternalWallet"` (Feature 104): mints an OpenID4VCI offer instead of writing to a wallet. **MUST be paired with a separate Claim action** carrying `x-credential-offer` and `outputMapping` from the issuing route — see Credential Claim Actions below.
 - `targetAudience: "SorchaInternal"` is **deprecated** — bypasses the register and breaks on multi-node deployments. Always prefer `SorchaLocalWallet`.
@@ -667,7 +673,9 @@ Composes `SorchaLocalWallet` issuance with **Open Participants & Late Binding** 
     { "id": 2, "sender": "verifier", "schemaRef": "VerifierDecision/v1" },
     { "id": 3, "sender": "verifier",
       "credentialIssuanceConfig": {
-        "credentialType": "AssuredIdentityCredential/v1",
+        "credentialType": "AssuredIdentityCredential",
+        "vct": "https://sorcha.dev/vc/assured-identity/v1",
+        "displayName": "Assured Identity",
         "targetAudience": "SorchaLocalWallet",
         "recipientParticipantId": "applicant",
         "claimMappings": [

--- a/.claude/skills/verifiable-credentials/SKILL.md
+++ b/.claude/skills/verifiable-credentials/SKILL.md
@@ -103,12 +103,18 @@ All credential domain models live in `Sorcha.Blueprint.Models.Credentials` (note
 // Sorcha.Blueprint.Models/Credentials/CredentialIssuanceConfig.cs
 public class CredentialIssuanceConfig
 {
-    public string CredentialType { get; set; } = string.Empty;
+    public string CredentialType { get; set; } = string.Empty;   // short-name / fallback / readable id — NOT the wire vct
+    public string? Vct { get; set; }                             // canonical absolute URI, e.g. https://sorcha.dev/vc/assured-identity/v1 — the SD-JWT VC's sole type identifier
+    public string? DisplayName { get; set; }                     // authored human card label, e.g. "Assured Identity"
     public IEnumerable<ClaimMapping> ClaimMappings { get; set; } = [];
     public string RecipientParticipantId { get; set; } = string.Empty;
     // ... plus display config, status list binding, validity window
 }
+```
 
+**VCT / display decoupling (2026-07-15).** `Vct` is the canonical, **case-sensitive absolute URI** that is the credential's sole machine-matching identity — written to `claims["vct"]` and nowhere else. The wire SD-JWT VC carries **`vct` only; there is no `type` claim** (SD-JWT VC §3.2.2.1 — Sorcha previously wrote both, which was non-standard, and has stopped). `DisplayName` is the authored human card label; when omitted the card falls back to `Humanize(vct)`. `CredentialType` is demoted to a short-name/fallback/readable id, used only when `Vct` is omitted. Matching is **case-sensitive exact** (`Ordinal`) everywhere — `CredentialVerifier`/`CredentialMatcher` moved off `OrdinalIgnoreCase`; the PWA's `PresentationEngine` was already `Ordinal`. Every platform credential type has a canonical constant in `Sorcha.CitizenWallet.Abstractions.Constants.VctUris` (e.g. `VctUris.AssuredIdentityV1 = "https://sorcha.dev/vc/assured-identity/v1"`) — new blueprints should declare `vct` from that registry, not rely on the bare-name fallback. A parametrised `BlueprintVctConformanceTests` enforces every shipped blueprint's `vct` matches its `VctUris` constant.
+
+```csharp
 // Sorcha.Blueprint.Models/Credentials/CredentialRequirement.cs
 public class CredentialRequirement
 {
@@ -267,7 +273,9 @@ Actions carry credential configs as first-class fields (not an `x-*` schema exte
 {
   "actionId": "issue-graduation",
   "credentialIssuance": {
-    "credentialType": "GraduationCredential",
+    "credentialType": "CompletionCertificateCredential",
+    "vct": "https://sorcha.dev/vc/completion-certificate/v1",
+    "displayName": "Completion Certificate",
     "recipientParticipantId": "student",
     "claimMappings": [
       { "claimName": "name",           "sourceField": "/student/name" },
@@ -290,6 +298,8 @@ Actions carry credential configs as first-class fields (not an `x-*` schema exte
   ]
 }
 ```
+
+`vct` is the canonical URI (from `VctUris.CompletionCertificateV1`) — the credential's sole wire type identifier; `credentialType` is the short-name fallback used only when `vct` is omitted; `displayName` is the card label. `IdentityAttestation` above is an action-local requirement type, not a platform-catalogued credential, so it stays a bare name — there is no `VctUris` constant for it.
 
 > **Feature 135:** `CredentialRequirement.acceptedIssuers` was **removed** and replaced by `trustPolicy` (a `sources[]` + `combinator` + `minAssuranceLevel` shape decided by the unified `ITrustEvaluator`). The `did-allowlist` source above is the direct equivalent of the old flat issuer list; omit `trustPolicy` (or use a `{ "kind": "register" }` source) to trust register-resolved issuers. Full shape: the "EUDI credential format & unified trust (Feature 135)" section of the `sorcha-architecture` skill. **Do not** write `acceptedIssuers` — it is silently ignored.
 

--- a/blueprints/examples/healthcare/medical-equipment-refurb.json
+++ b/blueprints/examples/healthcare/medical-equipment-refurb.json
@@ -641,6 +641,8 @@
         ],
         "credentialIssuanceConfig": {
           "credentialType": "RefurbishmentCertificateCredential",
+          "vct": "https://sorcha.dev/vc/refurbishment-certificate/v1",
+          "displayName": "Refurbishment Certificate",
           "recipientParticipantId": "biomedical-engineer",
           "expiryDuration": "P365D",
           "claimMappings": [

--- a/blueprints/templates/council-id-application-template.json
+++ b/blueprints/templates/council-id-application-template.json
@@ -125,6 +125,8 @@
         ],
         "credentialIssuanceConfig": {
           "credentialType": "CouncilDigitalIdCredential",
+          "vct": "https://sorcha.dev/vc/council-digital-id/v1",
+          "displayName": "Council Digital ID",
           "claimMappings": [
             { "claimName": "holder_name", "sourceField": "/fullName" },
             { "claimName": "date_of_birth", "sourceField": "/dateOfBirth" },

--- a/blueprints/templates/license-approval-template.json
+++ b/blueprints/templates/license-approval-template.json
@@ -103,6 +103,8 @@
         ],
         "credentialIssuanceConfig": {
           "credentialType": "LicenseCredential",
+          "vct": "https://sorcha.dev/vc/licence/v1",
+          "displayName": "Licence",
           "claimMappings": [
             { "claimName": "holder_name", "sourceField": "/applicantName" },
             { "claimName": "license_type", "sourceField": "/licenseType" },

--- a/blueprints/templates/work-order-template.json
+++ b/blueprints/templates/work-order-template.json
@@ -39,7 +39,7 @@
         "isStartingAction": true,
         "credentialRequirements": [
           {
-            "type": "LicenseCredential",
+            "type": "https://sorcha.dev/vc/licence/v1",
             "description": "A valid license credential issued by a recognized licensing authority",
             "requiredClaims": [
               { "claimName": "license_type" }

--- a/demos/AIAS/blueprints/aias-assured-identity.template.json
+++ b/demos/AIAS/blueprints/aias-assured-identity.template.json
@@ -180,6 +180,8 @@
         ],
         "credentialIssuanceConfig": {
           "credentialType": "AssuredIdentityCredential",
+          "vct": "https://sorcha.dev/vc/assured-identity/v1",
+          "displayName": "Assured Identity",
           "targetAudience": "SorchaLocalWallet",
           "recipientParticipantId": "citizen",
           "holderKeySourceField": "/holderKeys/holderJwk",

--- a/demos/AssuredIdentity/blueprints/assured-identity.template.json
+++ b/demos/AssuredIdentity/blueprints/assured-identity.template.json
@@ -166,6 +166,8 @@
         ],
         "credentialIssuanceConfig": {
           "credentialType": "AssuredIdentityCredential",
+          "vct": "https://sorcha.dev/vc/assured-identity/v1",
+          "displayName": "Assured Identity",
           "targetAudience": "SorchaLocalWallet",
           "recipientParticipantId": "citizen",
           "holderKeySourceField": "/holderKeys/holderJwk",

--- a/demos/Membership/instances/loyalty-discount.blueprint.json
+++ b/demos/Membership/instances/loyalty-discount.blueprint.json
@@ -40,7 +40,7 @@
         "isStartingAction": true,
         "credentialRequirements": [
           {
-            "type": "AssuredIdentityCredential",
+            "type": "https://sorcha.dev/vc/assured-identity/v1",
             "presentationSource": "SorchaWallet",
             "trustPolicy": {
               "sources": [
@@ -130,6 +130,8 @@
         ],
         "credentialIssuanceConfig": {
           "credentialType": "MembershipCredential/v1",
+          "vct": "https://sorcha.dev/vc/membership/v1",
+          "displayName": "Membership",
           "targetAudience": "SorchaLocalWallet",
           "recipientParticipantId": "applicant",
           "claimMappings": [

--- a/demos/Membership/presentations/membership-pos.presentation.json
+++ b/demos/Membership/presentations/membership-pos.presentation.json
@@ -1,7 +1,7 @@
 {
   "$comment": "POS (point-of-sale) presentation request for the membership credential. Off-register verification via Sorcha.Verifier (PresentationRequestBuilder.CreateAsync). The verifier requests ONLY memberNumber + tier; identity (name, DOB) is withheld by omission because DCQL claims list only what may be disclosed. The discount a tier earns is the verifier's policy (verifierProfile.tierDiscountMap) and is NEVER read from the credential. This file documents both the builder inputs and the exact DCQL query the builder emits (Feature 181 — DCQL replaced Presentation Exchange).",
   "verifierRequest": {
-    "requiredVct": "MembershipCredential/v1",
+    "requiredVct": "https://sorcha.dev/vc/membership/v1",
     "requiredClaims": ["memberNumber", "tier"],
     "optionalClaims": [],
     "purpose": "Verify membership at point of sale",
@@ -13,7 +13,7 @@
         "id": "credential",
         "format": "dc+sd-jwt",
         "meta": {
-          "vct_values": ["MembershipCredential/v1"]
+          "vct_values": ["https://sorcha.dev/vc/membership/v1"]
         },
         "claims": [
           { "path": ["memberNumber"] },

--- a/docs/reference/API-DOCUMENTATION.md
+++ b/docs/reference/API-DOCUMENTATION.md
@@ -869,7 +869,7 @@ tokens (every real PWA sign-in, Feature 136) never carry, so every genuine citiz
   "dataSchemas": [ { "type": "object", "properties": { "email": { "type": "string" } } } ],
   "calculations": null,
   "credentialRequirements": null,
-  "credentialIssuanceConfig": { "credentialType": "AssuredIdentityCredential", "claimMappings": [ ], "recipientParticipantId": "citizen" }
+  "credentialIssuanceConfig": { "credentialType": "AssuredIdentityCredential", "vct": "https://sorcha.dev/vc/assured-identity/v1", "displayName": "Assured Identity", "claimMappings": [ ], "recipientParticipantId": "citizen" }
 }
 ```
 

--- a/docs/superpowers/plans/2026-07-15-credential-vct-decoupling-RESTART-PROMPT.md
+++ b/docs/superpowers/plans/2026-07-15-credential-vct-decoupling-RESTART-PROMPT.md
@@ -1,0 +1,41 @@
+# Restart prompt — execute the credential VCT decoupling
+
+Paste everything below the line as your first message in a fresh Claude Code session at `C:\Projects\Sorcha`. It is self-contained: it names the skills to load, the memories that matter, the branch, the standards guardrails, and the execution method. The plan and design docs carry the detail; this prompt gets you into them correctly.
+
+---
+
+Execute the implementation plan at `docs/superpowers/plans/2026-07-15-credential-vct-decoupling.md` (design: `docs/superpowers/specs/2026-07-15-credential-vct-decoupling-design.md`).
+
+## What this is
+The Sorcha Wallet PWA verifier reports **"None of your credentials match this verifier's request for https://sorcha.dev/vc/assured-identity/v1"** even though the citizen holds an Assured Identity credential. Root cause: one field (`CredentialIssuanceConfig.CredentialType`) is overloaded to mean the SD-JWT `vct`, a legacy `type` claim, and the display label. The blueprint sets the bare name `AssuredIdentityCredential`; the verifier/matcher/tests expect the URI form. The fix decouples the three concerns, drops the non-standard `type` claim, converts **every** credential type to a canonical `VctUris` URI + authored `displayName`, and makes VCT matching case-sensitive (spec-conformant). Blueprints are sacrificial — the product owner authorised updating every one.
+
+## Load these skills FIRST (before any code)
+1. `superpowers:subagent-driven-development` — the execution method. Dispatch a fresh implementer subagent per task, review (spec-compliance + quality) between tasks, broad review at the end. Use a progress ledger.
+2. `verifiable-credentials` — Sorcha's SD-JWT VC implementation, the `CredentialIssuer`/`CredentialVerifier`/`SdJwtService` types, the two trust rails, and the DID-anchoring three-address model. Read before touching issuance.
+3. `sorcha-architecture` — Feature 135 (unified trust + DCQL), Feature 114/181 (citizen wallet, DCQL dialect). Load when touching credential verification/matching.
+4. `blueprint-builder` — the `credentialIssuanceConfig` / `credentialRequirements` action fields you are converting across every blueprint.
+
+## Standards guardrails (do NOT violate — verified against draft-ietf-oauth-sd-jwt-vc §3.2.2.1)
+- `vct` is the **sole** type identifier; **there is no `type` claim** in SD-JWT VC. Do not write `claims["type"]`. Do not "keep it for safety."
+- `vct` is a **case-sensitive** `StringOrURI` / Collision-Resistant Name; matching is **case-sensitive exact**. Do NOT make VCT matching case-insensitive — the blueprint-side matchers are being tightened *to* `Ordinal`, not loosened.
+- VCT URIs are lowercase kebab-case: `https://sorcha.dev/vc/{type}/v1`.
+
+## Project conventions that bite
+- `dotnet test` takes ONE project and **`--filter` does not isolate tests** (Microsoft.Testing.Platform) — run the whole project and read `Failed: N, Passed: N` totals. Always `dotnet build` before `dotnet test` (stale DLLs → phantom fails). Record each project's baseline before editing.
+- **Never `git add -A`.** The working tree carries the user's unrelated untracked work (storyboards, an E2E test file). Stage explicit paths only. Task 8 (blueprint conversion) is the highest risk here — list every path.
+- **Never run two implementer subagents concurrently on this one checkout** — `git stash` is not file-scoped and will swallow the other agent's tree (this happened this session). One implementer at a time, or use worktree isolation.
+- Every new file: `// SPDX-License-Identifier: MIT` / `// Copyright (c) 2026 Sorcha Contributors`, file-scoped namespace, test naming `MethodName_Scenario_ExpectedBehavior`, xUnit v3 + FluentAssertions.
+- The PWA (`Sorcha.Wallet.Pwa`) is Blazor WASM — BCL only, no `Sorcha.Cryptography` reference.
+- No EF migration is needed or wanted (`CredentialEntity.Type` is an existing column; only the value flowing into it changes).
+- `claude-review` CI check fails ~30s on infra (token setup) on every PR right now — that's flaky-only red, not a real finding; the repo convention is to merge past it (admin merge) once the real checks (`build-and-test`, image builds) are green.
+
+## Branch
+Work on `feature/credential-vct-decoupling` — already created, the design + plan are committed on it (it branches from master at commit `3b620ab0`). Do NOT branch again. Confirm with `git rev-parse --abbrev-ref HEAD`.
+
+## Deployment reality (for context, not part of the plan's code)
+This ships to n1 as a Docker deploy (PWA + services load into the app at runtime — no app reinstall needed for the credential/verifier change). The user re-claims their credential afterwards (design §8: existing credentials carry the old bare-name vct and must be re-issued; no migration/alias). The native app is unaffected.
+
+## The one guarantee to trust
+Task 8's **parametrised conformance test** walks every blueprint under `demos/`, `walkthroughs/`, `blueprints/` and asserts each credential type's `vct` (issuance) and `type` (requirements) equal its `VctUris` constant. Write that test FIRST, let it fail with the full worklist, then convert until it's green. That test — not a hand-typed file list — is what proves the lockstep conversion missed nothing. If it passes and the full suites pass, the corpus is consistent.
+
+Begin by loading the four skills, reading the plan and design docs, confirming the branch, then dispatch Task 1.

--- a/docs/superpowers/plans/2026-07-15-credential-vct-decoupling.md
+++ b/docs/superpowers/plans/2026-07-15-credential-vct-decoupling.md
@@ -1,0 +1,528 @@
+# Credential VCT Decoupling Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make a credential's `vct` a canonical URI decoupled from its display label, drop the non-standard `type` claim, and convert every credential type to a `VctUris`-anchored URI so the citizen-wallet verifier stops reporting "None of your credentials match".
+
+**Architecture:** Split the overloaded `CredentialIssuanceConfig.CredentialType` into an explicit `Vct` (canonical URI, machine identity) + `DisplayName` (authored human label), both optional with fallbacks. Every SD-JWT VC carries `vct` only (SD-JWT VC has no `type` claim). Every credential type gets one `VctUris` constant; a parametrised conformance test asserts every blueprint literal equals its constant so JSON and C# cannot drift. Matching is case-sensitive exact everywhere (spec-conformant).
+
+**Tech Stack:** .NET 10 / C# 14, System.Text.Json, xUnit v3 + FluentAssertions + Moq, Blazor WASM (the PWA reader must stay libsodium-free).
+
+## Global Constraints
+
+- License header on every new file: `// SPDX-License-Identifier: MIT` / `// Copyright (c) 2026 Sorcha Contributors`. File-scoped namespaces. Test naming `MethodName_Scenario_ExpectedBehavior`.
+- **SD-JWT VC conformance (draft-ietf-oauth-sd-jwt-vc §3.2.2.1):** `vct` is the sole type claim, a **case-sensitive** `StringOrURI`; there is **no** `type` claim; matching is **case-sensitive exact**. Do not reintroduce a `type` claim; do not make VCT matching case-insensitive.
+- **VCT URIs are lowercase kebab-case:** `https://sorcha.dev/vc/{type}/v1`.
+- **Never** hard-code `<Version>` in a `.csproj`. **No EF migration** — `CredentialEntity.Type` is an existing column; we change what value flows into it, not its schema.
+- `dotnet build` before `dotnet test`. `dotnet test` takes ONE project. `--filter` does NOT isolate tests in this repo (MTP) — run the whole project and read totals. Record each project's baseline before editing it.
+- **Never `git add -A`** — the tree carries unrelated untracked user work. Stage explicit paths only.
+- The PWA (`Sorcha.Wallet.Pwa`) is Blazor WASM: BCL only, no `Sorcha.Cryptography` reference.
+
+**Spec:** `docs/superpowers/specs/2026-07-15-credential-vct-decoupling-design.md`
+
+---
+
+## File Structure
+
+| File | Change |
+|---|---|
+| `src/Common/Sorcha.Cryptography/SdJwt/VctUris.cs` (or wherever `VctUris` lives — grep) | Add one constant per credential type |
+| `src/Common/Sorcha.Blueprint.Models/Credentials/CredentialIssuanceConfig.cs` | Add `Vct` + `DisplayName` |
+| `src/Core/Sorcha.Blueprint.Engine/Credentials/CredentialIssuer.cs:44-45,75,84` | `vct` only; `Vct ?? CredentialType`; DisplayName → display config |
+| `src/Services/Sorcha.Wallet.Service/Endpoints/CredentialEndpoints.cs:705-706` | Mirror: `vct` only |
+| `src/Services/Sorcha.Wallet.Service/Services/Implementation/EfCoreCitizenCredentialEventStream.cs` (`BuildPayload`) | Populate `DisplayMeta.credentialName` |
+| `src/Apps/Sorcha.Wallet.Pwa/Services/ISyncService.cs` (`ToCachedCredential`) | Map `DisplayMeta.credentialName` → `DisplayLabel` |
+| `src/Core/Sorcha.Blueprint.Engine/Credentials/CredentialVerifier.cs` (`TypeMatches`) | `OrdinalIgnoreCase` → `Ordinal` |
+| `src/Services/Sorcha.Wallet.Service/Credentials/CredentialMatcher.cs:64,138` | `OrdinalIgnoreCase` → `Ordinal` |
+| `src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/Verification/DefaultPresetCatalogue.cs:17` | Reference `VctUris.AssuredIdentityV1` |
+| Blueprint validation seam (grep: where `CredentialIssuanceConfig` is validated at publish) | `Vct` absolute-URI check |
+| All blueprints under `demos/`, `walkthroughs/`, `blueprints/` | Convert every credential type to URI + `displayName` |
+| Test projects (Engine, Wallet.Service, UI.Core, Wallet.Pwa, a blueprint-conformance test) | New tests per task |
+
+---
+
+## Task 1: VctUris registry — one constant per credential type
+
+**Files:**
+- Modify: `VctUris` (grep `class VctUris` / `CitizenDeviceDelegationV1` to find it — reported at `Sorcha.Cryptography` VctUris.cs)
+- Test: the same test project that covers `VctUris` today (grep), else add `VctUrisTests` in the owning project's test project
+
+**Interfaces:**
+- Produces: `public const string VctUris.AssuredIdentityV1`, `.DrivingLicenceV1`, `.BlueBadgeV1`, `.MembershipV1`, `.LicenceV1`, `.CouncilDigitalIdV1`, `.VerifiedInvoiceV1`, `.TradeFinanceV1`, `.PlanningPermissionV1`, `.BuildingWarrantV1`, `.CompletionCertificateV1`, `.JobAssignmentV1`, `.ServiceCompletionV1`, `.ForestProductDppV1`, `.CyberEssentialsUacV1`, `.RefurbishmentCertificateV1` — all `https://sorcha.dev/vc/{kebab}/v1`.
+
+- [ ] **Step 1: Open `VctUris` and confirm the existing shape**
+
+Run: grep for the class and read it.
+```bash
+grep -rn "class VctUris\|CitizenDeviceDelegationV1" src/Common --include=*.cs
+```
+Expected: one file with `public const string CitizenDeviceDelegationV1 = "https://sorcha.dev/vc/citizen-device-delegation/v1";`. Match its exact style.
+
+- [ ] **Step 2: Write a failing test asserting the new constants exist with correct values**
+
+Add to the `VctUris` test file (or create it, license header + file-scoped namespace):
+
+```csharp
+[Theory]
+[InlineData("AssuredIdentityV1", "https://sorcha.dev/vc/assured-identity/v1")]
+[InlineData("DrivingLicenceV1", "https://sorcha.dev/vc/driving-licence/v1")]
+[InlineData("BlueBadgeV1", "https://sorcha.dev/vc/blue-badge/v1")]
+[InlineData("MembershipV1", "https://sorcha.dev/vc/membership/v1")]
+public void VctUris_CanonicalConstants_HaveExpectedLowercaseUri(string field, string expected)
+{
+    var value = (string)typeof(VctUris).GetField(field)!.GetValue(null)!;
+    value.Should().Be(expected);
+    value.Should().Be(value.ToLowerInvariant(), "VCT URIs are lowercase kebab-case");
+}
+```
+
+- [ ] **Step 3: Run — verify it fails**
+
+Run: `dotnet build <owning project> && dotnet test <owning test project>`
+Expected: FAIL — `AssuredIdentityV1` field not found.
+
+- [ ] **Step 4: Add the constants**
+
+Add to `VctUris` (adjust the `{kebab}` slugs to match §6 of the spec exactly):
+
+```csharp
+public const string AssuredIdentityV1 = "https://sorcha.dev/vc/assured-identity/v1";
+public const string DrivingLicenceV1 = "https://sorcha.dev/vc/driving-licence/v1";
+public const string BlueBadgeV1 = "https://sorcha.dev/vc/blue-badge/v1";
+public const string MembershipV1 = "https://sorcha.dev/vc/membership/v1";
+public const string LicenceV1 = "https://sorcha.dev/vc/licence/v1";
+public const string CouncilDigitalIdV1 = "https://sorcha.dev/vc/council-digital-id/v1";
+public const string VerifiedInvoiceV1 = "https://sorcha.dev/vc/verified-invoice/v1";
+public const string TradeFinanceV1 = "https://sorcha.dev/vc/trade-finance/v1";
+public const string PlanningPermissionV1 = "https://sorcha.dev/vc/planning-permission/v1";
+public const string BuildingWarrantV1 = "https://sorcha.dev/vc/building-warrant/v1";
+public const string CompletionCertificateV1 = "https://sorcha.dev/vc/completion-certificate/v1";
+public const string JobAssignmentV1 = "https://sorcha.dev/vc/job-assignment/v1";
+public const string ServiceCompletionV1 = "https://sorcha.dev/vc/service-completion/v1";
+public const string ForestProductDppV1 = "https://sorcha.dev/vc/forest-product-dpp/v1";
+public const string CyberEssentialsUacV1 = "https://sorcha.dev/vc/cyber-essentials-uac/v1";
+public const string RefurbishmentCertificateV1 = "https://sorcha.dev/vc/refurbishment-certificate/v1";
+```
+
+- [ ] **Step 5: Run — verify it passes, then commit**
+
+Run: `dotnet build <owning project> && dotnet test <owning test project>` → PASS.
+```bash
+git add <VctUris.cs> <VctUris test file>
+git commit -m "feat: [vct] add canonical VCT constants for every credential type"
+```
+
+---
+
+## Task 2: Add `Vct` + `DisplayName` to `CredentialIssuanceConfig`
+
+**Files:**
+- Modify: `src/Common/Sorcha.Blueprint.Models/Credentials/CredentialIssuanceConfig.cs`
+- Test: `tests/Sorcha.Blueprint.Models.Tests/…` (grep for the existing config test; if none, assert via a serialization round-trip test in the Engine test project)
+
+**Interfaces:**
+- Produces: `CredentialIssuanceConfig.Vct` (`string?`, JSON `vct`), `CredentialIssuanceConfig.DisplayName` (`string?`, JSON `displayName`).
+
+- [ ] **Step 1: Write the failing test — JSON round-trips the two new fields**
+
+```csharp
+[Fact]
+public void CredentialIssuanceConfig_RoundTrips_VctAndDisplayName()
+{
+    var json = """
+    {"credentialType":"AssuredIdentityCredential",
+     "vct":"https://sorcha.dev/vc/assured-identity/v1",
+     "displayName":"Assured Identity",
+     "recipientParticipantId":"applicant",
+     "claimMappings":[{"claimName":"x","sourceField":"/x"}]}
+    """;
+    var cfg = JsonSerializer.Deserialize<CredentialIssuanceConfig>(json, JsonDefaults.Api)!;
+    cfg.Vct.Should().Be("https://sorcha.dev/vc/assured-identity/v1");
+    cfg.DisplayName.Should().Be("Assured Identity");
+}
+```
+
+- [ ] **Step 2: Run — verify it fails** (`Vct`/`DisplayName` don't exist). `dotnet build` will error on the missing members.
+
+- [ ] **Step 3: Add the fields** after `CredentialType` (line 22):
+
+```csharp
+    /// <summary>
+    /// Canonical SD-JWT VC type identifier (the <c>vct</c> claim). MUST be an absolute URI,
+    /// lowercase kebab-case: <c>https://sorcha.dev/vc/{type}/v1</c>. This is the machine
+    /// matching identity — a verifier's request and the held credential match on this string
+    /// (case-sensitive exact, per SD-JWT VC §3.2.2.1). When null, <see cref="CredentialType"/>
+    /// is used as the vct (defensive fallback for hand-authored/legacy configs).
+    /// </summary>
+    [JsonPropertyName("vct")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Vct { get; set; }
+
+    /// <summary>
+    /// Human-readable label shown on the credential card (e.g. "Assured Identity"). Decoupled
+    /// from <see cref="Vct"/> so display never depends on parsing the URI. When null, the wallet
+    /// falls back to humanising the vct.
+    /// </summary>
+    [JsonPropertyName("displayName")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? DisplayName { get; set; }
+```
+
+- [ ] **Step 4: Run — verify it passes.** `dotnet build src/Common/Sorcha.Blueprint.Models/... && dotnet test <the test project>` → PASS.
+
+- [ ] **Step 5: Commit**
+```bash
+git add src/Common/Sorcha.Blueprint.Models/Credentials/CredentialIssuanceConfig.cs <test file>
+git commit -m "feat: [vct] add explicit Vct + DisplayName to CredentialIssuanceConfig"
+```
+
+---
+
+## Task 3: Issuer emits `vct` only (drop `type`), from `Vct ?? CredentialType`
+
+**Files:**
+- Modify: `src/Core/Sorcha.Blueprint.Engine/Credentials/CredentialIssuer.cs:44-45` (+ display config at ~84)
+- Modify: `src/Services/Sorcha.Wallet.Service/Endpoints/CredentialEndpoints.cs:705-706` (mirror)
+- Test: `tests/Sorcha.Blueprint.Engine.Tests/Credentials/CredentialIssuerTests.cs`
+
+**Interfaces:**
+- Consumes: `CredentialIssuanceConfig.Vct`, `.DisplayName` (Task 2).
+- Produces: minted SD-JWT whose payload has `vct` (= `Vct ?? CredentialType`) and **no** `type` claim; `IssuedCredentialInfo.Type` = the same vct string.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `CredentialIssuerTests.cs` (match the file's existing factory/mocking):
+
+```csharp
+[Fact]
+public async Task IssueAsync_WithVct_WritesVctClaim_AndNoTypeClaim()
+{
+    var config = MakeConfig();               // existing helper
+    config.Vct = "https://sorcha.dev/vc/assured-identity/v1";
+    config.CredentialType = "AssuredIdentityCredential";
+
+    var info = await _issuer.IssueAsync(config, Data(), IssuerDid, RecipientDid, Key(), "EdDSA");
+
+    info.Claims["vct"].Should().Be("https://sorcha.dev/vc/assured-identity/v1");
+    info.Claims.Should().NotContainKey("type", "SD-JWT VC has no type claim");
+    info.Type.Should().Be("https://sorcha.dev/vc/assured-identity/v1");
+}
+
+[Fact]
+public async Task IssueAsync_WithoutVct_FallsBackToCredentialType()
+{
+    var config = MakeConfig();
+    config.Vct = null;
+    config.CredentialType = "LegacyBareName";
+
+    var info = await _issuer.IssueAsync(config, Data(), IssuerDid, RecipientDid, Key(), "EdDSA");
+
+    info.Claims["vct"].Should().Be("LegacyBareName");
+    info.Claims.Should().NotContainKey("type");
+}
+```
+
+- [ ] **Step 2: Run — verify both fail** (`type` still written; `vct` still = CredentialType even when `Vct` set). Run the Engine test project.
+
+- [ ] **Step 3: Change the issuer.** Replace `CredentialIssuer.cs:44-45`:
+
+```csharp
+        // SD-JWT VC (draft-ietf-oauth-sd-jwt-vc §3.2.2.1): vct is the SOLE type claim, a
+        // case-sensitive URI. There is no `type` claim in the profile — do not write one.
+        var vct = string.IsNullOrWhiteSpace(config.Vct) ? config.CredentialType : config.Vct;
+        claims["vct"] = vct;
+```
+
+Change line 75 `Type = config.CredentialType,` → `Type = vct,`.
+
+Confirm the display-config block (~84) carries `DisplayName`. If `DisplayConfigJson` is built from `config.DisplayConfig`, thread `config.DisplayName` into it so it reaches the credential (the exact shape depends on `CredentialDisplayConfig` / how `DisplayConfigJson` is serialized — **read lines 84-95 first**; the credential's stored display carrier must end up with the credential name so Task 4 can surface it). If `CredentialDisplayConfig` has no name field, carry `DisplayName` on `IssuedCredentialInfo` and persist it where `CredentialEntity` display data is written — trace `IssuedCredentialInfo` → `CredentialEntity` and put the name on the entity's display JSON.
+
+- [ ] **Step 4: Mirror in the Wallet Service direct-issue path.** `CredentialEndpoints.cs:705-706` currently:
+```csharp
+claims["type"] = request.CredentialType;
+claims["vct"] = request.CredentialType;
+```
+Replace with (add a `Vct` to `IssueCredentialRequest` mirroring the config, or fall back to `CredentialType`):
+```csharp
+claims["vct"] = string.IsNullOrWhiteSpace(request.Vct) ? request.CredentialType : request.Vct;
+```
+Read `IssueCredentialRequest` first; add a nullable `Vct` property if absent.
+
+- [ ] **Step 5: Run — verify passing.** `dotnet build && dotnet test tests/Sorcha.Blueprint.Engine.Tests/...` → PASS. Also run `tests/Sorcha.Wallet.Service.Tests` (baseline first) — any test asserting a `type` claim was asserting the non-standard artefact; update it to assert `vct` only and note it in the commit.
+
+- [ ] **Step 6: Commit**
+```bash
+git add src/Core/Sorcha.Blueprint.Engine/Credentials/CredentialIssuer.cs \
+        src/Services/Sorcha.Wallet.Service/Endpoints/CredentialEndpoints.cs \
+        tests/Sorcha.Blueprint.Engine.Tests/Credentials/CredentialIssuerTests.cs
+git commit -m "fix: [vct] issue vct only (drop non-standard type claim); use Vct ?? CredentialType"
+```
+
+---
+
+## Task 4: Carry the authored display name to the PWA card
+
+**Files:**
+- Modify: `src/Services/Sorcha.Wallet.Service/Services/Implementation/EfCoreCitizenCredentialEventStream.cs` (`BuildPayload`)
+- Modify: `src/Apps/Sorcha.Wallet.Pwa/Services/ISyncService.cs` (`ToCachedCredential`, ~line 273)
+- Test: `tests/Sorcha.Wallet.Pwa.Tests/...` (sync mapping) + a Wallet.Service test for `BuildPayload`
+
+**Interfaces:**
+- Consumes: the credential's stored display name (Task 3).
+- Produces: `CachedCredentialPayload.DisplayMeta.credentialName` populated on sync-out; `CachedCredential.DisplayLabel` populated on the PWA so `CredentialDisplay.Name` shows it instead of `Humanize(vct)`.
+
+- [ ] **Step 1: Read the three shapes first**
+
+Read `CachedCredentialPayload` (`Sorcha.CitizenWallet.Abstractions/Models/CachedCredentialPayload.cs` — `DisplayMeta` is `JsonObject?`), `EfCoreCitizenCredentialEventStream.BuildPayload` (currently sets `Vct = entity.Type`, no label), and `ISyncService.ToCachedCredential` (`:273`, currently `DisplayLabel` unset). Note the x-review shape of `DisplayMeta` (`credentialName`, `issuerName`, `colourTheme`).
+
+- [ ] **Step 2: Write the failing PWA mapping test**
+
+```csharp
+[Fact]
+public void ToCachedCredential_PopulatesDisplayLabel_FromDisplayMetaCredentialName()
+{
+    var payload = new CachedCredentialPayload
+    {
+        Id = "urn:credential:x",
+        Vct = "https://sorcha.dev/vc/assured-identity/v1",
+        DisplayMeta = new JsonObject { ["credentialName"] = "Assured Identity" }
+    };
+    var cached = SyncService.ToCachedCredential(payload);   // make static or expose a seam if needed
+    cached.DisplayLabel.Should().Be("Assured Identity");
+}
+```
+
+- [ ] **Step 3: Run — verify it fails** (`DisplayLabel` null).
+
+- [ ] **Step 4: Populate on both sides**
+
+In `EfCoreCitizenCredentialEventStream.BuildPayload`, set `DisplayMeta.credentialName` from the entity's stored display name (from Task 3). If the entity stores display JSON, parse the credential name out of it; if Task 3 added a dedicated column, read that.
+
+In `ISyncService.ToCachedCredential`, map it:
+```csharp
+DisplayLabel = payload.DisplayMeta?["credentialName"]?.GetValue<string>(),
+```
+
+- [ ] **Step 5: Run — verify passing.** Build + run `tests/Sorcha.Wallet.Pwa.Tests` and `tests/Sorcha.Wallet.Service.Tests` (baselines first). The existing `CredentialDisplayTests.Humanize` table must still pass (fallback path unchanged when `DisplayLabel` is null).
+
+- [ ] **Step 6: Commit**
+```bash
+git add src/Services/Sorcha.Wallet.Service/Services/Implementation/EfCoreCitizenCredentialEventStream.cs \
+        src/Apps/Sorcha.Wallet.Pwa/Services/ISyncService.cs <the two test files>
+git commit -m "feat: [vct] carry authored displayName through sync to the PWA card"
+```
+
+---
+
+## Task 5: Case-sensitive VCT matching everywhere (spec conformance)
+
+**Files:**
+- Modify: `src/Core/Sorcha.Blueprint.Engine/Credentials/CredentialVerifier.cs` (`TypeMatches`, ~line 216)
+- Modify: `src/Services/Sorcha.Wallet.Service/Credentials/CredentialMatcher.cs:64,138`
+- Test: the existing tests for each (grep `CredentialVerifierTests`, `CredentialMatcherTests`)
+
+**Interfaces:** none new — behaviour-preserving under the single-definition invariant; removes non-standard case leniency.
+
+- [ ] **Step 1: Write a failing test proving a case-mismatched requirement no longer matches**
+
+In `CredentialMatcherTests`:
+```csharp
+[Fact]
+public void Match_TypeCaseMismatch_DoesNotMatch()
+{
+    var cred = MakeCredential(type: "https://sorcha.dev/vc/assured-identity/v1");
+    var req  = MakeRequirement(type: "https://sorcha.dev/vc/Assured-Identity/v1"); // wrong case
+    _matcher.Match(cred, req).Should().BeFalse("SD-JWT VC vct matching is case-sensitive");
+}
+```
+
+- [ ] **Step 2: Run — verify it fails** (today `OrdinalIgnoreCase` returns true).
+
+- [ ] **Step 3: Change both comparisons.** In `CredentialVerifier.TypeMatches` and `CredentialMatcher.cs:64,138`, replace `StringComparison.OrdinalIgnoreCase` with `StringComparison.Ordinal` for the **type/vct** comparison only (do not touch unrelated comparisons in those files). Leave `PresentationEngine.MatchCandidates` as-is (already `Ordinal`).
+
+- [ ] **Step 4: Run — verify passing.** Build + run both test projects (baselines first). Every existing type-match test uses consistent casing (they'll pass); if any deliberately relied on case-folding, it was asserting non-conformant behaviour — update + note it.
+
+- [ ] **Step 5: Commit**
+```bash
+git add src/Core/Sorcha.Blueprint.Engine/Credentials/CredentialVerifier.cs \
+        src/Services/Sorcha.Wallet.Service/Credentials/CredentialMatcher.cs <test files>
+git commit -m "fix: [vct] case-sensitive vct matching (SD-JWT VC / DCQL conformance)"
+```
+
+---
+
+## Task 6: Publish-time validation — `Vct` must be an absolute URI
+
+**Files:**
+- Modify: the blueprint publish validation seam that already validates `CredentialIssuanceConfig` (grep: `credentialIssuanceConfig` / `CredentialType` in a validator; likely `Sorcha.Blueprint.Service` publish validation or `Sorcha.Blueprint.Engine` `SchemaValidator`/blueprint validation)
+- Test: that validator's test project
+
+- [ ] **Step 1: Locate the seam.** `grep -rn "CredentialIssuanceConfig" src/Services/Sorcha.Blueprint.Service src/Core/Sorcha.Blueprint.Engine --include=*.cs` and find where issuance config is validated at publish. Read it.
+
+- [ ] **Step 2: Write the failing test**
+
+```csharp
+[Fact]
+public void Validate_VctNotAbsoluteUri_Fails()
+{
+    var cfg = MakeConfig();
+    cfg.Vct = "not a uri";
+    var result = _validator.Validate(cfg);   // match the real API
+    result.IsValid.Should().BeFalse();
+    result.Errors.Should().Contain(e => e.Contains("vct", StringComparison.OrdinalIgnoreCase));
+}
+```
+
+- [ ] **Step 3: Run — verify it fails.**
+
+- [ ] **Step 4: Add the rule.** When `Vct` is non-null, require `Uri.TryCreate(cfg.Vct, UriKind.Absolute, out _)`; else emit a validation error. Do not URI-validate the `CredentialType` fallback.
+
+- [ ] **Step 5: Run — verify passing. Commit.**
+```bash
+git add <validator> <validator test>
+git commit -m "feat: [vct] reject a non-URI vct at blueprint publish"
+```
+
+---
+
+## Task 7: Verifier presets reference `VctUris`
+
+**Files:**
+- Modify: `src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/Verification/DefaultPresetCatalogue.cs:17`
+- Test: existing preset/DCQL tests (grep `DefaultPresetCatalogue`, `DcqlRoundTripTests`)
+
+- [ ] **Step 1: Replace the literal.** `DefaultPresetCatalogue.cs:17` `private const string AssuredIdentityVct = "https://sorcha.dev/vc/assured-identity/v1";` → `= VctUris.AssuredIdentityV1;` (add the `using`). Grep for any other C# file with a `sorcha.dev/vc/...` literal that is a *production* reference (not a test fixture) and point it at the constant.
+
+- [ ] **Step 2: Run the affected test projects** (UI.Core, Verifier). They should pass unchanged (same string, now sourced from the constant).
+
+- [ ] **Step 3: Commit**
+```bash
+git add src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/Verification/DefaultPresetCatalogue.cs
+git commit -m "refactor: [vct] verifier presets reference VctUris constants"
+```
+
+---
+
+## Task 8: Convert every blueprint + the parametrised conformance test (the completeness guarantee)
+
+This task is TDD in the large: the conformance test is written **first** and fails until every blueprint is converted. The test — not a hand-enumerated file list — is what proves no site was missed.
+
+**Files:**
+- Create: `tests/Sorcha.Blueprint.<engine-or-models>.Tests/Credentials/BlueprintVctConformanceTests.cs`
+- Modify: every blueprint under `demos/`, `walkthroughs/`, `blueprints/` that issues or requires a credential type in the §6 table
+
+- [ ] **Step 1: Enumerate the sites**
+```bash
+grep -rln "credentialType\|\"type\":" demos walkthroughs blueprints --include=*.json | sort -u
+```
+Then per bare name from the §6 table, list every occurrence (issue + require):
+```bash
+for t in AssuredIdentityCredential DrivingLicenceCredential BlueBadgeCredential MembershipCredential LicenseCredential CouncilDigitalIdCredential VerifiedInvoiceCredential TradeFinanceCredential PlanningPermissionCredential BuildingWarrantCredential CompletionCertificateCredential JobAssignmentCredential ServiceCompletionCredential ForestProductDPPCredential CyberEssentialsUacPosture RefurbishmentCertificateCredential; do
+  echo "== $t"; grep -rln "$t" demos walkthroughs blueprints --include=*.json
+done
+```
+
+- [ ] **Step 2: Write the failing conformance test**
+
+A data-driven test that loads every blueprint JSON, and for each `credentialIssuanceConfig` asserts `vct` is present + equals the `VctUris` constant for that credential (mapped by the human `displayName` or an explicit name→constant table in the test), and that every `credentialRequirements[].type` naming a platform type equals the same constant. Build a `Dictionary<string,string>` in the test mapping each bare name → its `VctUris` value; walk all blueprint files; collect violations; assert empty with a message listing every offending file+path.
+
+```csharp
+// Skeleton — fill the map from §6, walk demos/ walkthroughs/ blueprints/, assert no violations.
+public class BlueprintVctConformanceTests
+{
+    private static readonly Dictionary<string, string> Canonical = new()
+    {
+        ["AssuredIdentityCredential"] = VctUris.AssuredIdentityV1,
+        ["DrivingLicenceCredential"] = VctUris.DrivingLicenceV1,
+        // … all 16 from §6 …
+    };
+
+    [Fact]
+    public void EveryBlueprint_UsesCanonicalVct_ForIssuanceAndRequirements()
+    {
+        var repoRoot = FindRepoRoot();      // walk up to the dir containing Sorcha.sln
+        var violations = new List<string>();
+        foreach (var file in EnumerateBlueprintJson(repoRoot))   // demos/ walkthroughs/ blueprints/
+        {
+            var doc = JsonNode.Parse(File.ReadAllText(file))!;
+            CheckIssuanceVct(doc, file, violations);     // credentialIssuanceConfig.vct == Canonical[knownType]
+            CheckRequirementTypes(doc, file, violations); // credentialRequirements[].type: if a URI or a known bare name, must equal a Canonical value
+        }
+        violations.Should().BeEmpty(because:
+            "every credential type must use its canonical VctUris URI:\n" + string.Join("\n", violations));
+    }
+}
+```
+
+- [ ] **Step 3: Run — verify it fails**, listing every unconverted site. This list is your worklist.
+
+- [ ] **Step 4: Convert each blueprint** from the Step 3 list. For each `credentialIssuanceConfig`:
+  - keep `credentialType` as-is (fallback + readable id),
+  - add `"vct": "<canonical URI>"`,
+  - add `"displayName": "<label from §6>"`.
+  For each `credentialRequirements[].type` that names a platform type, replace the bare name with the canonical URI.
+
+Re-run the conformance test after each file (or each type) and watch violations shrink to zero.
+
+- [ ] **Step 5: Run — verify the conformance test passes.** Then rebuild + run the **full** affected test suites (Engine, Wallet.Service, UI.Core, Wallet.Pwa) — several existing walkthrough/integration tests assert bare-name types; update them to the canonical URIs (they are the same conversion). Baselines first; every change is the mechanical bare-name→URI swap.
+
+- [ ] **Step 6: Commit** (stage the blueprint files + the test + any updated existing tests explicitly — this is the one task most at risk of `git add -A`; list paths)
+```bash
+git add tests/.../BlueprintVctConformanceTests.cs \
+        demos/... walkthroughs/... blueprints/... <updated existing tests>
+git commit -m "feat: [vct] convert every credential type to its canonical VctUris URI + displayName"
+```
+
+---
+
+## Task 9: End-to-end regression — the reported bug
+
+**Files:**
+- Test: `tests/Sorcha.Wallet.Pwa.Tests/...` (or the DCQL/verifier test project where `PresentationEngine` matching is covered)
+
+- [ ] **Step 1: Write the test that reproduces "None of your credentials match"**
+
+Mint (or fixture) an Assured-Identity credential with `vct = VctUris.AssuredIdentityV1`; build the `DefaultPresetCatalogue` "confirm-identity"/"age-over-18" request (which now sources `VctUris.AssuredIdentityV1`); run `PresentationEngine.MatchQuery`; assert `Satisfiable == true` and the credential is a candidate.
+
+```csharp
+[Fact]
+public void MatchQuery_AssuredIdentityCredential_SatisfiesAssuredIdentityPreset()
+{
+    var cred = CachedCredentialWithVct(VctUris.AssuredIdentityV1);
+    var query = DcqlFromPreset(DefaultPresetCatalogue.ConfirmIdentity());  // match real API
+    var result = _engine.MatchQuery(query, new[] { cred });
+    result.Satisfiable.Should().BeTrue();
+}
+```
+
+- [ ] **Step 2: Run — verify it passes** (Tasks 1-8 make it green). If it fails, the wiring from constant → preset → engine has a gap — fix before proceeding.
+
+- [ ] **Step 3: Commit**
+```bash
+git add <test file>
+git commit -m "test: [vct] Assured Identity credential satisfies the verifier preset (regression)"
+```
+
+---
+
+## Task 10: Docs sync
+
+- [ ] **Step 1:** Update `.claude/skills/verifiable-credentials/SKILL.md` and `.claude/skills/blueprint-builder/SKILL.md`: `credentialIssuanceConfig` now carries `vct` (canonical URI) + `displayName`; `credentialType` is a fallback/short-name; SD-JWT VC carries `vct` only (no `type` claim); VCT matching is case-sensitive; new blueprints use `VctUris` + a canonical URI. Update the example JSON blocks (they currently show bare `credentialType`).
+- [ ] **Step 2:** If `docs/reference/API-DOCUMENTATION.md` documents the issue endpoint's `credentialType`, add `vct`.
+- [ ] **Step 3: Commit**
+```bash
+git add .claude/skills/verifiable-credentials/SKILL.md .claude/skills/blueprint-builder/SKILL.md docs/reference/API-DOCUMENTATION.md
+git commit -m "docs: [vct] canonical vct + displayName; vct-only, case-sensitive"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:** §2 fields → Task 2. §2.1 vct-only → Task 3. §3 display carrier → Tasks 3-4. §4 case-sensitive → Task 5. §5 VctUris + conformance → Tasks 1, 7, 8. §6 full conversion → Task 8. §7 publish validation → Task 6. §8 re-issue (no code — a runtime reality, covered by the design note). §10 tests → each task + Task 9. §12 standards → Tasks 3, 5. Docs → Task 10.
+
+**Known reads-before-edit (honest):** Tasks 3 (display-config threading, `IssueCredentialRequest`), 4 (`BuildPayload`, `ToCachedCredential`, `CachedCredentialPayload`), 6 (validation seam) require reading the exact current method bodies — the plan gives the precise file:line and the transformation, and the failing test pins the outcome. This is intended: the surrounding code must be read, not guessed.
+
+**Ordering:** 1 (constants) → 2 (fields) → 3 (issuer) → 4 (display) → 5 (matcher) → 6 (validation) → 7 (presets) → 8 (blueprints + conformance) → 9 (e2e) → 10 (docs). Task 8's conformance test depends on Task 1's constants; Task 9 depends on 7 + 8.
+
+**The completeness guarantee:** Task 8's parametrised conformance test is what makes "convert *every* type in lockstep" verifiable rather than hopeful — a missed issuer or requirer is a red test, not a silent phone-only no-match.

--- a/docs/superpowers/specs/2026-07-15-credential-vct-decoupling-design.md
+++ b/docs/superpowers/specs/2026-07-15-credential-vct-decoupling-design.md
@@ -27,19 +27,22 @@ Per the SD-JWT VC profile Sorcha implements, `vct` **should be a URI / collision
 
 | Concern | Field | Written to | Fallback when null |
 |---|---|---|---|
-| **Machine matching identity** | new `Vct` (string, optional, absolute URI) | `claims["vct"]`, `claims["type"]`, and `CredentialEntity.Type` — **all three kept equal**, or matching breaks | `CredentialType` |
+| **Machine matching identity** | new `Vct` (string, optional, absolute URI) | `claims["vct"]` (the SD-JWT VC type claim — see §2.1) and the internal `CredentialEntity.Type` storage column | `CredentialType` |
 | **Human display label** | new `DisplayName` (string, optional) | the credential's display carrier → PWA card name | `Humanize(vct)` (current behaviour) |
 | **Short internal type name** | existing `CredentialType` (`[Required]`, unchanged) | nothing new; it is the `Vct` fallback and a human-readable blueprint id | — |
 
 The two fallbacks remain as **defensive graceful-degradation** (a hand-authored or external config that omits `Vct` still mints *something* usable), but they are no longer a load-bearing path: **every blueprint shipped in the repo is converted to set `Vct` explicitly** (§6). After this change there is one naming world — canonical URIs — not two. The fallback only catches an authoring omission; it is not the way any real credential is issued.
 
-### 2.1 Why `type`/`vct`/`CredentialEntity.Type` must all agree
+### 2.1 `vct` only — drop the non-standard `type` claim
 
-- `CredentialVerifier.ReadCredentialType` (blueprint-side) reads `vct`, falls back to `type`.
-- `CredentialMatcher` matches on `CredentialEntity.Type`.
+SD-JWT VC (§3.2.2.1) defines **`vct` as the sole credential-type identifier; there is no `type` claim** in the profile. Today `CredentialIssuer.cs:45` writes both `claims["vct"]` and `claims["type"]` from the same field — the `type` claim is a non-standard artefact. Since blueprints are sacrificial, we do the conformant thing: **the wire SD-JWT carries `vct` only.**
+
+Internally, the canonical VCT must still land identically in the three places that read it, but those are Sorcha storage/logic, not wire claims:
+- `CredentialVerifier.ReadCredentialType` (blueprint-side) reads the `vct` claim (its `type` fallback becomes dead — harmless, `vct` is always present).
+- `CredentialMatcher` matches on the internal `CredentialEntity.Type` **storage column**, populated from the credential's `vct` at ingest.
 - `PresentationEngine` (PWA) matches on `CachedCredential.MatchIdentifier` = `Vct`, sourced from the synced `CredentialEntity.Type`.
 
-So the canonical VCT must land identically in all three. Issuance sets `vct = type = Vct ?? CredentialType`, and `CredentialEntity.Type` (the stored value that feeds sync + matching) is that same string. The short `CredentialType` name is **not** emitted as a separate claim.
+So issuance sets `claims["vct"] = Vct ?? CredentialType` and stops writing `claims["type"]`; `CredentialEntity.Type` (an internal column name we leave as-is) holds that same VCT string. The short `CredentialType` name is never emitted as a claim.
 
 ## 3. Display gets its own source (it cannot come from the URI)
 
@@ -52,12 +55,14 @@ So the canonical VCT must land identically in all three. Issuance sets `vct = ty
 
 Concretely, the sync-out path (`EfCoreCitizenCredentialEventStream.BuildPayload`, which today emits no label) must populate `DisplayMeta.credentialName` from the stored display config, and `ISyncService.ToCachedCredential` must map it to `DisplayLabel`. These are the two spots the label is currently dropped.
 
-## 4. Case-insensitive matching everywhere
+## 4. Case-SENSITIVE exact matching everywhere (spec-conformant)
 
-The PWA matcher (`PresentationEngine.MatchCandidates`) uses `StringComparison.Ordinal` (case-sensitive); the blueprint-side matchers use `OrdinalIgnoreCase`. For this fix both sides carry the identical URI, so exact match works — but the inconsistency is a latent trap (a capitalisation typo would pass server-side and silently fail on the phone, the exact class of bug being fixed).
+**Corrects an earlier draft of this design.** SD-JWT VC §3.2.2.1 requires the `vct` value to be a **case-sensitive** `StringOrURI`, and OpenID4VP DCQL matches `vct_values` by exact string. So case-sensitive exact match is the standard; a case-insensitive comparison would be **non-conformant**.
 
-- Change `PresentationEngine.MatchCandidates` to `OrdinalIgnoreCase` so both sides agree.
-- Document the convention: **VCT URIs are lowercase.** (Advisory; the case-insensitive compare is the safety net.)
+- The PWA matcher (`PresentationEngine.MatchCandidates`, `StringComparison.Ordinal`) is already conformant — **leave it case-sensitive.**
+- The blueprint-side matchers (`CredentialVerifier`, `CredentialMatcher`) use `OrdinalIgnoreCase` — the deviation. Align them **to `Ordinal`** for strict conformance. Behaviourally inert given the invariant below, but it removes a non-standard leniency.
+- Consistency is guaranteed **not** by a lenient compare but by the **single `VctUris` definition + conformance test** (§5): every issue and require side references one constant, so casing (and the whole path) is identical by construction. That is strictly stronger than case-folding — it also catches a wrong *path*, not just wrong case.
+- Convention: **VCT URIs are lowercase kebab-case.** Not a safety net (the compare is exact) — just a house style so the single definitions are predictable.
 
 ## 5. Anti-drift — one definition per type, conformance-tested
 
@@ -110,11 +115,11 @@ The credential already in a wallet was minted with `vct = AssuredIdentityCredent
 
 **Model** — `Sorcha.Blueprint.Models/Credentials/CredentialIssuanceConfig.cs` (+`Vct`, +`DisplayName`).
 
-**Issuance** — `Sorcha.Blueprint.Engine/Credentials/CredentialIssuer.cs` (write `vct=type=Vct??CredentialType`; write `DisplayName` to display config). The Wallet Service direct-issue path (`CredentialEndpoints.cs:705-706`) mirrors the same rule. (HAIP + mdoc paths are out of scope — they don't feed the PWA verifier in the failing flow; note them in the plan as follow-ups.)
+**Issuance** — `Sorcha.Blueprint.Engine/Credentials/CredentialIssuer.cs` (write `claims["vct"] = Vct ?? CredentialType`; **stop writing `claims["type"]`**; write `DisplayName` to display config). The Wallet Service direct-issue path (`CredentialEndpoints.cs:705-706`) mirrors the same rule. (HAIP + mdoc paths are out of scope — they don't feed the PWA verifier in the failing flow; note them in the plan as follow-ups.)
 
 **Sync / display carrier** — `EfCoreCitizenCredentialEventStream.BuildPayload` (populate `DisplayMeta.credentialName`), `ISyncService.ToCachedCredential` (map to `DisplayLabel`).
 
-**Matcher** — `PresentationEngine.MatchCandidates` (`Ordinal` → `OrdinalIgnoreCase`).
+**Matcher** — `CredentialVerifier` + `CredentialMatcher` (`OrdinalIgnoreCase` → `Ordinal`, spec conformance). `PresentationEngine.MatchCandidates` stays `Ordinal` (already conformant).
 
 **Constants + presets** — `VctUris` (one constant per type in §6's table), `DefaultPresetCatalogue` + any C# VCT literal (reference the constants).
 
@@ -138,4 +143,17 @@ The credential already in a wallet was minted with `vct = AssuredIdentityCredent
 - **SC-3** Every credential type is now a canonical URI VCT with an authored `displayName`; the bare-name world is gone. The optional-field fallback survives only as defensive degradation for an omitted `Vct`.
 - **SC-4** Every cross-blueprint issue↔require pair (Assured Identity ← blue-badge / driving-licence / membership, and any others) still matches after conversion, proven by the parametrised conformance test.
 - **SC-5** The AIAS blueprint VCT and the verifier preset constant cannot drift without a failing test.
-- **SC-6** A capitalisation-only VCT difference no longer produces a silent phone-only no-match.
+- **SC-6** VCT matching is case-sensitive exact everywhere (SD-JWT VC / DCQL conformant); consistency is enforced by the single `VctUris` definition + conformance test, not by lenient comparison.
+
+## 12. Standards conformance
+
+Checked against the SD-JWT VC profile (`draft-ietf-oauth-sd-jwt-vc`, §3.2.2.1) and OpenID4VP DCQL:
+
+| Rule | Spec | This design |
+|---|---|---|
+| `vct` REQUIRED, sole type identifier | §3.2.2.1 | ✓ `vct` written on every credential; it is the only type claim |
+| `vct` MUST be a case-sensitive `StringOrURI` + Collision-Resistant Name | §3.2.2.1 | ✓ canonical `https://sorcha.dev/vc/{type}/v1` URIs |
+| No `type` claim in the profile | §3.2.2.1 | ✓ **fixed** — stop emitting the non-standard `claims["type"]` |
+| `vct` matched case-sensitively / exactly | §3.2.2.1 + DCQL `vct_values` exact match | ✓ **corrected** — case-sensitive everywhere; earlier case-insensitive draft was non-conformant |
+
+No standard is broken by this change; two pre-existing deviations (the `type` claim and the blueprint-side case-insensitive match) are corrected by it.

--- a/docs/superpowers/specs/2026-07-15-credential-vct-decoupling-design.md
+++ b/docs/superpowers/specs/2026-07-15-credential-vct-decoupling-design.md
@@ -1,0 +1,141 @@
+# Credential VCT / display / type decoupling
+
+**Date:** 2026-07-15
+**Status:** Approved (design)
+**Surface:** `Sorcha.Blueprint.Models`, `Sorcha.Blueprint.Engine` credential issuance, the Wallet Service issue path, the Citizen Wallet PWA matcher + display, the AIAS/Assured-Identity blueprints, the verifier presets.
+
+---
+
+## 1. Why
+
+On a real phone, presenting an Assured Identity credential to the PWA verifier failed with **"None of your credentials match this verifier's request for `https://sorcha.dev/vc/assured-identity/v1`"** — even though the citizen holds exactly that credential.
+
+Root cause: **one field, `CredentialIssuanceConfig.CredentialType`, is overloaded to mean three different things** — the credential's `vct` (machine matching identity), the `type` claim, and (via `Humanize`) the human display label. The AIAS blueprint sets it to the bare name `AssuredIdentityCredential`; `CredentialIssuer.cs:45` writes that verbatim into `claims["vct"]`; but every verifier preset, DCQL test, and matcher in the "citizen wallet" world expects the SD-JWT-VC-conformant URI form `https://sorcha.dev/vc/assured-identity/v1`. The PWA matcher does exact string equality, so it never matches.
+
+There are **two disjoint naming worlds** that never reconcile:
+
+- **Blueprint world** — every blueprint's `credentialType` and every `CredentialRequirement.type` is a bare PascalCase name. Internally consistent (bare issues match bare requirements via `OrdinalIgnoreCase`).
+- **Citizen-wallet / desk-verifier / test world** — canonical URIs (`https://sorcha.dev/vc/...`). Internally consistent.
+
+The two only meet where a blueprint-issued credential is presented to the URI-expecting PWA — today, the Assured Identity path.
+
+Per the SD-JWT VC profile Sorcha implements, `vct` **should be a URI / collision-resistant name**, so the URI form is the conformant target and the bare name is the off-spec side.
+
+## 2. The fix — separate the three concerns
+
+`CredentialIssuanceConfig` gains two optional fields; the existing `CredentialType` is demoted to a fallback + readable id.
+
+| Concern | Field | Written to | Fallback when null |
+|---|---|---|---|
+| **Machine matching identity** | new `Vct` (string, optional, absolute URI) | `claims["vct"]`, `claims["type"]`, and `CredentialEntity.Type` — **all three kept equal**, or matching breaks | `CredentialType` |
+| **Human display label** | new `DisplayName` (string, optional) | the credential's display carrier → PWA card name | `Humanize(vct)` (current behaviour) |
+| **Short internal type name** | existing `CredentialType` (`[Required]`, unchanged) | nothing new; it is the `Vct` fallback and a human-readable blueprint id | — |
+
+The two fallbacks remain as **defensive graceful-degradation** (a hand-authored or external config that omits `Vct` still mints *something* usable), but they are no longer a load-bearing path: **every blueprint shipped in the repo is converted to set `Vct` explicitly** (§6). After this change there is one naming world — canonical URIs — not two. The fallback only catches an authoring omission; it is not the way any real credential is issued.
+
+### 2.1 Why `type`/`vct`/`CredentialEntity.Type` must all agree
+
+- `CredentialVerifier.ReadCredentialType` (blueprint-side) reads `vct`, falls back to `type`.
+- `CredentialMatcher` matches on `CredentialEntity.Type`.
+- `PresentationEngine` (PWA) matches on `CachedCredential.MatchIdentifier` = `Vct`, sourced from the synced `CredentialEntity.Type`.
+
+So the canonical VCT must land identically in all three. Issuance sets `vct = type = Vct ?? CredentialType`, and `CredentialEntity.Type` (the stored value that feeds sync + matching) is that same string. The short `CredentialType` name is **not** emitted as a separate claim.
+
+## 3. Display gets its own source (it cannot come from the URI)
+
+`CredentialDisplay.Humanize` reads the **last** URI segment (`CredentialDisplay.cs:66`). For `https://sorcha.dev/vc/assured-identity/v1` that segment is `v1`, so the card would read **"V1"**. Display therefore must not be derived from the VCT once VCTs are URIs.
+
+- Issuance writes `DisplayName` into the credential's display carrier: `CredentialEntity.DisplayConfigJson` / the sync wire `CachedCredentialPayload.DisplayMeta.credentialName`, surfacing as `CachedCredential.DisplayLabel`.
+- `CredentialDisplay.Name` **already** prefers `DisplayLabel` over `Humanize(vct)` — no change to the display component's precedence.
+- When `DisplayName` is absent, `Humanize(vct)` remains the fallback (bare-name blueprints keep their current card names).
+- `DisplayName` defaults from the blueprint's `x-review` header `credentialName` **at authoring time where present** (it already carries "Assured Identity"), but the config field is the source of truth at issuance.
+
+Concretely, the sync-out path (`EfCoreCitizenCredentialEventStream.BuildPayload`, which today emits no label) must populate `DisplayMeta.credentialName` from the stored display config, and `ISyncService.ToCachedCredential` must map it to `DisplayLabel`. These are the two spots the label is currently dropped.
+
+## 4. Case-insensitive matching everywhere
+
+The PWA matcher (`PresentationEngine.MatchCandidates`) uses `StringComparison.Ordinal` (case-sensitive); the blueprint-side matchers use `OrdinalIgnoreCase`. For this fix both sides carry the identical URI, so exact match works — but the inconsistency is a latent trap (a capitalisation typo would pass server-side and silently fail on the phone, the exact class of bug being fixed).
+
+- Change `PresentationEngine.MatchCandidates` to `OrdinalIgnoreCase` so both sides agree.
+- Document the convention: **VCT URIs are lowercase.** (Advisory; the case-insensitive compare is the safety net.)
+
+## 5. Anti-drift — one definition per type, conformance-tested
+
+Canonical VCT URIs currently appear as scattered string literals; only `citizen-device-delegation/v1` has a constant (`VctUris.CitizenDeviceDelegationV1`). We make `VctUris` the **single registry of every platform credential-type VCT**:
+
+- One constant per credential type, e.g. `VctUris.AssuredIdentityV1 = "https://sorcha.dev/vc/assured-identity/v1"`, `VctUris.DrivingLicenceV1`, `VctUris.BlueBadgeV1`, … (full list in §6).
+- Every C# reference (verifier presets `DefaultPresetCatalogue`, any request builder) uses the constant, never a literal.
+- A **parametrised conformance test** asserts, for every converted blueprint, that its issuance `vct` (and every requirement `type` that names a platform type) equals the matching `VctUris` constant. The JSON cannot import the constant, so this test is the only thing that keeps the whole corpus from drifting — and it covers all types, not just one.
+
+This is still the "convention + validation" decision (the VCT is declared as data in the blueprint; the constant is the C#-side anchor), just applied across the whole type catalogue rather than one type.
+
+## 6. Full conversion — every credential type
+
+Blueprints are sacrificial (product-owner directive, 2026-07-15): rather than convert one type and leave the rest as a latent trap, **every credential type moves to a canonical URI + `displayName` in the same change**, retiring the bare-name world entirely.
+
+The naming rule: `https://sorcha.dev/vc/{kebab-case-type}/v1`, dropping a redundant `Credential`/`Posture` suffix (`AssuredIdentityCredential` → `assured-identity`). `displayName` is the humanised label the card should show.
+
+| Bare name today | Canonical VCT | `displayName` |
+|---|---|---|
+| `AssuredIdentityCredential` | `.../assured-identity/v1` | Assured Identity |
+| `DrivingLicenceCredential` | `.../driving-licence/v1` | Driving Licence |
+| `BlueBadgeCredential` | `.../blue-badge/v1` | Blue Badge |
+| `MembershipCredential/v1` | `.../membership/v1` | Membership |
+| `LicenseCredential` | `.../licence/v1` | Licence |
+| `CouncilDigitalIdCredential` | `.../council-digital-id/v1` | Council Digital ID |
+| `VerifiedInvoiceCredential` | `.../verified-invoice/v1` | Verified Invoice |
+| `TradeFinanceCredential` | `.../trade-finance/v1` | Trade Finance |
+| `PlanningPermissionCredential` | `.../planning-permission/v1` | Planning Permission |
+| `BuildingWarrantCredential` | `.../building-warrant/v1` | Building Warrant |
+| `CompletionCertificateCredential` | `.../completion-certificate/v1` | Completion Certificate |
+| `JobAssignmentCredential` | `.../job-assignment/v1` | Job Assignment |
+| `ServiceCompletionCredential` | `.../service-completion/v1` | Service Completion |
+| `ForestProductDPPCredential` | `.../forest-product-dpp/v1` | Forest Product DPP |
+| `CyberEssentialsUacPosture` | `.../cyber-essentials-uac/v1` | Cyber Essentials UAC |
+| `RefurbishmentCertificateCredential` | `.../refurbishment-certificate/v1` | Refurbishment Certificate |
+
+**The lockstep invariant:** for each type, the issuer `vct` **and** every `CredentialRequirement.type` that names it move to the same URI together. The parametrised conformance test (§5) enforces this across the corpus, so a missed requirer is a test failure, not a silent runtime no-match. The definitive list of files is derived at implementation time by grepping each bare name across `demos/`, `walkthroughs/`, and `blueprints/` — every occurrence (issue or require) is converted.
+
+Types that are only ever issued and never required cross-blueprint still get a constant + `displayName` for consistency and for future presentation.
+
+## 7. Publish-time validation
+
+When `Vct` is set, it must be a valid **absolute URI**. Enforced at blueprint publish (the existing validation seam that already checks issuance config), failing the publish with a clear message rather than minting an unmatchable credential. Bare-name `CredentialType` (fallback path) keeps its existing `[Required] MinLen1 MaxLen200` rule and is not URI-validated.
+
+## 8. Existing credentials
+
+The credential already in a wallet was minted with `vct = AssuredIdentityCredential`. Per the product owner, **re-issue is acceptable** — no migration and no matcher alias. After this ships, the citizen re-claims the credential and the new one carries the URI VCT. This is called out so it is not a surprise: the *old* credential will still fail to present until replaced.
+
+## 9. Files touched
+
+**Model** — `Sorcha.Blueprint.Models/Credentials/CredentialIssuanceConfig.cs` (+`Vct`, +`DisplayName`).
+
+**Issuance** — `Sorcha.Blueprint.Engine/Credentials/CredentialIssuer.cs` (write `vct=type=Vct??CredentialType`; write `DisplayName` to display config). The Wallet Service direct-issue path (`CredentialEndpoints.cs:705-706`) mirrors the same rule. (HAIP + mdoc paths are out of scope — they don't feed the PWA verifier in the failing flow; note them in the plan as follow-ups.)
+
+**Sync / display carrier** — `EfCoreCitizenCredentialEventStream.BuildPayload` (populate `DisplayMeta.credentialName`), `ISyncService.ToCachedCredential` (map to `DisplayLabel`).
+
+**Matcher** — `PresentationEngine.MatchCandidates` (`Ordinal` → `OrdinalIgnoreCase`).
+
+**Constants + presets** — `VctUris` (one constant per type in §6's table), `DefaultPresetCatalogue` + any C# VCT literal (reference the constants).
+
+**Blueprints** — every blueprint under `demos/`, `walkthroughs/`, `blueprints/` that issues or requires any credential type in §6's table. The exact file set is enumerated by grep at implementation time; the conformance test guarantees none is missed.
+
+**Publish validation** — the issuance-config validation seam.
+
+## 10. Tests
+
+- **Issuance unit:** a config with `Vct` set writes that URI to `vct` and `type`; with `Vct` null, writes `CredentialType` (fallback preserved).
+- **Display unit:** `DisplayName` set → card name is the authored label; `DisplayName` null → `Humanize(vct)` (existing `CredentialDisplayTests` table still passes).
+- **Matcher unit:** a URI-VCT credential matches a URI-VCT request under `OrdinalIgnoreCase`, including a capitalisation-mismatch case that would have failed under `Ordinal`.
+- **Conformance (parametrised across the whole corpus):** for every converted blueprint, its issuance `vct` and every platform-type requirement `type` equal the matching `VctUris` constant. This single test is what proves the lockstep held for all ~16 types and no requirer was missed.
+- **End-to-end intent (the regression that started this):** an Assured-Identity credential minted from the converted blueprint satisfies the `DefaultPresetCatalogue` Assured-Identity request — the exact path that shows "None match" today.
+- **Publish validation:** a config with a non-URI `Vct` fails publish.
+
+## 11. Success criteria
+
+- **SC-1** An Assured Identity credential issued from the converted blueprint presents successfully to the PWA verifier's Assured-Identity request (the reported bug).
+- **SC-2** The citizen's card still reads "Assured Identity", sourced from `DisplayName`, not from parsing the URI.
+- **SC-3** Every credential type is now a canonical URI VCT with an authored `displayName`; the bare-name world is gone. The optional-field fallback survives only as defensive degradation for an omitted `Vct`.
+- **SC-4** Every cross-blueprint issue↔require pair (Assured Identity ← blue-badge / driving-licence / membership, and any others) still matches after conversion, proven by the parametrised conformance test.
+- **SC-5** The AIAS blueprint VCT and the verifier preset constant cannot drift without a failing test.
+- **SC-6** A capitalisation-only VCT difference no longer produces a silent phone-only no-match.

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/Verification/DefaultPresetCatalogue.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/Verification/DefaultPresetCatalogue.cs
@@ -2,6 +2,7 @@
 // Copyright (c) 2026 Sorcha Contributors
 
 using Microsoft.Extensions.Options;
+using Sorcha.CitizenWallet.Abstractions.Constants;
 using Sorcha.UI.Components.User.Models.Verification;
 
 namespace Sorcha.UI.Components.User.Services.Verification;
@@ -14,7 +15,7 @@ namespace Sorcha.UI.Components.User.Services.Verification;
 /// </summary>
 public sealed class DefaultPresetCatalogue : IVerificationPresetCatalogue
 {
-    private const string AssuredIdentityVct = "https://sorcha.dev/vc/assured-identity/v1";
+    private const string AssuredIdentityVct = VctUris.AssuredIdentityV1;
 
     /// <summary>
     /// Builtin presets, used when no presets are configured. Mirrors the desk verifier's original

--- a/src/Apps/Sorcha.Verifier/Endpoints/DemoMintEndpoint.cs
+++ b/src/Apps/Sorcha.Verifier/Endpoints/DemoMintEndpoint.cs
@@ -6,6 +6,7 @@ using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
 using Microsoft.AspNetCore.Builder;
+using Sorcha.CitizenWallet.Abstractions.Constants;
 using Sorcha.Verifier.Services;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;using Sorcha.Verifier.Engine;
@@ -98,7 +99,7 @@ public static class DemoMintEndpoint
             ["sub"] = $"did:sorcha:device:{deviceThumbprint}",
             ["iat"] = nowUnix,
             ["exp"] = DateTimeOffset.UtcNow.AddDays(365).ToUnixTimeSeconds(),
-            ["vct"] = "https://sorcha.dev/vc/citizen-device-delegation/v1",
+            ["vct"] = VctUris.CitizenDeviceDelegationV1,
             ["delegated_capabilities"] = new[] { "presentation.holder-key-binding" },
             ["cnf"] = new Dictionary<string, object> { ["jwk"] = body.DeviceJwk },
             // Status-list bit deliberately omitted in demo mode — wallet's NoopStatusListService

--- a/src/Apps/Sorcha.Wallet.Pwa/Services/ISyncService.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Services/ISyncService.cs
@@ -263,7 +263,12 @@ public sealed class SyncService : ISyncService
         // check. A future revision can add ICredentialCache.RemoveAsync.
     }
 
-    private static CachedCredential ToCachedCredential(CachedCredentialPayload payload) => new()
+    /// <summary>
+    /// Maps a wire <see cref="CachedCredentialPayload"/> to the local cache shape.
+    /// Internal (not private) so <c>Sorcha.Wallet.Pwa.Tests</c> (an
+    /// <c>InternalsVisibleTo</c> friend assembly) can exercise the mapping directly.
+    /// </summary>
+    internal static CachedCredential ToCachedCredential(CachedCredentialPayload payload) => new()
     {
         // The cache uses Guid as an opaque local key; the canonical credential id
         // (urn:credential:...) survives in payload.RawSdJwt + the presentation
@@ -274,6 +279,9 @@ public sealed class SyncService : ISyncService
         RawSdJwt = payload.Jwt,
         AvailableClaimNames = [],
         IssuerDid = payload.IssuerDid,
+        // Credential VCT decoupling (Task 4): the authored display name, when the
+        // issuer supplied one, wins over CredentialDisplay.Humanize(vct) on the card.
+        DisplayLabel = payload.DisplayMeta?["credentialName"]?.GetValue<string>(),
     };
 
     private static Guid StringToCacheGuid(string credentialId)

--- a/src/Common/Sorcha.Blueprint.Models/Credentials/CredentialDisplayConfig.cs
+++ b/src/Common/Sorcha.Blueprint.Models/Credentials/CredentialDisplayConfig.cs
@@ -40,4 +40,12 @@ public class CredentialDisplayConfig
     [JsonPropertyName("highlightClaims")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public Dictionary<string, string>? HighlightClaims { get; set; }
+
+    /// <summary>
+    /// Authored human-readable credential name shown on the card (e.g. "Assured Identity"),
+    /// decoupled from the vct URI. Sourced from CredentialIssuanceConfig.DisplayName at issuance.
+    /// </summary>
+    [JsonPropertyName("credentialName")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? CredentialName { get; set; }
 }

--- a/src/Common/Sorcha.Blueprint.Models/Credentials/CredentialIssuanceConfig.cs
+++ b/src/Common/Sorcha.Blueprint.Models/Credentials/CredentialIssuanceConfig.cs
@@ -22,6 +22,26 @@ public class CredentialIssuanceConfig
     public string CredentialType { get; set; } = string.Empty;
 
     /// <summary>
+    /// Canonical SD-JWT VC type identifier (the <c>vct</c> claim). MUST be an absolute URI,
+    /// lowercase kebab-case: <c>https://sorcha.dev/vc/{type}/v1</c>. This is the machine
+    /// matching identity — a verifier's request and the held credential match on this string
+    /// (case-sensitive exact, per SD-JWT VC §3.2.2.1). When null, <see cref="CredentialType"/>
+    /// is used as the vct (defensive fallback for hand-authored/legacy configs).
+    /// </summary>
+    [JsonPropertyName("vct")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Vct { get; set; }
+
+    /// <summary>
+    /// Human-readable label shown on the credential card (e.g. "Assured Identity"). Decoupled
+    /// from <see cref="Vct"/> so display never depends on parsing the URI. When null, the wallet
+    /// falls back to humanising the vct.
+    /// </summary>
+    [JsonPropertyName("displayName")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? DisplayName { get; set; }
+
+    /// <summary>
     /// Maps action data fields to credential claims.
     /// </summary>
     [DataAnnotations.Required]

--- a/src/Common/Sorcha.CitizenWallet.Abstractions/Constants/VctUris.cs
+++ b/src/Common/Sorcha.CitizenWallet.Abstractions/Constants/VctUris.cs
@@ -14,4 +14,68 @@ public static class VctUris
     /// </summary>
     public const string CitizenDeviceDelegationV1 =
         "https://sorcha.dev/vc/citizen-device-delegation/v1";
+
+    /// <summary>Assured identity credential v1.</summary>
+    public const string AssuredIdentityV1 =
+        "https://sorcha.dev/vc/assured-identity/v1";
+
+    /// <summary>Driving licence credential v1.</summary>
+    public const string DrivingLicenceV1 =
+        "https://sorcha.dev/vc/driving-licence/v1";
+
+    /// <summary>Blue badge credential v1.</summary>
+    public const string BlueBadgeV1 =
+        "https://sorcha.dev/vc/blue-badge/v1";
+
+    /// <summary>Membership credential v1.</summary>
+    public const string MembershipV1 =
+        "https://sorcha.dev/vc/membership/v1";
+
+    /// <summary>Licence credential v1.</summary>
+    public const string LicenceV1 =
+        "https://sorcha.dev/vc/licence/v1";
+
+    /// <summary>Council digital ID credential v1.</summary>
+    public const string CouncilDigitalIdV1 =
+        "https://sorcha.dev/vc/council-digital-id/v1";
+
+    /// <summary>Verified invoice credential v1.</summary>
+    public const string VerifiedInvoiceV1 =
+        "https://sorcha.dev/vc/verified-invoice/v1";
+
+    /// <summary>Trade finance credential v1.</summary>
+    public const string TradeFinanceV1 =
+        "https://sorcha.dev/vc/trade-finance/v1";
+
+    /// <summary>Planning permission credential v1.</summary>
+    public const string PlanningPermissionV1 =
+        "https://sorcha.dev/vc/planning-permission/v1";
+
+    /// <summary>Building warrant credential v1.</summary>
+    public const string BuildingWarrantV1 =
+        "https://sorcha.dev/vc/building-warrant/v1";
+
+    /// <summary>Completion certificate credential v1.</summary>
+    public const string CompletionCertificateV1 =
+        "https://sorcha.dev/vc/completion-certificate/v1";
+
+    /// <summary>Job assignment credential v1.</summary>
+    public const string JobAssignmentV1 =
+        "https://sorcha.dev/vc/job-assignment/v1";
+
+    /// <summary>Service completion credential v1.</summary>
+    public const string ServiceCompletionV1 =
+        "https://sorcha.dev/vc/service-completion/v1";
+
+    /// <summary>Forest product digital product passport credential v1.</summary>
+    public const string ForestProductDppV1 =
+        "https://sorcha.dev/vc/forest-product-dpp/v1";
+
+    /// <summary>Cyber Essentials UAC credential v1.</summary>
+    public const string CyberEssentialsUacV1 =
+        "https://sorcha.dev/vc/cyber-essentials-uac/v1";
+
+    /// <summary>Refurbishment certificate credential v1.</summary>
+    public const string RefurbishmentCertificateV1 =
+        "https://sorcha.dev/vc/refurbishment-certificate/v1";
 }

--- a/src/Common/Sorcha.CitizenWallet.Abstractions/Constants/VctUris.cs
+++ b/src/Common/Sorcha.CitizenWallet.Abstractions/Constants/VctUris.cs
@@ -78,4 +78,8 @@ public static class VctUris
     /// <summary>Refurbishment certificate credential v1.</summary>
     public const string RefurbishmentCertificateV1 =
         "https://sorcha.dev/vc/refurbishment-certificate/v1";
+
+    /// <summary>Building permit credential v1.</summary>
+    public const string BuildingPermitV1 =
+        "https://sorcha.dev/vc/building-permit/v1";
 }

--- a/src/Common/Sorcha.ServiceClients.Http/Wallet/IWalletServiceClient.cs
+++ b/src/Common/Sorcha.ServiceClients.Http/Wallet/IWalletServiceClient.cs
@@ -196,6 +196,15 @@ public interface IWalletServiceClient
     /// <param name="holderJwk">Feature 137 — recipient holder's public JWK (slot 108) for the SD-JWT
     /// <c>cnf</c> key-confirmation binding. When supplied, the issued credential is bound to the holder
     /// key so only the holder can present it. Null leaves the credential unbound (pre-137 behaviour).</param>
+    /// <param name="trustAnchor">Feature 181 US4 — the credential's X.509 trust anchor selector.</param>
+    /// <param name="vct">Canonical SD-JWT VC type identifier (the <c>vct</c> claim). MUST be an absolute
+    /// URI, case-sensitive exact match per SD-JWT VC §3.2.2.1. When null, <paramref name="credentialType"/>
+    /// is used as the vct (defensive fallback for legacy callers). Decoupling the vct from the bare
+    /// credential type is what lets the citizen's stored credential carry the canonical URI.</param>
+    /// <param name="displayName">Authored human-readable credential name shown on the wallet card
+    /// (e.g. "Assured Identity"), decoupled from the vct URI. When supplied, the issuer records it as
+    /// <c>credentialName</c> in the credential's display config so the citizen card never depends on
+    /// parsing the URI.</param>
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>Issued credential information including the signed SD-JWT VC token</returns>
     Task<CredentialIssuanceResult> IssueCredentialAsync(
@@ -214,6 +223,8 @@ public interface IWalletServiceClient
         string? tenantId = null,
         JsonElement? holderJwk = null,
         string? trustAnchor = null,
+        string? vct = null,
+        string? displayName = null,
         CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -499,6 +510,13 @@ public class CredentialIssuanceResult
     /// (multi-node audit CRITICAL #2).
     /// </summary>
     public string? RegisterId { get; init; }
+
+    /// <summary>
+    /// Serialised issuer-defined display config (<c>CredentialDisplayConfig</c> JSON) carrying the
+    /// authored <c>credentialName</c>. Threaded from the issuance endpoint so the SorchaLocalWallet
+    /// register envelope can carry it to the citizen entity. Null when no display name was supplied.
+    /// </summary>
+    public string? DisplayConfigJson { get; init; }
 }
 
 /// <summary>

--- a/src/Common/Sorcha.ServiceClients.Http/Wallet/WalletServiceClient.cs
+++ b/src/Common/Sorcha.ServiceClients.Http/Wallet/WalletServiceClient.cs
@@ -393,6 +393,8 @@ public class WalletServiceClient : IWalletServiceClient
         string? tenantId = null,
         JsonElement? holderJwk = null,
         string? trustAnchor = null,
+        string? vct = null,
+        string? displayName = null,
         CancellationToken cancellationToken = default)
     {
         try
@@ -418,7 +420,9 @@ public class WalletServiceClient : IWalletServiceClient
                 issuerOrgName,
                 tenantId,
                 holderJwk,
-                trustAnchor
+                trustAnchor,
+                vct,
+                displayName
             };
 
             var response = await _httpClient.PostAsJsonAsync(

--- a/src/Core/Sorcha.Blueprint.Engine/Credentials/CredentialIssuer.cs
+++ b/src/Core/Sorcha.Blueprint.Engine/Credentials/CredentialIssuer.cs
@@ -40,9 +40,11 @@ public class CredentialIssuer : ICredentialIssuer
         // Step 1: Map action data fields to credential claims
         var claims = MapClaims(config.ClaimMappings, processedData);
 
-        // Add standard claims
-        claims["type"] = config.CredentialType;
-        claims["vct"] = config.CredentialType;
+        // Add standard claims.
+        // SD-JWT VC (draft-ietf-oauth-sd-jwt-vc §3.2.2.1): vct is the SOLE type claim, a
+        // case-sensitive URI. There is no `type` claim in the profile — do not write one.
+        var vct = string.IsNullOrWhiteSpace(config.Vct) ? config.CredentialType : config.Vct;
+        claims["vct"] = vct;
 
         // Step 2: Calculate expiry
         var issuedAt = DateTimeOffset.UtcNow;
@@ -69,10 +71,19 @@ public class CredentialIssuer : ICredentialIssuer
         // Step 5: Generate credential ID
         var credentialId = $"urn:uuid:{Guid.NewGuid()}";
 
+        // Step 6: Thread the authored display name into the display carrier so it survives
+        // to IssuedCredentialInfo.DisplayConfigJson / CredentialEntity independently of vct.
+        var displayConfig = config.DisplayConfig;
+        if (!string.IsNullOrWhiteSpace(config.DisplayName))
+        {
+            displayConfig ??= new CredentialDisplayConfig();
+            displayConfig.CredentialName = config.DisplayName;
+        }
+
         return new IssuedCredentialInfo
         {
             CredentialId = credentialId,
-            Type = config.CredentialType,
+            Type = vct,
             IssuerDid = issuerDid,
             SubjectDid = recipientDid,
             Claims = claims,
@@ -81,8 +92,8 @@ public class CredentialIssuer : ICredentialIssuer
             RawToken = token.RawToken,
             UsagePolicy = config.UsagePolicy.ToString(),
             MaxPresentations = config.MaxPresentations,
-            DisplayConfigJson = config.DisplayConfig != null
-                ? JsonSerializer.Serialize(config.DisplayConfig)
+            DisplayConfigJson = displayConfig != null
+                ? JsonSerializer.Serialize(displayConfig)
                 : null
         };
     }

--- a/src/Core/Sorcha.Blueprint.Engine/Credentials/CredentialVerifier.cs
+++ b/src/Core/Sorcha.Blueprint.Engine/Credentials/CredentialVerifier.cs
@@ -213,7 +213,7 @@ public class CredentialVerifier : ICredentialVerifier
     }
 
     private static bool TypeMatches(string credentialType, string requirementType) =>
-        string.Equals(credentialType, requirementType, StringComparison.OrdinalIgnoreCase);
+        string.Equals(credentialType, requirementType, StringComparison.Ordinal);
 
     private readonly record struct MatchOutcome(VerifiedCredentialDetail? Detail, CredentialValidationError? Error)
     {

--- a/src/Services/Sorcha.Blueprint.Service/Program.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Program.cs
@@ -3579,11 +3579,21 @@ public class PublishService(
         const string SorchaLocalWalletRecipientCode = "VAL_BP_CRED_001";
         const string SorchaLocalWalletImplicitDisclosureWarning = "WARN_BP_CRED_002";
         const string SorchaLocalWalletRejectNotTerminalCode = "VAL_BP_CRED_003";
+        const string CredentialVctNotAbsoluteUriCode = "VAL_BP_CRED_004";
 
         foreach (var action in blueprint.Actions)
         {
             var issuance = action.CredentialIssuanceConfig;
             if (issuance is null) continue;
+
+            // VAL_BP_CRED_004 — a declared vct must be an absolute URI (SD-JWT VC vct is a URI).
+            if (!string.IsNullOrWhiteSpace(issuance.Vct) && !Uri.TryCreate(issuance.Vct, UriKind.Absolute, out _))
+            {
+                errors.Add(
+                    $"[{CredentialVctNotAbsoluteUriCode}] Action {action.Id} ('{action.Title}'): " +
+                    $"credentialIssuanceConfig.vct '{issuance.Vct}' is not an absolute URI. The vct must be an " +
+                    $"absolute URI, e.g. https://sorcha.dev/vc/{{type}}/v1.");
+            }
 
             // This block is the deprecation handler for SorchaInternal — it references the obsolete
             // value deliberately, to warn authors and to treat it as SorchaLocalWallet at runtime.

--- a/src/Services/Sorcha.Blueprint.Service/Services/BlueprintToolExecutor.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Services/BlueprintToolExecutor.cs
@@ -1254,6 +1254,19 @@ public class BlueprintToolExecutor : IBlueprintToolExecutor
                             location = $"actions[{action.Id}].credentialIssuanceConfig"
                         });
                     }
+
+                    // Feature: credential VCT decoupling (design §7) — a declared vct must be an
+                    // absolute URI (SD-JWT VC vct is a URI). Reject rather than mint an
+                    // unmatchable credential. Do NOT apply this to the credentialType fallback.
+                    if (!string.IsNullOrWhiteSpace(issuance.Vct) && !Uri.TryCreate(issuance.Vct, UriKind.Absolute, out _))
+                    {
+                        errors.Add(new
+                        {
+                            code = "INVALID_CREDENTIAL_VCT",
+                            message = $"Action '{action.Title}' credentialIssuanceConfig.vct '{issuance.Vct}' is not an absolute URI. The vct must be an absolute URI, e.g. https://sorcha.dev/vc/{{type}}/v1.",
+                            location = $"actions[{action.Id}].credentialIssuanceConfig"
+                        });
+                    }
                 }
             }
         }

--- a/src/Services/Sorcha.Blueprint.Service/Services/Implementation/ActionExecutionService.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Services/Implementation/ActionExecutionService.cs
@@ -802,6 +802,7 @@ public class ActionExecutionService : IActionExecutionService, IPresentationRout
             {
                 ["credentialId"] = localWalletCredential.CredentialId,
                 ["credentialType"] = localWalletCredential.Type,
+                ["displayConfig"] = localWalletCredential.DisplayConfigJson,
                 ["issuerDid"] = localWalletCredential.IssuerDid,
                 ["subjectDid"] = localWalletCredential.SubjectDid,
                 ["issuedAt"] = localWalletCredential.IssuedAt,
@@ -2388,6 +2389,11 @@ public class ActionExecutionService : IActionExecutionService, IPresentationRout
                 trustAnchor: config.TrustAnchor == Sorcha.Blueprint.Models.Credentials.TrustAnchor.X509Lotl
                     ? "x509-lotl"
                     : null,
+                // Credential VCT decoupling — carry the canonical vct URI and the authored
+                // display name so the issuer stamps the citizen entity's Type with the vct
+                // and records credentialName in the display config (not the bare type).
+                vct: config.Vct,
+                displayName: config.DisplayName,
                 cancellationToken: cancellationToken);
 
             return result;

--- a/src/Services/Sorcha.Wallet.Service/Credentials/CredentialMatcher.cs
+++ b/src/Services/Sorcha.Wallet.Service/Credentials/CredentialMatcher.cs
@@ -61,7 +61,7 @@ public class CredentialMatcher
         foreach (var credential in credentials)
         {
             // Type match
-            if (!string.Equals(credential.Type, requirement.Type, StringComparison.OrdinalIgnoreCase))
+            if (!string.Equals(credential.Type, requirement.Type, StringComparison.Ordinal))
                 continue;
 
             // Issuer check (feature 135: issuer allowlist now lives on the trust policy)
@@ -135,7 +135,7 @@ public class CredentialMatcher
             CredentialEntity? match = null;
             foreach (var credential in credentials)
             {
-                if (!string.Equals(credential.Type, requirement.Type, StringComparison.OrdinalIgnoreCase))
+                if (!string.Equals(credential.Type, requirement.Type, StringComparison.Ordinal))
                     continue;
 
                 // Feature 120 US5 — equivalence-aware allowlist match.

--- a/src/Services/Sorcha.Wallet.Service/Endpoints/CredentialEndpoints.cs
+++ b/src/Services/Sorcha.Wallet.Service/Endpoints/CredentialEndpoints.cs
@@ -701,11 +701,23 @@ public static class CredentialEndpoints
         //    embed a W3C BitstringStatusListEntry credentialStatus claim BEFORE signing so
         //    external verifiers can determine lifecycle state from the token alone.
         // SD-JWT VC (draft-ietf-oauth-sd-jwt-vc §3.2.2.1): vct is the SOLE type claim — no
-        // `type` claim in the profile.
+        // `type` claim in the profile. Credential VCT decoupling: the vct URI (not the bare
+        // CredentialType) is also stamped onto every stored CredentialEntity.Type and the
+        // response Type below — because the SorchaLocalWallet register envelope copies the
+        // response Type into credentialType, that is what propagates the URI to the citizen.
+        var vct = string.IsNullOrWhiteSpace(request.Vct) ? request.CredentialType : request.Vct;
         var claims = new Dictionary<string, object>(request.Claims)
         {
-            ["vct"] = string.IsNullOrWhiteSpace(request.Vct) ? request.CredentialType : request.Vct
+            ["vct"] = vct
         };
+
+        // Credential VCT decoupling: serialise the authored display name into the issuer-defined
+        // display config so the citizen card shows credentialName without parsing the URI. Match
+        // the plain JsonSerializer.Serialize used elsewhere in this handler; CredentialDisplayConfig
+        // carries [JsonPropertyName("credentialName")] so the emitted key is stable.
+        string? displayConfigJson = string.IsNullOrWhiteSpace(request.DisplayName)
+            ? null
+            : JsonSerializer.Serialize(new CredentialDisplayConfig { CredentialName = request.DisplayName });
 
         if (!string.IsNullOrEmpty(request.StatusListUrl) && request.StatusListIndex.HasValue)
         {
@@ -803,7 +815,7 @@ public static class CredentialEndpoints
         var issuerEntity = new CredentialEntity
         {
             Id = credentialId,
-            Type = request.CredentialType,
+            Type = vct,
             IssuerDid = walletAddress,
             SubjectDid = request.RecipientWallet,
             ClaimsJson = claimsJson,
@@ -816,7 +828,8 @@ public static class CredentialEndpoints
             WalletAddress = walletAddress,
             CreatedAt = DateTimeOffset.UtcNow,
             StatusListUrl = request.StatusListUrl,
-            StatusListIndex = request.StatusListIndex
+            StatusListIndex = request.StatusListIndex,
+            DisplayConfigJson = displayConfigJson
         };
         await store.StoreAsync(issuerEntity, cancellationToken);
 
@@ -833,7 +846,7 @@ public static class CredentialEndpoints
                 var recipientEntity = new CredentialEntity
                 {
                     Id = credentialId,
-                    Type = request.CredentialType,
+                    Type = vct,
                     IssuerDid = walletAddress,
                     SubjectDid = request.RecipientWallet,
                     ClaimsJson = claimsJson,
@@ -845,7 +858,8 @@ public static class CredentialEndpoints
                     WalletAddress = request.RecipientWallet,
                     CreatedAt = DateTimeOffset.UtcNow,
                     StatusListUrl = request.StatusListUrl,
-                    StatusListIndex = request.StatusListIndex
+                    StatusListIndex = request.StatusListIndex,
+                    DisplayConfigJson = displayConfigJson
                 };
                 await store.StoreAsync(recipientEntity, cancellationToken);
 
@@ -878,13 +892,14 @@ public static class CredentialEndpoints
         return Results.Ok(new IssuedCredentialResponse
         {
             CredentialId = credentialId,
-            Type = request.CredentialType,
+            Type = vct,
             IssuerDid = walletAddress,
             SubjectDid = request.RecipientWallet,
             Claims = claims,
             IssuedAt = issuedAt,
             ExpiresAt = expiresAt,
-            RawToken = token.RawToken
+            RawToken = token.RawToken,
+            DisplayConfigJson = displayConfigJson
         });
     }
 }
@@ -932,6 +947,14 @@ public class IssueCredentialRequest
     /// </summary>
     [StringLength(512)]
     public string? Vct { get; init; }
+
+    /// <summary>
+    /// Authored human-readable credential name shown on the wallet card (e.g. "Assured Identity"),
+    /// decoupled from the vct URI. When supplied, the issuer serialises it as <c>credentialName</c>
+    /// in the credential's display config so the citizen card never depends on parsing the URI.
+    /// </summary>
+    [StringLength(256)]
+    public string? DisplayName { get; init; }
 
     [Required]
     public required Dictionary<string, object> Claims { get; init; }
@@ -1041,4 +1064,11 @@ public class IssuedCredentialResponse
     public required DateTimeOffset IssuedAt { get; init; }
     public DateTimeOffset? ExpiresAt { get; init; }
     public required string RawToken { get; init; }
+
+    /// <summary>
+    /// Serialised issuer-defined display config (<c>CredentialDisplayConfig</c> JSON) carrying the
+    /// authored <c>credentialName</c>. Null when no display name was supplied. Threaded so the
+    /// SorchaLocalWallet register envelope can carry it to the citizen entity.
+    /// </summary>
+    public string? DisplayConfigJson { get; init; }
 }

--- a/src/Services/Sorcha.Wallet.Service/Endpoints/CredentialEndpoints.cs
+++ b/src/Services/Sorcha.Wallet.Service/Endpoints/CredentialEndpoints.cs
@@ -700,10 +700,11 @@ public static class CredentialEndpoints
         //    Feature 093 US2: if the caller supplied a pre-allocated status list URL + index,
         //    embed a W3C BitstringStatusListEntry credentialStatus claim BEFORE signing so
         //    external verifiers can determine lifecycle state from the token alone.
+        // SD-JWT VC (draft-ietf-oauth-sd-jwt-vc §3.2.2.1): vct is the SOLE type claim — no
+        // `type` claim in the profile.
         var claims = new Dictionary<string, object>(request.Claims)
         {
-            ["type"] = request.CredentialType,
-            ["vct"] = request.CredentialType
+            ["vct"] = string.IsNullOrWhiteSpace(request.Vct) ? request.CredentialType : request.Vct
         };
 
         if (!string.IsNullOrEmpty(request.StatusListUrl) && request.StatusListIndex.HasValue)
@@ -923,6 +924,14 @@ public class IssueCredentialRequest
     [Required(AllowEmptyStrings = false)]
     [StringLength(256)]
     public required string CredentialType { get; init; }
+
+    /// <summary>
+    /// Canonical SD-JWT VC type identifier (the <c>vct</c> claim). MUST be an absolute URI,
+    /// case-sensitive exact match per SD-JWT VC §3.2.2.1. When null, <see cref="CredentialType"/>
+    /// is used as the vct (defensive fallback for legacy callers).
+    /// </summary>
+    [StringLength(512)]
+    public string? Vct { get; init; }
 
     [Required]
     public required Dictionary<string, object> Claims { get; init; }

--- a/src/Services/Sorcha.Wallet.Service/Services/Implementation/EfCoreCitizenCredentialEventStream.cs
+++ b/src/Services/Sorcha.Wallet.Service/Services/Implementation/EfCoreCitizenCredentialEventStream.cs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Sorcha Contributors
 
+using System.Text.Json.Nodes;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Sorcha.CitizenWallet.Abstractions.Models;
@@ -130,6 +131,7 @@ public sealed class EfCoreCitizenCredentialEventStream : ICitizenCredentialEvent
                 ExpiresAt = entity.ExpiresAt,
                 StatusListUri = null,
                 StatusListIndex = null,
+                DisplayMeta = BuildDisplayMeta(entity.DisplayConfigJson),
             },
             CitizenCredentialEventKind.Revoked => new RevokedCredentialEntry
             {
@@ -151,6 +153,41 @@ public sealed class EfCoreCitizenCredentialEventStream : ICitizenCredentialEvent
                 RevokedAt = DateTimeOffset.UtcNow,
             },
         };
+    }
+
+    /// <summary>
+    /// Extracts the authored <c>credentialName</c> (Credential VCT decoupling, Task 3.5)
+    /// from the stored <see cref="CredentialEntity.DisplayConfigJson"/> and wraps it as the
+    /// sync-out <c>DisplayMeta</c> shape. Returns null on missing/malformed/empty input so
+    /// legacy credentials (issued before Task 3.5, or with no authored display name) keep
+    /// the PWA's <c>Humanize(vct)</c> fallback rather than surfacing a synthetic label.
+    /// </summary>
+    private static JsonObject? BuildDisplayMeta(string? displayConfigJson)
+    {
+        if (string.IsNullOrWhiteSpace(displayConfigJson))
+        {
+            return null;
+        }
+
+        try
+        {
+            var parsed = JsonNode.Parse(displayConfigJson);
+            var credentialName = parsed?["credentialName"]?.GetValue<string>();
+            return string.IsNullOrWhiteSpace(credentialName)
+                ? null
+                : new JsonObject { ["credentialName"] = credentialName };
+        }
+        catch (System.Text.Json.JsonException)
+        {
+            return null;
+        }
+        catch (InvalidOperationException)
+        {
+            // Node shape didn't match expectations (e.g. displayConfigJson parsed to a
+            // non-object, or credentialName is present but not a string) — fall back to
+            // the Humanize(vct) path rather than throwing out of an event-stream read.
+            return null;
+        }
     }
 
     private static CredentialRevocationReason MapRevocationReason(CredentialStatus status) =>

--- a/src/Services/Sorcha.Wallet.Service/Services/Implementation/InboundCredentialDetector.cs
+++ b/src/Services/Sorcha.Wallet.Service/Services/Implementation/InboundCredentialDetector.cs
@@ -198,6 +198,7 @@ public sealed class InboundCredentialDetector : IInboundCredentialDetector
                 IssuerOrgName = extract.IssuerOrgName,
                 SubjectDid = walletAddress,
                 ClaimsJson = extract.ClaimsJson,
+                DisplayConfigJson = extract.DisplayConfigJson,
                 IssuedAt = extract.IssuedAt,
                 ExpiresAt = extract.ExpiresAt,
                 RawToken = extract.RawToken,
@@ -518,6 +519,11 @@ public sealed class InboundCredentialDetector : IInboundCredentialDetector
             expiresAt = parsedExpires;
         }
 
+        var displayConfigJson = credential.TryGetProperty("displayConfig", out var displayEl)
+            && displayEl.ValueKind == JsonValueKind.String
+                ? displayEl.GetString()
+                : null;
+
         var issuerOrgName = credential.TryGetProperty("issuerOrgName", out var orgEl) ? orgEl.GetString() : null;
         var blueprintId = credential.TryGetProperty("issuanceBlueprintId", out var bpEl) ? bpEl.GetString() : null;
         var instanceId = credential.TryGetProperty("issuanceInstanceId", out var instEl) ? instEl.GetString() : null;
@@ -545,6 +551,7 @@ public sealed class InboundCredentialDetector : IInboundCredentialDetector
             RawToken = rawToken!,
             IssuerOrgName = issuerOrgName,
             ClaimsJson = claimsJson,
+            DisplayConfigJson = displayConfigJson,
             IssuedAt = issuedAt,
             ExpiresAt = expiresAt,
             TransactionId = txId,

--- a/src/Services/Sorcha.Wallet.Service/Services/Interfaces/IInboundCredentialDetector.cs
+++ b/src/Services/Sorcha.Wallet.Service/Services/Interfaces/IInboundCredentialDetector.cs
@@ -61,6 +61,14 @@ public sealed record InboundCredentialExtract
     /// <summary>Serialised JSON of the credential claims.</summary>
     public required string ClaimsJson { get; init; }
 
+    /// <summary>
+    /// Serialised issuer-defined display config (<c>CredentialDisplayConfig</c> JSON) carrying the
+    /// authored <c>credentialName</c>, as sealed into the register envelope by the issuing flow.
+    /// Null when the issuer supplied no display name. Credential VCT decoupling — lets the citizen
+    /// card show the authored name without parsing the vct URI.
+    /// </summary>
+    public string? DisplayConfigJson { get; init; }
+
     /// <summary>Issuance timestamp embedded in the credential.</summary>
     public required DateTimeOffset IssuedAt { get; init; }
 

--- a/tests/Sorcha.Blueprint.Engine.Tests/Credentials/CredentialIssuerTests.cs
+++ b/tests/Sorcha.Blueprint.Engine.Tests/Credentials/CredentialIssuerTests.cs
@@ -52,7 +52,7 @@ public class CredentialIssuerTests
     }
 
     [Fact]
-    public async Task IssueAsync_AddsStandardClaims_TypeAndVct()
+    public async Task IssueAsync_AddsStandardClaims_VctOnly_NoTypeClaim()
     {
         // Arrange
         var config = CreateConfig("IdentityAttestation");
@@ -65,8 +65,65 @@ public class CredentialIssuerTests
             new byte[] { 1, 2, 3 }, "EdDSA");
 
         // Assert
-        result.Claims.Should().ContainKey("type").WhoseValue.Should().Be("IdentityAttestation");
+        // SD-JWT VC (draft-ietf-oauth-sd-jwt-vc §3.2.2.1): vct is the SOLE type claim.
         result.Claims.Should().ContainKey("vct").WhoseValue.Should().Be("IdentityAttestation");
+        result.Claims.Should().NotContainKey("type", "SD-JWT VC has no type claim");
+    }
+
+    [Fact]
+    public async Task IssueAsync_WithVct_WritesVctClaim_AndNoTypeClaim()
+    {
+        // Arrange
+        var config = CreateConfig("AssuredIdentityCredential");
+        config.Vct = "https://sorcha.dev/vc/assured-identity/v1";
+        SetupSdJwtService();
+
+        // Act
+        var result = await _issuer.IssueAsync(
+            config, new Dictionary<string, object>(), "did:issuer:1", "did:recipient:1",
+            new byte[] { 1, 2, 3 }, "EdDSA");
+
+        // Assert
+        result.Claims["vct"].Should().Be("https://sorcha.dev/vc/assured-identity/v1");
+        result.Claims.Should().NotContainKey("type", "SD-JWT VC has no type claim");
+        result.Type.Should().Be("https://sorcha.dev/vc/assured-identity/v1");
+    }
+
+    [Fact]
+    public async Task IssueAsync_WithoutVct_FallsBackToCredentialType()
+    {
+        // Arrange
+        var config = CreateConfig("LegacyBareName");
+        config.Vct = null;
+        SetupSdJwtService();
+
+        // Act
+        var result = await _issuer.IssueAsync(
+            config, new Dictionary<string, object>(), "did:issuer:1", "did:recipient:1",
+            new byte[] { 1, 2, 3 }, "EdDSA");
+
+        // Assert
+        result.Claims["vct"].Should().Be("LegacyBareName");
+        result.Claims.Should().NotContainKey("type");
+        result.Type.Should().Be("LegacyBareName");
+    }
+
+    [Fact]
+    public async Task IssueAsync_WithDisplayName_CarriesCredentialNameInDisplayConfigJson()
+    {
+        // Arrange
+        var config = CreateConfig("AssuredIdentityCredential");
+        config.DisplayName = "Assured Identity";
+        SetupSdJwtService();
+
+        // Act
+        var result = await _issuer.IssueAsync(
+            config, new Dictionary<string, object>(), "did:issuer:1", "did:recipient:1",
+            new byte[] { 1, 2, 3 }, "EdDSA");
+
+        // Assert
+        result.DisplayConfigJson.Should().NotBeNull();
+        result.DisplayConfigJson.Should().Contain("\"credentialName\":\"Assured Identity\"");
     }
 
     [Fact]

--- a/tests/Sorcha.Blueprint.Models.Tests/Credentials/ActionCredentialSerializationTests.cs
+++ b/tests/Sorcha.Blueprint.Models.Tests/Credentials/ActionCredentialSerializationTests.cs
@@ -160,6 +160,28 @@ public class ActionCredentialSerializationTests
     }
 
     [Fact]
+    public void Deserialize_CredentialIssuanceConfigWithVctAndDisplayName_RoundTrips()
+    {
+        var json = """
+        {
+            "credentialType": "AssuredIdentityCredential",
+            "vct": "https://sorcha.dev/vc/assured-identity/v1",
+            "displayName": "Assured Identity",
+            "recipientParticipantId": "applicant",
+            "claimMappings": [
+                { "claimName": "x", "sourceField": "/x" }
+            ]
+        }
+        """;
+
+        var config = JsonSerializer.Deserialize<CredentialIssuanceConfig>(json, Options);
+
+        config.Should().NotBeNull();
+        config!.Vct.Should().Be("https://sorcha.dev/vc/assured-identity/v1");
+        config.DisplayName.Should().Be("Assured Identity");
+    }
+
+    [Fact]
     public void Serialize_FullRoundTrip_PreservesAllData()
     {
         var original = new Action

--- a/tests/Sorcha.Blueprint.Models.Tests/Credentials/BlueprintVctConformanceTests.cs
+++ b/tests/Sorcha.Blueprint.Models.Tests/Credentials/BlueprintVctConformanceTests.cs
@@ -41,6 +41,7 @@ public class BlueprintVctConformanceTests
         ["ForestProductDPPCredential"] = VctUris.ForestProductDppV1,
         ["CyberEssentialsUacPosture"] = VctUris.CyberEssentialsUacV1,
         ["RefurbishmentCertificateCredential"] = VctUris.RefurbishmentCertificateV1,
+        ["BuildingPermitCredential"] = VctUris.BuildingPermitV1,
     };
 
     private static readonly HashSet<string> CanonicalUris = new(Canonical.Values, StringComparer.Ordinal);
@@ -137,16 +138,20 @@ public class BlueprintVctConformanceTests
 
         var (known, expected) = Resolve(credentialType);
 
-        // Only credential nodes we recognise (known platform type) or that already declare a vct are subject
-        // to the guarantee. A credentialIssuanceConfig for a non-platform type (no vct) is left alone.
-        if (!known && string.IsNullOrEmpty(vct))
+        // A credentialIssuanceConfig with neither a credentialType nor a vct has nothing to check.
+        if (string.IsNullOrEmpty(credentialType) && string.IsNullOrEmpty(vct))
         {
             return;
         }
 
         if (string.IsNullOrEmpty(vct))
         {
-            violations.Add($"{relFile}: {path} — credentialType '{credentialType}' is missing its canonical 'vct' (expected '{expected}')");
+            // credentialType is populated but not recognised, and there is no vct to fall back on — this is
+            // either a brand-new platform type that hasn't been added to VctUris/Canonical yet, or a typo.
+            // Either way it must be surfaced, not silently skipped, so future bare types can't slip through.
+            violations.Add(known
+                ? $"{relFile}: {path} — credentialType '{credentialType}' is missing its canonical 'vct' (expected '{expected}')"
+                : $"{relFile}: {path} — credentialType '{credentialType}' is not a known VctUris type — add it to VctUris + the Canonical map");
             return;
         }
 

--- a/tests/Sorcha.Blueprint.Models.Tests/Credentials/BlueprintVctConformanceTests.cs
+++ b/tests/Sorcha.Blueprint.Models.Tests/Credentials/BlueprintVctConformanceTests.cs
@@ -1,0 +1,223 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Text.Json.Nodes;
+using System.Text.RegularExpressions;
+using FluentAssertions;
+using Sorcha.CitizenWallet.Abstractions.Constants;
+
+namespace Sorcha.Blueprint.Models.Tests.Credentials;
+
+/// <summary>
+/// Completeness guarantee for the credential-VCT-decoupling work: walks every blueprint JSON in the
+/// corpus and asserts that each platform credential type uses its canonical <see cref="VctUris"/> URI.
+///
+/// It locates credential nodes STRUCTURALLY — recursively finding every property named
+/// <c>credentialIssuanceConfig</c> (an object) or <c>credentialRequirements</c> (an array). It never
+/// scans generic JSON-Schema <c>"type"</c> keys (blueprint JSON is full of <c>"type":"object"/"string"</c>),
+/// so schema definitions cannot be mistaken for credential types.
+/// </summary>
+public class BlueprintVctConformanceTests
+{
+    /// <summary>
+    /// Bare credential-type name (as written in blueprint JSON) → canonical <see cref="VctUris"/> URI.
+    /// Values reference the real constants (never hardcoded URIs) — that is the anti-drift point.
+    /// </summary>
+    private static readonly Dictionary<string, string> Canonical = new(StringComparer.Ordinal)
+    {
+        ["AssuredIdentityCredential"] = VctUris.AssuredIdentityV1,
+        ["DrivingLicenceCredential"] = VctUris.DrivingLicenceV1,
+        ["BlueBadgeCredential"] = VctUris.BlueBadgeV1,
+        ["MembershipCredential"] = VctUris.MembershipV1,
+        ["LicenseCredential"] = VctUris.LicenceV1,
+        ["CouncilDigitalIdCredential"] = VctUris.CouncilDigitalIdV1,
+        ["VerifiedInvoiceCredential"] = VctUris.VerifiedInvoiceV1,
+        ["TradeFinanceCredential"] = VctUris.TradeFinanceV1,
+        ["PlanningPermissionCredential"] = VctUris.PlanningPermissionV1,
+        ["BuildingWarrantCredential"] = VctUris.BuildingWarrantV1,
+        ["CompletionCertificateCredential"] = VctUris.CompletionCertificateV1,
+        ["JobAssignmentCredential"] = VctUris.JobAssignmentV1,
+        ["ServiceCompletionCredential"] = VctUris.ServiceCompletionV1,
+        ["ForestProductDPPCredential"] = VctUris.ForestProductDppV1,
+        ["CyberEssentialsUacPosture"] = VctUris.CyberEssentialsUacV1,
+        ["RefurbishmentCertificateCredential"] = VctUris.RefurbishmentCertificateV1,
+    };
+
+    private static readonly HashSet<string> CanonicalUris = new(Canonical.Values, StringComparer.Ordinal);
+
+    private static readonly Regex VersionSuffix = new(@"/v\d+$", RegexOptions.Compiled);
+
+    [Fact]
+    public void EveryBlueprintCredentialType_UsesCanonicalVctUri_NoBareNamesRemain()
+    {
+        var repoRoot = FindRepoRoot(AppContext.BaseDirectory);
+        var searchDirs = new[] { "demos", "walkthroughs", "blueprints" };
+
+        var violations = new List<string>();
+
+        foreach (var relDir in searchDirs)
+        {
+            var dir = Path.Combine(repoRoot, relDir);
+            if (!Directory.Exists(dir))
+            {
+                continue;
+            }
+
+            foreach (var file in Directory.EnumerateFiles(dir, "*.json", SearchOption.AllDirectories))
+            {
+                JsonNode? root;
+                try
+                {
+                    root = JsonNode.Parse(File.ReadAllText(file));
+                }
+                catch
+                {
+                    // A non-blueprint / malformed .json under these dirs is not a violation — skip it.
+                    continue;
+                }
+
+                if (root is not JsonObject)
+                {
+                    continue;
+                }
+
+                var relFile = Path.GetRelativePath(repoRoot, file).Replace('\\', '/');
+                Walk(root, "$", relFile, violations);
+            }
+        }
+
+        violations.Should().BeEmpty(
+            "every platform credential type must use its canonical VctUris URI. Unconverted sites:\n"
+            + string.Join("\n", violations));
+    }
+
+    /// <summary>
+    /// Recursively descends the node tree. Whenever it meets a property named
+    /// <c>credentialIssuanceConfig</c> (object) or <c>credentialRequirements</c> (array) it inspects that
+    /// credential node. All other keys — including JSON-Schema <c>"type"</c> keys — are only recursed into,
+    /// never interpreted as credential types.
+    /// </summary>
+    private static void Walk(JsonNode? node, string path, string relFile, List<string> violations)
+    {
+        switch (node)
+        {
+            case JsonObject obj:
+                foreach (var kv in obj)
+                {
+                    var childPath = $"{path}.{kv.Key}";
+
+                    if (kv.Key == "credentialIssuanceConfig" && kv.Value is JsonObject cfg)
+                    {
+                        InspectIssuance(cfg, childPath, relFile, violations);
+                    }
+                    else if (kv.Key == "credentialRequirements" && kv.Value is JsonArray reqs)
+                    {
+                        InspectRequirements(reqs, childPath, relFile, violations);
+                    }
+
+                    Walk(kv.Value, childPath, relFile, violations);
+                }
+
+                break;
+
+            case JsonArray arr:
+                for (var i = 0; i < arr.Count; i++)
+                {
+                    Walk(arr[i], $"{path}[{i}]", relFile, violations);
+                }
+
+                break;
+        }
+    }
+
+    private static void InspectIssuance(JsonObject cfg, string path, string relFile, List<string> violations)
+    {
+        var credentialType = (cfg["credentialType"] as JsonValue)?.GetValue<string>();
+        var vct = (cfg["vct"] as JsonValue)?.GetValue<string>();
+
+        var (known, expected) = Resolve(credentialType);
+
+        // Only credential nodes we recognise (known platform type) or that already declare a vct are subject
+        // to the guarantee. A credentialIssuanceConfig for a non-platform type (no vct) is left alone.
+        if (!known && string.IsNullOrEmpty(vct))
+        {
+            return;
+        }
+
+        if (string.IsNullOrEmpty(vct))
+        {
+            violations.Add($"{relFile}: {path} — credentialType '{credentialType}' is missing its canonical 'vct' (expected '{expected}')");
+            return;
+        }
+
+        if (known)
+        {
+            if (!string.Equals(vct, expected, StringComparison.Ordinal))
+            {
+                violations.Add($"{relFile}: {path} — vct '{vct}' does not equal canonical '{expected}' for credentialType '{credentialType}'");
+            }
+        }
+        else if (!CanonicalUris.Contains(vct))
+        {
+            violations.Add($"{relFile}: {path} — vct '{vct}' is not a recognised canonical VctUris value");
+        }
+    }
+
+    private static void InspectRequirements(JsonArray reqs, string path, string relFile, List<string> violations)
+    {
+        for (var i = 0; i < reqs.Count; i++)
+        {
+            if (reqs[i] is not JsonObject req)
+            {
+                continue;
+            }
+
+            var type = (req["type"] as JsonValue)?.GetValue<string>();
+            var (known, expected) = Resolve(type);
+
+            if (known && !string.Equals(type, expected, StringComparison.Ordinal))
+            {
+                violations.Add($"{path}[{i}].type — requirement type '{type}' should be canonical '{expected}' (in {relFile})");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Resolves a raw credential-type string to whether it names a known platform type and its canonical URI.
+    /// Handles the bare name, the <c>&lt;BareName&gt;/vN</c> suffix form, and an already-canonical URI.
+    /// </summary>
+    private static (bool Known, string? Expected) Resolve(string? raw)
+    {
+        if (string.IsNullOrEmpty(raw))
+        {
+            return (false, null);
+        }
+
+        // Already a URI: canonical iff it is one of the known VctUris values. Do NOT strip a trailing
+        // /vN from a URI (that would mangle ".../assured-identity/v1").
+        if (raw.StartsWith("http", StringComparison.OrdinalIgnoreCase))
+        {
+            return CanonicalUris.Contains(raw) ? (true, raw) : (false, null);
+        }
+
+        var bare = VersionSuffix.Replace(raw, string.Empty);
+        return Canonical.TryGetValue(bare, out var uri) ? (true, uri) : (false, null);
+    }
+
+    private static string FindRepoRoot(string startDir)
+    {
+        var dir = startDir;
+        while (dir is not null)
+        {
+            if (File.Exists(Path.Combine(dir, "Sorcha.sln")))
+            {
+                return dir;
+            }
+
+            dir = Directory.GetParent(dir)?.FullName;
+        }
+
+        throw new DirectoryNotFoundException(
+            $"Could not locate repo root (dir containing Sorcha.sln) walking up from '{startDir}'.");
+    }
+}

--- a/tests/Sorcha.Blueprint.Models.Tests/Sorcha.Blueprint.Models.Tests.csproj
+++ b/tests/Sorcha.Blueprint.Models.Tests/Sorcha.Blueprint.Models.Tests.csproj
@@ -34,6 +34,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Common\Sorcha.Blueprint.Models\Sorcha.Blueprint.Models.csproj" />
+    <ProjectReference Include="..\..\src\Common\Sorcha.CitizenWallet.Abstractions\Sorcha.CitizenWallet.Abstractions.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Sorcha.Blueprint.Service.Tests/Services/BlueprintToolExecutorTests.cs
+++ b/tests/Sorcha.Blueprint.Service.Tests/Services/BlueprintToolExecutorTests.cs
@@ -634,6 +634,129 @@ public class BlueprintToolExecutorTests
         output!.warnings.Should().Contain(w => w.code == "NO_STARTING_ACTION");
     }
 
+    [Fact]
+    public async Task ExecuteAsync_ValidateBlueprint_ReturnsErrorForNonAbsoluteUriVct()
+    {
+        // Arrange
+        var builder = BlueprintBuilder.Create();
+        await _executor.ExecuteAsync("create_blueprint",
+            CreateArgs(new { title = "Test Blueprint", description = "Test blueprint" }), builder);
+        await _executor.ExecuteAsync("add_participant",
+            CreateArgs(new { id = "issuer", name = "Issuer" }), builder);
+        await _executor.ExecuteAsync("add_participant",
+            CreateArgs(new { id = "holder", name = "Holder" }), builder);
+        await _executor.ExecuteAsync("add_action",
+            CreateArgs(new
+            {
+                id = 1,
+                title = "Issue",
+                description = "Issue a credential",
+                sender = "issuer",
+                isStartingAction = true
+            }), builder);
+
+        var issueResult = await _executor.ExecuteAsync("issue_credential",
+            CreateArgs(new
+            {
+                actionId = 1,
+                credentialType = "AssuredIdentity",
+                recipientParticipantId = "holder",
+                claimMappings = new[]
+                {
+                    new { claimName = "name", sourceField = "/name" }
+                }
+            }), builder);
+        issueResult.Success.Should().BeTrue();
+
+        // Set an invalid (non-absolute-URI) vct via the metadata escape-hatch.
+        var metadataResult = await _executor.ExecuteAsync("set_action_metadata",
+            CreateArgs(new
+            {
+                actionId = 1,
+                credentialIssuanceConfig = new
+                {
+                    credentialType = "AssuredIdentity",
+                    vct = "not a uri",
+                    recipientParticipantId = "holder",
+                    claimMappings = new[]
+                    {
+                        new { claimName = "name", sourceField = "/name" }
+                    }
+                }
+            }), builder);
+        metadataResult.Success.Should().BeTrue();
+
+        // Act
+        var result = await _executor.ExecuteAsync("validate_blueprint", CreateArgs(new { }), builder);
+
+        // Assert
+        var resultJson = result.Result!.RootElement.ToString();
+        var output = JsonSerializer.Deserialize<ValidationOutput>(resultJson);
+        output!.isValid.Should().BeFalse();
+        output.errors.Should().Contain(e => e.code == "INVALID_CREDENTIAL_VCT");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ValidateBlueprint_AllowsAbsoluteUriVct()
+    {
+        // Arrange
+        var builder = BlueprintBuilder.Create();
+        await _executor.ExecuteAsync("create_blueprint",
+            CreateArgs(new { title = "Test Blueprint", description = "Test blueprint" }), builder);
+        await _executor.ExecuteAsync("add_participant",
+            CreateArgs(new { id = "issuer", name = "Issuer" }), builder);
+        await _executor.ExecuteAsync("add_participant",
+            CreateArgs(new { id = "holder", name = "Holder" }), builder);
+        await _executor.ExecuteAsync("add_action",
+            CreateArgs(new
+            {
+                id = 1,
+                title = "Issue",
+                description = "Issue a credential",
+                sender = "issuer",
+                isStartingAction = true
+            }), builder);
+
+        var issueResult = await _executor.ExecuteAsync("issue_credential",
+            CreateArgs(new
+            {
+                actionId = 1,
+                credentialType = "AssuredIdentity",
+                recipientParticipantId = "holder",
+                claimMappings = new[]
+                {
+                    new { claimName = "name", sourceField = "/name" }
+                }
+            }), builder);
+        issueResult.Success.Should().BeTrue();
+
+        // Set a valid absolute-URI vct via the metadata escape-hatch.
+        var metadataResult = await _executor.ExecuteAsync("set_action_metadata",
+            CreateArgs(new
+            {
+                actionId = 1,
+                credentialIssuanceConfig = new
+                {
+                    credentialType = "AssuredIdentity",
+                    vct = "https://sorcha.dev/vc/assured-identity/v1",
+                    recipientParticipantId = "holder",
+                    claimMappings = new[]
+                    {
+                        new { claimName = "name", sourceField = "/name" }
+                    }
+                }
+            }), builder);
+        metadataResult.Success.Should().BeTrue();
+
+        // Act
+        var result = await _executor.ExecuteAsync("validate_blueprint", CreateArgs(new { }), builder);
+
+        // Assert
+        var resultJson = result.Result!.RootElement.ToString();
+        var output = JsonSerializer.Deserialize<ValidationOutput>(resultJson);
+        output!.errors.Should().NotContain(e => e.code == "INVALID_CREDENTIAL_VCT");
+    }
+
     #endregion
 
     #region Unknown Tool Tests

--- a/tests/Sorcha.Blueprint.Service.Tests/Services/PublicKeyResolutionTests.cs
+++ b/tests/Sorcha.Blueprint.Service.Tests/Services/PublicKeyResolutionTests.cs
@@ -582,7 +582,7 @@ public class PublicKeyResolutionTests
             It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Dictionary<string, object>>(),
             It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<List<string>?>(), It.IsAny<string?>(),
             It.IsAny<string?>(), It.IsAny<int?>(), It.IsAny<string?>(), It.IsAny<bool>(),
-            It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<JsonElement?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()),
+            It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<JsonElement?>(), It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()),
             Times.Never, "fail-closed must issue zero credentials (SC-004)");
     }
 
@@ -619,7 +619,7 @@ public class PublicKeyResolutionTests
                 It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Dictionary<string, object>>(),
                 It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<List<string>?>(), It.IsAny<string?>(),
                 It.IsAny<string?>(), It.IsAny<int?>(), It.IsAny<string?>(), It.IsAny<bool>(),
-                It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<JsonElement?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+                It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<JsonElement?>(), It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
             .Callback(new InvocationAction(inv => capturedHolderJwk = (JsonElement?)inv.Arguments[13]))
             .ReturnsAsync(new CredentialIssuanceResult
             {

--- a/tests/Sorcha.CitizenWallet.Abstractions.Tests/ConstantsTests.cs
+++ b/tests/Sorcha.CitizenWallet.Abstractions.Tests/ConstantsTests.cs
@@ -51,6 +51,7 @@ public sealed class ConstantsTests
     [InlineData("ForestProductDppV1", "https://sorcha.dev/vc/forest-product-dpp/v1")]
     [InlineData("CyberEssentialsUacV1", "https://sorcha.dev/vc/cyber-essentials-uac/v1")]
     [InlineData("RefurbishmentCertificateV1", "https://sorcha.dev/vc/refurbishment-certificate/v1")]
+    [InlineData("BuildingPermitV1", "https://sorcha.dev/vc/building-permit/v1")]
     public void VctUris_CanonicalConstants_HaveExpectedLowercaseUri(string field, string expected)
     {
         var value = (string)typeof(VctUris).GetField(field)!.GetValue(null)!;

--- a/tests/Sorcha.CitizenWallet.Abstractions.Tests/ConstantsTests.cs
+++ b/tests/Sorcha.CitizenWallet.Abstractions.Tests/ConstantsTests.cs
@@ -33,4 +33,28 @@ public sealed class ConstantsTests
         VctUris.CitizenDeviceDelegationV1
             .Should().Be("https://sorcha.dev/vc/citizen-device-delegation/v1");
     }
+
+    [Theory]
+    [InlineData("AssuredIdentityV1", "https://sorcha.dev/vc/assured-identity/v1")]
+    [InlineData("DrivingLicenceV1", "https://sorcha.dev/vc/driving-licence/v1")]
+    [InlineData("BlueBadgeV1", "https://sorcha.dev/vc/blue-badge/v1")]
+    [InlineData("MembershipV1", "https://sorcha.dev/vc/membership/v1")]
+    [InlineData("LicenceV1", "https://sorcha.dev/vc/licence/v1")]
+    [InlineData("CouncilDigitalIdV1", "https://sorcha.dev/vc/council-digital-id/v1")]
+    [InlineData("VerifiedInvoiceV1", "https://sorcha.dev/vc/verified-invoice/v1")]
+    [InlineData("TradeFinanceV1", "https://sorcha.dev/vc/trade-finance/v1")]
+    [InlineData("PlanningPermissionV1", "https://sorcha.dev/vc/planning-permission/v1")]
+    [InlineData("BuildingWarrantV1", "https://sorcha.dev/vc/building-warrant/v1")]
+    [InlineData("CompletionCertificateV1", "https://sorcha.dev/vc/completion-certificate/v1")]
+    [InlineData("JobAssignmentV1", "https://sorcha.dev/vc/job-assignment/v1")]
+    [InlineData("ServiceCompletionV1", "https://sorcha.dev/vc/service-completion/v1")]
+    [InlineData("ForestProductDppV1", "https://sorcha.dev/vc/forest-product-dpp/v1")]
+    [InlineData("CyberEssentialsUacV1", "https://sorcha.dev/vc/cyber-essentials-uac/v1")]
+    [InlineData("RefurbishmentCertificateV1", "https://sorcha.dev/vc/refurbishment-certificate/v1")]
+    public void VctUris_CanonicalConstants_HaveExpectedLowercaseUri(string field, string expected)
+    {
+        var value = (string)typeof(VctUris).GetField(field)!.GetValue(null)!;
+        value.Should().Be(expected);
+        value.Should().Be(value.ToLowerInvariant(), "VCT URIs are lowercase kebab-case");
+    }
 }

--- a/tests/Sorcha.ServiceClients.Tests/Wallet/WalletServiceClientIssueCredentialTests.cs
+++ b/tests/Sorcha.ServiceClients.Tests/Wallet/WalletServiceClientIssueCredentialTests.cs
@@ -133,6 +133,110 @@ public class WalletServiceClientIssueCredentialTests
         doc.RootElement.TryGetProperty("tenantId", out _).Should().BeFalse();
     }
 
+    [Fact]
+    public async Task IssueCredentialAsync_WithVctAndDisplayName_IncludesBothInRequestBody_AndMapsDisplayConfigOut()
+    {
+        // Credential VCT decoupling: the client must carry the canonical vct URI and the authored
+        // display name on the wire, and surface the response's displayConfigJson back on the result.
+        string? capturedBody = null;
+        var handler = new Mock<HttpMessageHandler>();
+        handler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Returns<HttpRequestMessage, CancellationToken>(async (req, ct) =>
+            {
+                capturedBody = req.Content is null ? null : await req.Content.ReadAsStringAsync(ct);
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(
+                        JsonSerializer.Serialize(new
+                        {
+                            credentialId = "urn:uuid:test",
+                            type = "https://credentials.sorcha.dev/assured-identity",
+                            issuerDid = "did:sorcha:w:issuer",
+                            subjectDid = "did:sorcha:w:recipient",
+                            claims = new Dictionary<string, object> { ["foo"] = "bar" },
+                            issuedAt = DateTimeOffset.UtcNow,
+                            rawToken = "eyJ.test.token",
+                            displayConfigJson = "{\"credentialName\":\"Assured Identity\"}",
+                        }, JsonOptions),
+                        System.Text.Encoding.UTF8,
+                        "application/json"),
+                };
+            });
+
+        var client = BuildClient(handler);
+
+        var result = await client.IssueCredentialAsync(
+            issuerWalletAddress: "ws1qissuer",
+            credentialType: "AssuredIdentityCredential",
+            claims: new Dictionary<string, object> { ["foo"] = "bar" },
+            recipientWallet: "ws1qrecipient",
+            vct: "https://credentials.sorcha.dev/assured-identity",
+            displayName: "Assured Identity");
+
+        capturedBody.Should().NotBeNullOrEmpty();
+        using var doc = JsonDocument.Parse(capturedBody!);
+        doc.RootElement.TryGetProperty("vct", out var vctEl).Should().BeTrue(
+            "the citizen entity's Type is stamped from the vct URI the client sends");
+        vctEl.GetString().Should().Be("https://credentials.sorcha.dev/assured-identity");
+        doc.RootElement.TryGetProperty("displayName", out var displayEl).Should().BeTrue(
+            "the issuer records the authored credential name from the client-supplied displayName");
+        displayEl.GetString().Should().Be("Assured Identity");
+
+        result.DisplayConfigJson.Should().Be("{\"credentialName\":\"Assured Identity\"}",
+            "the client must surface the response displayConfigJson so the envelope can carry it to the citizen");
+    }
+
+    [Fact]
+    public async Task IssueCredentialAsync_WithoutVctOrDisplayName_OmitsBothFromRequestBody()
+    {
+        // Backward-compat: legacy callers that supply neither must not put null placeholders on the
+        // wire (WalletServiceClient uses WhenWritingNull) so the server falls back to CredentialType.
+        string? capturedBody = null;
+        var handler = new Mock<HttpMessageHandler>();
+        handler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Returns<HttpRequestMessage, CancellationToken>(async (req, ct) =>
+            {
+                capturedBody = req.Content is null ? null : await req.Content.ReadAsStringAsync(ct);
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(
+                        JsonSerializer.Serialize(new
+                        {
+                            credentialId = "urn:uuid:test",
+                            type = "TestCredential",
+                            issuerDid = "did:sorcha:w:issuer",
+                            subjectDid = "did:sorcha:w:recipient",
+                            claims = new Dictionary<string, object> { ["foo"] = "bar" },
+                            issuedAt = DateTimeOffset.UtcNow,
+                            rawToken = "eyJ.test.token",
+                        }, JsonOptions),
+                        System.Text.Encoding.UTF8,
+                        "application/json"),
+                };
+            });
+
+        var client = BuildClient(handler);
+
+        await client.IssueCredentialAsync(
+            issuerWalletAddress: "ws1qissuer",
+            credentialType: "TestCredential",
+            claims: new Dictionary<string, object> { ["foo"] = "bar" },
+            recipientWallet: "ws1qrecipient");
+
+        capturedBody.Should().NotBeNullOrEmpty();
+        using var doc = JsonDocument.Parse(capturedBody!);
+        doc.RootElement.TryGetProperty("vct", out _).Should().BeFalse();
+        doc.RootElement.TryGetProperty("displayName", out _).Should().BeFalse();
+    }
+
     private static WalletServiceClient BuildClient(Mock<HttpMessageHandler> handler)
     {
         var http = new HttpClient(handler.Object);

--- a/tests/Sorcha.Wallet.Pwa.Tests/Services/Presentation/AssuredIdentityPresetRegressionTests.cs
+++ b/tests/Sorcha.Wallet.Pwa.Tests/Services/Presentation/AssuredIdentityPresetRegressionTests.cs
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Sorcha.CitizenWallet.Abstractions.Constants;
+using Sorcha.UI.Components.User.Services.Verification;
+using Sorcha.UI.Core.Models.Presentation;
+using Sorcha.Verifier.Engine.Dcql;
+using Sorcha.Wallet.Pwa.Services.Presentation;
+using Xunit;
+
+namespace Sorcha.Wallet.Pwa.Tests.Services.Presentation;
+
+/// <summary>
+/// Credential-VCT-decoupling (Task 9) — end-to-end regression for the reported bug where the PWA
+/// verifier reported "None of your credentials match" for an Assured Identity credential. Proves
+/// that an Assured-Identity credential (<see cref="VctUris.AssuredIdentityV1"/> as its <c>vct</c>)
+/// satisfies the verifier's built-in Assured-Identity presets (<see cref="DefaultPresetCatalogue"/>),
+/// exercising the exact constant → preset → DCQL query → <see cref="PresentationEngine.MatchQuery"/>
+/// path Tasks 1-8 wired up. A first-run pass here is the proof the bug is fixed — a failure would
+/// mean that wiring still has a gap.
+/// </summary>
+public class AssuredIdentityPresetRegressionTests
+{
+    private static readonly PresentationEngine Engine = new(TimeProvider.System, NullLogger<PresentationEngine>.Instance);
+
+    // No configured presets ⇒ the catalogue falls back to its builtin set (same as production
+    // when "VerifierPresets" is unconfigured).
+    private static readonly DefaultPresetCatalogue Catalogue = new(Options.Create(new VerifierPresetsOptions()));
+
+    [Fact]
+    public void MatchQuery_AssuredIdentityCredential_SatisfiesAssuredIdentityPreset()
+    {
+        var preset = Catalogue.GetByKey("confirm-identity");
+        preset.Should().NotBeNull();
+        preset!.RequiredVct.Should().Be(VctUris.AssuredIdentityV1);
+
+        var cred = Cred(VctUris.AssuredIdentityV1, "fullName", "portrait");
+        var request = RequestFromPreset(preset);
+
+        var result = Engine.MatchQuery(request, [cred]);
+
+        result.Satisfiable.Should().BeTrue();
+        result.UnsatisfiedRequiredQueryIds.Should().BeEmpty();
+        var queryMatch = result.PerQuery.Should().ContainSingle().Subject;
+        queryMatch.IsSatisfiable.Should().BeTrue();
+        queryMatch.Candidates.Should().ContainSingle().Which.Credential.Should().BeSameAs(cred);
+    }
+
+    [Fact]
+    public void MatchQuery_AssuredIdentityCredential_SatisfiesAgeOver18Preset()
+    {
+        var preset = Catalogue.GetByKey("age-over-18");
+        preset.Should().NotBeNull();
+        preset!.RequiredVct.Should().Be(VctUris.AssuredIdentityV1);
+
+        var cred = Cred(VctUris.AssuredIdentityV1, "age_over_18", "portrait");
+        var request = RequestFromPreset(preset);
+
+        var result = Engine.MatchQuery(request, [cred]);
+
+        result.Satisfiable.Should().BeTrue();
+        result.PerQuery.Should().ContainSingle().Which.Candidates.Should().ContainSingle()
+            .Which.Credential.Should().BeSameAs(cred);
+    }
+
+    // ── builders (mirrors DcqlMatchTests) ──────────────────────────────────────
+
+    private static CachedCredential Cred(string vct, params string[] claims) => new()
+    {
+        Id = Guid.NewGuid(),
+        Vct = vct,
+        RawSdJwt = "header.body.sig~",
+        AvailableClaimNames = claims,
+    };
+
+    /// <summary>
+    /// Builds the DCQL query the verifier would send for a preset via the ONE shared production
+    /// builder (<c>DcqlRequestBuilder</c>) — the exact path <c>VerifierEndpoints</c> uses
+    /// (<c>DcqlRequestBuilder.Build([DcqlCredentialAsk.SdJwt(id, vct, required, optional)])</c>).
+    /// Required vs. optional claims must go through the builder rather than a flat <c>Claims</c>
+    /// list: without <c>claim_sets</c>, <see cref="DcqlRequestParser.SplitClaims"/> treats every
+    /// listed claim as required, which would silently mis-model the preset's optional claims.
+    /// </summary>
+    private static ParsedPresentationRequest RequestFromPreset(Sorcha.UI.Components.User.Models.Verification.VerificationPreset preset)
+    {
+        var query = DcqlRequestBuilder.Build(
+            [DcqlCredentialAsk.SdJwt(preset.Key, preset.RequiredVct, preset.RequiredClaims, preset.OptionalClaims)]);
+
+        return new ParsedPresentationRequest
+        {
+            ClientId = "did:sorcha:org:verifier",
+            ResponseUri = "https://verifier.test/cb",
+            Nonce = "nonce-1",
+            Query = query,
+            RequiredVct = preset.RequiredVct,
+            RequiredClaims = preset.RequiredClaims,
+            OptionalClaims = preset.OptionalClaims,
+        };
+    }
+}

--- a/tests/Sorcha.Wallet.Pwa.Tests/Services/SyncServiceTests.cs
+++ b/tests/Sorcha.Wallet.Pwa.Tests/Services/SyncServiceTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Net.Http;
+using System.Text.Json.Nodes;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
@@ -239,4 +240,42 @@ public sealed class SyncServiceTests
         IssuerDid = "did:sorcha:org:test",
         IssuedAt = DateTimeOffset.UtcNow,
     };
+
+    // ---- Credential VCT decoupling (Task 4) — display label mapping ------
+
+    [Fact]
+    public void ToCachedCredential_PopulatesDisplayLabel_FromDisplayMetaCredentialName()
+    {
+        var payload = NewPayload() with
+        {
+            DisplayMeta = new JsonObject { ["credentialName"] = "Assured Identity" },
+        };
+
+        var cached = SyncService.ToCachedCredential(payload);
+
+        cached.DisplayLabel.Should().Be("Assured Identity");
+    }
+
+    [Fact]
+    public void ToCachedCredential_NoDisplayMeta_LeavesDisplayLabelNull()
+    {
+        var payload = NewPayload() with { DisplayMeta = null };
+
+        var cached = SyncService.ToCachedCredential(payload);
+
+        cached.DisplayLabel.Should().BeNull();
+    }
+
+    [Fact]
+    public void ToCachedCredential_DisplayMetaWithoutCredentialName_LeavesDisplayLabelNull()
+    {
+        var payload = NewPayload() with
+        {
+            DisplayMeta = new JsonObject { ["issuerName"] = "Riverside Council" },
+        };
+
+        var cached = SyncService.ToCachedCredential(payload);
+
+        cached.DisplayLabel.Should().BeNull();
+    }
 }

--- a/tests/Sorcha.Wallet.Service.Tests/CitizenWallet/EfCoreCitizenCredentialEventStreamTests.cs
+++ b/tests/Sorcha.Wallet.Service.Tests/CitizenWallet/EfCoreCitizenCredentialEventStreamTests.cs
@@ -131,6 +131,45 @@ public class EfCoreCitizenCredentialEventStreamTests
     }
 
     [Fact]
+    public async Task ReadAsync_AddedKind_WithDisplayConfigJson_PopulatesDisplayMetaCredentialName()
+    {
+        // Credential VCT decoupling (Task 4): the authored displayName (Task 3.5) must
+        // survive onto the sync-out payload so the PWA card shows it instead of a
+        // humanized vct.
+        var (stream, db) = CreateSut();
+        var pid = Guid.NewGuid();
+        var credential = NewCredential("urn:credential:1", "ws1qcitizen");
+        credential.DisplayConfigJson = """{"credentialName":"Assured Identity"}""";
+        await SeedAsync(db, pid, (1L, 0, credential.Id, credential));
+
+        var events = await stream.ReadAsync(pid, afterSeq: 0L);
+
+        var evt = events.Should().ContainSingle().Subject;
+        var payload = evt.Payload.Should().BeOfType<CachedCredentialPayload>().Subject;
+        payload.DisplayMeta.Should().NotBeNull();
+        payload.DisplayMeta!["credentialName"]!.GetValue<string>().Should().Be("Assured Identity");
+    }
+
+    [Fact]
+    public async Task ReadAsync_AddedKind_WithoutDisplayConfigJson_LeavesDisplayMetaNull()
+    {
+        // Legacy credentials (issued before Task 3.5, or with no authored display name)
+        // must keep the PWA's Humanize(vct) fallback rather than surfacing a synthetic
+        // DisplayMeta.
+        var (stream, db) = CreateSut();
+        var pid = Guid.NewGuid();
+        var credential = NewCredential("urn:credential:1", "ws1qcitizen");
+        credential.DisplayConfigJson = null;
+        await SeedAsync(db, pid, (1L, 0, credential.Id, credential));
+
+        var events = await stream.ReadAsync(pid, afterSeq: 0L);
+
+        var evt = events.Should().ContainSingle().Subject;
+        var payload = evt.Payload.Should().BeOfType<CachedCredentialPayload>().Subject;
+        payload.DisplayMeta.Should().BeNull();
+    }
+
+    [Fact]
     public async Task ReadAsync_RevokedKind_ProducesRevokedCredentialEntry()
     {
         var (stream, db) = CreateSut();

--- a/tests/Sorcha.Wallet.Service.Tests/Credentials/CredentialMatcherTests.cs
+++ b/tests/Sorcha.Wallet.Service.Tests/Credentials/CredentialMatcherTests.cs
@@ -76,6 +76,45 @@ public class CredentialMatcherTests
     }
 
     [Fact]
+    public void Match_TypeCaseMismatch_DoesNotMatch()
+    {
+        // SD-JWT VC §3.2.2.1 / OpenID4VP DCQL: vct/type matching is exact and case-sensitive.
+        var requirements = new[]
+        {
+            new CredentialRequirement { Type = "https://sorcha.dev/vc/Assured-Identity/v1" } // wrong case
+        };
+
+        var credentials = new List<CredentialEntity>
+        {
+            CreateCredential("cred-1", "https://sorcha.dev/vc/assured-identity/v1", "did:sorcha:issuer:gov")
+        };
+
+        var result = _matcher.Match(requirements, credentials);
+
+        result["https://sorcha.dev/vc/Assured-Identity/v1"].Should().BeNull();
+    }
+
+    [Fact]
+    public void Match_TypeCaseMatch_Matches()
+    {
+        // Positive control — identical casing still matches.
+        var requirements = new[]
+        {
+            new CredentialRequirement { Type = "https://sorcha.dev/vc/assured-identity/v1" }
+        };
+
+        var credentials = new List<CredentialEntity>
+        {
+            CreateCredential("cred-1", "https://sorcha.dev/vc/assured-identity/v1", "did:sorcha:issuer:gov")
+        };
+
+        var result = _matcher.Match(requirements, credentials);
+
+        result["https://sorcha.dev/vc/assured-identity/v1"].Should().NotBeNull();
+        result["https://sorcha.dev/vc/assured-identity/v1"]!.Id.Should().Be("cred-1");
+    }
+
+    [Fact]
     public void Match_IssuerFilter_RejectsUntrustedIssuer()
     {
         var requirements = new[]

--- a/tests/Sorcha.Wallet.Service.Tests/Endpoints/IssueCredentialVctDecouplingTests.cs
+++ b/tests/Sorcha.Wallet.Service.Tests/Endpoints/IssueCredentialVctDecouplingTests.cs
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Reflection;
+
+using FluentAssertions;
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging.Abstractions;
+
+using Moq;
+
+using Sorcha.Cryptography.SdJwt;
+using Sorcha.Wallet.Core.Domain.Entities;
+using Sorcha.Wallet.Core.Domain.Enums;
+using Sorcha.Wallet.Core.Repositories.Interfaces;
+using Sorcha.Wallet.Service.Credentials;
+using Sorcha.Wallet.Service.Endpoints;
+using Sorcha.Wallet.Service.Services.Implementation;
+using Sorcha.Wallet.Service.Services.Interfaces;
+
+using Xunit;
+
+using WalletEntity = Sorcha.Wallet.Core.Domain.Entities.Wallet;
+
+namespace Sorcha.Wallet.Service.Tests.Endpoints;
+
+/// <summary>
+/// Credential VCT decoupling — the live issuance endpoint must stamp the stored
+/// <see cref="CredentialEntity.Type"/> with the canonical <c>vct</c> URI (not the bare
+/// <c>CredentialType</c>) and record the authored display name as <c>credentialName</c>
+/// in <see cref="CredentialEntity.DisplayConfigJson"/>. Because the SorchaLocalWallet
+/// register envelope copies the issuer response <c>Type</c> into <c>credentialType</c>,
+/// this is what propagates the URI all the way to the citizen entity.
+///
+/// Reflection-based static-handler invocation per the established pattern in
+/// <see cref="IssueCredentialStatusListUrlGuardTests"/>. This test drives the full store
+/// path by wiring a valid issuance key + a stub SD-JWT signer, so the guard's 409
+/// fail-closed (no issuance key) is not reached.
+/// </summary>
+public sealed class IssueCredentialVctDecouplingTests
+{
+    private const string WalletAddress = "ws1qissuer1";
+    private const string VctUri = "https://credentials.sorcha.dev/assured-identity";
+
+    private readonly Mock<IWalletRepository> _walletRepository = new();
+    private readonly Mock<ISdJwtService> _sdJwt = new();
+    private readonly Mock<ICredentialStore> _store = new();
+    private readonly Mock<IIssuanceKeyService> _issuanceKey = new();
+    private readonly Mock<IWalletInboxWriter> _inboxWriter = new();
+    private readonly List<CredentialEntity> _stored = new();
+
+    public IssueCredentialVctDecouplingTests()
+    {
+        _walletRepository.Setup(r => r.GetByAddressAsync(
+                WalletAddress, false, false, false, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new WalletEntity
+            {
+                Address = WalletAddress,
+                EncryptedPrivateKey = "test-key",
+                EncryptionKeyId = "test-kid",
+                Algorithm = "ED25519",
+                Owner = "test-owner",
+                Tenant = "test-tenant",
+                Name = "test-wallet",
+                Status = WalletStatus.Active
+            });
+
+        _issuanceKey.Setup(s => s.GetOrDeriveAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IssuanceKeyState?)null);
+        _issuanceKey.Setup(s => s.GetActiveSigningMaterialAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Guid orgId, CancellationToken _) => new IssuanceSigningMaterial(
+                OrganizationId: orgId,
+                IssuerDid: "did:sorcha:org:ws1qissuer1",
+                Kid: "did:sorcha:org:ws1qissuer1#vc-issuance-1",
+                PrivateKey: new byte[32],
+                Algorithm: "ED25519",
+                RotationIndex: 1));
+
+        _sdJwt.Setup(s => s.CreateTokenAsync(
+                It.IsAny<Dictionary<string, object>>(),
+                It.IsAny<IEnumerable<string>?>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<byte[]>(),
+                It.IsAny<string>(),
+                It.IsAny<DateTimeOffset?>(),
+                It.IsAny<CancellationToken>(),
+                It.IsAny<IReadOnlyList<byte[]>?>(),
+                It.IsAny<string?>()))
+            .ReturnsAsync(new SdJwtToken { RawToken = "eyJhbGciOiJFZERTQSJ9.test.sig~" });
+
+        _store.Setup(s => s.StoreAsync(It.IsAny<CredentialEntity>(), It.IsAny<CancellationToken>()))
+            .Callback<CredentialEntity, CancellationToken>((e, _) => _stored.Add(e))
+            .Returns(Task.CompletedTask);
+
+        _inboxWriter.Setup(w => w.WriteCredentialReceivedAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+    }
+
+    [Fact]
+    public async Task IssueCredential_WithVct_StoresIssuerEntityTypeAsVctUri()
+    {
+        var request = new IssueCredentialRequest
+        {
+            CredentialType = "AssuredIdentityCredential",
+            Vct = VctUri,
+            Claims = new Dictionary<string, object> { ["foo"] = "bar" },
+            RecipientWallet = "ws1qrecipient1",
+            SkipRecipientStore = true,
+            TenantId = Guid.NewGuid().ToString()
+        };
+
+        var result = await InvokeAsync(WalletAddress, request);
+
+        result.GetType().Name.Should().Contain("Ok");
+        var issuer = _stored.Should().ContainSingle().Subject;
+        issuer.Type.Should().Be(VctUri,
+            "the citizen entity's Type is stamped from the vct URI via the response → envelope → detector chain");
+    }
+
+    [Fact]
+    public async Task IssueCredential_WithDisplayName_StoresDisplayConfigJsonWithCredentialName()
+    {
+        var request = new IssueCredentialRequest
+        {
+            CredentialType = "AssuredIdentityCredential",
+            Vct = VctUri,
+            DisplayName = "Assured Identity",
+            Claims = new Dictionary<string, object> { ["foo"] = "bar" },
+            RecipientWallet = "ws1qrecipient1",
+            SkipRecipientStore = true,
+            TenantId = Guid.NewGuid().ToString()
+        };
+
+        await InvokeAsync(WalletAddress, request);
+
+        var issuer = _stored.Should().ContainSingle().Subject;
+        issuer.DisplayConfigJson.Should().NotBeNull();
+        issuer.DisplayConfigJson.Should().Contain("credentialName");
+        issuer.DisplayConfigJson.Should().Contain("Assured Identity");
+    }
+
+    [Fact]
+    public async Task IssueCredential_WithoutVct_FallsBackToCredentialTypeAndNullDisplayConfig()
+    {
+        var request = new IssueCredentialRequest
+        {
+            CredentialType = "AssuredIdentityCredential",
+            Claims = new Dictionary<string, object> { ["foo"] = "bar" },
+            RecipientWallet = "ws1qrecipient1",
+            SkipRecipientStore = true,
+            TenantId = Guid.NewGuid().ToString()
+        };
+
+        await InvokeAsync(WalletAddress, request);
+
+        var issuer = _stored.Should().ContainSingle().Subject;
+        issuer.Type.Should().Be("AssuredIdentityCredential",
+            "no vct supplied → the bare CredentialType remains the defensive fallback");
+        issuer.DisplayConfigJson.Should().BeNull("no display name supplied → no display config");
+    }
+
+    private async Task<IResult> InvokeAsync(string walletAddress, IssueCredentialRequest request)
+    {
+        var method = typeof(CredentialEndpoints).GetMethod(
+            "IssueCredential",
+            BindingFlags.NonPublic | BindingFlags.Static)!;
+        method.Should().NotBeNull("IssueCredential handler should exist");
+
+        var result = method.Invoke(null, [
+            walletAddress,
+            request,
+            _walletRepository.Object,
+            null!, // IKeyManagementService — not used on the issuance-key signing path (Feature 149)
+            _sdJwt.Object,
+            _store.Object,
+            new NullLoggerFactory(),
+            _inboxWriter.Object,
+            _issuanceKey.Object,
+            null,  // IOrgCertChainProvider (optional)
+            CancellationToken.None
+        ]);
+        return await (Task<IResult>)result!;
+    }
+}

--- a/tests/Sorcha.Wallet.Service.Tests/Services/InboundCredentialDetectorShapeTests.cs
+++ b/tests/Sorcha.Wallet.Service.Tests/Services/InboundCredentialDetectorShapeTests.cs
@@ -273,6 +273,53 @@ public class InboundCredentialDetectorShapeTests
     }
 
     [Fact]
+    public void DisplayConfig_Present_IsParsedIntoExtract()
+    {
+        // Credential VCT decoupling: the SorchaLocalWallet envelope now carries the issuer-authored
+        // display config (serialised CredentialDisplayConfig) under "displayConfig". The detector must
+        // read it into the extract so the citizen entity's DisplayConfigJson is populated — and the
+        // vct URI arrives in credentialType, becoming the citizen entity's Type.
+        const string WithDisplayConfigJson = /*lang=json,strict*/ """
+        {
+          "/credential": {
+            "credentialId": "urn:uuid:vct-decoupling-test-1",
+            "credentialType": "https://credentials.sorcha.dev/assured-identity",
+            "issuerDid": "did:sorcha:org:ws11qgovernment",
+            "displayConfig": "{\"credentialName\":\"Assured Identity\"}",
+            "issuedAt": "2026-04-15T10:30:00+00:00",
+            "rawToken": "eyJhbGciOiJFZERTQSJ9.test.token"
+          }
+        }
+        """;
+
+        var doc = JsonSerializer.Deserialize<JsonElement>(WithDisplayConfigJson);
+        var field = InboundCredentialDetector.FindCredentialField(doc);
+        field.Should().NotBeNull();
+
+        var extract = InboundCredentialDetector.TryParseExtract(field!.Value, "tx-vct-decoupling");
+
+        extract.Should().NotBeNull();
+        extract!.CredentialType.Should().Be("https://credentials.sorcha.dev/assured-identity",
+            "the vct URI rides in credentialType and becomes the citizen entity's Type");
+        extract.DisplayConfigJson.Should().Be("{\"credentialName\":\"Assured Identity\"}");
+        extract.DisplayConfigJson.Should().Contain("credentialName");
+    }
+
+    [Fact]
+    public void DisplayConfig_Absent_ExtractHasNullDisplayConfig()
+    {
+        // Legacy / no-display-name issuance omits displayConfig — the parser must leave it null,
+        // never throw or fabricate a value.
+        var doc = JsonSerializer.Deserialize<JsonElement>(WriterShapeJson);
+        var field = InboundCredentialDetector.FindCredentialField(doc);
+
+        var extract = InboundCredentialDetector.TryParseExtract(field!.Value, "tx-no-display");
+
+        extract.Should().NotBeNull();
+        extract!.DisplayConfigJson.Should().BeNull();
+    }
+
+    [Fact]
     public void OptionalFields_Absent_StillParses()
     {
         // ExpiresAt, BlueprintId, and InstanceId are all optional in

--- a/walkthroughs/AssuredIdentity/blueprints/assured-identity.json
+++ b/walkthroughs/AssuredIdentity/blueprints/assured-identity.json
@@ -185,6 +185,8 @@
         ],
         "credentialIssuanceConfig": {
           "credentialType": "AssuredIdentityCredential",
+          "vct": "https://sorcha.dev/vc/assured-identity/v1",
+          "displayName": "Assured Identity",
           "targetAudience": "SorchaLocalWallet",
           "recipientParticipantId": "citizen",
           "holderKeySourceField": "/holderKeys/holderJwk",

--- a/walkthroughs/AssuredIdentity/blueprints/driving-licence.json
+++ b/walkthroughs/AssuredIdentity/blueprints/driving-licence.json
@@ -102,7 +102,7 @@
         "requiredPriorActions": [1],
         "credentialRequirements": [
           {
-            "type": "AssuredIdentityCredential",
+            "type": "https://sorcha.dev/vc/assured-identity/v1",
             "presentationSource": "HaipExternalWallet",
             "requiredClaims": [
               { "claimName": "givenName" },
@@ -145,6 +145,8 @@
         "requiredPriorActions": [2],
         "credentialIssuanceConfig": {
           "credentialType": "DrivingLicenceCredential",
+          "vct": "https://sorcha.dev/vc/driving-licence/v1",
+          "displayName": "Driving Licence",
           "targetAudience": "HaipExternalWallet",
           "recipientParticipantId": "citizen",
           "claimMappings": [

--- a/walkthroughs/ConstructionPermit/construction-permit-template.json
+++ b/walkthroughs/ConstructionPermit/construction-permit-template.json
@@ -660,6 +660,8 @@
         },
         "credentialIssuanceConfig": {
           "credentialType": "BuildingPermitCredential",
+          "vct": "https://sorcha.dev/vc/building-permit/v1",
+          "displayName": "Building Permit",
           "recipientParticipantId": "contractor",
           "expiryDuration": "P1095D",
           "claimMappings": [

--- a/walkthroughs/CyberEssentialsUac/ce-uac-assessment-template.json
+++ b/walkthroughs/CyberEssentialsUac/ce-uac-assessment-template.json
@@ -308,6 +308,8 @@
         ],
         "credentialIssuanceConfig": {
           "credentialType": "CyberEssentialsUacPosture",
+          "vct": "https://sorcha.dev/vc/cyber-essentials-uac/v1",
+          "displayName": "Cyber Essentials UAC",
           "recipientParticipantId": "subject-org",
           "expiryDuration": "P1Y",
           "targetAudience": "SorchaLocalWallet",

--- a/walkthroughs/CyberEssentialsUac/cyber-insurance-application-template.json
+++ b/walkthroughs/CyberEssentialsUac/cyber-insurance-application-template.json
@@ -70,7 +70,7 @@
         ],
         "credentialRequirements": [
           {
-            "type": "CyberEssentialsUacPosture",
+            "type": "https://sorcha.dev/vc/cyber-essentials-uac/v1",
             "presentationSource": "SorchaInternal",
             "trustPolicy": {
               "sources": [

--- a/walkthroughs/CyberEssentialsUac/run-agents.ps1
+++ b/walkthroughs/CyberEssentialsUac/run-agents.ps1
@@ -199,7 +199,7 @@ while ((Get-Date) -lt $credDeadline) {
         $walletCreds = Invoke-SorchaApi -Method GET -Uri $walletCredUrl -Headers $subjectSession.Headers
         $items = if ($walletCreds.credentials) { $walletCreds.credentials } else { $walletCreds }
         if ($items) {
-            $postureCred = @($items) | Where-Object { $_.type -eq "CyberEssentialsUacPosture" } | Select-Object -First 1
+            $postureCred = @($items) | Where-Object { $_.type -eq "https://sorcha.dev/vc/cyber-essentials-uac/v1" } | Select-Object -First 1
             if ($postureCred) { break }
         }
     } catch { }
@@ -235,7 +235,7 @@ Write-WtInfo "S1-4: Fetching CyberEssentialsUacPosture presentation from subject
 $pres = Get-SorchaCredentialPresentation `
     -WalletUrl       $sorchaEnv.WalletUrl `
     -WalletAddress   $state.roles.'subject-org'.walletAddress `
-    -CredentialType  "CyberEssentialsUacPosture" `
+    -CredentialType  "https://sorcha.dev/vc/cyber-essentials-uac/v1" `
     -Token           $subjectSession.Token
 
 Assert ($pres -ne $null) "subject-org holds a presentable CyberEssentialsUacPosture credential"
@@ -357,7 +357,7 @@ function Get-PostureCount {
     try {
         $r = Invoke-SorchaApi -Method GET -Uri $url -Headers $headers
         $items = if ($r.credentials) { $r.credentials } else { $r }
-        return (@($items) | Where-Object { $_.type -eq "CyberEssentialsUacPosture" }).Count
+        return (@($items) | Where-Object { $_.type -eq "https://sorcha.dev/vc/cyber-essentials-uac/v1" }).Count
     } catch { return 0 }
 }
 $postureWalletUrl = "$($sorchaEnv.WalletUrl)/v1/wallets/$($state.roles.'subject-org'.walletAddress)/credentials/?status=All"

--- a/walkthroughs/CyberEssentialsUac/run-revocation.ps1
+++ b/walkthroughs/CyberEssentialsUac/run-revocation.ps1
@@ -130,7 +130,7 @@ $walletCreds = Invoke-SorchaApi `
 
 $cred = $null
 if ($walletCreds) {
-    $cred = @($walletCreds) | Where-Object { $_.type -eq "CyberEssentialsUacPosture" } | Select-Object -First 1
+    $cred = @($walletCreds) | Where-Object { $_.type -eq "https://sorcha.dev/vc/cyber-essentials-uac/v1" } | Select-Object -First 1
 }
 
 if (-not $cred) {
@@ -201,7 +201,7 @@ Write-WtStep "S3-4: Building presentation from revoked credential"
 $presR = Get-SorchaCredentialPresentation `
     -WalletUrl      $sorchaEnv.WalletUrl `
     -WalletAddress  $state.roles.'subject-org'.walletAddress `
-    -CredentialType "CyberEssentialsUacPosture" `
+    -CredentialType "https://sorcha.dev/vc/cyber-essentials-uac/v1" `
     -Token          $subjectSession.Token
 
 Assert ($presR -ne $null) "presentation object constructed from revoked credential"

--- a/walkthroughs/ForestryCertification/forestry-certification-template.json
+++ b/walkthroughs/ForestryCertification/forestry-certification-template.json
@@ -252,6 +252,8 @@
         ],
         "credentialIssuanceConfig": {
           "credentialType": "ForestProductDPPCredential",
+          "vct": "https://sorcha.dev/vc/forest-product-dpp/v1",
+          "displayName": "Forest Product DPP",
           "recipientParticipantId": "sales-mgr",
           "expiryDuration": "P365D",
           "claimMappings": [

--- a/walkthroughs/PropertyInspection/property-inspection-template.json
+++ b/walkthroughs/PropertyInspection/property-inspection-template.json
@@ -182,6 +182,8 @@
         ],
         "credentialIssuanceConfig": {
           "credentialType": "JobAssignmentCredential",
+          "vct": "https://sorcha.dev/vc/job-assignment/v1",
+          "displayName": "Job Assignment",
           "recipientParticipantId": "contractor",
           "expiryDuration": "P30D",
           "claimMappings": [
@@ -460,6 +462,8 @@
         ],
         "credentialIssuanceConfig": {
           "credentialType": "ServiceCompletionCredential",
+          "vct": "https://sorcha.dev/vc/service-completion/v1",
+          "displayName": "Service Completion",
           "recipientParticipantId": "tenant",
           "expiryDuration": "P3650D",
           "claimMappings": [

--- a/walkthroughs/SelfBuildHouse/building-warrant-template.json
+++ b/walkthroughs/SelfBuildHouse/building-warrant-template.json
@@ -55,7 +55,7 @@
         "isStartingAction": true,
         "credentialRequirements": [
           {
-            "type": "PlanningPermissionCredential",
+            "type": "https://sorcha.dev/vc/planning-permission/v1",
             "requiredClaims": [
               { "claimName": "permitReference" },
               { "claimName": "siteAddress" }
@@ -818,6 +818,8 @@
         ],
         "credentialIssuanceConfig": {
           "credentialType": "BuildingWarrantCredential",
+          "vct": "https://sorcha.dev/vc/building-warrant/v1",
+          "displayName": "Building Warrant",
           "recipientParticipantId": "self-builder",
           "expiryDuration": "P1095D",
           "claimMappings": [
@@ -911,7 +913,7 @@
         "requiredPriorActions": [1, 4],
         "credentialRequirements": [
           {
-            "type": "BuildingWarrantCredential",
+            "type": "https://sorcha.dev/vc/building-warrant/v1",
             "requiredClaims": [
               { "claimName": "warrantReference" }
             ],
@@ -1405,6 +1407,8 @@
         ],
         "credentialIssuanceConfig": {
           "credentialType": "CompletionCertificateCredential",
+          "vct": "https://sorcha.dev/vc/completion-certificate/v1",
+          "displayName": "Completion Certificate",
           "recipientParticipantId": "self-builder",
           "claimMappings": [
             { "claimName": "completionRef", "sourceField": "/completionRef" },

--- a/walkthroughs/SelfBuildHouse/planning-permission-template.json
+++ b/walkthroughs/SelfBuildHouse/planning-permission-template.json
@@ -1402,6 +1402,8 @@
         ],
         "credentialIssuanceConfig": {
           "credentialType": "PlanningPermissionCredential",
+          "vct": "https://sorcha.dev/vc/planning-permission/v1",
+          "displayName": "Planning Permission",
           "recipientParticipantId": "self-builder",
           "expiryDuration": "P1095D",
           "claimMappings": [

--- a/walkthroughs/SelfBuildHouse/run.ps1
+++ b/walkthroughs/SelfBuildHouse/run.ps1
@@ -252,13 +252,13 @@ foreach ($sid in $scenariosToRun) {
             if ($aid -eq 1) {
                 $p = Get-SorchaCredentialPresentation -WalletUrl $walletUrl `
                     -WalletAddress $selfBuilderWallet `
-                    -CredentialType "PlanningPermissionCredential" `
+                    -CredentialType "https://sorcha.dev/vc/planning-permission/v1" `
                     -Token $selfBuilderToken
                 if ($p) { return @($p) }
             } elseif ($aid -ge 5) {
                 $p = Get-SorchaCredentialPresentation -WalletUrl $walletUrl `
                     -WalletAddress $selfBuilderWallet `
-                    -CredentialType "BuildingWarrantCredential" `
+                    -CredentialType "https://sorcha.dev/vc/building-warrant/v1" `
                     -Token $selfBuilderToken
                 if ($p) { return @($p) }
             }

--- a/walkthroughs/Strathcarron/blueprints/strathcarron-blue-badge.json
+++ b/walkthroughs/Strathcarron/blueprints/strathcarron-blue-badge.json
@@ -42,7 +42,7 @@
         "isStartingAction": true,
         "credentialRequirements": [
           {
-            "type": "AssuredIdentityCredential",
+            "type": "https://sorcha.dev/vc/assured-identity/v1",
             "presentationSource": "SorchaWallet",
             "requiredClaims": [
               { "claimName": "givenName" },
@@ -115,6 +115,8 @@
         "requiredPriorActions": [2],
         "credentialIssuanceConfig": {
           "credentialType": "BlueBadgeCredential",
+          "vct": "https://sorcha.dev/vc/blue-badge/v1",
+          "displayName": "Blue Badge",
           "targetAudience": "SorchaLocalWallet",
           "recipientParticipantId": "citizen",
           "claimMappings": [

--- a/walkthroughs/Strathcarron/blueprints/strathcarron-driving-licence.json
+++ b/walkthroughs/Strathcarron/blueprints/strathcarron-driving-licence.json
@@ -72,6 +72,8 @@
         "requiredPriorActions": [1],
         "credentialIssuanceConfig": {
           "credentialType": "AssuredIdentityCredential",
+          "vct": "https://sorcha.dev/vc/assured-identity/v1",
+          "displayName": "Assured Identity",
           "targetAudience": "SorchaLocalWallet",
           "recipientParticipantId": "citizen",
           "claimMappings": [

--- a/walkthroughs/TradeFinance/invoice-finance-template.json
+++ b/walkthroughs/TradeFinance/invoice-finance-template.json
@@ -62,7 +62,7 @@
         "isStartingAction": true,
         "credentialRequirements": [
           {
-            "type": "VerifiedInvoiceCredential",
+            "type": "https://sorcha.dev/vc/verified-invoice/v1",
             "requiredClaims": [
               { "claimName": "invoiceNumber" },
               { "claimName": "invoiceAmount" },
@@ -73,7 +73,7 @@
             "description": "A verified invoice credential from the procurement register is required to request financing"
           },
           {
-            "type": "ForestProductDPPCredential",
+            "type": "https://sorcha.dev/vc/forest-product-dpp/v1",
             "requiredClaims": [
               { "claimName": "certificationScheme" },
               { "claimName": "sustainabilityScore" },
@@ -522,6 +522,8 @@
         ],
         "credentialIssuanceConfig": {
           "credentialType": "TradeFinanceCredential",
+          "vct": "https://sorcha.dev/vc/trade-finance/v1",
+          "displayName": "Trade Finance",
           "recipientParticipantId": "sales-mgr",
           "expiryDuration": "P180D",
           "claimMappings": [

--- a/walkthroughs/TradeFinance/procurement-to-pay-template.json
+++ b/walkthroughs/TradeFinance/procurement-to-pay-template.json
@@ -959,6 +959,8 @@
         ],
         "credentialIssuanceConfig": {
           "credentialType": "VerifiedInvoiceCredential",
+          "vct": "https://sorcha.dev/vc/verified-invoice/v1",
+          "displayName": "Verified Invoice",
           "recipientParticipantId": "sales-mgr",
           "expiryDuration": "P90D",
           "claimMappings": [

--- a/walkthroughs/TradeFinance/run.ps1
+++ b/walkthroughs/TradeFinance/run.ps1
@@ -497,7 +497,7 @@ foreach ($sid in $scenariosToRun) {
 
             # Auto-accept any pending credentials we plan to present (invoice + DPP)
             # before fetching the active list, so they appear as Active downstream.
-            $autoAcceptTypes = @("VerifiedInvoiceCredential", "ForestProductDPPCredential")
+            $autoAcceptTypes = @("https://sorcha.dev/vc/verified-invoice/v1", "https://sorcha.dev/vc/forest-product-dpp/v1")
             foreach ($p in ($pending | Where-Object { $autoAcceptTypes -contains $_.type })) {
                 Write-WtInfo "  Accepting pending $($p.type) $($p.id)..."
                 $null = Invoke-SorchaApi -Method PATCH `
@@ -510,7 +510,7 @@ foreach ($sid in $scenariosToRun) {
                 -Uri "$($env.WalletUrl)/v1/wallets/$salesMgrWallet/credentials" `
                 -Headers $credHeaders
 
-            $invoiceCred = $creds | Where-Object { $_.type -eq "VerifiedInvoiceCredential" } | Select-Object -First 1
+            $invoiceCred = $creds | Where-Object { $_.type -eq "https://sorcha.dev/vc/verified-invoice/v1" } | Select-Object -First 1
 
             if ($invoiceCred) {
                 Write-WtInfo "  Found credential: $($invoiceCred.id)"
@@ -526,7 +526,7 @@ foreach ($sid in $scenariosToRun) {
                     @{
                         credentialId    = $invoiceCred.id
                         disclosedClaims = @{
-                            type           = "VerifiedInvoiceCredential"
+                            type           = "https://sorcha.dev/vc/verified-invoice/v1"
                             invoiceNumber  = $scenarioData.procurement."5".invoiceNumber
                             invoiceAmount  = $scenarioData.procurement."5".invoiceTotal
                             poReference    = $scenarioData.procurement."1".poReference
@@ -543,7 +543,7 @@ foreach ($sid in $scenariosToRun) {
             # Optional ForestProductDPPCredential — issued by the ForestryCertification
             # walkthrough to sales-mgr. When present, the financing template's calc
             # applies a +10% advance-rate uplift if sustainabilityScore >= 70.
-            $dppCred = $creds | Where-Object { $_.type -eq "ForestProductDPPCredential" } | Select-Object -First 1
+            $dppCred = $creds | Where-Object { $_.type -eq "https://sorcha.dev/vc/forest-product-dpp/v1" } | Select-Object -First 1
             if ($dppCred) {
                 Write-WtInfo "  Found DPP credential: $($dppCred.id)"
 
@@ -560,7 +560,7 @@ foreach ($sid in $scenariosToRun) {
                 $credPresentations += @{
                     credentialId    = $dppCred.id
                     disclosedClaims = @{
-                        type                  = "ForestProductDPPCredential"
+                        type                  = "https://sorcha.dev/vc/forest-product-dpp/v1"
                         certificationScheme   = "FSC"
                         sustainabilityScore   = 87
                         embodiedCarbonKgCO2e  = 36.4

--- a/walkthroughs/TradeFinance/soak.ps1
+++ b/walkthroughs/TradeFinance/soak.ps1
@@ -370,7 +370,7 @@ while ((Get-Date) -lt $soakEnd) {
         $pending = Invoke-SorchaApi -Method GET `
             -Uri "$($env.WalletUrl)/v1/wallets/$salesMgrWallet/credentials?status=PendingAcceptance" `
             -Headers $credHeaders
-        foreach ($p in ($pending | Where-Object { $_.type -eq "VerifiedInvoiceCredential" })) {
+        foreach ($p in ($pending | Where-Object { $_.type -eq "https://sorcha.dev/vc/verified-invoice/v1" })) {
             $null = Invoke-SorchaApi -Method PATCH `
                 -Uri "$($env.WalletUrl)/v1/wallets/$salesMgrWallet/credentials/$($p.id)" `
                 -Body @{ status = "Active" } `
@@ -380,7 +380,7 @@ while ((Get-Date) -lt $soakEnd) {
         $creds = Invoke-SorchaApi -Method GET `
             -Uri "$($env.WalletUrl)/v1/wallets/$salesMgrWallet/credentials" `
             -Headers $credHeaders
-        $invoiceCred = $creds | Where-Object { $_.type -eq "VerifiedInvoiceCredential" } |
+        $invoiceCred = $creds | Where-Object { $_.type -eq "https://sorcha.dev/vc/verified-invoice/v1" } |
             Sort-Object -Property issuedAt -Descending | Select-Object -First 1
 
         if ($invoiceCred) {
@@ -392,7 +392,7 @@ while ((Get-Date) -lt $soakEnd) {
             $credPresentations = @(@{
                 credentialId    = $invoiceCred.id
                 disclosedClaims = @{
-                    type           = "VerifiedInvoiceCredential"
+                    type           = "https://sorcha.dev/vc/verified-invoice/v1"
                     invoiceNumber  = $scenario.procurement.'5'.invoiceNumber
                     invoiceAmount  = $scenario.procurement.'5'.invoiceTotal
                     poReference    = $scenario.procurement.'1'.poReference


### PR DESCRIPTION
## Credential VCT / display / type decoupling

Fixes the PWA verifier reporting **"None of your credentials match this verifier's request for `https://sorcha.dev/vc/assured-identity/v1`"** even when the citizen holds exactly that credential.

**Root cause:** `CredentialIssuanceConfig.CredentialType` was overloaded to mean three things — the SD-JWT `vct`, a legacy `type` claim, and the display label. Blueprints set the bare name `AssuredIdentityCredential`; the PWA verifier/matcher/presets expect the canonical URI. They never matched.

### What changed
- **`vct` decoupled** from display + short-name: `CredentialIssuanceConfig` gains `Vct` (canonical URI, machine matching identity) + `DisplayName` (card label); `CredentialType` demoted to a fallback/short-name.
- **SD-JWT VC conformance:** issue `vct` **only** — the non-standard `type` claim is dropped (draft-ietf-oauth-sd-jwt-vc §3.2.2.1). VCT matching is now **case-sensitive exact** (`Ordinal`) everywhere.
- **Live-path threading (plan gap closed):** the real blueprint→citizen flow goes through the Wallet Service direct-issue path; `vct`+`displayName` are now threaded client → endpoint → register envelope → `InboundCredentialDetector`, so the citizen's `CredentialEntity.Type` is the URI and `DisplayConfigJson` carries the label. The authored `displayName` reaches the PWA card via sync.
- **Anti-drift:** every credential type has a `VctUris` constant (17 incl. BuildingPermit); a parametrised **conformance test** asserts every blueprint's `vct`/requirement `type` equals its constant and **fails on any unknown issuance type**.
- **Full conversion:** every blueprint under `demos/`, `walkthroughs/`, `blueprints/` converted to canonical URI + `displayName`.
- **Publish validation:** a declared `vct` must be an absolute URI.
- **Docs synced:** `verifiable-credentials` + `blueprint-builder` skills, API reference.

### Proof
- Regression test: an Assured-Identity credential with `vct = VctUris.AssuredIdentityV1` satisfies the verifier's Assured-Identity preset via the production DCQL path (would have failed pre-plan) — SC-1.
- All suites green: Blueprint.Models 428, Engine 581, Blueprint.Service 966, Wallet.Service 927, Wallet.Pwa 380, UI.Core 1475, ServiceClients 314, CitizenWallet.Abstractions 37.

### Out of scope (follow-ups)
- HAIP/OID4VCI membership-render + `run-haip-sd.ps1` paths need decoupling-aware re-threading (design §9 scoped HAIP out).
- Existing wallets carry the old bare-name vct → citizen re-claims the credential after deploy (no migration, by design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HEbVmbJ6mBWhrynB5B4WCQ
