### PR TITLE
fix: PWA 'None of your credentials match' — populate AvailableClaimNames from the SD-JWT

### DIFF
--- a/src/Apps/Sorcha.Wallet.Pwa/Services/ISyncService.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Services/ISyncService.cs
@@ -277,7 +277,14 @@ public sealed class SyncService : ISyncService
         Id = StringToCacheGuid(payload.Id),
         Vct = payload.Vct,
         RawSdJwt = payload.Jwt,
-        AvailableClaimNames = [],
+        // Extract the disclosable claim names from the SD-JWT so DCQL claim matching works.
+        // Leaving this empty made PresentationEngine.MatchCandidates reject every request that
+        // requires claims (i.e. every real verifier preset), regardless of vct — the credential
+        // would always report "None of your credentials match".
+        AvailableClaimNames = SdJwtReader.ReadDisclosedClaims(payload.Jwt)
+            .Select(c => c.Name)
+            .Distinct(StringComparer.Ordinal)
+            .ToList(),
         IssuerDid = payload.IssuerDid,
         // Credential VCT decoupling (Task 4): the authored display name, when the
         // issuer supplied one, wins over CredentialDisplay.Humanize(vct) on the card.

--- a/tests/Sorcha.Wallet.Pwa.Tests/Services/SyncServiceTests.cs
+++ b/tests/Sorcha.Wallet.Pwa.Tests/Services/SyncServiceTests.cs
@@ -278,4 +278,39 @@ public sealed class SyncServiceTests
 
         cached.DisplayLabel.Should().BeNull();
     }
+
+    [Fact]
+    public void ToCachedCredential_PopulatesAvailableClaimNames_FromSdJwtDisclosures()
+    {
+        // Regression: ToCachedCredential used to hard-code AvailableClaimNames = [], which made
+        // PresentationEngine.MatchCandidates reject every request that requires claims (every real
+        // verifier preset), regardless of vct — surfacing as "None of your credentials match".
+        var fullName = SdJwtDisclosure("salt1", "fullName", "Ada Lovelace");
+        var portrait = SdJwtDisclosure("salt2", "portrait", "data:image/jpeg;base64,AAAA");
+        var jwt = SdJwtBody(new
+            {
+                vct = "https://sorcha.dev/vc/assured-identity/v1",
+                _sd = new[] { SdJwtDigest(fullName), SdJwtDigest(portrait) },
+            })
+            + "~" + fullName + "~" + portrait + "~";
+
+        var cached = SyncService.ToCachedCredential(NewPayload() with { Jwt = jwt });
+
+        cached.AvailableClaimNames.Should().Contain(new[] { "fullName", "portrait" },
+            "the DCQL matcher checks required claims against AvailableClaimNames");
+    }
+
+    private static string SdJwtBody(object payload) =>
+        "eyJhbGciOiJFUzI1NiJ9." +
+        System.Buffers.Text.Base64Url.EncodeToString(
+            System.Text.Json.JsonSerializer.SerializeToUtf8Bytes(payload)) +
+        ".c2ln";
+
+    private static string SdJwtDisclosure(string salt, string name, object value) =>
+        System.Buffers.Text.Base64Url.EncodeToString(System.Text.Encoding.UTF8.GetBytes(
+            System.Text.Json.JsonSerializer.Serialize(new object[] { salt, name, value })));
+
+    private static string SdJwtDigest(string disclosure) =>
+        System.Buffers.Text.Base64Url.EncodeToString(
+            System.Security.Cryptography.SHA256.HashData(System.Text.Encoding.ASCII.GetBytes(disclosure)));
 }


### PR DESCRIPTION
## Symptom
Presenting from the wallet PWA always shows **'None of your credentials match this verifier's request for <vct>'** — even when the citizen holds a credential with exactly that vct (verified live on n1: server returns the credential with vct `https://sorcha.dev/vc/assured-identity/v1`).

## Root cause
`SyncService.ToCachedCredential` hard-coded `AvailableClaimNames = []`. `PresentationEngine.MatchCandidates` checks the DCQL request's required claims against `credential.AvailableClaimNames` — an empty list satisfies **no** required claim, so **every request that requires claims fails to match, regardless of vct**. Every real verifier preset ("Confirm identity" → fullName+portrait, "Age over 18?" → age_over_18+portrait) requires claims, so nothing ever matched. (The Task 9 vct regression test populated `AvailableClaimNames` by hand, which masked this — the real sync path never did.)

## Fix
Extract the disclosable claim names from the SD-JWT via the existing `SdJwtReader.ReadDisclosedClaims(payload.Jwt)` and populate `AvailableClaimNames`. One-line change in the cache mapping; regression test added (`ToCachedCredential_PopulatesAvailableClaimNames_FromSdJwtDisclosures`). PWA tests 381/381.

## Note (not this PR)
Separately, the AIAS credential has no `age_over_18` claim, so "Age over 18?" is unsatisfiable by it — "Confirm identity" (fullName+portrait) is the matching preset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HEbVmbJ6mBWhrynB5B4WCQ