### PR TITLE
fix: [#1189] verifier ServiceAuthClient needs tenant address on :8080

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -718,6 +718,7 @@ services:
       ServiceAuth__ClientSecret: verifier-service-secret
       ServiceAuth__Scopes: "blueprints:read"
       Verifier__HaipBaseUrl: http://haip-service:8080
+      ServiceClients__TenantService__Address: http://tenant-service:8080
     networks:
       - sorcha-network
     depends_on:


### PR DESCRIPTION
Follow-up to #1190. The Open Verifier's `ServiceAuthClient` defaulted its tenant base address to `http://tenant-service` (**port 80**) — nothing listens there, so `RefreshTokenAsync` threw `Connection refused (tenant-service:80)`, the verifier got no service token, and the HAIP create-request 401'd (the exact 'verification unavailable' the user still saw after #1190).

Every other ServiceAuthClient-using service sets `ServiceClients__TenantService__Address: http://tenant-service:8080`; the verifier block was missing it. This adds it.

**Verified live on n1** (compose patched + verifier recreated): `Connection refused` gone; `/verify` serves; token flow now reaches tenant :8080. (Raw proof from #1190 already stands: service-verifier token → HAIP create-request 201.)

Fixes the residual gap on #1189.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HEbVmbJ6mBWhrynB5B4WCQ