### PR TITLE
fix: [#1189] Open Verifier authenticates to HAIP verifier endpoints via service principal

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -714,6 +714,9 @@ services:
       ASPNETCORE_ENVIRONMENT: Docker
       ASPNETCORE_URLS: http://+:8080
       ApiGateway__BaseUrl: http://api-gateway:8080
+      ServiceAuth__ClientId: service-verifier
+      ServiceAuth__ClientSecret: verifier-service-secret
+      Verifier__HaipBaseUrl: http://haip-service:8080
     networks:
       - sorcha-network
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -716,6 +716,7 @@ services:
       ApiGateway__BaseUrl: http://api-gateway:8080
       ServiceAuth__ClientId: service-verifier
       ServiceAuth__ClientSecret: verifier-service-secret
+      ServiceAuth__Scopes: "blueprints:read"
       Verifier__HaipBaseUrl: http://haip-service:8080
     networks:
       - sorcha-network

--- a/src/Apps/Sorcha.Verifier/Program.cs
+++ b/src/Apps/Sorcha.Verifier/Program.cs
@@ -2,6 +2,7 @@
 // Copyright (c) 2026 Sorcha Contributors
 
 using MudBlazor.Services;
+using Sorcha.ServiceClients.Auth;
 using Sorcha.UI.Components.User.Extensions;
 using Sorcha.UI.Components.User.Services.Verification;
 using Sorcha.Verifier.Components;
@@ -23,10 +24,22 @@ builder.Services.AddHttpClient();
 // request builder land with T088-T091).
 builder.Services.AddCitizenVerifier(builder.Configuration);
 
+// Feature 164 / #1189: the Open Verifier authenticates to the HAIP verifier endpoints as the
+// `service-verifier` service principal (client_credentials via ServiceAuthClient).
+builder.Services.AddHttpClient<ServiceAuthClient>();
+builder.Services.AddSingleton<IServiceAuthClient, ServiceAuthClient>();
+builder.Services.AddTransient<ServiceAuthMessageHandler>();
+
 // Feature 163: shared user-facing component library seams (IVerificationPresetCatalogue,
 // IVerificationTransport, IRegisterAnchorClient). IRegisterAnchorClient is already wired
 // by AddCitizenVerifier above so AddSorchaUserComponents' guard skips re-registration.
-builder.Services.AddSorchaUserComponents(builder.Configuration);
+var haipBaseUrl = builder.Configuration["Verifier:HaipBaseUrl"]
+    ?? builder.Configuration["ServiceClients:HaipService:Address"]
+    ?? "http://haip-service:8080";
+builder.Services.AddSorchaUserComponents(
+    builder.Configuration,
+    haipBaseUrl: haipBaseUrl,
+    configureHaipClient: b => b.AddHttpMessageHandler<ServiceAuthMessageHandler>());
 
 // Feature 164 B3 (US3): override stub transport with the live HAIP transport + stable org identity.
 // These registrations appear AFTER AddSorchaUserComponents (which uses TryAdd) so the DI overrides

--- a/src/Apps/Sorcha.Verifier/Services/ServiceAuthMessageHandler.cs
+++ b/src/Apps/Sorcha.Verifier/Services/ServiceAuthMessageHandler.cs
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Net.Http.Headers;
+using Sorcha.ServiceClients.Auth;
+
+namespace Sorcha.Verifier.Services;
+
+/// <summary>
+/// Attaches a service-tier bearer token to outbound HAIP verifier requests (Feature 164 / #1189).
+/// The Open Verifier authenticates to the authenticated HAIP create-request + result endpoints as
+/// the <c>service-verifier</c> service principal via <see cref="IServiceAuthClient"/>.
+/// </summary>
+public sealed class ServiceAuthMessageHandler(IServiceAuthClient authClient) : DelegatingHandler
+{
+    protected override async Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        var token = await authClient.GetTokenAsync(cancellationToken);
+        if (!string.IsNullOrEmpty(token))
+        {
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        }
+        return await base.SendAsync(request, cancellationToken);
+    }
+}

--- a/src/Apps/Sorcha.Verifier/Sorcha.Verifier.csproj
+++ b/src/Apps/Sorcha.Verifier/Sorcha.Verifier.csproj
@@ -15,6 +15,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\Common\Sorcha.CitizenWallet.Abstractions\Sorcha.CitizenWallet.Abstractions.csproj" />
+    <ProjectReference Include="..\..\Common\Sorcha.ServiceClients.Http\Sorcha.ServiceClients.Http.csproj" />
     <ProjectReference Include="..\..\Common\Sorcha.ServiceDefaults\Sorcha.ServiceDefaults.csproj" />
     <ProjectReference Include="..\..\Common\Sorcha.Verifier.Engine\Sorcha.Verifier.Engine.csproj" />
     <ProjectReference Include="..\Sorcha.UI\Sorcha.UI.Components.User\Sorcha.UI.Components.User.csproj" />

--- a/src/Apps/Sorcha.Verifier/appsettings.json
+++ b/src/Apps/Sorcha.Verifier/appsettings.json
@@ -13,6 +13,7 @@
   },
   "ServiceAuth": {
     "ClientId": "service-verifier",
-    "ClientSecret": "verifier-service-secret"
+    "ClientSecret": "verifier-service-secret",
+    "Scopes": "blueprints:read"
   }
 }

--- a/src/Apps/Sorcha.Verifier/appsettings.json
+++ b/src/Apps/Sorcha.Verifier/appsettings.json
@@ -8,6 +8,11 @@
   "AllowedHosts": "*",
   "Verifier": {
     "ClockSkewSeconds": 60,
-    "KbJwtMaxLifetimeSeconds": 120
+    "KbJwtMaxLifetimeSeconds": 120,
+    "HaipBaseUrl": "http://haip-service:8080"
+  },
+  "ServiceAuth": {
+    "ClientId": "service-verifier",
+    "ClientSecret": "verifier-service-secret"
   }
 }

--- a/src/Services/Sorcha.Tenant.Service/Data/DatabaseInitializer.cs
+++ b/src/Services/Sorcha.Tenant.Service/Data/DatabaseInitializer.cs
@@ -31,6 +31,7 @@ public class DatabaseInitializer
     public static readonly Guid ValidatorServicePrincipalId = new("00000000-0000-0000-0002-000000000005");
     public static readonly Guid TenantServicePrincipalId = new("00000000-0000-0000-0002-000000000006");
     public static readonly Guid HaipServicePrincipalId = new("00000000-0000-0000-0002-000000000007");
+    public static readonly Guid VerifierServicePrincipalId = new("00000000-0000-0000-0002-000000000008");
 
     // Default credentials (can be overridden via configuration)
     public const string DefaultAdminEmail = "admin@sorcha.local";
@@ -448,6 +449,17 @@ public class DatabaseInitializer
                 // presentation-callback endpoint (Feature 111). RequireService
                 // policy only checks the token_type=service claim, so the scope
                 // list is informational here. blueprints:read kept narrow.
+                new[] { "blueprints:read" }
+            ),
+            (
+                VerifierServicePrincipalId,
+                "Verifier Service",
+                "service-verifier",
+                "verifier-service-secret",
+                // The Open/desk Verifier (Sorcha.Verifier) uses its service token to call the HAIP
+                // Service's authenticated create-request + result endpoints (Feature 164 / #1189).
+                // RequireAuthorization only checks for any authenticated caller, so the scope list is
+                // informational here.
                 new[] { "blueprints:read" }
             )
         };

--- a/tests/Sorcha.Verifier.Tests/Services/ServiceAuthMessageHandlerTests.cs
+++ b/tests/Sorcha.Verifier.Tests/Services/ServiceAuthMessageHandlerTests.cs
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Sorcha.ServiceClients.Auth;
+using Sorcha.Verifier.Services;
+using Xunit;
+
+namespace Sorcha.Verifier.Tests.Services;
+
+/// <summary>
+/// Feature 164 / #1189 — <see cref="ServiceAuthMessageHandler"/> attaches the service-tier bearer
+/// token from <see cref="IServiceAuthClient"/> to outbound HAIP verifier requests, so the Open
+/// Verifier can call the authenticated <c>POST /api/v1/verifier/requests</c> endpoint.
+/// </summary>
+public sealed class ServiceAuthMessageHandlerTests
+{
+    private sealed class StubServiceAuthClient(string? token) : IServiceAuthClient
+    {
+        public Task<string?> GetTokenAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult(token);
+    }
+
+    private sealed class RecordingInnerHandler : DelegatingHandler
+    {
+        public HttpRequestMessage? LastRequest { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            LastRequest = request;
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+        }
+    }
+
+    [Fact]
+    public async Task SendAsync_WithToken_SetsBearerHeader()
+    {
+        var inner = new RecordingInnerHandler();
+        var handler = new ServiceAuthMessageHandler(new StubServiceAuthClient("test-service-token"))
+        {
+            InnerHandler = inner
+        };
+        using var invoker = new HttpMessageInvoker(handler);
+        using var request = new HttpRequestMessage(HttpMethod.Post, "http://haip-service/api/v1/verifier/requests");
+
+        await invoker.SendAsync(request, CancellationToken.None);
+
+        inner.LastRequest.Should().NotBeNull();
+        inner.LastRequest!.Headers.Authorization.Should().NotBeNull();
+        inner.LastRequest.Headers.Authorization!.Scheme.Should().Be("Bearer");
+        inner.LastRequest.Headers.Authorization.Parameter.Should().Be("test-service-token");
+    }
+
+    [Fact]
+    public async Task SendAsync_NoToken_LeavesAuthorizationUnset()
+    {
+        var inner = new RecordingInnerHandler();
+        var handler = new ServiceAuthMessageHandler(new StubServiceAuthClient(null))
+        {
+            InnerHandler = inner
+        };
+        using var invoker = new HttpMessageInvoker(handler);
+        using var request = new HttpRequestMessage(HttpMethod.Post, "http://haip-service/api/v1/verifier/requests");
+
+        await invoker.SendAsync(request, CancellationToken.None);
+
+        inner.LastRequest.Should().NotBeNull();
+        inner.LastRequest!.Headers.Authorization.Should().BeNull();
+    }
+}


### PR DESCRIPTION
## Fix #1189 — Open Verifier can't create a verification request ("verification unavailable")

The Open Verifier at `/verify` failed on any preset because it was never wired to reach the HAIP verifier endpoint:
1. `Sorcha.Verifier/Program.cs` called `AddSorchaUserComponents(builder.Configuration)` with **no `haipBaseUrl`** → the `IHaipVerifierClient` HttpClient had no `BaseAddress` (`InvalidOperationException`).
2. `POST /api/v1/verifier/requests` (haip-service) is `.RequireAuthorization()`; the verifier sent no bearer → 401.

### Fix (no security weakening)
Give the Open Verifier a **confidential service principal** (`service-verifier`) and obtain a service-tier bearer via the existing `ServiceAuthClient` (OAuth2 client_credentials → tenant `/api/service-auth/token`), attached to the HAIP client only. The F164 auth gate is untouched — no anonymous relaxation, no self-minting.

- **Tenant:** seed a `service-verifier` principal (`…0002-…0008`, scope `blueprints:read`) in `DatabaseInitializer` (idempotent-add; picked up on next tenant startup).
- **Verifier:** `ServiceAuthMessageHandler` (DelegatingHandler) attaches `Bearer <token>` from `IServiceAuthClient`; `Program.cs` registers it + `ServiceAuthClient` and passes `haipBaseUrl` (default `http://haip-service:8080`) + `configureHaipClient` so the handler binds to the HAIP client.
- **Config:** verifier `ServiceAuth__{ClientId,ClientSecret,Scopes}` + `Verifier__HaipBaseUrl` in `docker-compose.yml` + appsettings. `Scopes=blueprints:read` matches the seeded grant so the token issues (the scope is intersected tenant-side).

### Tests
`ServiceAuthMessageHandler` set/unset-bearer unit tests (Verifier.Tests 103/103); Tenant.Tests green.

Fixes #1189.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HEbVmbJ6mBWhrynB5B4WCQ
