### PR TITLE
feat: [#1195] device-bound credential re-issuance — one assurance, N device bindings (Phase 2)

### DIFF
--- a/demos/AIAS/blueprints/aias-assured-identity.template.json
+++ b/demos/AIAS/blueprints/aias-assured-identity.template.json
@@ -117,10 +117,10 @@
               },
               "holderKeys": {
                 "type": "object",
-                "title": "Device binding",
-                "description": "Your device's public signing key plus your wallet's delivery keys. Captured automatically and read-only — the credential is bound to THIS device (standard OID4VP holder binding, #1195) and encrypted to your wallet so only you can present it. Feature 137 (cross-node submission).",
-                "format": "sorcha-device-key",
-                "x-device-key": { "required": true }
+                "title": "Your holder key",
+                "description": "Your wallet's holder public key (web-issued). Captured automatically and read-only — the credential is bound to your wallet's holder key (standard OID4VP holder binding, #1195) and encrypted to your wallet so only you can present it.",
+                "format": "sorcha-holder-key",
+                "x-holder-key": { "required": true }
               }
             },
             "required": ["name", "dob", "email", "address"]

--- a/demos/AIAS/blueprints/aias-device-registration.template.json
+++ b/demos/AIAS/blueprints/aias-device-registration.template.json
@@ -46,13 +46,8 @@
             "presentationSource": "SorchaWallet",
             "requiredClaims": [
               { "claimName": "givenName" },
-              { "claimName": "middleName" },
               { "claimName": "familyName" },
-              { "claimName": "fullName" },
-              { "claimName": "dateOfBirth" },
-              { "claimName": "email" },
-              { "claimName": "address" },
-              { "claimName": "portrait" }
+              { "claimName": "dateOfBirth" }
             ]
           }
         ],

--- a/demos/AIAS/blueprints/aias-device-registration.template.json
+++ b/demos/AIAS/blueprints/aias-device-registration.template.json
@@ -46,8 +46,13 @@
             "presentationSource": "SorchaWallet",
             "requiredClaims": [
               { "claimName": "givenName" },
+              { "claimName": "middleName" },
               { "claimName": "familyName" },
-              { "claimName": "dateOfBirth" }
+              { "claimName": "fullName" },
+              { "claimName": "dateOfBirth" },
+              { "claimName": "email" },
+              { "claimName": "address" },
+              { "claimName": "portrait" }
             ]
           }
         ],

--- a/demos/AIAS/blueprints/aias-device-registration.template.json
+++ b/demos/AIAS/blueprints/aias-device-registration.template.json
@@ -1,0 +1,138 @@
+{
+  "id": "aias-device-registration-v1",
+  "title": "AIAS Bind Identity to Device",
+  "description": "AIAS conference demo (Feature 174 / #1195 Phase 2 — 'one assurance, two bindings'). The citizen already holds a web-issued, holder-cnf AssuredIdentityCredential. Driven by the 'Bind to device' button in the Citizen Wallet PWA, this workflow gates on PRESENTING that root credential (proving entitlement) and captures the phone's device public JWK, then mints a device-cnf copy of the AssuredIdentityCredential bound to that device key. The complete assured claim set is carried forward from the verified presentation via full disclosure. The issuing-agency name is injected via the {{issuerName}} token at provision time. Register selection is left to the publish/deploy tooling (same AIAS register as the apply blueprint) — no register id is baked in.",
+  "version": 1,
+  "category": "identity",
+  "tags": ["aias", "assured-identity", "identity", "device-binding", "device-cnf", "oid4vp", "verifiable-credential", "credential-presentation", "credential-bootstrapped", "portrait"],
+  "author": "Sorcha Team",
+  "published": true,
+  "template": {
+    "id": "aias-device-registration",
+    "title": "AIAS Bind Identity to Device",
+    "description": "Citizen presents their web-issued AssuredIdentityCredential to prove entitlement and captures their device public key; AIAS mints a device-bound (device-cnf) copy of the credential carrying the full assured claim set.",
+    "version": 1,
+    "metadata": {
+      "category": "Identity & Credentials",
+      "complexity": "Simple",
+      "actions": "2",
+      "features": "OpenID4VP, Credential Presentation Gate, Device Key Capture, Device-cnf Re-issuance, Verifiable Credential, Portrait Carry-Forward",
+      "sector": "Identity & Trust"
+    },
+    "participants": [
+      {
+        "id": "citizen",
+        "name": "Credential Holder",
+        "organisation": "Public",
+        "description": "Already holds a web-issued AssuredIdentityCredential and is binding it to a new device via their Citizen Wallet PWA"
+      },
+      {
+        "id": "aias-issuer",
+        "name": "AIAS Issuer",
+        "organisation": "{{issuerName}}",
+        "description": "The AIAS issuing service — mints a device-cnf copy of the citizen's AssuredIdentityCredential bound to the presented device key"
+      }
+    ],
+    "actions": [
+      {
+        "id": 1,
+        "title": "Bind your identity to this device",
+        "description": "Present your existing Assured Identity credential from your Citizen Wallet to prove it is yours, and this device's key is captured so AIAS can bind a copy of your credential to it. Nothing is issued until you have presented.",
+        "sender": "citizen",
+        "isStartingAction": true,
+        "credentialRequirements": [
+          {
+            "type": "https://sorcha.dev/vc/assured-identity/v1",
+            "presentationSource": "SorchaWallet",
+            "requiredClaims": [
+              { "claimName": "givenName" },
+              { "claimName": "familyName" },
+              { "claimName": "dateOfBirth" }
+            ]
+          }
+        ],
+        "dataSchemas": [
+          {
+            "type": "object",
+            "x-introduction": "Bind your Assured Identity to this device. Your wallet presents your existing credential to prove it is yours, and this device's public key is captured automatically — the new copy is cryptographically bound to this device.",
+            "x-sections": [
+              { "title": "This device", "fields": ["deviceKey"] }
+            ],
+            "properties": {
+              "deviceKey": {
+                "type": "object",
+                "title": "This device's key",
+                "description": "This device's public key (device-cnf). Captured automatically and read-only — the device-bound copy of your credential is bound to this key so only this device can present it.",
+                "format": "sorcha-device-key",
+                "x-device-key": { "required": true }
+              }
+            }
+          }
+        ],
+        "disclosures": [
+          { "participantAddress": "citizen", "dataPointers": ["/*"] },
+          { "participantAddress": "aias-issuer", "dataPointers": ["/*"] }
+        ],
+        "routes": [
+          {
+            "id": "to-issue",
+            "nextActionIds": [2],
+            "isDefault": true,
+            "description": "Entitlement presented and device key captured — mint the device-bound copy"
+          }
+        ]
+      },
+      {
+        "id": 2,
+        "title": "Issue device-bound Assured Identity",
+        "description": "AIAS mints a device-cnf copy of the citizen's AssuredIdentityCredential bound to the presented device key. The full assured claim set (name, date of birth, email, address and portrait) is carried forward verbatim from the verified presentation via full disclosure.",
+        "sender": "aias-issuer",
+        "requiredPriorActions": [1],
+        "dataSchemas": [
+          {
+            "type": "object",
+            "x-introduction": "Automatic device binding — no human decision. The device-bound copy is minted from the verified presentation.",
+            "properties": {}
+          }
+        ],
+        "credentialIssuanceConfig": {
+          "credentialType": "AssuredIdentityCredential",
+          "vct": "https://sorcha.dev/vc/assured-identity/v1",
+          "displayName": "Assured Identity",
+          "targetAudience": "SorchaLocalWallet",
+          "recipientParticipantId": "citizen",
+          "holderKeySourceField": "/deviceKey/holderJwk",
+          "issuanceCondition": { "==": [1, 1] },
+          "claimMappings": [
+            { "claimName": "givenName",   "sourceField": "/presentedCredential/givenName" },
+            { "claimName": "middleName",  "sourceField": "/presentedCredential/middleName" },
+            { "claimName": "familyName",  "sourceField": "/presentedCredential/familyName" },
+            { "claimName": "fullName",    "sourceField": "/presentedCredential/fullName" },
+            { "claimName": "dateOfBirth", "sourceField": "/presentedCredential/dateOfBirth" },
+            { "claimName": "email",       "sourceField": "/presentedCredential/email" },
+            { "claimName": "address",     "sourceField": "/presentedCredential/address" },
+            { "claimName": "portrait",    "sourceField": "/presentedCredential/portrait" }
+          ],
+          "disclosable": [
+            "givenName", "middleName", "familyName", "fullName", "dateOfBirth", "email",
+            "/address/line1", "/address/line2", "/address/town", "/address/region",
+            "/address/postcode", "/address/country",
+            "portrait"
+          ]
+        },
+        "disclosures": [
+          { "participantAddress": "aias-issuer", "dataPointers": ["/*"] },
+          { "participantAddress": "citizen", "dataPointers": ["/*"] }
+        ],
+        "routes": [
+          {
+            "id": "device-bound-terminal",
+            "nextActionIds": [],
+            "isDefault": true,
+            "description": "Device-bound copy issued — workflow complete"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/docs/reference/API-DOCUMENTATION.md
+++ b/docs/reference/API-DOCUMENTATION.md
@@ -888,7 +888,7 @@ found; `403` if the caller is not a recorded participant on the instance.
 
 ### Timebound Presentation Lifecycle (Feature 111)
 
-Three-event on-register lifecycle for timebound credential presentations. When an action carries `credentialRequirements` targeting HaipExternalWallet and the citizen submits without pre-attached presentations, `/execute` returns **`202 Accepted`** with `AwaitingPresentation=true` and a QR code. A `PresentationInitiated` transaction is written to the register immediately. The action does NOT complete until the verifier callback writes a `PresentationOutcome` with `kind=success`. Retry after a decline is first-class; a second attempt after a successful outcome returns **`409 Conflict`**.
+Three-event on-register lifecycle for timebound credential presentations. When an action carries `credentialRequirements` targeting HaipExternalWallet **or SorchaWallet** (#1195 Phase 2, Task 6b) and the citizen submits without pre-attached presentations, `/execute` returns **`202 Accepted`** with `AwaitingPresentation=true` and a QR code / authorization request URI. A `PresentationInitiated` transaction is written to the register immediately. The action does NOT complete until the verifier callback writes a `PresentationOutcome` with `kind=success`. Retry after a decline is first-class; a second attempt after a successful outcome returns **`409 Conflict`**.
 
 #### `POST /api/instances/{instanceId}/actions/{actionId}/execute` — 202 semantics
 
@@ -945,6 +945,10 @@ Wallet-facing, intentionally unauthenticated for OpenID4VP wallet interoperabili
 State values: `awaiting-presentation` · `success` · `decline` · `abandoned` · `abandoned-with-late-outcome` · `expired`.
 
 The register's transaction stream is the authoritative history — query `PresentationInitiated` / `PresentationOutcome` / `PresentationAbandoned` transactions from the Register Service for the full event record.
+
+#### `POST /api/presentations/callbacks/sorcha-wallet/{presentationRequestId}`
+
+**#1195 Phase 2 (Task 6b)** — the Citizen Wallet PWA's direct_post target for a `SorchaWallet`-gated presentation (this URI is the `response_uri` in the served request object). **Consumer-tier** (`RequireConsumerAudience`) — the citizen's own token authorises the post; the literal route segment outranks the generic `{consumerName}` template, so every sorcha-wallet post lands here. Body: `{ "vpToken": "<compact SD-JWT presentation with KB-JWT>" }`. Verification happens server-side in the sorcha-wallet consumer against the verifier session persisted on pending state at initiation (nonce, vct, required claims, client_id — single-use, TTL-bound). Refusals are named: `session-missing` (unknown/pre-wiring attempt), `session-expired` (post-window), and validator errors (nonce mismatch, vct mismatch, missing claims) decline with distinct reasons. Response shape matches the generic callback below.
 
 #### `POST /api/presentations/callbacks/{consumerName}/{presentationRequestId}`
 

--- a/docs/reference/API-DOCUMENTATION.md
+++ b/docs/reference/API-DOCUMENTATION.md
@@ -1453,6 +1453,24 @@ Resolves the caller's slot-108 holder public JWK (for the SD-JWT `cnf` binding) 
 ```
 `401` — missing/invalid citizen token. `404` — no wallet resolvable for the caller (indistinguishable from non-existence).
 
+##### POST /api/v1/wallet/presentations/sign-kb
+
+Signs a KB-JWT signing input with the **authenticated caller's** server-custodied slot-108 holder key (#1195 Phase 2, Task 6a). Lets the wallet PWA present a holder-`cnf` credential (e.g. the `AssuredIdentityCredential` root) without the holder private key ever leaving server custody. Consumer-tier (`RequireConsumerAudience`), rate-limited (`Strict`). The signing wallet is resolved from the JWT only — the body carries no wallet address, so a citizen can only sign under their own holder key.
+
+**Request:**
+```json
+{ "signingInput": "<base64url(header)>.<base64url(payload)>" }
+```
+
+The decoded header MUST carry `typ: "kb+jwt"` (the endpoint refuses to sign anything else — the same key signs device delegation credentials, so it must never be a general-purpose signing oracle) and an `alg` matching the holder key's algorithm (EC P-256 → `ES256`, OKP Ed25519 → `EdDSA`).
+
+**Response:** `200 OK`
+```json
+{ "signature": "<base64url raw signature>", "algorithm": "EdDSA" }
+```
+
+`400` — not a KB-JWT header, or header `alg` mismatches the holder key (named error). `401` — missing/invalid citizen token. `404` — no wallet resolvable for the caller.
+
 #### 11. Cross-Device Presentation History (Feature 114 US5)
 
 The citizen's durable, cross-device record of presentations they have made. Reported presentations (via `POST /api/v1/wallet/presentations/log`) are persisted to a per-citizen Wallet Service store so the same history appears on any device the citizen pairs. **There is no register/ledger write** — a free-standing offline presentation has no originating register; these are citizen-owned convenience records carrying disclosed claim **names only**, never values.

--- a/docs/superpowers/plans/2026-07-16-device-bound-reissuance-RESTART-PROMPT.md
+++ b/docs/superpowers/plans/2026-07-16-device-bound-reissuance-RESTART-PROMPT.md
@@ -1,0 +1,54 @@
+# Restart prompt — execute the device-bound credential re-issuance (#1195 Phase 2)
+
+Paste everything below the line as your first message in a fresh Claude Code session at `C:\Projects\Sorcha`. It is self-contained: it names the skills to load, the memories that matter, the branch, the standards guardrails, and the execution method. The plan and design docs carry the detail; this prompt gets you into them correctly.
+
+---
+
+Execute the implementation plan at `docs/superpowers/plans/2026-07-16-device-bound-reissuance.md` (design: `docs/superpowers/specs/2026-07-16-device-bound-reissuance-design.md`). **Read both in full before any code.**
+
+## What this is
+#1195 **Phase 2**. Phase 1 (merged #1197) made the citizen *present* standards-cleanly (`cnf` = device key, OID4VP `direct_post`, no delegation) but assumed the AIAS application ran in the wallet PWA. It doesn't — **the Assured Identity is created in the web app, where there is no device key**. `cnf` is frozen at mint, so one credential can't be both web- and device-signable.
+
+The model: **one assurance, two bindings.** The web-issued **root** credential stays holder-`cnf` (server-custody presentable, web/remote). A second AIAS **device-registration blueprint**, driven by a **"Bind to device" button on the wallet ID card**, presents the root (proving entitlement + supplying the claims) and mints a **device-`cnf`** copy bound to the phone's non-extractable P-256 key. A `DeviceBoundCredentialPolicy` caps this at **3 devices per user, evicting the oldest** via the Token Status List (F114) + F118 inbox notice. The wallet **selects which credential to present per surface** (device copy in person, root on the web). This is 8 tasks.
+
+**First task is a correction:** revert the AIAS *apply* blueprint's starting field `sorcha-device-key` → `sorcha-holder-key` (Phase 1 put it there for the demo shortcut; the root must be holder-`cnf`).
+
+## Load these skills FIRST (before any code)
+1. `superpowers:subagent-driven-development` — the execution method. Fresh implementer subagent per task; two-stage review (spec-compliance + quality) between tasks; a progress ledger at `.superpowers/sdd/progress.md`. **One implementer at a time on this checkout.**
+2. `verifiable-credentials` — Sorcha's SD-JWT VC implementation (`SdJwtService`, `cnf` binding, issuance), OID4VCI proof-of-possession, the Token Status List. Read before touching issuance or the policy.
+3. `sorcha-architecture` — Feature 114 (citizen wallet, device registry, status-list publisher/worker, inbox writers), Feature 118 (inbox), Feature 137 (holder-key source field → `cnf`). Load for the policy + wallet surfaces.
+4. `blueprint-builder` — the **Open Participants / late binding** and **credential-bootstrapped application** patterns (the device-registration blueprint uses both), `credentialIssuanceConfig` / `credentialRequirements`.
+
+## Standards guardrails (do NOT violate)
+- `cnf` is the SD-JWT VC holder-binding key and is **immutable after mint**. A device copy is a **re-issue** (AIAS re-signs), not an edit. Standard OID4VCI: the device proves possession of its key, the issuer binds it.
+- **Delegation stays OFF every presentation path.** Phase 1 removed it; do not reintroduce it. Entitlement for the device copy is proven by *presenting the root*, not by a delegation JWT.
+- The device copy's **identity claims come from the verified root presentation** (AIAS-signed, tamper-evident) — never from client-supplied payload. Request full disclosure of the root in the bind flow.
+- `vct` stays the canonical URI `https://sorcha.dev/vc/assured-identity/v1`, case-sensitive (per #1187). Both credentials share it.
+- Revocation = a **Token Status List** bit flip (reuse F114), not deletion.
+
+## Project conventions that bite
+- `dotnet test` takes ONE project and **`--filter` does not isolate** (Microsoft.Testing.Platform) — run the whole project, read `Failed: N, Passed: N`. Always `dotnet build` before `dotnet test`. Record each project's baseline before editing tests.
+- **Never `git add -A`.** The tree carries the user's untracked work (`walkthroughs/_storyboards/`, `tests/Sorcha.UI.E2E.Tests/Docker/StoryboardWalkthroughTests.cs`, a modified `.gitignore`) that MUST stay untracked. Stage explicit paths only.
+- **Never run two implementer subagents concurrently on this checkout** — `git stash` is not file-scoped and swallows the other agent's tree. One at a time, or worktree isolation.
+- Every new `.cs`: `// SPDX-License-Identifier: MIT` / `// Copyright (c) 2026 Sorcha Contributors`, file-scoped namespace, test naming `MethodName_Scenario_ExpectedBehavior`, xUnit v3 + FluentAssertions, Moq.
+- The PWA (`Sorcha.Wallet.Pwa`) is Blazor WASM — BCL only, no `Sorcha.Cryptography`/Newtonsoft; `JsonElement` not `JsonNode`. User feedback via `IInlineFeedback`, NEVER `ISnackbar` (CI gate).
+- Components.User `RootNamespace` = `Sorcha.UI.Core` regardless of folder.
+- `claude-review` CI fails ~28s on an infra token-exchange on every PR right now — **flaky-only red**, no findings; merge past it once the real checks (`build-and-test`, image builds) are green.
+- The device key is phone-only (`IDeviceKeyService`, non-extractable P-256). Anything binding to it runs in the PWA; the `sorcha-device-key` control (shipped #1197) writes the device public JWK to a `/…/holderJwk` slot; `IDeviceKeyProvider` is the shared seam (PWA impl wins over the null default).
+
+## Investigation points the plan anchors (confirm by grep before coding — the proven #1195 pattern)
+- The exact `presentationSource` enum value for an internally-held Sorcha credential (Task 2).
+- Where the mint distinguishes a device copy (P-256 `cnf`) from the web root (Ed25519 `cnf`), and whether it lives in Wallet.Service or Blueprint.Service (Tasks 4/5). Project memory says live issuance is the **Wallet Service direct-issue** path.
+- The claim-source pointer prefix `/presentedCredential/*` — Task 3 defines it and threads verified-presentation claims into the issuance source doc; Task 2's `claimMappings` reuse it.
+- The present-surface signal (in-person/offline vs web/remote) for Task 7's selection; default = prefer a signable device copy, fall back to the root.
+
+## Branch
+Work on `feature/device-bound-reissuance` — already created; the design + plan + this prompt are committed on it (branches from master at the #1197 merge). Do NOT branch again. Confirm with `git rev-parse --abbrev-ref HEAD`.
+
+## Deployment reality (context, not code)
+Ships to n1 as a Docker deploy: client images (`sorcha-wallet-pwa`, `sorcha-ui-web`) + `wallet-service` (the policy/mint). The mobile wallet loads the PWA remotely (`mobile/wallet/capacitor.config.json` `server.url = n1.sorcha.dev/wallet`), so a deploy reaches TestFlight/Play on next load — but Blazor WASM caches hard (force-close/reopen). Full E2E needs a phone: apply on web → **Bind to device** in the wallet → present in person → verify. Per-service recreate command + genesis notes are in the `n1-deploy` skill.
+
+## Success = the four SCs in design §10
+Web apply → holder-`cnf` root (server-custody presentable); "Bind to device" → device-`cnf` copy that standard-verifies in person with no delegation; ≤3 device copies with oldest-evicted + notified; wallet auto-selects the right credential per surface.
+
+Begin by loading the four skills, reading the plan and design docs, confirming the branch, initialising the SDD ledger, then dispatch Task 1 (the apply-blueprint correction).

--- a/docs/superpowers/plans/2026-07-16-device-bound-reissuance.md
+++ b/docs/superpowers/plans/2026-07-16-device-bound-reissuance.md
@@ -1,0 +1,218 @@
+# Device-bound Credential Re-issuance — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task (fresh implementer per task + two-stage review), exactly as #1195 Phase 1 was executed in this repo. Steps use checkbox (`- [ ]`) syntax. Each task lists **Anchors** the implementer must READ before coding (paths drift — grep to confirm) and writes its own literal tests from the described cases.
+
+**Goal:** Let a citizen who was assured on the web (holder-`cnf` root credential) mint device-bound (`cnf` = device key) copies of their Assured Identity from the wallet PWA via a "Bind to device" ID-card action, capped at 3 devices with LRU eviction, so they can present standards-cleanly in person.
+
+**Architecture:** One assurance, two bindings. The web-issued root stays holder-`cnf` (server-custody presentable). A second AIAS blueprint, driven by an in-wallet button, presents the root (proving entitlement + supplying claims) and mints a device-`cnf` copy bound to the phone's non-extractable P-256 key. A `DeviceBoundCredentialPolicy` in the issuance service enforces max-3 with status-list eviction. The wallet selects which credential to present per surface.
+
+**Tech Stack:** .NET 10 / C# 14, Blazor WASM (PWA), SD-JWT VC + OID4VCI/OID4VP, IETF Token Status List (F114), Sorcha blueprints.
+
+**Design:** `docs/superpowers/specs/2026-07-16-device-bound-reissuance-design.md` — READ IT FIRST.
+
+## Global Constraints
+
+- License header (`// SPDX-License-Identifier: MIT` / `// Copyright (c) 2026 Sorcha Contributors`) on every new `.cs` file; file-scoped namespaces (except `.razor`).
+- Components.User `RootNamespace` is `Sorcha.UI.Core` regardless of folder.
+- NEVER `git add -A` — the tree carries untracked storyboard work (`walkthroughs/_storyboards/`, `StoryboardWalkthroughTests.cs`, a modified `.gitignore`) that MUST stay untracked. Stage explicit paths only.
+- Never hardcode `<Version>`. WASM code = BCL only (no Newtonsoft). `JsonElement` (not `JsonNode`) with JsonSchema.Net.
+- MTP test runner: `--filter` does NOT isolate — run the whole project, read the totals; `dotnet build` before `dotnet test`; capture baselines before changing tests. `dotnet test` takes ONE project.
+- Do NOT weaken security: no self-minting tokens, no making auth-gated endpoints anonymous. Do NOT re-introduce delegation onto the presentation path.
+- Branch: `feature/device-bound-reissuance` (already exists, carries the spec+plan). Stay on it; no push/merge until the whole plan is green and reviewed.
+
+---
+
+### Task 1: Phase-1 correction — root credential back to holder-`cnf`
+
+**Files:**
+- Modify: `demos/AIAS/blueprints/aias-assured-identity.template.json` (the `holderKeys` starting-action field)
+
+**Interfaces:**
+- Produces: the AIAS **apply** blueprint issues a holder-`cnf` root again (`format: "sorcha-holder-key"`), `holderKeySourceField: "/holderKeys/holderJwk"` unchanged.
+
+**Anchors:** the `holderKeys` property (~line 118) currently reads `"format": "sorcha-device-key"` + `"x-device-key"` (from #1197). The issuance config `holderKeySourceField` at ~line 187 stays.
+
+- [ ] **Step 1:** Change the `holderKeys` field `format` back to `"sorcha-holder-key"` and `x-device-key` → `x-holder-key`; restore the holder-oriented title/description (bound to your wallet holder key, web-issued). Leave `holderKeySourceField` as-is.
+- [ ] **Step 2:** Validate JSON: `python3 -c "import json;json.load(open('demos/AIAS/blueprints/aias-assured-identity.template.json'));print('ok')"` → `ok`.
+- [ ] **Step 3:** Confirm no other checked-in AIAS apply copy diverges: `grep -rn "sorcha-device-key" demos/AIAS/` returns nothing (the device-key format now belongs only to Task 2's blueprint).
+- [ ] **Step 4: Commit**
+
+```bash
+git add demos/AIAS/blueprints/aias-assured-identity.template.json
+git commit -m "fix: [#1195] AIAS apply blueprint root back to holder-cnf (web-issued); device binding moves to enrolment"
+```
+
+---
+
+### Task 2: The device-registration blueprint
+
+**Files:**
+- Create: `demos/AIAS/blueprints/aias-device-registration.template.json`
+- Test: add a publish/validate assertion where the AIAS demo blueprints are tested (grep `aias-assured-identity` under `tests/` and `demos/AIAS/` for the existing publish/validate harness; co-locate).
+
+**Interfaces:**
+- Produces: a blueprint whose starting action (a) gates on presenting an `AssuredIdentityCredential` and (b) captures a device public JWK at `/deviceKey/holderJwk` (via `format: "sorcha-device-key"`), and whose issuance action mints a device-`cnf` `AssuredIdentityCredential` with `holderKeySourceField: "/deviceKey/holderJwk"`, `recipientParticipantId: "citizen"`, claims sourced from the verified presentation (Task 3).
+
+**Anchors:** mirror `demos/AIAS/blueprints/aias-assured-identity.template.json` for participant/action/issuance shape. Use the `blueprint-builder` skill's **credential-bootstrapped application** pattern (`credentialRequirements` on the open starting action) and **Open Participants** rules (citizen `walletAddress` OMITTED).
+
+- [ ] **Step 1:** Author the blueprint JSON. Participants: `citizen` (walletAddress omitted, organisation Public), `aias-issuer` (walletAddress from the demo's AIAS wallet, templated like the apply blueprint). Starting action `id:1`, `isStartingAction:true`, `sender:"citizen"`:
+  - `credentialRequirements`: `[{ "type": "AssuredIdentityCredential", "presentationSource": "SorchaLocalWallet", "requiredClaims": [ {"claimName":"givenName"}, {"claimName":"familyName"}, {"claimName":"dateOfBirth"} ] }]` (verify the exact `presentationSource` enum value the engine accepts for an internally-held Sorcha credential — grep `presentationSource` / `PresentationSource` in `Sorcha.Blueprint.*`).
+  - `dataSchemas`: one object with a single `deviceKey` property, `"format": "sorcha-device-key"`, `"x-device-key": { "required": true }`. No other user fields.
+  - `routes`: `[{ "id":"to-issue", "nextActionIds":[2], "isDefault":true }]`.
+  - Issuance action `id:2`, `sender:"aias-issuer"`, `requiredPriorActions:[1]`, with `credentialIssuanceConfig`: `credentialType:"AssuredIdentityCredential"`, `vct:"https://sorcha.dev/vc/assured-identity/v1"`, `displayName:"Assured Identity"`, `targetAudience:"SorchaLocalWallet"`, `recipientParticipantId:"citizen"`, `holderKeySourceField:"/deviceKey/holderJwk"`, `issuanceCondition` always-true, and `claimMappings` sourcing from the presented credential's verified claims (Task 3 defines the source-pointer prefix; use it here).
+- [ ] **Step 2:** Validate JSON parses (as Task 1 Step 2).
+- [ ] **Step 3:** Write a test that the blueprint **publishes without validation errors** (mirror the existing AIAS apply-blueprint publish test; assert no `VAL_BP_*` errors, open citizen participant accepted, credentialRequirement + device-key field present). Run the project; expect pass.
+- [ ] **Step 4: Commit** (stage the blueprint + the test file explicitly).
+
+---
+
+### Task 3: Engine — source issuance claims from the verified presentation
+
+**Files:**
+- Modify: the issuance path that binds `credentialIssuanceConfig.claimMappings` to a source document — `src/Services/Sorcha.Blueprint.Service/Services/Implementation/ActionExecutionService.cs` (the credential-bootstrapped gate + issuance) and/or the wallet-service direct-issue path (`src/Services/Sorcha.Wallet.Service/Endpoints/CredentialEndpoints.cs`, `IssueCredentialChainResolver.cs`, `SdJwtClaimProjection.cs`).
+- Test: `tests/Sorcha.Blueprint.Service.Tests/...` (co-locate with the existing credential-bootstrapped / issuance tests — grep `credentialRequirements` in tests).
+
+**Interfaces:**
+- Consumes: the verified presentation result from the starting action's `credentialRequirement` gate (the same `VerifiedClaims` the Phase-1 `HaipPresentationVerifier`/internal verifier produced — grep `VerifiedClaims` in `Sorcha.Verifier.Engine` / `Sorcha.Blueprint.*`).
+- Produces: the issuance source document exposes the verified presentation's claims under a stable pointer prefix (propose `/presentedCredential/*`) so `claimMappings` `sourceField` like `/presentedCredential/givenName` resolves. Document the exact prefix in this task and reuse it in Task 2.
+
+**Anchors:** READ how `claimMappings.sourceField` pointers are resolved today (the issuance source doc assembly — grep `claimMappings` / `sourceField` / `ResolveClaimSource`). The credential-bootstrapped gate already verifies the presentation; find where its result is dropped and thread the verified claims into the source doc.
+
+- [ ] **Step 1: Failing test** — an issuance action whose blueprint has a `credentialRequirement` and `claimMappings` with `sourceField: "/presentedCredential/givenName"` mints a credential whose `givenName` claim equals the value from the **verified presented** credential (not from the submitted payload). Assert the payload cannot override it (submit a different `givenName` in the payload → issued claim still equals the presented value).
+- [ ] **Step 2:** Run → FAIL (`/presentedCredential/*` not resolvable today).
+- [ ] **Step 3:** Implement: capture the starting action's verified-presentation claims and expose them in the issuance source document under `/presentedCredential/*`; ensure they take precedence over client payload for identity claims. Keep it minimal and additive.
+- [ ] **Step 4:** Run → PASS. Run the whole test project; confirm no regression.
+- [ ] **Step 5: Commit** (explicit paths).
+
+---
+
+### Task 4: `DeviceBoundCredentialPolicy` — count + LRU eviction
+
+**Files:**
+- Create: `src/Services/Sorcha.Wallet.Service/Services/Implementation/DeviceBoundCredentialPolicy.cs` (+ `IDeviceBoundCredentialPolicy` interface in the service's `Services/Interfaces/`). (Confirm the wallet service is where device-`cnf` AIAS creds are minted — per project memory the live issuance path is the Wallet Service direct-issue; if the mint actually lands in Blueprint.Service, create the policy there instead and adjust Task 5.)
+- Test: `tests/Sorcha.Wallet.Service.Tests/...` (co-locate with credential-issuance tests).
+
+**Interfaces:**
+- Produces:
+  ```csharp
+  public interface IDeviceBoundCredentialPolicy
+  {
+      /// Called BEFORE minting a device-bound copy. Enforces max-3 per (user, credentialType)
+      /// keyed on device-key JWK thumbprint. Returns the disposition; performs eviction
+      /// (status-list revoke + inbox notify) as a side-effect when a NEW device exceeds the cap.
+      Task<DeviceBindDisposition> ReconcileAsync(
+          Guid userId, string credentialType, string deviceKeyThumbprint, CancellationToken ct);
+  }
+  public enum DeviceBindKind { NewWithinCap, ReplaceExisting, NewWithEviction }
+  public sealed record DeviceBindDisposition(DeviceBindKind Kind, string? EvictedCredentialId);
+  ```
+- Consumes: a store of live device-bound copies per user (grep the credential store — `wallet."Credentials"` / `ICredentialStore` / `ICredentialRepository`), the JWK thumbprint helper (RFC 7638 — grep `Thumbprint` in `Sorcha.Cryptography`), the status-list revoke API (grep `Revoke` in `CredentialDisplay.cs`, `CredentialCommands.cs`, and the wallet-service status-list service from F114), and the F118 inbox writer (`CitizenDeviceInboxWriter` per CLAUDE.md pattern #12).
+
+**Anchors:** F114 status-list publisher/worker + the revoke entrypoint; `CitizenDeviceInboxWriter`; RFC 7638 thumbprint util. `MAX_DEVICES = 3`.
+
+- [ ] **Step 1: Failing tests** (one class, cases):
+  - `ReconcileAsync` with 2 existing distinct thumbprints + a new one → `NewWithinCap`, no eviction, no revoke called.
+  - With 3 existing + the SAME thumbprint as one → `ReplaceExisting`, no eviction, count unchanged.
+  - With 3 existing distinct + a NEW thumbprint → `NewWithEviction`, `EvictedCredentialId` == the oldest (by issued-at); status-list revoke invoked for it; inbox notify invoked for the evicted device.
+  - Revoke throws → `ReconcileAsync` propagates (issuance must abort); assert no partial state.
+- [ ] **Step 2:** Run → FAIL (types absent).
+- [ ] **Step 3:** Implement the policy: load live device-bound copies for `(userId, credentialType)`; thumbprint match → ReplaceExisting; else if count < 3 → NewWithinCap; else evict oldest (revoke via status list, then inbox notify) → NewWithEviction. Revoke-before-return; on revoke failure, throw.
+- [ ] **Step 4:** Run → PASS; whole project green.
+- [ ] **Step 5: Commit** (explicit paths).
+
+---
+
+### Task 5: Wire the policy into the device-copy issuance path
+
+**Files:**
+- Modify: the mint entrypoint for device-bound AIAS copies (`src/Services/Sorcha.Wallet.Service/Endpoints/CredentialEndpoints.cs` or the resolver from Task 4's investigation).
+- Register `IDeviceBoundCredentialPolicy` in the wallet service DI + `IStorageRegistrationLog` if it holds state (follow CLAUDE.md pattern #10/#13 if it introduces a repository).
+- Test: `tests/Sorcha.Wallet.Service.Tests/...` integration.
+
+**Interfaces:**
+- Consumes: `IDeviceBoundCredentialPolicy.ReconcileAsync` (Task 4).
+- Produces: device-`cnf` AIAS issuance calls `ReconcileAsync(userId, "AssuredIdentityCredential", thumbprint(deviceJwk))` **before** minting; a `ReplaceExisting` disposition revokes/replaces the prior copy for that thumbprint; a thrown reconcile aborts the mint (no credential issued).
+
+**Anchors:** identify how the mint knows it is a *device-bound* copy vs the web root — distinguish by `cnf` being a device (P-256, `crv:"P-256"`) vs holder (Ed25519) key, or by the blueprint/credentialType context. Only device-bound copies go through the policy; the web root does NOT.
+
+- [ ] **Step 1: Failing test** — minting a device-bound AIAS copy invokes `ReconcileAsync`; a 4th distinct device triggers eviction end-to-end (assert the oldest copy's status is revoked and the new one is issued); minting the holder-`cnf` web root does NOT call the policy.
+- [ ] **Step 2:** Run → FAIL.
+- [ ] **Step 3:** Implement the wiring (compute thumbprint, call policy, honour disposition, abort on throw). Register DI.
+- [ ] **Step 4:** Run → PASS; whole project green.
+- [ ] **Step 5: Commit** (explicit paths).
+
+---
+
+### Task 6: PWA "Bind to device" ID-card action + flow
+
+**Files:**
+- Create: `src/Apps/Sorcha.Wallet.Pwa/Services/DeviceBindingService.cs` (+ interface) — orchestrates capture→present→submit→cache.
+- Modify: `src/Apps/Sorcha.Wallet.Pwa/Pages/CredentialDetail.razor` (add the button on the AIAS root card) — confirm this is the ID-card surface; `CredentialDetailView.razor` in Components.User may be the shared render.
+- Test: `tests/Sorcha.Wallet.Pwa.Tests/...` (bUnit for the button visibility; a service test for the flow with mocked deps).
+
+**Interfaces:**
+- Consumes: `IDeviceKeyService.GetPublicJwkAsync()` (device public JWK), `IPresentationEngine` (present the root server-custody), the device-registration blueprint submission client (the same client the PWA uses to submit blueprint actions — grep how the PWA submits actions today; if none exists in the PWA, this is the new-surface cost noted in the design — add a minimal submit call to the blueprint service), `ICredentialCache` (cache the returned copy).
+- Produces:
+  ```csharp
+  public interface IDeviceBindingService
+  {
+      /// True when `credential` is an AssuredIdentityCredential root (holder-cnf) and THIS device
+      /// has no live device-bound copy of it yet.
+      bool CanBind(CachedCredential credential);
+      /// Captures the device key, presents the root, submits the device-registration blueprint,
+      /// caches the returned device-cnf copy. Throws on gate/mint failure (surface inline).
+      Task<CachedCredential> BindToThisDeviceAsync(CachedCredential root, CancellationToken ct);
+  }
+  ```
+
+**Anchors:** `CredentialDetail.razor` for the button host; `IDeviceKeyService` (PWA); `PresentationEngine`/`IPresentationEngine`; `ICredentialCache`; the Phase-1 `sorcha-device-key` capture pattern (reuse the JWK shape). Feedback via `IInlineFeedback` (CLAUDE.md pattern #12) — NOT `ISnackbar`.
+
+- [ ] **Step 1: Failing tests** — `CanBind` true for an AIAS holder-`cnf` root with no device copy, false when a device copy already exists or the credential isn't an AIAS root; `BindToThisDeviceAsync` (mocked deps) calls capture→present→submit→cache in order and returns the cached device copy; a present/gate failure throws and caches nothing.
+- [ ] **Step 2:** Run → FAIL.
+- [ ] **Step 3:** Implement the service + wire the button on the card (visible per `CanBind`; on click runs `BindToThisDeviceAsync`, shows inline success/error, refreshes the card). Register DI in the PWA.
+- [ ] **Step 4:** Run PWA test project → PASS; whole project green.
+- [ ] **Step 5: Commit** (explicit paths).
+
+---
+
+### Task 7: Wallet presentation selection per surface
+
+**Files:**
+- Modify: `src/Apps/Sorcha.Wallet.Pwa/Services/Presentation/PresentationEngine.cs` (candidate selection).
+- Test: `tests/Sorcha.Wallet.Pwa.Tests/Services/Presentation/...` (extend `PresentationEngineTests.cs`).
+
+**Interfaces:**
+- Consumes: the credential cache (root + device copies), a signal of the present surface (in-person/offline/device vs web/remote — determine what's available; if the present request or transport already carries this, use it; else default: prefer a device-`cnf` copy this device can sign for, fall back to the holder-`cnf` root).
+- Produces: `MatchCandidates`/selection returns the device-`cnf` copy when this device holds one and can sign; otherwise the holder-`cnf` root (server-custody). When an offline/in-person present is requested and no device copy exists → a distinct "bind this device first" outcome the UI can route to Task 6.
+
+**Anchors:** the existing candidate matching (`MatchCandidates` in `PresentationEngine.cs`), how a credential's `cnf` key type is known (device P-256 vs holder Ed25519 — read from the cached SD-JWT `cnf.jwk.crv`/`kty`), and how the current present flow decides signing (Phase-1 `Present.razor` device-signs; server-custody signing path for the root — grep the wallet-service KB-JWT signing endpoint).
+
+- [ ] **Step 1: Failing tests** — with both a root and a this-device copy cached, selection for a device/in-person present returns the device copy; for a web/remote present returns the root; with only a root cached and an offline present requested, selection yields the "bind first" outcome.
+- [ ] **Step 2:** Run → FAIL.
+- [ ] **Step 3:** Implement the selection rule (minimal, driven by `cnf` key type + surface). Do NOT reintroduce delegation.
+- [ ] **Step 4:** Run → PASS; whole project green.
+- [ ] **Step 5: Commit** (explicit paths).
+
+---
+
+### Task 8: Verifier / E2E parity
+
+**Files:**
+- Test: extend `tests/Sorcha.Haip.Service.Tests/Endpoints/VerifierEndpointTests.cs` (reuse `DeviceCnfPresentationFactory` from Phase 1) and/or a wallet-service test for server-custody root presentation.
+
+**Interfaces:**
+- Consumes: the Phase-1 device-cnf harness (`DeviceCnfPresentationFactory`, `HandleDirectPost`, `HaipPresentationVerifier`).
+
+- [ ] **Step 1:** Add a test asserting a **device-`cnf`** AIAS copy (device-signed KB-JWT) verifies through `HandleDirectPost` (this largely exists from Phase 1 Task 4 — extend it to the AIAS `vct`/claim set to prove the real credential shape, not just a generic license cred).
+- [ ] **Step 2:** Add a test that a **holder-`cnf`** root presented **server-custody** (wallet service signs the KB-JWT) verifies through the standard verifier — proving the root's web/remote path. If server-custody signing isn't unit-testable in isolation, assert at the `HaipPresentationVerifier` level that a holder-`cnf` credential with a holder-key-signed KB-JWT verifies (`HolderKeyVerified == true`).
+- [ ] **Step 3:** Run the Haip (and wallet) test project(s) → PASS.
+- [ ] **Step 4: Commit** (explicit paths).
+
+---
+
+## Self-Review (author)
+
+- **Spec coverage:** §3→Task 1; §4 blueprint→Task 2; §4.1 claim source→Task 3; §5 cap/eviction→Tasks 4–5; §4.2 button/flow→Task 6; §6 selection→Task 7; §9 verifier→Task 8. All spec sections mapped.
+- **Ordering:** 1 (correction) → 2 (blueprint) → 3 (claim piping, needed by 2's issuance) → 4 (policy) → 5 (wire policy) → 6 (PWA flow) → 7 (selection) → 8 (verifier). Tasks 3 and 4 are independent and could parallelise; keep serial under SDD for a clean checkout (one implementer at a time, per repo rule).
+- **Known investigation points (not placeholders — anchored):** exact `presentationSource` enum (Task 2), the claim-source pointer prefix `/presentedCredential/*` (Task 3, defined there + reused in 2), which service mints device copies (Task 4/5), the present-surface signal (Task 7). Each names where to look; the implementer confirms by grep before coding — the proven #1195 pattern.
+- **Post-plan:** after all 8 green + reviewed, this is #1195 Phase 2 — open a PR, merge on green (flaky-review-only red OK), deploy client + wallet-service images to n1, then the on-phone verify (apply on web → Bind to device in the wallet → present in person → verify).

--- a/docs/superpowers/specs/2026-07-16-device-bound-reissuance-design.md
+++ b/docs/superpowers/specs/2026-07-16-device-bound-reissuance-design.md
@@ -1,0 +1,145 @@
+# Device-bound credential re-issuance — one assurance, many device bindings
+
+**Date:** 2026-07-16
+**Status:** Design (approved 2026-07-16)
+**Tracking:** #1195 Phase 2 (extends the Phase 1 present-side conformance shipped in #1197)
+**Surface:** AIAS / Assured-Identity blueprints, SD-JWT VC issuance (`cnf` binding), the citizen wallet PWA (ID-card "Bind to device" action + `IDeviceKeyService`), the credential issuance service (device-count policy), the Token Status List publisher/worker (F114), the F118 inbox.
+
+---
+
+## 1. Why
+
+#1195 Phase 1 made the citizen *present* standards-cleanly (OID4VP `direct_post`, `cnf` = device key, no delegation). But it exposed a product-level contradiction it papered over with a demo shortcut:
+
+- The **Assured Identity is created in the web app** (`/app`) — agent review, portrait capture, postcode/profanity checks. The web has **no device key** (the device key is a non-extractable P-256 WebCrypto key that exists only in the wallet PWA on a phone).
+- A standards presentation from a phone requires `cnf` = the device key, and `cnf` is **frozen at mint time** inside the issuer's signature.
+
+You cannot make one credential both "server-signable for web" and "device-signable for phone" under base SD-JWT VC — `cnf` is a single key. So the model must be **two credentials from one assurance**, and the device-bound one must be minted where the device key lives (the phone).
+
+## 2. The model — one assurance, two bindings, select at presentation
+
+| | Root credential | Device credential(s) |
+|---|---|---|
+| `cnf.jwk` | **holder key** (Ed25519, server-custodied) | **device key** (P-256, non-extractable, per device) |
+| Created | web apply (`/app`), once, at AIAS approval | on demand, in the wallet PWA, per device |
+| Presents | server-custody (wallet service signs the KB-JWT) — web/remote flows | device signs the KB-JWT — in-person/offline flows |
+| Standard? | yes (a legitimate server-side wallet holds `cnf` and signs) | yes (textbook SD-JWT VC / OID4VP) |
+| Count | one | capped at **3 per user** (evict oldest) |
+
+**The assurance (AIAS's attestation of the verified attributes) is created once; the binding is a cheap, swappable layer re-minted per device.** The wallet chooses which credential to present based on what it can sign for on the current surface (§6). Verifiers stay standard and unaware of the distinction.
+
+### 2.1 What the standards provide (grounding)
+
+- **Bind-a-key-by-proof-of-possession is the standard OID4VCI issuance flow** — the wallet sends a `proof` JWT signed by the key to bind (carrying the issuer `c_nonce`); the issuer embeds it as `cnf`. "Submit a device key, receive a device-bound credential" is textbook, not a workaround.
+- **Multiple device-bound copies is first-class** — OID4VCI's `proofs` array / Batch Credential Endpoint mints N copies of one credential each bound to a different key, designed for multi-device.
+- **Revocation is a one-bit flip** — SD-JWT VCs carry a `status` claim → an IETF **Token Status List** (bitstring); flipping one bit revokes a single copy. Sorcha already runs the publisher + worker (F114).
+- **The device-count *policy* is deliberately NOT in the standards** — "max 3, evict oldest" is pure issuer business logic. The standards give the primitives (bind-by-proof, batch, status-list revoke); the cap and eviction are ours to define.
+
+## 3. The Phase-1 correction (ship first)
+
+Phase 1 (#1197) put a `sorcha-device-key` field on the **apply** blueprint and assumed the citizen applies in the PWA. The real flow is a **web apply**. Therefore:
+
+- **Revert the AIAS apply blueprint's starting-action field `sorcha-device-key` → `sorcha-holder-key`.** The root credential is holder-`cnf` again (today's working web path). `holderKeySourceField` (`/holderKeys/holderJwk`) unchanged.
+- **Keep** Phase 1's `Present.razor` `direct_post` conformance (`670a2b0d`) — it serves *both* credential types' presentation.
+- **Keep** the `sorcha-device-key` control in the codebase — it is now used by the **device-registration blueprint** (§4), not the apply blueprint.
+
+## 4. The device-registration blueprint + the "Bind to device" flow
+
+A **second AIAS blueprint** (AIAS org = issuer participant; `citizen` = open, late-bound participant). Its starting action runs **in the wallet PWA**, triggered by a **"Bind to device" button on the credential's ID card**.
+
+### 4.1 Blueprint shape
+
+- **Participants:** `citizen` (walletAddress omitted — open, late-bound), `aias-issuer` (pre-bound AIAS wallet).
+- **Starting action (`isStartingAction: true`, sender `citizen`):**
+  - `credentialRequirements`: must **present** an `AssuredIdentityCredential` (the root). This proves entitlement. The wallet presents the root server-custody.
+  - `dataSchemas`: a single `deviceKey` object, `format: "sorcha-device-key"` (auto-captured device **public** JWK). **No human-entered fields.**
+- **Issuance action (sender `aias-issuer`, `requiredPriorActions: [starting]`):**
+  - `credentialIssuanceConfig`: `credentialType: AssuredIdentityCredential`, same `vct`/`displayName` as the root, `targetAudience: SorchaLocalWallet`, `recipientParticipantId: citizen`, `holderKeySourceField` → the captured device JWK (so `cnf` = device key).
+  - **Claim source (security):** the copied claims come from the **verified root presentation itself** — the root is AIAS-signed, so the KB-verified presentation's disclosed claims are tamper-evident (a forged claim would break AIAS's signature). The bind flow requests **full disclosure** of the root (it is automated — the citizen is not hand-picking claims), so the device copy carries the complete assured claim set. This avoids any separate "look up the user's record" step and keeps the presented credential as the single source of truth. *Implementation dependency:* the engine must pipe the verified presentation's claims into the issuance step's source document (the credential-bootstrapped gate proves possession today; feeding its `VerifiedClaims` into `claimMappings` is the new wiring). Client-supplied payload data is NOT trusted for identity claims.
+
+### 4.2 In-wallet flow (the button)
+
+1. ID card renders **"Bind to device"** when the held credential is an `AssuredIdentityCredential` root (holder-`cnf`) and this device has no live device copy of it.
+2. On tap: capture the device **public** JWK (`IDeviceKeyService.GetPublicJwkAsync`); the private key never leaves the device.
+3. Present the root (server-custody) to satisfy the blueprint's `credentialRequirement`.
+4. Submit the device-registration blueprint's starting action (device JWK payload).
+5. Receive the device-`cnf` copy; cache it (`ICredentialCache`).
+6. The ID card now offers in-person/offline presentation from this device.
+
+No form engine is added to the wallet — the flow wires two existing primitives (present engine + `IDeviceKeyService`) behind one button.
+
+## 5. The 3-device cap + eviction
+
+A **`DeviceBoundCredentialPolicy`** in the credential issuance service (not the blueprint — the cap is cross-instance stateful). On each device-`cnf` AIAS issuance:
+
+- **Identity of a "device"** = the device key's **JWK thumbprint** (RFC 7638).
+- **Idempotent re-bind:** if the submitted device key thumbprint already holds a live device copy, **replace in place** (refresh) — no count increment.
+- **Cap = 3 distinct device thumbprints** holding a live device-`cnf` AIAS copy per user.
+- **Eviction (new key exceeding 3):** revoke the **oldest** copy (by issued-at) via a **Token Status List bit flip** (F114 publisher/worker) + write an **F118 inbox notification** to the evicted device. Silent LRU (per the approved "oldest gets revoked").
+- **Ordering:** revoke-oldest must succeed **before** the new copy is issued — no orphaned 4th copy, no >3 live window. Treat as a single logical transaction; on revoke failure, fail the issuance.
+
+A user-facing device-management list ("your devices", manual revoke) is a natural follow-up, **out of scope** for this spec.
+
+## 6. Presentation selection (wallet-side)
+
+At present time the wallet selects the credential it can actually sign for on this surface:
+
+- **In-person / offline / device-mediated:** a device-`cnf` copy bound to *this* device → device signs the KB-JWT.
+- **Web / remote / server-mediated:** the holder-`cnf` root → wallet service signs (server-custody).
+- **No device copy on this device + offline present requested:** prompt "Bind this device first" (route to the §4 button).
+
+Both branches are plain SD-JWT VC presentations; the verifier does nothing special. Delegation is absent from every presentation path.
+
+## 7. Components & boundaries
+
+**New:**
+- `demos/AIAS/blueprints/aias-device-registration.template.json` — the §4 blueprint.
+- PWA "Bind to device" ID-card action + the in-wallet flow (§4.2).
+- `DeviceBoundCredentialPolicy` (count/evict, §5) in the issuance service.
+- Wallet present-selection rule (§6).
+
+**Changed:**
+- AIAS apply blueprint: `sorcha-device-key` → `sorcha-holder-key` (§3).
+
+**Reused:** Token Status List publisher/worker (F114) · F118 inbox · presentation engine · `IDeviceKeyService` · `sorcha-device-key` control · the Phase-1 `HandleDirectPost` verifier harness.
+
+## 8. Error handling
+
+| Condition | Behaviour |
+|---|---|
+| No root credential held | "Bind to device" hidden/disabled; prompt to get assured first |
+| Root revoked / present fails | Starting-action `credentialRequirement` fails → no copy issued |
+| Device key unavailable (non-PWA host) | Action unavailable (device binding is phone-only) |
+| Eviction (revoke-oldest) fails | Abort issuance — never leave >3 live or orphan a copy |
+| Offline present, no device copy | "Bind this device first" prompt |
+| Same device re-binds | Idempotent replace-in-place (§5) |
+
+## 9. Testing
+
+- **Blueprint:** device-registration blueprint publishes + validates (open citizen participant, credentialRequirement present, device-key field).
+- **In-wallet flow (integration):** capture device key + present root + submit → device-`cnf` copy cached; `cnf` = the device key, claims = the authoritative assurance.
+- **Cap/eviction (unit):** 4th distinct device evicts the oldest (status bit flipped + F118 notified); re-binding an existing thumbprint is idempotent (no increment); revoke-failure aborts issuance.
+- **Presentation selection:** device-side present picks the device copy (device-signs); web/remote picks the root (server-custody).
+- **Verifier (reuse Phase-1 harness):** the device copy standard-verifies via `HandleDirectPost` + `HaipPresentationVerifier`; the root verifies server-custody.
+
+## 10. Success criteria
+
+- **SC-1** A citizen applies for Assured Identity on the **web** and receives a holder-`cnf` root that presents server-custody for remote verification.
+- **SC-2** From the wallet, **"Bind to device"** mints a device-`cnf` copy (device key never leaves the phone) that presents in-person/offline and standard-verifies with no delegation.
+- **SC-3** A user holds at most **3** live device-`cnf` AIAS copies; binding a 4th device revokes the oldest (status-list) and notifies it; re-binding an existing device is idempotent.
+- **SC-4** The wallet presents the right credential per surface automatically (device copy in person, root on the web).
+
+## 11. Resolved decisions
+
+1. **Cap unit** = device-bound AIAS credentials (3 per user), AIAS-scoped. (Not platform-wide enrolled devices — that generalisation is a later concern.)
+2. **Entitlement gate** = present the root credential (full disclosure); **claims** sourced from that verified, AIAS-signed presentation (tamper-evident), not from client-supplied payload data.
+3. **Flow surface** = focused in-wallet "Bind to device" action (not a web pairing handoff, not a general application runner). Keeps it a blueprint for on-ledger AIAS provenance.
+4. **Re-signer** = AIAS re-issues (the blueprint's issuer participant is AIAS), preserving "assured by AIAS" provenance on every copy.
+5. **Eviction** = silent LRU (oldest revoked); device-management UI deferred.
+
+## 12. Out of scope
+
+- Platform-wide "enrolled devices" cap generalisation (this is AIAS-credential-scoped).
+- A user-facing device-management list / manual device revoke.
+- Applying an equivalent device-copy flow to non-AIAS credentials (driving licence, etc.).
+- The optional holder→device delegation `/verify` extension method (delegation is simply absent here).

--- a/src/Apps/Sorcha.Wallet.Pwa/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Extensions/ServiceCollectionExtensions.cs
@@ -271,6 +271,16 @@ public static class ServiceCollectionExtensions
             .AddHttpMessageHandler<BearerTokenHandler>()
             .AddHttpMessageHandler<ServerClockHandler>();
 
+        // #1195 Phase 2 (Task 6) — "Bind to device": presents the holder-cnf AIAS root
+        // server-custody (KB-JWT signed by the wallet service via /presentations/sign-kb)
+        // and drives the device-registration blueprint. The typed HttpClient carries the
+        // bearer chain for the direct_post + request-object fetch.
+        services.AddSingleton(new DeviceBindingOptions());
+        services.AddHttpClient<IDeviceBindingService, DeviceBindingService>(c =>
+            c.BaseAddress = new Uri(gatewayBaseAddress))
+            .AddHttpMessageHandler<BearerTokenHandler>()
+            .AddHttpMessageHandler<ServerClockHandler>();
+
         // Feature 128 — shared has-any-device probe. Drives the wallet PWA
         // pairing-takeover trigger (sub-PR A3) and the Sorcha Web nag-banner
         // trigger (sub-PR B). Registered Singleton so the cached value +

--- a/src/Apps/Sorcha.Wallet.Pwa/Pages/CredentialDetail.razor
+++ b/src/Apps/Sorcha.Wallet.Pwa/Pages/CredentialDetail.razor
@@ -18,9 +18,12 @@
 @using Sorcha.UI.Core.Components.Wallet
 @using Sorcha.UI.Core.Models.Forms
 @using Sorcha.UI.Core.Services.Credentials
+@using Sorcha.UI.Core.Services.Feedback
 @using Sorcha.Wallet.Pwa.Services
 @using Sorcha.Wallet.Pwa.Services.Presentation
 @inject ICredentialCache Credentials
+@inject IDeviceBindingService DeviceBinding
+@inject IInlineFeedback Feedback
 @inject NavigationManager Nav
 
 <PageTitle>Credential</PageTitle>
@@ -137,6 +140,19 @@
             </MudExpansionPanel>
         </MudExpansionPanels>
 
+        @* #1195 Phase 2 — "Bind to device": visible only for an AssuredIdentity ROOT
+           (holder-cnf) when this device holds no live device-bound copy yet. *@
+        @if (_canBind)
+        {
+            <MudButton Color="Color.Secondary" Variant="Variant.Outlined"
+                       StartIcon="@Icons.Material.Filled.PhonelinkLock"
+                       OnClick="BindAsync" FullWidth="true" Class="mb-2"
+                       Disabled="_binding"
+                       data-testid="credential-detail-bind-button">
+                @(_binding ? "Binding to this device…" : "Bind to this device")
+            </MudButton>
+        }
+
         <MudButton Color="Color.Primary" Variant="Variant.Filled"
                    StartIcon="@Icons.Material.Filled.QrCodeScanner"
                    OnClick="@(() => Nav.NavigateTo("present"))" FullWidth="true"
@@ -160,13 +176,30 @@
     private string _statusIcon = Icons.Material.Filled.CheckCircle;
     private Color _statusColor = Color.Success;
 
-    protected override async Task OnInitializedAsync()
+    private bool _canBind;
+    private bool _binding;
+
+    protected override async Task OnInitializedAsync() => await LoadAsync();
+
+    private async Task LoadAsync()
     {
         var all = await Credentials.ListAsync();
         _credential = all.FirstOrDefault(c => c.Id == Id);
         _loading = false;
 
         if (_credential is null) return;
+
+        // #1195 Phase 2 — root/copy discrimination for the "Bind to device" affordance.
+        // Never let a probe failure break the detail page: no binding is a normal answer.
+        try
+        {
+            await DeviceBinding.InitializeAsync();
+            _canBind = DeviceBinding.CanBind(_credential);
+        }
+        catch
+        {
+            _canBind = false;
+        }
 
         _title = CredentialDisplay.Name(_credential);
         // Only show a caption when it adds information beyond the title.
@@ -201,5 +234,43 @@
         var spaced = name.Replace('_', ' ').Replace('-', ' ').Trim();
         if (spaced.Length == 0) return name;
         return char.ToUpperInvariant(spaced[0]) + spaced[1..];
+    }
+
+    /// <summary>
+    /// #1195 Phase 2 — run the bind flow. Failures are NEVER silent: every outcome surfaces
+    /// via IInlineFeedback, errors with autoDismissMs: 0 (explicit acknowledgement). A
+    /// DeliveryTimeout is a PENDING outcome (warning copy), not an error.
+    /// </summary>
+    private async Task BindAsync()
+    {
+        if (_credential is null || _binding) return;
+        _binding = true;
+        try
+        {
+            await DeviceBinding.BindToThisDeviceAsync(_credential, CancellationToken.None);
+            Feedback.ShowSuccess(
+                "Your identity is now bound to this device — you can present it in person, even offline.");
+            _canBind = false;
+            await LoadAsync();
+        }
+        catch (DeviceBindingException ex) when (ex.Failure == DeviceBindingFailure.DeliveryTimeout)
+        {
+            // Pending, not failed — and the button hides so a duplicate bind isn't invited
+            // while the first is still in flight server-side.
+            Feedback.ShowWarning(ex.Message, autoDismissMs: 0);
+            _canBind = false;
+        }
+        catch (DeviceBindingException ex)
+        {
+            Feedback.ShowError(ex.Message, autoDismissMs: 0);
+        }
+        catch (Exception ex)
+        {
+            Feedback.ShowError($"Device binding failed: {ex.Message}", autoDismissMs: 0);
+        }
+        finally
+        {
+            _binding = false;
+        }
     }
 }

--- a/src/Apps/Sorcha.Wallet.Pwa/Pages/Present.razor
+++ b/src/Apps/Sorcha.Wallet.Pwa/Pages/Present.razor
@@ -15,10 +15,14 @@
 @using Microsoft.AspNetCore.Authorization
 @attribute [Authorize]
 @implements IAsyncDisposable
+@using System.Buffers.Text
 @using System.Net.Http
 @using System.Net.Http.Json
+@using System.Text
 @using System.Text.Json
 @using Microsoft.JSInterop
+@using Sorcha.ServiceClients.CitizenWallet
+@using Sorcha.UI.Core.Services.HolderKeys
 @using Sorcha.Wallet.Pwa.Components
 @using Sorcha.Wallet.Pwa.Models.Device
 @using Sorcha.Wallet.Pwa.Services
@@ -29,6 +33,8 @@
 @inject ICredentialCache Credentials
 @inject IDeviceKeyService DeviceKey
 @inject IStatusListService StatusList
+@inject ICitizenWalletClient WalletClient
+@inject IHolderKeyClient HolderKeys
 @inject HttpClient Http
 @inject IJSRuntime JS
 @inject IPresentationLog PresentationLog
@@ -163,11 +169,22 @@
         <NoMatchingCredentialDialog RequiredVct="@_request?.RequiredVct"
                                     OnCancel="Reset" />
     }
-    else if (_phase == Phase.PickCredential && _matches is not null)
+    else if (_phase == Phase.BindFirst)
     {
-        <CredentialPickerDialog Matches="_matches"
-                                OnChosen="OnCredentialChosen"
-                                OnCancel="Reset" />
+        @* #1195 Phase 2 (Task 7) — the selection layer answered BindDeviceFirst: the citizen's
+           assured-identity root can satisfy this request, but only a device-bound copy can be
+           presented on this surface, and THIS device holds none. An explicit routing outcome —
+           never a doomed present (device-signing the root fails verification with no local error). *@
+        <MudAlert Severity="Severity.Info" Class="mb-3" data-testid="present-bind-first">
+            This request needs a credential bound to this device, and this device isn't bound yet.
+            Bind it first, then present again.
+        </MudAlert>
+        <MudButton Variant="Variant.Filled" Color="Color.Primary"
+                   data-testid="present-bind-cta"
+                   OnClick="GoToBindSurface">
+            Bind this device
+        </MudButton>
+        <MudButton Class="ml-2" Variant="Variant.Outlined" OnClick="Reset">Cancel</MudButton>
     }
     else if (_phase == Phase.Consent && _selected is not null && _request is not null)
     {
@@ -220,7 +237,7 @@
 @code {
     private const string VideoElementId = "sorcha-qr-scan-video";
 
-    private enum Phase { AwaitingDeepLink, NoMatch, PickCredential, Consent, PickAlternative, PickQueryCredential, MultiConsent, Done }
+    private enum Phase { AwaitingDeepLink, NoMatch, BindFirst, Consent, PickAlternative, PickQueryCredential, MultiConsent, Done }
 
     // Feature 185. False until proven otherwise — an affordance the device cannot honour must not appear.
     private bool _proximitySupported;
@@ -230,8 +247,11 @@
     private string? _error;
     private bool _busy;
     private ParsedPresentationRequest? _request;
-    private IReadOnlyList<CredentialMatch>? _matches;
     private CredentialMatch? _selected;
+    // #1195 Phase 2 (Task 7) — HOW the selected credential's KB-JWT is signed. Returned by the
+    // selection layer together with the credential; this page must never re-derive it.
+    private PresentationSigningMode _signingMode = PresentationSigningMode.Device;
+    private CredentialMatch? _bindRoot;
     private Dictionary<string, bool> _optionalToggles = new();
     private string _responseStatus = string.Empty;
     private string _responseMessage = string.Empty;
@@ -344,15 +364,33 @@
                 return;
             }
 
-            _matches = Engine.Match(_request, _cachedCreds);
-            if (_matches.Count == 0) { _phase = Phase.NoMatch; return; }
-            if (_matches.Count == 1)
+            // #1195 Phase 2 (Task 7) — the selection layer picks WHICH credential + signing path
+            // this surface uses. This page is the web/remote surface: the holder-cnf root presents
+            // SERVER-CUSTODY (the wallet service signs the KB-JWT); a device-cnf copy device-signs.
+            var deviceThumbprint = await TryGetDeviceThumbprintAsync();
+            var holderThumbprint = await TryGetHolderThumbprintAsync();
+            var selection = Engine.Select(
+                _request, _cachedCreds, deviceThumbprint, holderThumbprint, PresentationSurface.Remote);
+            switch (selection.Outcome)
             {
-                _selected = _matches[0];
-                EnterConsent();
-                return;
+                case PresentationSelectionOutcome.Selected:
+                    _selected = selection.Match;
+                    _signingMode = selection.SigningMode;
+                    EnterConsent();
+                    break;
+                case PresentationSelectionOutcome.BindDeviceFirst:
+                    _bindRoot = selection.RootToBind;
+                    _phase = Phase.BindFirst;
+                    break;
+                case PresentationSelectionOutcome.HolderKeyUnavailable:
+                    // Fail-closed, named — never a guessed present that cannot verify.
+                    _error = "Your wallet's holder key couldn't be reached, so the right credential " +
+                             "for this request can't be determined. Check your connection and try again.";
+                    break;
+                default:
+                    _phase = Phase.NoMatch;
+                    break;
             }
-            _phase = Phase.PickCredential;
         }
         catch (Exception ex)
         {
@@ -367,13 +405,6 @@
                 _error = ex.Message;
             }
         }
-    }
-
-    private void OnCredentialChosen(CredentialMatch? match)
-    {
-        if (match is null) return;
-        _selected = match;
-        EnterConsent();
     }
 
     private void EnterConsent()
@@ -394,9 +425,31 @@
                 .Concat(_optionalToggles.Where(kv => kv.Value).Select(kv => kv.Key))
                 .ToList();
 
-            var deviceJwk = await DeviceKey.GetPublicJwkAsync();
+            // #1195 Phase 2 (Task 7) — the signer follows the selection's signing mode. The
+            // holder-cnf root signs SERVER-CUSTODY (Task 6a endpoint; the holder private key
+            // never reaches this device); a device-cnf copy / legacy credential device-signs.
+            JsonElement signerJwk;
+            Func<byte[], CancellationToken, Task<byte[]>> signer;
+            if (_signingMode == PresentationSigningMode.ServerCustody)
+            {
+                var holderKeys = await HolderKeys.GetHolderKeysAsync();
+                if (holderKeys is null)
+                {
+                    _error = "Your wallet's holder key couldn't be reached, so this presentation " +
+                             "can't be signed. Check your connection and try again.";
+                    return;
+                }
+                signerJwk = holderKeys.HolderJwk;
+                signer = SignWithHolderKeyAsync;
+            }
+            else
+            {
+                signerJwk = await DeviceKey.GetPublicJwkAsync();
+                signer = DeviceKey.SignAsync;
+            }
+
             var vp = await Engine.BuildVpTokenAsync(
-                _selected, approved, _request, deviceJwk, DeviceKey.SignAsync);
+                _selected, approved, _request, signerJwk, signer);
 
             // Standard OpenID4VP 1.0 direct_post (§8.2): vp_token is ALWAYS the object-keyed
             // envelope, even for the single-ask flow — a bare compact string is the retired
@@ -456,6 +509,53 @@
             // Activity log is a convenience surface; never let it break the flow.
         }
     }
+
+    // ─────────────────── #1195 Phase 2 (Task 7) — selection inputs + server-custody leg ───────────────────
+
+    /// <summary>This device's key thumbprint, or null when no usable device key exists (non-PWA host).</summary>
+    private async Task<string?> TryGetDeviceThumbprintAsync()
+    {
+        try { return await DeviceKey.GetThumbprintAsync(); }
+        catch { return null; }   // a host without a device key is a normal answer, not an error
+    }
+
+    /// <summary>
+    /// The citizen's holder-key thumbprint (RFC 7638, from the wallet service's holder JWK), or null
+    /// when unreachable — in which case the selection layer fails CLOSED rather than guessing.
+    /// </summary>
+    private async Task<string?> TryGetHolderThumbprintAsync()
+    {
+        try
+        {
+            var holderKeys = await HolderKeys.GetHolderKeysAsync();
+            return holderKeys is null
+                ? null
+                : PresentationEngine.ComputeJwkThumbprint(holderKeys.HolderJwk);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Server-custody signer for a holder-cnf root: round-trips the KB-JWT signing input through
+    /// <c>POST /api/v1/wallet/presentations/sign-kb</c> (Task 6a). The holder private key never
+    /// reaches this device.
+    /// </summary>
+    private async Task<byte[]> SignWithHolderKeyAsync(byte[] signingInput, CancellationToken ct)
+    {
+        var response = await WalletClient.SignKbJwtAsync(
+            new Sorcha.CitizenWallet.Abstractions.Models.KbJwtSignRequest
+            {
+                SigningInput = Encoding.ASCII.GetString(signingInput),
+            }, ct);
+        return Base64Url.DecodeFromChars(response.Signature);
+    }
+
+    /// <summary>Route the BindDeviceFirst outcome to the root's credential card (the Task 6 bind surface).</summary>
+    private void GoToBindSurface()
+        => Nav.NavigateTo(_bindRoot is not null ? $"credentials/{_bindRoot.Credential.Id}" : "cards");
 
     // ─────────────────── Feature 181 US2 — multi-credential orchestration ───────────────────
 
@@ -677,8 +777,9 @@
         _phase = Phase.AwaitingDeepLink;
         _deepLink = string.Empty;
         _request = null;
-        _matches = null;
         _selected = null;
+        _signingMode = PresentationSigningMode.Device;
+        _bindRoot = null;
         _optionalToggles = new();
         _cachedCreds = [];
         _result = null;

--- a/src/Apps/Sorcha.Wallet.Pwa/Pages/Present.razor
+++ b/src/Apps/Sorcha.Wallet.Pwa/Pages/Present.razor
@@ -169,6 +169,14 @@
         <NoMatchingCredentialDialog RequiredVct="@_request?.RequiredVct"
                                     OnCancel="Reset" />
     }
+    else if (_phase == Phase.PickCredential && _pickerMatches is not null)
+    {
+        @* Fix round 2 — the picker returns for genuinely DISTINCT candidates (the root +
+           this-device-copy pair of one credential family is collapsed by the selection layer). *@
+        <CredentialPickerDialog Matches="_pickerMatches"
+                                OnChosen="OnCredentialChosen"
+                                OnCancel="Reset" />
+    }
     else if (_phase == Phase.BindFirst)
     {
         @* #1195 Phase 2 (Task 7) — the selection layer answered BindDeviceFirst: the citizen's
@@ -237,7 +245,7 @@
 @code {
     private const string VideoElementId = "sorcha-qr-scan-video";
 
-    private enum Phase { AwaitingDeepLink, NoMatch, BindFirst, Consent, PickAlternative, PickQueryCredential, MultiConsent, Done }
+    private enum Phase { AwaitingDeepLink, NoMatch, BindFirst, PickCredential, Consent, PickAlternative, PickQueryCredential, MultiConsent, Done }
 
     // Feature 185. False until proven otherwise — an affordance the device cannot honour must not appear.
     private bool _proximitySupported;
@@ -252,6 +260,10 @@
     // selection layer together with the credential; this page must never re-derive it.
     private PresentationSigningMode _signingMode = PresentationSigningMode.Device;
     private CredentialMatch? _bindRoot;
+    // Fix round 2 — ChoiceRequired state: each candidate carries its own signing mode; the picker
+    // maps the chosen match back to its candidate so the pairing is carried through, not re-derived.
+    private IReadOnlyList<PresentationCandidate>? _candidates;
+    private IReadOnlyList<CredentialMatch>? _pickerMatches;
     private Dictionary<string, bool> _optionalToggles = new();
     private string _responseStatus = string.Empty;
     private string _responseMessage = string.Empty;
@@ -382,6 +394,11 @@
                     _bindRoot = selection.RootToBind;
                     _phase = Phase.BindFirst;
                     break;
+                case PresentationSelectionOutcome.ChoiceRequired:
+                    _candidates = selection.Candidates;
+                    _pickerMatches = selection.Candidates!.Select(c => c.Match).ToList();
+                    _phase = Phase.PickCredential;
+                    break;
                 case PresentationSelectionOutcome.HolderKeyUnavailable:
                     // Fail-closed, named — never a guessed present that cannot verify.
                     _error = "Your wallet's holder key couldn't be reached, so the right credential " +
@@ -405,6 +422,18 @@
                 _error = ex.Message;
             }
         }
+    }
+
+    /// <summary>Fix round 2 — the citizen's pick maps back to its candidate so the credential keeps
+    /// the signing mode the selection layer paired it with (never re-derived here).</summary>
+    private void OnCredentialChosen(CredentialMatch? match)
+    {
+        if (match is null || _candidates is null) return;
+        var candidate = _candidates.FirstOrDefault(c => ReferenceEquals(c.Match, match));
+        if (candidate is null) return;
+        _selected = candidate.Match;
+        _signingMode = candidate.SigningMode;
+        EnterConsent();
     }
 
     private void EnterConsent()
@@ -697,7 +726,16 @@
         _error = null;
         try
         {
+            // #1195 Phase 2 (Task 7 fix round 2) — classify EACH consented query by cnf thumbprint:
+            // a holder-cnf root presents SERVER-CUSTODY, a this-device copy / legacy credential
+            // device-signs. Mixed modes compose (per-presentation KB-JWTs; no envelope signature).
+            // A device-signed root is the recorded silent-verification-failure trap.
+            var deviceThumbprint = await TryGetDeviceThumbprintAsync();
+            var holderThumbprint = await TryGetHolderThumbprintAsync();
+
             var consented = new List<ConsentedQuery>();
+            var anyServerCustody = false;
+            var anyDeviceSigned = false;
             foreach (var id in _activeQueryIds)
             {
                 if (!_selections.TryGetValue(id, out var sel)) continue;
@@ -706,7 +744,29 @@
                     ? toggles.Where(kv => kv.Value).Select(kv => kv.Key)
                     : Enumerable.Empty<string>();
                 var approved = sel.SatisfiedRequired.Concat(optional).ToList();
-                consented.Add(new ConsentedQuery(id, sel, qm.RequiredClaims, approved));
+
+                PresentationSigningMode mode;
+                switch (PresentationEngine.ClassifyBinding(
+                    sel.Credential.RawSdJwt, deviceThumbprint, holderThumbprint))
+                {
+                    case PresentationEngine.CredentialBinding.HolderRoot:
+                        mode = PresentationSigningMode.ServerCustody;
+                        anyServerCustody = true;
+                        break;
+                    case PresentationEngine.CredentialBinding.ThisDevice:
+                    case PresentationEngine.CredentialBinding.Unbound:
+                        mode = PresentationSigningMode.Device;
+                        anyDeviceSigned = true;
+                        break;
+                    default:
+                        // Foreign copy / unclassifiable — named, never a doomed present.
+                        _error = $"'{sel.Credential.DisplayLabel ?? sel.Credential.Vct}' can't be " +
+                                 "presented from this device, so nothing was shared. " +
+                                 "Present it from the device it's bound to, or try again once your " +
+                                 "wallet's holder key is reachable.";
+                        return;
+                }
+                consented.Add(new ConsentedQuery(id, sel, qm.RequiredClaims, approved, mode));
             }
 
             if (consented.Count == 0)
@@ -715,11 +775,33 @@
                 return;
             }
 
-            var deviceJwk = await DeviceKey.GetPublicJwkAsync();
+            JsonElement? holderJwk = null;
+            Func<byte[], CancellationToken, Task<byte[]>>? holderSigner = null;
+            if (anyServerCustody)
+            {
+                var holderKeys = await HolderKeys.GetHolderKeysAsync();
+                if (holderKeys is null)
+                {
+                    _error = "Your wallet's holder key couldn't be reached, so this presentation " +
+                             "can't be signed. Check your connection and try again.";
+                    return;
+                }
+                holderJwk = holderKeys.HolderJwk;
+                holderSigner = SignWithHolderKeyAsync;
+            }
+
+            // The device pair is only resolved when a device-signed entry exists — a host without a
+            // device key can still present a pure server-custody envelope.
+            JsonElement deviceJwk = default;
+            if (anyDeviceSigned)
+            {
+                deviceJwk = await DeviceKey.GetPublicJwkAsync();
+            }
+
             // One SD-JWT presentation per consented query, assembled into the object-keyed
-            // OpenID4VP 1.0 vp_token envelope.
+            // OpenID4VP 1.0 vp_token envelope — each signed under ITS OWN mode.
             var vpTokenEnvelope = await Engine.BuildVpTokenEnvelopeAsync(
-                consented, _request, deviceJwk, DeviceKey.SignAsync);
+                consented, _request, deviceJwk, DeviceKey.SignAsync, holderJwk, holderSigner);
 
             var form = new FormUrlEncodedContent(new Dictionary<string, string>
             {
@@ -780,6 +862,8 @@
         _selected = null;
         _signingMode = PresentationSigningMode.Device;
         _bindRoot = null;
+        _candidates = null;
+        _pickerMatches = null;
         _optionalToggles = new();
         _cachedCreds = [];
         _result = null;

--- a/src/Apps/Sorcha.Wallet.Pwa/Services/Applications/IApplicationActionClient.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Services/Applications/IApplicationActionClient.cs
@@ -256,8 +256,16 @@ public sealed class HttpApplicationActionClient : IApplicationActionClient
 
             if (response.IsSuccessStatusCode)
             {
+                // #1195 Phase 2 — a presentation-gated action (F111) answers success-shaped
+                // but AwaitingPresentation: surface the minted presentation request so the
+                // wallet can drive the presentation leg (DeviceBindingService). A body that
+                // doesn't parse degrades to the plain success shape (older servers).
+                var (awaiting, requestId, requestUri) = await TryReadPresentationGateAsync(response, ct);
                 return new ApplicationSubmissionResult(
-                    ApplicationSubmissionStatus.Success, context.InstanceId, ErrorCode: null, ErrorDetail: null);
+                    ApplicationSubmissionStatus.Success, context.InstanceId, ErrorCode: null, ErrorDetail: null,
+                    AwaitingPresentation: awaiting,
+                    PresentationRequestId: requestId,
+                    PresentationRequestUri: requestUri);
             }
 
             var detail = await SafeReadAsync(response, ct);
@@ -283,6 +291,45 @@ public sealed class HttpApplicationActionClient : IApplicationActionClient
     private static async Task<string?> SafeReadAsync(HttpResponseMessage r, CancellationToken ct)
     {
         try { return await r.Content.ReadAsStringAsync(ct); } catch { return null; }
+    }
+
+    /// <summary>
+    /// Reads the F111 presentation-gate fields off a successful execute response
+    /// (<c>awaitingPresentation</c> + <c>presentationRequest.requestId/presentationRequestUri</c>,
+    /// server shape <c>ActionSubmissionResponse</c>). Best-effort: an unparseable body is
+    /// treated as a plain (non-gated) success, never a failure.
+    /// </summary>
+    private static async Task<(bool Awaiting, Guid? RequestId, string? RequestUri)> TryReadPresentationGateAsync(
+        HttpResponseMessage response, CancellationToken ct)
+    {
+        try
+        {
+            var body = await response.Content.ReadFromJsonAsync<ExecuteResponseDto>(JsonOptions, ct);
+            if (body is not { AwaitingPresentation: true } ||
+                string.IsNullOrEmpty(body.PresentationRequest?.PresentationRequestUri))
+            {
+                return (false, null, null);
+            }
+            return (true, body.PresentationRequest.RequestId, body.PresentationRequest.PresentationRequestUri);
+        }
+        catch
+        {
+            return (false, null, null);
+        }
+    }
+
+    /// <summary>Narrow wire shape of the execute response — only the presentation-gate fields.</summary>
+    private sealed class ExecuteResponseDto
+    {
+        public bool AwaitingPresentation { get; set; }
+        public PresentationRequestDto? PresentationRequest { get; set; }
+    }
+
+    /// <summary>Wire shape of <c>ActionSubmissionResponse.PresentationRequest</c> (the fields the wallet consumes).</summary>
+    private sealed class PresentationRequestDto
+    {
+        public Guid? RequestId { get; set; }
+        public string? PresentationRequestUri { get; set; }
     }
 
     /// <summary>

--- a/src/Apps/Sorcha.Wallet.Pwa/Services/Applications/IApplicationSubmissionService.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Services/Applications/IApplicationSubmissionService.cs
@@ -40,11 +40,21 @@ public sealed record ApplicationSubmissionRequest(
 /// <param name="InstanceId">Created blueprint-instance id on success; null otherwise.</param>
 /// <param name="ErrorCode">Stable error code on failure; null on success.</param>
 /// <param name="ErrorDetail">Human-readable diagnostic on failure; null on success.</param>
+/// <param name="AwaitingPresentation">
+/// #1195 Phase 2 — true when the submitted action is gated on a credential presentation
+/// (F111): the action has NOT completed; the server minted a presentation request the
+/// wallet must now fulfil. Mirrors <c>ActionSubmissionResponse.AwaitingPresentation</c>.
+/// </param>
+/// <param name="PresentationRequestId">The F111 presentation request id, when awaiting.</param>
+/// <param name="PresentationRequestUri">The <c>openid4vp://…</c> authorization request URI, when awaiting.</param>
 public sealed record ApplicationSubmissionResult(
     ApplicationSubmissionStatus Status,
     Guid? InstanceId,
     string? ErrorCode,
-    string? ErrorDetail);
+    string? ErrorDetail,
+    bool AwaitingPresentation = false,
+    Guid? PresentationRequestId = null,
+    string? PresentationRequestUri = null);
 
 /// <summary>Submission outcome class — drives UI branching.</summary>
 public enum ApplicationSubmissionStatus

--- a/src/Apps/Sorcha.Wallet.Pwa/Services/DeviceBindingService.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Services/DeviceBindingService.cs
@@ -1,0 +1,556 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Buffers.Text;
+using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.Logging;
+using Sorcha.CitizenWallet.Abstractions.Constants;
+using Sorcha.CitizenWallet.Abstractions.Models;
+using Sorcha.ServiceClients.CitizenWallet;
+using Sorcha.UI.Core.Models.Presentation;
+using Sorcha.UI.Core.Services.HolderKeys;
+using Sorcha.Wallet.Pwa.Services.Applications;
+using Sorcha.Wallet.Pwa.Services.Catalogue;
+using Sorcha.Wallet.Pwa.Services.Presentation;
+
+namespace Sorcha.Wallet.Pwa.Services;
+
+/// <summary>
+/// #1195 Phase 2 (Task 6) — the "Bind to device" flow behind the AIAS root credential's
+/// ID-card action. Orchestrates: capture the device public JWK → start + submit the
+/// device-registration blueprint's gated starting action (which mints the F127
+/// presentation request) → present the holder-<c>cnf</c> root SERVER-CUSTODY (the
+/// wallet service signs the KB-JWT via <c>POST /api/v1/wallet/presentations/sign-kb</c>;
+/// the holder private key never reaches the device) → bounded wait for the device-<c>cnf</c>
+/// copy to arrive through the F114 sync path.
+/// </summary>
+public interface IDeviceBindingService
+{
+    /// <summary>
+    /// Prime the root/copy discriminator: resolves this device's key thumbprint and a
+    /// snapshot of the cached credentials. Idempotent; safe to call on page load. A device
+    /// without a usable key (non-PWA host) primes to a state where <see cref="CanBind"/> is
+    /// always false — device binding is phone-only by design.
+    /// </summary>
+    Task InitializeAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// True when <paramref name="credential"/> is an AssuredIdentityCredential ROOT
+    /// (holder-<c>cnf</c> — its <c>cnf.jwk</c> thumbprint differs from this device's key)
+    /// and THIS device has no live device-bound copy of it yet. Requires
+    /// <see cref="InitializeAsync"/> to have completed; returns false before that.
+    /// </summary>
+    bool CanBind(CachedCredential credential);
+
+    /// <summary>
+    /// Captures the device key, presents the root (server custody), submits the
+    /// device-registration blueprint, and waits (bounded) for the device-<c>cnf</c> copy to
+    /// land in the local cache. Throws <see cref="DeviceBindingException"/> on any gate/mint
+    /// failure — loudly and distinguishably (surface inline); nothing is cached on failure.
+    /// A <see cref="DeviceBindingFailure.DeliveryTimeout"/> is an explicit PENDING outcome:
+    /// the presentation succeeded but the copy hasn't synced yet.
+    /// </summary>
+    Task<CachedCredential> BindToThisDeviceAsync(CachedCredential root, CancellationToken ct);
+}
+
+/// <summary>Which leg of the bind flow failed — drives distinguishable UI copy.</summary>
+public enum DeviceBindingFailure
+{
+    /// <summary>The device key is unavailable (non-PWA host / WebCrypto bridge failure).</summary>
+    DeviceKeyUnavailable,
+    /// <summary>A supporting call (catalogue, instance-create, holder keys) failed — transient.</summary>
+    ServiceUnavailable,
+    /// <summary>The device-registration blueprint is not published on this service.</summary>
+    BlueprintNotFound,
+    /// <summary>The starting action's form context could not be loaded.</summary>
+    FormLoadFailed,
+    /// <summary>The starting-action submission was rejected (validation / server error).</summary>
+    SubmitRejected,
+    /// <summary>A policy said no (409 — e.g. the device cap could not be honoured). Retrying cannot change the answer.</summary>
+    PolicyRefused,
+    /// <summary>The server accepted the action but did not start the identity check (SorchaWallet presentation initiation missing server-side).</summary>
+    PresentationNotInitiated,
+    /// <summary>The presentation request could not be fetched/parsed.</summary>
+    PresentationRequestInvalid,
+    /// <summary>The root credential cannot satisfy the presentation request.</summary>
+    RootNotEligible,
+    /// <summary>The server-custody KB-JWT signing call failed.</summary>
+    HolderSigningFailed,
+    /// <summary>The presentation outcome post (direct_post) was refused.</summary>
+    PresentationSubmitRejected,
+    /// <summary>The presentation completed but the device copy hasn't synced within the wait window — PENDING, not failed.</summary>
+    DeliveryTimeout,
+}
+
+/// <summary>
+/// A named, distinguishable bind-flow failure. Verification/presentation failures are NEVER
+/// silent — every leg throws with a citizen-readable message and a machine-readable
+/// <see cref="Failure"/> kind, and <see cref="Retryable"/> says whether trying again can help.
+/// </summary>
+public sealed class DeviceBindingException : Exception
+{
+    /// <summary>Which leg failed.</summary>
+    public DeviceBindingFailure Failure { get; }
+
+    /// <summary>True when the failure is transient (e.g. 503) and a retry may succeed.</summary>
+    public bool Retryable { get; }
+
+    /// <summary>Initialises a new instance.</summary>
+    public DeviceBindingException(
+        DeviceBindingFailure failure, string message, bool retryable = false, Exception? inner = null)
+        : base(message, inner)
+    {
+        Failure = failure;
+        Retryable = retryable;
+    }
+}
+
+/// <summary>Tuning knobs for the bounded post-presentation delivery wait.</summary>
+public sealed record DeviceBindingOptions
+{
+    /// <summary>Delay between sync/cache polls while waiting for the device copy.</summary>
+    public TimeSpan PollInterval { get; init; } = TimeSpan.FromSeconds(3);
+
+    /// <summary>Total wait for the device copy before reporting the explicit pending outcome.</summary>
+    public TimeSpan DeliveryTimeout { get; init; } = TimeSpan.FromSeconds(30);
+}
+
+/// <summary>Default <see cref="IDeviceBindingService"/>.</summary>
+public sealed class DeviceBindingService : IDeviceBindingService
+{
+    /// <summary>
+    /// Published device-registration blueprint ids are <c>{templateId}-{timestamp}</c>; the
+    /// stable discriminator is the template id prefix (see
+    /// <c>demos/AIAS/blueprints/aias-device-registration.template.json</c>). The catalogue
+    /// carries no tags/vct metadata, so the id prefix is the most robust discovery available.
+    /// </summary>
+    internal const string DeviceRegistrationBlueprintIdPrefix = "aias-device-registration";
+
+    /// <summary>The blueprint slot the issuance action reads the device JWK from (<c>holderKeySourceField</c>).</summary>
+    internal const string DeviceKeySlot = "/deviceKey/holderJwk";
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    private readonly IDeviceKeyService _deviceKeys;
+    private readonly ICatalogueClient _catalogue;
+    private readonly IApplicationActionClient _actions;
+    private readonly IPresentationEngine _engine;
+    private readonly IHolderKeyClient _holderKeyClient;
+    private readonly ICitizenWalletClient _walletClient;
+    private readonly ICredentialCache _cache;
+    private readonly ISyncService _sync;
+    private readonly HttpClient _http;
+    private readonly TimeProvider _time;
+    private readonly ILogger<DeviceBindingService> _logger;
+    private readonly DeviceBindingOptions _options;
+
+    private bool _initialized;
+    private string? _deviceThumbprint;
+    private IReadOnlyList<CachedCredential> _snapshot = [];
+
+    /// <summary>Initialises a new instance.</summary>
+    public DeviceBindingService(
+        IDeviceKeyService deviceKeys,
+        ICatalogueClient catalogue,
+        IApplicationActionClient actions,
+        IPresentationEngine engine,
+        IHolderKeyClient holderKeyClient,
+        ICitizenWalletClient walletClient,
+        ICredentialCache cache,
+        ISyncService sync,
+        HttpClient http,
+        TimeProvider time,
+        ILogger<DeviceBindingService> logger,
+        DeviceBindingOptions? options = null)
+    {
+        _deviceKeys = deviceKeys ?? throw new ArgumentNullException(nameof(deviceKeys));
+        _catalogue = catalogue ?? throw new ArgumentNullException(nameof(catalogue));
+        _actions = actions ?? throw new ArgumentNullException(nameof(actions));
+        _engine = engine ?? throw new ArgumentNullException(nameof(engine));
+        _holderKeyClient = holderKeyClient ?? throw new ArgumentNullException(nameof(holderKeyClient));
+        _walletClient = walletClient ?? throw new ArgumentNullException(nameof(walletClient));
+        _cache = cache ?? throw new ArgumentNullException(nameof(cache));
+        _sync = sync ?? throw new ArgumentNullException(nameof(sync));
+        _http = http ?? throw new ArgumentNullException(nameof(http));
+        _time = time ?? throw new ArgumentNullException(nameof(time));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _options = options ?? new DeviceBindingOptions();
+    }
+
+    /// <inheritdoc />
+    public async Task InitializeAsync(CancellationToken ct = default)
+    {
+        try
+        {
+            _deviceThumbprint = await _deviceKeys.GetThumbprintAsync(ct);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            // A host without a usable device key (e.g. the bridge is absent) is a normal
+            // answer: device binding is phone-only. CanBind stays false; never a crash.
+            _logger.LogInformation(ex, "Device key unavailable — device binding disabled on this host.");
+            _deviceThumbprint = null;
+        }
+
+        try
+        {
+            _snapshot = await _cache.ListAsync(ct);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Credential snapshot unavailable — CanBind will answer false.");
+            _snapshot = [];
+        }
+
+        _initialized = true;
+    }
+
+    /// <inheritdoc />
+    public bool CanBind(CachedCredential credential)
+    {
+        ArgumentNullException.ThrowIfNull(credential);
+
+        if (!_initialized || _deviceThumbprint is null) return false;
+        if (credential.Format != CachedCredentialFormat.SdJwtVc) return false;
+        // vct matching is case-sensitive Ordinal (VCT decoupling, #1187).
+        if (!string.Equals(credential.Vct, VctUris.AssuredIdentityV1, StringComparison.Ordinal)) return false;
+
+        // Root discriminator: the root's cnf is the HOLDER key; a device-bound copy's cnf
+        // is THIS device's key. No readable cnf ⇒ we cannot prove it is a root ⇒ not bindable.
+        if (!TryGetCnfJwkThumbprint(credential.RawSdJwt, out var cnfThumbprint)) return false;
+        if (string.Equals(cnfThumbprint, _deviceThumbprint, StringComparison.Ordinal)) return false;
+
+        // Already bound: any OTHER live AIAS credential whose cnf is this device's key.
+        foreach (var other in _snapshot)
+        {
+            if (other.Id == credential.Id) continue;
+            if (!string.Equals(other.Vct, VctUris.AssuredIdentityV1, StringComparison.Ordinal)) continue;
+            if (TryGetCnfJwkThumbprint(other.RawSdJwt, out var otherThumbprint) &&
+                string.Equals(otherThumbprint, _deviceThumbprint, StringComparison.Ordinal))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <inheritdoc />
+    public async Task<CachedCredential> BindToThisDeviceAsync(CachedCredential root, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(root);
+
+        // ── 1. Capture: this device's public JWK + thumbprint ────────────────────────────
+        JsonElement deviceJwk;
+        string deviceThumbprint;
+        try
+        {
+            deviceJwk = await _deviceKeys.GetPublicJwkAsync(ct);
+            deviceThumbprint = await _deviceKeys.GetThumbprintAsync(ct);
+        }
+        catch (OperationCanceledException) { throw; }
+        catch (Exception ex)
+        {
+            throw new DeviceBindingException(
+                DeviceBindingFailure.DeviceKeyUnavailable,
+                "This device's key isn't available, so it can't be bound. Device binding only works in the wallet app.",
+                retryable: false, ex);
+        }
+
+        // ── 2. Discover the device-registration service + start an instance ──────────────
+        IReadOnlyList<CatalogueItem> services;
+        try
+        {
+            services = await _catalogue.GetServicesAsync(ct);
+        }
+        catch (OperationCanceledException) { throw; }
+        catch (Exception ex)
+        {
+            throw new DeviceBindingException(
+                DeviceBindingFailure.ServiceUnavailable,
+                "Couldn't reach the service catalogue to start device binding. Check your connection and try again.",
+                retryable: true, ex);
+        }
+
+        var item = services.FirstOrDefault(s =>
+            s.BlueprintId.StartsWith(DeviceRegistrationBlueprintIdPrefix, StringComparison.Ordinal));
+        if (item is null)
+        {
+            throw new DeviceBindingException(
+                DeviceBindingFailure.BlueprintNotFound,
+                "Device binding isn't available on this service yet (the device-registration workflow is not published).",
+                retryable: false);
+        }
+
+        var instanceIdRaw = await _catalogue.StartAsync(item, ct);
+        if (!Guid.TryParse(instanceIdRaw, out var instanceId))
+        {
+            throw new DeviceBindingException(
+                DeviceBindingFailure.ServiceUnavailable,
+                "The device-binding workflow could not be started. Try again in a moment.",
+                retryable: true);
+        }
+
+        // ── 3. Load + submit the gated starting action (device JWK payload) ───────────────
+        // Submitting the SorchaWallet-gated action is what MINTS the presentation request
+        // (F127/F111) — so the submit leg precedes the present leg by construction.
+        var load = await _actions.LoadFormAsync(instanceId, ct);
+        if (load.Status != ApplicationFormLoadStatus.Loaded || load.Context is null)
+        {
+            throw new DeviceBindingException(
+                DeviceBindingFailure.FormLoadFailed,
+                load.Status == ApplicationFormLoadStatus.NetworkError
+                    ? "Couldn't reach the service to prepare device binding. Check your connection and try again."
+                    : $"The device-binding workflow could not be prepared ({load.Status}).",
+                retryable: load.Status == ApplicationFormLoadStatus.NetworkError);
+        }
+
+        var formData = new Dictionary<string, object?> { [DeviceKeySlot] = deviceJwk };
+        var submit = await _actions.SubmitAsync(load.Context, formData, ct);
+        if (submit.Status != ApplicationSubmissionStatus.Success)
+        {
+            if (string.Equals(submit.ErrorCode, "HTTP_409", StringComparison.Ordinal))
+            {
+                throw new DeviceBindingException(
+                    DeviceBindingFailure.PolicyRefused,
+                    "The service refused this binding (the device limit could not be honoured, or a binding is already in flight). Retrying won't change the answer.",
+                    retryable: false);
+            }
+
+            var transient = submit.Status == ApplicationSubmissionStatus.ServerError;
+            throw new DeviceBindingException(
+                DeviceBindingFailure.SubmitRejected,
+                $"The device-binding request was rejected{(submit.ErrorDetail is null ? "." : $": {submit.ErrorDetail}")}"
+                    + (transient ? " Try again in a moment." : string.Empty),
+                retryable: transient);
+        }
+
+        if (!submit.AwaitingPresentation || string.IsNullOrEmpty(submit.PresentationRequestUri))
+        {
+            // Named server gap — NEVER silent. The SorchaWallet presentation initiation is not
+            // wired on the action-execute path yet; without it no identity check ever starts.
+            throw new DeviceBindingException(
+                DeviceBindingFailure.PresentationNotInitiated,
+                "The service accepted the request but did not start the identity check, so nothing was bound. " +
+                "(Server-side: SorchaWallet presentation initiation is not enabled on action submission.)",
+                retryable: false);
+        }
+
+        // ── 4. Present the ROOT, server-custody ───────────────────────────────────────────
+        ParsedPresentationRequest request;
+        try
+        {
+            request = await _engine.ParseAsync(submit.PresentationRequestUri, FetchRequestObjectAsync, ct);
+        }
+        catch (OperationCanceledException) { throw; }
+        catch (Exception ex)
+        {
+            throw new DeviceBindingException(
+                DeviceBindingFailure.PresentationRequestInvalid,
+                $"The identity check could not be started: {ex.Message}",
+                retryable: false, ex);
+        }
+
+        var matches = _engine.Match(request, [root]);
+        if (matches.Count == 0)
+        {
+            throw new DeviceBindingException(
+                DeviceBindingFailure.RootNotEligible,
+                "Your Assured Identity credential can't satisfy the identity check this service asked for, so nothing was bound.",
+                retryable: false);
+        }
+        var match = matches[0];
+
+        var holderKeys = await _holderKeyClient.GetHolderKeysAsync(ct);
+        if (holderKeys is null)
+        {
+            throw new DeviceBindingException(
+                DeviceBindingFailure.ServiceUnavailable,
+                "Couldn't resolve your wallet's holder key for the identity check. Try again in a moment.",
+                retryable: true);
+        }
+
+        // Full disclosure of the root (design §4.1): the bind flow is automated — the citizen
+        // is not hand-picking claims — so every disclosable claim is approved. The engine
+        // validates that the approved set covers the request's required claims.
+        var approved = root.AvailableClaimNames
+            .Union(match.SatisfiedRequired, StringComparer.Ordinal)
+            .ToList();
+
+        string vpToken;
+        try
+        {
+            vpToken = await _engine.BuildVpTokenAsync(
+                match, approved, request, holderKeys.HolderJwk, SignWithHolderKeyAsync, ct);
+        }
+        catch (OperationCanceledException) { throw; }
+        catch (DeviceBindingException) { throw; }
+        catch (Exception ex)
+        {
+            throw new DeviceBindingException(
+                DeviceBindingFailure.HolderSigningFailed,
+                $"The identity check could not be signed: {ex.Message}",
+                retryable: false, ex);
+        }
+
+        // ── 5. direct_post the outcome to the request's response_uri ──────────────────────
+        // Wire shape per SorchaWalletVerificationPayload: JSON { vpToken } (the compact
+        // SD-JWT presentation; the sorcha-wallet consumer validates it server-side).
+        HttpResponseMessage response;
+        try
+        {
+            response = await _http.PostAsJsonAsync(
+                request.ResponseUri, new SorchaWalletOutcomePost(vpToken), JsonOptions, ct);
+        }
+        catch (OperationCanceledException) { throw; }
+        catch (Exception ex)
+        {
+            throw new DeviceBindingException(
+                DeviceBindingFailure.PresentationSubmitRejected,
+                "The identity check couldn't be submitted — the service was unreachable. Try again in a moment.",
+                retryable: true, ex);
+        }
+
+        if (!response.IsSuccessStatusCode)
+        {
+            var status = (int)response.StatusCode;
+            var transient = status is 502 or 503 or 504;
+            throw new DeviceBindingException(
+                DeviceBindingFailure.PresentationSubmitRejected,
+                $"The identity check was refused (HTTP {status})." +
+                (transient ? " This is temporary — try again in a moment." : " Nothing was bound."),
+                retryable: transient);
+        }
+
+        _logger.LogInformation(
+            "Device-binding presentation submitted for instance {InstanceId}; awaiting device-cnf copy (requestId {RequestId})",
+            instanceId, submit.PresentationRequestId);
+
+        // ── 6. Bounded wait: the copy arrives async via the F114 sync path ────────────────
+        var deadline = _time.GetUtcNow() + _options.DeliveryTimeout;
+        while (true)
+        {
+            ct.ThrowIfCancellationRequested();
+
+            try
+            {
+                await _sync.SyncAsync(ct);
+            }
+            catch (OperationCanceledException) { throw; }
+            catch (Exception ex)
+            {
+                // A single failed sync poll is not fatal; the deadline bounds the loop.
+                _logger.LogWarning(ex, "Sync poll failed while waiting for the device-bound copy; will retry.");
+            }
+
+            var all = await _cache.ListAsync(ct);
+            var copy = all.FirstOrDefault(c =>
+                c.Id != root.Id &&
+                string.Equals(c.Vct, VctUris.AssuredIdentityV1, StringComparison.Ordinal) &&
+                TryGetCnfJwkThumbprint(c.RawSdJwt, out var thumbprint) &&
+                string.Equals(thumbprint, deviceThumbprint, StringComparison.Ordinal));
+            if (copy is not null)
+            {
+                _snapshot = all; // keep CanBind's view current — the root is now bound.
+                return copy;
+            }
+
+            if (_time.GetUtcNow() >= deadline)
+            {
+                // Explicit PENDING outcome — a timeout must never present as success OR as a
+                // dead generic error: the presentation succeeded and the mint may still land.
+                throw new DeviceBindingException(
+                    DeviceBindingFailure.DeliveryTimeout,
+                    "Your identity was verified, but the device-bound copy is still processing. " +
+                    "It should appear in your wallet shortly — check back in a minute.",
+                    retryable: false);
+            }
+
+            await Task.Delay(_options.PollInterval, _time, ct);
+        }
+    }
+
+    /// <summary>
+    /// The server-custody holder signer handed to the presentation engine: round-trips the
+    /// KB-JWT signing input through <c>POST /api/v1/wallet/presentations/sign-kb</c> (Task 6a).
+    /// </summary>
+    private async Task<byte[]> SignWithHolderKeyAsync(byte[] signingInput, CancellationToken ct)
+    {
+        try
+        {
+            var response = await _walletClient.SignKbJwtAsync(
+                new KbJwtSignRequest { SigningInput = Encoding.ASCII.GetString(signingInput) }, ct);
+            return Base64Url.DecodeFromChars(response.Signature);
+        }
+        catch (OperationCanceledException) { throw; }
+        catch (Exception ex)
+        {
+            throw new DeviceBindingException(
+                DeviceBindingFailure.HolderSigningFailed,
+                "Your wallet couldn't sign the identity check (server-custody signing failed). Try again in a moment.",
+                retryable: true, ex);
+        }
+    }
+
+    /// <summary>Fetches the OpenID4VP request object (anonymous GET) for <see cref="IPresentationEngine.ParseAsync"/>.</summary>
+    private async Task<string> FetchRequestObjectAsync(string url, CancellationToken ct)
+    {
+        var response = await _http.GetAsync(url, ct);
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadAsStringAsync(ct);
+    }
+
+    /// <summary>
+    /// Reads the credential's <c>cnf.jwk</c> from the SD-JWT payload and computes its RFC 7638
+    /// thumbprint (EC P-256 and OKP Ed25519). False when the credential carries no readable cnf.
+    /// </summary>
+    internal static bool TryGetCnfJwkThumbprint(string rawSdJwt, out string thumbprint)
+    {
+        thumbprint = string.Empty;
+        if (string.IsNullOrWhiteSpace(rawSdJwt)) return false;
+
+        try
+        {
+            var jwt = rawSdJwt.Split('~')[0];
+            var parts = jwt.Split('.');
+            if (parts.Length < 2) return false;
+
+            using var payload = JsonDocument.Parse(Base64Url.DecodeFromChars(parts[1]));
+            if (!payload.RootElement.TryGetProperty("cnf", out var cnf) ||
+                cnf.ValueKind != JsonValueKind.Object ||
+                !cnf.TryGetProperty("jwk", out var jwk) ||
+                jwk.ValueKind != JsonValueKind.Object)
+            {
+                return false;
+            }
+
+            thumbprint = PresentationEngine.ComputeJwkThumbprint(jwk);
+            return thumbprint.Length > 0;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// The documented sorcha-wallet outcome wire shape (server: <c>SorchaWalletVerificationPayload</c>).
+    /// No delegation credential — Phase 2 presents the root server-custody, delegation-free.
+    /// </summary>
+    private sealed record SorchaWalletOutcomePost([property: JsonPropertyName("vpToken")] string VpToken);
+}

--- a/src/Apps/Sorcha.Wallet.Pwa/Services/Presentation/IPresentationEngine.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Services/Presentation/IPresentationEngine.cs
@@ -74,10 +74,20 @@ public interface IPresentationEngine
     /// signed by the device key and only the approved disclosure subset for that query.
     /// </summary>
     /// <param name="consented">The per-query disclosure plan the citizen approved (one entry per
-    /// query being presented).</param>
+    /// query being presented). Each entry carries its own <see cref="ConsentedQuery.SigningMode"/> —
+    /// mixed modes within one envelope are valid: every query's presentation is an independent
+    /// SD-JWT with its own KB-JWT, and the verifier validates each against its own credential's
+    /// <c>cnf</c> (no envelope-level signature exists).</param>
     /// <param name="request">The original request (nonce + audience binding).</param>
-    /// <param name="deviceJwk">Public JWK of the device key.</param>
+    /// <param name="deviceJwk">Public JWK of the device key — used by
+    /// <see cref="PresentationSigningMode.Device"/> entries.</param>
     /// <param name="deviceSigner">Async delegate that signs raw bytes with the device key.</param>
+    /// <param name="holderJwk">Public JWK of the citizen's server-custodied holder key — REQUIRED when
+    /// any entry is <see cref="PresentationSigningMode.ServerCustody"/> (#1195 Phase 2: the holder-cnf
+    /// root must never be device-signed; that KB-JWT fails verification with no local error).</param>
+    /// <param name="holderSigner">Async delegate for server-custody signing (the Task 6a
+    /// <c>sign-kb</c> endpoint). Absent while a ServerCustody entry exists ⇒ the build FAILS LOUDLY —
+    /// it never falls back to device-signing.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>The JSON object-keyed <c>vp_token</c> string ready for the direct_post body.</returns>
     Task<string> BuildVpTokenEnvelopeAsync(
@@ -85,6 +95,8 @@ public interface IPresentationEngine
         ParsedPresentationRequest request,
         System.Text.Json.JsonElement deviceJwk,
         Func<byte[], CancellationToken, Task<byte[]>> deviceSigner,
+        System.Text.Json.JsonElement? holderJwk = null,
+        Func<byte[], CancellationToken, Task<byte[]>>? holderSigner = null,
         CancellationToken ct = default);
 
     /// <summary>
@@ -193,7 +205,20 @@ public enum PresentationSelectionOutcome
     /// A retry after the holder key becomes reachable resolves it.
     /// </summary>
     HolderKeyUnavailable = 3,
+
+    /// <summary>
+    /// After collapsing the root + this-device-copy pair (the same credential family — one identity,
+    /// two bindings) into one per-surface representative, MULTIPLE genuinely distinct credentials
+    /// still match the ask. The citizen picks, exactly as before Task 7 —
+    /// <see cref="PresentationSelection.Candidates"/> carries the choices with their signing modes.
+    /// </summary>
+    ChoiceRequired = 4,
 }
+
+/// <summary>One pickable candidate in a <see cref="PresentationSelectionOutcome.ChoiceRequired"/>
+/// outcome: the credential plus HOW its KB-JWT is signed — the picker must carry the pairing through,
+/// never re-derive it.</summary>
+public sealed record PresentationCandidate(CredentialMatch Match, PresentationSigningMode SigningMode);
 
 /// <summary>
 /// The result of <see cref="IPresentationEngine.Select"/>: which credential to present and how to sign it,
@@ -218,6 +243,11 @@ public sealed record PresentationSelection
     /// to its credential card (the Task 6 bind button surface). Null for every other outcome.</summary>
     public CredentialMatch? RootToBind { get; init; }
 
+    /// <summary>The distinct pickable candidates behind a
+    /// <see cref="PresentationSelectionOutcome.ChoiceRequired"/> outcome (each with its signing mode),
+    /// in selection-preference order. Null for every other outcome.</summary>
+    public IReadOnlyList<PresentationCandidate>? Candidates { get; init; }
+
     /// <summary>A selected credential + its signing mode.</summary>
     internal static PresentationSelection Selected(CredentialMatch match, PresentationSigningMode mode) =>
         new() { Outcome = PresentationSelectionOutcome.Selected, Match = match, SigningMode = mode };
@@ -233,6 +263,10 @@ public sealed record PresentationSelection
     /// <summary>Bound-but-unclassifiable candidates and no holder thumbprint — fail closed.</summary>
     internal static PresentationSelection HolderKeyUnavailable { get; } =
         new() { Outcome = PresentationSelectionOutcome.HolderKeyUnavailable };
+
+    /// <summary>Multiple genuinely distinct candidates — the citizen picks.</summary>
+    internal static PresentationSelection Choice(IReadOnlyList<PresentationCandidate> candidates) =>
+        new() { Outcome = PresentationSelectionOutcome.ChoiceRequired, Candidates = candidates };
 }
 
 /// <summary>
@@ -244,8 +278,13 @@ public sealed record PresentationSelection
 /// <param name="Match">The credential the citizen chose for this query.</param>
 /// <param name="RequiredClaims">This query's required claim names.</param>
 /// <param name="ApprovedClaims">Claim names approved for disclosure (must cover every required claim).</param>
+/// <param name="SigningMode">Which key signs THIS query's KB-JWT (#1195 Phase 2, Task 7 fix round 2).
+/// Defaults to <see cref="PresentationSigningMode.Device"/> — the pre-Phase-2 behaviour. Callers must
+/// set <see cref="PresentationSigningMode.ServerCustody"/> for a holder-<c>cnf</c> root (classify via
+/// <c>PresentationEngine.ClassifyBinding</c>); device-signing the root is the recorded silent-failure trap.</param>
 public sealed record ConsentedQuery(
     string QueryId,
     CredentialMatch Match,
     IReadOnlyList<string> RequiredClaims,
-    IReadOnlyList<string> ApprovedClaims);
+    IReadOnlyList<string> ApprovedClaims,
+    PresentationSigningMode SigningMode = PresentationSigningMode.Device);

--- a/src/Apps/Sorcha.Wallet.Pwa/Services/Presentation/IPresentationEngine.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Services/Presentation/IPresentationEngine.cs
@@ -86,6 +86,126 @@ public interface IPresentationEngine
         System.Text.Json.JsonElement deviceJwk,
         Func<byte[], CancellationToken, Task<byte[]>> deviceSigner,
         CancellationToken ct = default);
+
+    /// <summary>
+    /// #1195 Phase 2 (Task 7) — choose the RIGHT credential + signing path for the present
+    /// <paramref name="surface"/>, so a presentation that cannot verify downstream is never even
+    /// attempted (standing requirement: no silent verification failures). A citizen may hold BOTH a
+    /// holder-<c>cnf</c> AIAS root (web-issued; presents SERVER-CUSTODY — the wallet service signs the
+    /// KB-JWT) AND device-<c>cnf</c> copies bound to specific devices (this device signs).
+    ///
+    /// <para>Selection rule (design §6):</para>
+    /// <list type="bullet">
+    /// <item><b>In-person / offline / device-mediated</b> → a device-<c>cnf</c> copy bound to THIS device
+    /// (device signs). None on this device but the root is present ⇒
+    /// <see cref="PresentationSelectionOutcome.BindDeviceFirst"/> — the UI routes to the Task 6 "Bind to
+    /// device" button; NEVER a doomed present.</item>
+    /// <item><b>Web / remote / server-mediated</b> → the holder-<c>cnf</c> root (server custody).</item>
+    /// <item><b>Auto</b> (default) → prefer a device copy this device can sign for, else the root.</item>
+    /// </list>
+    ///
+    /// <para>The layer is the guard for the recorded trap: device-signing the holder-<c>cnf</c> root
+    /// produces a KB-JWT that fails verification downstream with no local error. The root is therefore
+    /// NEVER paired with device-signing, and a device copy this device cannot sign for (a DIFFERENT
+    /// device's key, or a credential with no readable <c>cnf</c>) is never selected.</para>
+    /// </summary>
+    /// <param name="request">The parsed present request.</param>
+    /// <param name="credentials">The wallet's cached credentials (root + any device copies).</param>
+    /// <param name="deviceThumbprint">RFC 7638 thumbprint of THIS device's key
+    /// (<c>IDeviceKeyService.GetThumbprintAsync</c>), or <c>null</c> on a host without a usable device
+    /// key — in which case no device copy is signable and only the root (server custody) is selectable.</param>
+    /// <param name="surface">The present surface. Defaults to <see cref="PresentationSurface.Auto"/>.</param>
+    PresentationSelection Select(
+        ParsedPresentationRequest request,
+        IReadOnlyList<CachedCredential> credentials,
+        string? deviceThumbprint,
+        PresentationSurface surface = PresentationSurface.Auto);
+}
+
+/// <summary>
+/// The present surface, which decides WHICH credential + signing path a presentation uses
+/// (#1195 Phase 2, design §6). The tier follows the surface, not the credential the citizen
+/// picked — a device copy is device-signed in person; the root is server-custody signed remotely.
+/// </summary>
+public enum PresentationSurface
+{
+    /// <summary>
+    /// No explicit surface signal: prefer a device-<c>cnf</c> copy this device can sign for, else the
+    /// holder-<c>cnf</c> root (server custody). The additive default so existing callers are unaffected.
+    /// </summary>
+    Auto = 0,
+
+    /// <summary>
+    /// In-person / offline / device-mediated present (F185 proximity): REQUIRES a device-<c>cnf</c>
+    /// copy bound to this device. No copy but a bindable root present ⇒ <see cref="PresentationSelectionOutcome.BindDeviceFirst"/>.
+    /// </summary>
+    InPerson = 1,
+
+    /// <summary>
+    /// Web / remote / server-mediated present (<c>openid4vp://</c> <c>direct_post</c>): the holder-<c>cnf</c>
+    /// root, signed server-custody. Falls back to a this-device copy only when no root is cached.
+    /// </summary>
+    Remote = 2,
+}
+
+/// <summary>Which key signs the KB-JWT for the selected credential (#1195 Phase 2).</summary>
+public enum PresentationSigningMode
+{
+    /// <summary>THIS device's key signs the KB-JWT (<c>IDeviceKeyService.SignAsync</c>) — a device-<c>cnf</c> copy.</summary>
+    Device = 0,
+
+    /// <summary>The wallet service signs the KB-JWT under the citizen's holder key (server custody,
+    /// <c>POST /api/v1/wallet/presentations/sign-kb</c>) — the holder-<c>cnf</c> root.</summary>
+    ServerCustody = 1,
+}
+
+/// <summary>The kind of a <see cref="PresentationSelection"/> result.</summary>
+public enum PresentationSelectionOutcome
+{
+    /// <summary>A credential was selected; <see cref="PresentationSelection.Match"/> and
+    /// <see cref="PresentationSelection.SigningMode"/> are set.</summary>
+    Selected = 0,
+
+    /// <summary>No cached credential can satisfy this request on this surface.</summary>
+    NoMatch = 1,
+
+    /// <summary>
+    /// An in-person / offline present was requested, the root can satisfy it, but THIS device holds no
+    /// device-<c>cnf</c> copy yet. The UI routes to the Task 6 "Bind to device" flow — this is a DISTINCT
+    /// outcome, never a present that cannot verify.
+    /// </summary>
+    BindDeviceFirst = 2,
+}
+
+/// <summary>
+/// The result of <see cref="IPresentationEngine.Select"/>: which credential to present and how to sign it,
+/// or a distinct non-present outcome. The caller must not re-derive the signing path — pairing the wrong
+/// signer with the wrong credential is exactly the failure this layer prevents.
+/// </summary>
+public sealed record PresentationSelection
+{
+    /// <summary>The result kind.</summary>
+    public required PresentationSelectionOutcome Outcome { get; init; }
+
+    /// <summary>The selected credential + disclosure plan. Non-null only when <see cref="Outcome"/> is
+    /// <see cref="PresentationSelectionOutcome.Selected"/>.</summary>
+    public CredentialMatch? Match { get; init; }
+
+    /// <summary>How to sign the KB-JWT for <see cref="Match"/>. Meaningful only when
+    /// <see cref="Outcome"/> is <see cref="PresentationSelectionOutcome.Selected"/>.</summary>
+    public PresentationSigningMode SigningMode { get; init; }
+
+    /// <summary>A selected credential + its signing mode.</summary>
+    internal static PresentationSelection Selected(CredentialMatch match, PresentationSigningMode mode) =>
+        new() { Outcome = PresentationSelectionOutcome.Selected, Match = match, SigningMode = mode };
+
+    /// <summary>Nothing on this device can satisfy the request on this surface.</summary>
+    internal static PresentationSelection None { get; } =
+        new() { Outcome = PresentationSelectionOutcome.NoMatch };
+
+    /// <summary>The root is presentable but this device must be bound first.</summary>
+    internal static PresentationSelection BindFirst { get; } =
+        new() { Outcome = PresentationSelectionOutcome.BindDeviceFirst };
 }
 
 /// <summary>

--- a/src/Apps/Sorcha.Wallet.Pwa/Services/Presentation/IPresentationEngine.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Services/Presentation/IPresentationEngine.cs
@@ -107,18 +107,27 @@ public interface IPresentationEngine
     /// <para>The layer is the guard for the recorded trap: device-signing the holder-<c>cnf</c> root
     /// produces a KB-JWT that fails verification downstream with no local error. The root is therefore
     /// NEVER paired with device-signing, and a device copy this device cannot sign for (a DIFFERENT
-    /// device's key, or a credential with no readable <c>cnf</c>) is never selected.</para>
+    /// device's key) is never selected. Discrimination is by RFC 7638 <c>cnf.jwk</c> thumbprint against
+    /// BOTH keys — never by key type, which would misclassify a P-256 wallet's EC holder root. A
+    /// credential with no readable <c>cnf</c> is legacy/unbound and keeps its Phase-1 device-signed
+    /// behaviour (there is no binding for a verifier to check).</para>
     /// </summary>
     /// <param name="request">The parsed present request.</param>
     /// <param name="credentials">The wallet's cached credentials (root + any device copies).</param>
     /// <param name="deviceThumbprint">RFC 7638 thumbprint of THIS device's key
     /// (<c>IDeviceKeyService.GetThumbprintAsync</c>), or <c>null</c> on a host without a usable device
-    /// key — in which case no device copy is signable and only the root (server custody) is selectable.</param>
+    /// key — in which case no device copy is signable here.</param>
+    /// <param name="holderThumbprint">RFC 7638 thumbprint of the citizen's server-custodied holder key
+    /// (compute from <c>IHolderKeyClient.GetHolderKeysAsync().HolderJwk</c>), or <c>null</c> when it
+    /// could not be resolved — in which case a bound credential that is not THIS device's copy cannot be
+    /// classified and selection fails CLOSED with
+    /// <see cref="PresentationSelectionOutcome.HolderKeyUnavailable"/> rather than guessing.</param>
     /// <param name="surface">The present surface. Defaults to <see cref="PresentationSurface.Auto"/>.</param>
     PresentationSelection Select(
         ParsedPresentationRequest request,
         IReadOnlyList<CachedCredential> credentials,
         string? deviceThumbprint,
+        string? holderThumbprint,
         PresentationSurface surface = PresentationSurface.Auto);
 }
 
@@ -172,9 +181,18 @@ public enum PresentationSelectionOutcome
     /// <summary>
     /// An in-person / offline present was requested, the root can satisfy it, but THIS device holds no
     /// device-<c>cnf</c> copy yet. The UI routes to the Task 6 "Bind to device" flow — this is a DISTINCT
-    /// outcome, never a present that cannot verify.
+    /// outcome, never a present that cannot verify. <see cref="PresentationSelection.RootToBind"/> carries
+    /// the root so the UI can deep-link its credential card.
     /// </summary>
     BindDeviceFirst = 2,
+
+    /// <summary>
+    /// The citizen's holder-key thumbprint could not be resolved, and the only candidates are bound
+    /// credentials that are not THIS device's copy — they cannot be told apart (root vs a foreign
+    /// device's copy), so selection fails CLOSED rather than risking a presentation that cannot verify.
+    /// A retry after the holder key becomes reachable resolves it.
+    /// </summary>
+    HolderKeyUnavailable = 3,
 }
 
 /// <summary>
@@ -195,6 +213,11 @@ public sealed record PresentationSelection
     /// <see cref="Outcome"/> is <see cref="PresentationSelectionOutcome.Selected"/>.</summary>
     public PresentationSigningMode SigningMode { get; init; }
 
+    /// <summary>The holder-<c>cnf</c> root behind a
+    /// <see cref="PresentationSelectionOutcome.BindDeviceFirst"/> outcome, so the UI can route straight
+    /// to its credential card (the Task 6 bind button surface). Null for every other outcome.</summary>
+    public CredentialMatch? RootToBind { get; init; }
+
     /// <summary>A selected credential + its signing mode.</summary>
     internal static PresentationSelection Selected(CredentialMatch match, PresentationSigningMode mode) =>
         new() { Outcome = PresentationSelectionOutcome.Selected, Match = match, SigningMode = mode };
@@ -204,8 +227,12 @@ public sealed record PresentationSelection
         new() { Outcome = PresentationSelectionOutcome.NoMatch };
 
     /// <summary>The root is presentable but this device must be bound first.</summary>
-    internal static PresentationSelection BindFirst { get; } =
-        new() { Outcome = PresentationSelectionOutcome.BindDeviceFirst };
+    internal static PresentationSelection BindFirst(CredentialMatch root) =>
+        new() { Outcome = PresentationSelectionOutcome.BindDeviceFirst, RootToBind = root };
+
+    /// <summary>Bound-but-unclassifiable candidates and no holder thumbprint — fail closed.</summary>
+    internal static PresentationSelection HolderKeyUnavailable { get; } =
+        new() { Outcome = PresentationSelectionOutcome.HolderKeyUnavailable };
 }
 
 /// <summary>

--- a/src/Apps/Sorcha.Wallet.Pwa/Services/Presentation/PresentationEngine.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Services/Presentation/PresentationEngine.cs
@@ -410,11 +410,15 @@ public sealed class PresentationEngine : IPresentationEngine
             }
         }
 
-        // KB-JWT — header carries the device-key thumbprint as kid; payload binds nonce+aud.
+        // KB-JWT — header carries the signing key's thumbprint as kid; payload binds nonce+aud.
+        // The alg follows the SIGNING key's JWK (#1195 Phase 2): the device key is EC P-256
+        // (ES256), but a holder-cnf root presented server-custody may sign under an Ed25519
+        // holder key (EdDSA). Hardcoding ES256 here was the mirror image of the verifier-side
+        // "ES256-only verifier rejected Ed25519-holder presentations" bug.
         var kid = ComputeJwkThumbprint(deviceJwk);
         var header = new Dictionary<string, object>
         {
-            ["alg"] = "ES256",
+            ["alg"] = JoseAlgorithmFor(deviceJwk),
             ["typ"] = "kb+jwt",
             ["kid"] = kid,
         };
@@ -495,14 +499,27 @@ public sealed class PresentationEngine : IPresentationEngine
         }
     }
 
-    /// <summary>Compute the RFC 7638 JWK thumbprint for an EC P-256 public JWK.</summary>
+    /// <summary>
+    /// Compute the RFC 7638 JWK thumbprint. Handles EC (P-256 — canonical members
+    /// crv, kty, x, y) and OKP (Ed25519 — canonical members crv, kty, x). The OKP arm
+    /// exists for the holder-cnf root (#1195 Phase 2): the citizen's server-custodied
+    /// holder key is Ed25519 for the default wallet algorithm.
+    /// </summary>
     internal static string ComputeJwkThumbprint(JsonElement jwk)
     {
         var crv = jwk.GetProperty("crv").GetString();
         var kty = jwk.GetProperty("kty").GetString();
         var x = jwk.GetProperty("x").GetString();
-        var y = jwk.GetProperty("y").GetString();
-        var canonical = $"{{\"crv\":\"{crv}\",\"kty\":\"{kty}\",\"x\":\"{x}\",\"y\":\"{y}\"}}";
+        var canonical = string.Equals(kty, "OKP", StringComparison.Ordinal)
+            ? $"{{\"crv\":\"{crv}\",\"kty\":\"{kty}\",\"x\":\"{x}\"}}"
+            : $"{{\"crv\":\"{crv}\",\"kty\":\"{kty}\",\"x\":\"{x}\",\"y\":\"{jwk.GetProperty("y").GetString()}\"}}";
         return Base64Url.EncodeToString(SHA256.HashData(Encoding.UTF8.GetBytes(canonical)));
     }
+
+    /// <summary>The JOSE alg for a signing key's public JWK: OKP/Ed25519 → EdDSA; EC P-256 → ES256.</summary>
+    internal static string JoseAlgorithmFor(JsonElement jwk) =>
+        jwk.TryGetProperty("kty", out var kty) &&
+        string.Equals(kty.GetString(), "OKP", StringComparison.Ordinal)
+            ? "EdDSA"
+            : "ES256";
 }

--- a/src/Apps/Sorcha.Wallet.Pwa/Services/Presentation/PresentationEngine.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Services/Presentation/PresentationEngine.cs
@@ -516,6 +516,124 @@ public sealed class PresentationEngine : IPresentationEngine
         return Base64Url.EncodeToString(SHA256.HashData(Encoding.UTF8.GetBytes(canonical)));
     }
 
+    /// <inheritdoc />
+    public PresentationSelection Select(
+        ParsedPresentationRequest request,
+        IReadOnlyList<CachedCredential> credentials,
+        string? deviceThumbprint,
+        PresentationSurface surface = PresentationSurface.Auto)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(credentials);
+
+        // Only credentials that actually satisfy the request are candidates. Classify each by its key
+        // binding relative to THIS device: a copy we can device-sign, the holder-cnf root (server
+        // custody), or something unusable here (a DIFFERENT device's copy / no readable cnf).
+        CredentialMatch? deviceCopy = null;
+        CredentialMatch? root = null;
+        foreach (var candidate in Match(request, credentials))
+        {
+            switch (ClassifyBinding(candidate.Credential.RawSdJwt, deviceThumbprint))
+            {
+                case CredentialBinding.ThisDevice:
+                    deviceCopy ??= candidate;
+                    break;
+                case CredentialBinding.HolderRoot:
+                    root ??= candidate;
+                    break;
+                // CredentialBinding.Unusable — never selectable on this device.
+            }
+        }
+
+        switch (surface)
+        {
+            // In person / offline: ONLY a device-cnf copy this device can sign. No copy but a bindable
+            // root ⇒ the distinct bind-first outcome (route to the Task 6 button); never the root
+            // (device-signing it cannot verify), never a doomed present.
+            case PresentationSurface.InPerson:
+                if (deviceCopy is not null)
+                    return PresentationSelection.Selected(deviceCopy, PresentationSigningMode.Device);
+                return root is not null ? PresentationSelection.BindFirst : PresentationSelection.None;
+
+            // Web / remote: the holder-cnf root, server custody. Only when no root is cached does a
+            // this-device copy stand in (device-signed — still verifies).
+            case PresentationSurface.Remote:
+                if (root is not null)
+                    return PresentationSelection.Selected(root, PresentationSigningMode.ServerCustody);
+                return deviceCopy is not null
+                    ? PresentationSelection.Selected(deviceCopy, PresentationSigningMode.Device)
+                    : PresentationSelection.None;
+
+            // Auto (default): prefer a device copy this device can sign for, else the root.
+            default:
+                if (deviceCopy is not null)
+                    return PresentationSelection.Selected(deviceCopy, PresentationSigningMode.Device);
+                return root is not null
+                    ? PresentationSelection.Selected(root, PresentationSigningMode.ServerCustody)
+                    : PresentationSelection.None;
+        }
+    }
+
+    /// <summary>The key binding of a cached credential relative to THIS device (#1195 Phase 2, Task 7).</summary>
+    internal enum CredentialBinding
+    {
+        /// <summary>Its <c>cnf</c> is the Ed25519 (OKP) holder key — the root, presented server-custody.</summary>
+        HolderRoot,
+
+        /// <summary>Its <c>cnf</c> thumbprint is THIS device's key — a device copy this device can sign.</summary>
+        ThisDevice,
+
+        /// <summary>A different device's copy, or no readable <c>cnf</c> — never selectable here.</summary>
+        Unusable,
+    }
+
+    /// <summary>
+    /// Classify a cached credential's key binding relative to THIS device. The this-device
+    /// discrimination reuses <see cref="DeviceBindingService.TryGetCnfJwkThumbprint"/> (the Task 6
+    /// helper) — a match on the RFC 7638 thumbprint means this device can device-sign it. Otherwise the
+    /// holder-<c>cnf</c> root is told apart from a DIFFERENT device's copy by its <c>cnf.jwk.kty</c>: the
+    /// citizen's server-custodied holder key is Ed25519 (OKP) by design (see
+    /// <see cref="ComputeJwkThumbprint"/>), whereas device keys are EC P-256. Anything else is unusable
+    /// here — the guard for the recorded trap (device-signing the root, or signing a foreign device's
+    /// copy, yields a KB-JWT that fails verification with no local error).
+    /// </summary>
+    internal static CredentialBinding ClassifyBinding(string rawSdJwt, string? deviceThumbprint)
+    {
+        if (!DeviceBindingService.TryGetCnfJwkThumbprint(rawSdJwt, out var cnfThumbprint))
+            return CredentialBinding.Unusable;
+
+        if (!string.IsNullOrEmpty(deviceThumbprint) &&
+            string.Equals(cnfThumbprint, deviceThumbprint, StringComparison.Ordinal))
+            return CredentialBinding.ThisDevice;
+
+        return string.Equals(CnfKeyType(rawSdJwt), "OKP", StringComparison.Ordinal)
+            ? CredentialBinding.HolderRoot
+            : CredentialBinding.Unusable;
+    }
+
+    /// <summary>Reads <c>cnf.jwk.kty</c> from an SD-JWT credential's payload, or null when absent.</summary>
+    private static string? CnfKeyType(string rawSdJwt)
+    {
+        if (string.IsNullOrWhiteSpace(rawSdJwt)) return null;
+        try
+        {
+            var parts = rawSdJwt.Split('~')[0].Split('.');
+            if (parts.Length < 2) return null;
+            using var payload = JsonDocument.Parse(Base64Url.DecodeFromChars(parts[1]));
+            return payload.RootElement.TryGetProperty("cnf", out var cnf) &&
+                   cnf.ValueKind == JsonValueKind.Object &&
+                   cnf.TryGetProperty("jwk", out var jwk) &&
+                   jwk.ValueKind == JsonValueKind.Object &&
+                   jwk.TryGetProperty("kty", out var kty)
+                ? kty.GetString()
+                : null;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
     /// <summary>The JOSE alg for a signing key's public JWK: OKP/Ed25519 → EdDSA; EC P-256 → ES256.</summary>
     internal static string JoseAlgorithmFor(JsonElement jwk) =>
         jwk.TryGetProperty("kty", out var kty) &&

--- a/src/Apps/Sorcha.Wallet.Pwa/Services/Presentation/PresentationEngine.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Services/Presentation/PresentationEngine.cs
@@ -521,6 +521,7 @@ public sealed class PresentationEngine : IPresentationEngine
         ParsedPresentationRequest request,
         IReadOnlyList<CachedCredential> credentials,
         string? deviceThumbprint,
+        string? holderThumbprint,
         PresentationSurface surface = PresentationSurface.Auto)
     {
         ArgumentNullException.ThrowIfNull(request);
@@ -528,12 +529,15 @@ public sealed class PresentationEngine : IPresentationEngine
 
         // Only credentials that actually satisfy the request are candidates. Classify each by its key
         // binding relative to THIS device: a copy we can device-sign, the holder-cnf root (server
-        // custody), or something unusable here (a DIFFERENT device's copy / no readable cnf).
+        // custody), a legacy unbound credential (Phase-1 device-signed), a foreign device's copy
+        // (never selectable here), or unclassifiable (bound, but no holder thumbprint to compare).
         CredentialMatch? deviceCopy = null;
         CredentialMatch? root = null;
+        CredentialMatch? unbound = null;
+        var sawUnknown = false;
         foreach (var candidate in Match(request, credentials))
         {
-            switch (ClassifyBinding(candidate.Credential.RawSdJwt, deviceThumbprint))
+            switch (ClassifyBinding(candidate.Credential.RawSdJwt, deviceThumbprint, holderThumbprint))
             {
                 case CredentialBinding.ThisDevice:
                     deviceCopy ??= candidate;
@@ -541,97 +545,99 @@ public sealed class PresentationEngine : IPresentationEngine
                 case CredentialBinding.HolderRoot:
                     root ??= candidate;
                     break;
-                // CredentialBinding.Unusable — never selectable on this device.
+                case CredentialBinding.Unbound:
+                    unbound ??= candidate;
+                    break;
+                case CredentialBinding.Unknown:
+                    sawUnknown = true;
+                    break;
+                // CredentialBinding.Foreign — never selectable on this device.
             }
         }
 
         switch (surface)
         {
-            // In person / offline: ONLY a device-cnf copy this device can sign. No copy but a bindable
-            // root ⇒ the distinct bind-first outcome (route to the Task 6 button); never the root
-            // (device-signing it cannot verify), never a doomed present.
+            // In person / offline: device-signed only. A device-cnf copy first; a legacy unbound
+            // credential still device-signs (nothing for the verifier to check it against). A root
+            // WITHOUT a copy ⇒ the distinct bind-first outcome (route to the Task 6 button); never
+            // the root itself (device-signing it cannot verify), never a doomed present.
             case PresentationSurface.InPerson:
                 if (deviceCopy is not null)
                     return PresentationSelection.Selected(deviceCopy, PresentationSigningMode.Device);
-                return root is not null ? PresentationSelection.BindFirst : PresentationSelection.None;
+                if (unbound is not null)
+                    return PresentationSelection.Selected(unbound, PresentationSigningMode.Device);
+                if (root is not null)
+                    return PresentationSelection.BindFirst(root);
+                return sawUnknown ? PresentationSelection.HolderKeyUnavailable : PresentationSelection.None;
 
-            // Web / remote: the holder-cnf root, server custody. Only when no root is cached does a
-            // this-device copy stand in (device-signed — still verifies).
+            // Web / remote: the holder-cnf root, server custody. Without a root, a this-device copy or
+            // a legacy unbound credential stands in (device-signed — still verifies).
             case PresentationSurface.Remote:
                 if (root is not null)
                     return PresentationSelection.Selected(root, PresentationSigningMode.ServerCustody);
-                return deviceCopy is not null
-                    ? PresentationSelection.Selected(deviceCopy, PresentationSigningMode.Device)
-                    : PresentationSelection.None;
+                if (deviceCopy is not null)
+                    return PresentationSelection.Selected(deviceCopy, PresentationSigningMode.Device);
+                if (unbound is not null)
+                    return PresentationSelection.Selected(unbound, PresentationSigningMode.Device);
+                return sawUnknown ? PresentationSelection.HolderKeyUnavailable : PresentationSelection.None;
 
-            // Auto (default): prefer a device copy this device can sign for, else the root.
+            // Auto (default): prefer a device copy this device can sign for, else the root, else legacy.
             default:
                 if (deviceCopy is not null)
                     return PresentationSelection.Selected(deviceCopy, PresentationSigningMode.Device);
-                return root is not null
-                    ? PresentationSelection.Selected(root, PresentationSigningMode.ServerCustody)
-                    : PresentationSelection.None;
+                if (root is not null)
+                    return PresentationSelection.Selected(root, PresentationSigningMode.ServerCustody);
+                if (unbound is not null)
+                    return PresentationSelection.Selected(unbound, PresentationSigningMode.Device);
+                return sawUnknown ? PresentationSelection.HolderKeyUnavailable : PresentationSelection.None;
         }
     }
 
     /// <summary>The key binding of a cached credential relative to THIS device (#1195 Phase 2, Task 7).</summary>
     internal enum CredentialBinding
     {
-        /// <summary>Its <c>cnf</c> is the Ed25519 (OKP) holder key — the root, presented server-custody.</summary>
+        /// <summary>Its <c>cnf</c> thumbprint is the citizen's holder key — the root, presented server-custody.</summary>
         HolderRoot,
 
         /// <summary>Its <c>cnf</c> thumbprint is THIS device's key — a device copy this device can sign.</summary>
         ThisDevice,
 
-        /// <summary>A different device's copy, or no readable <c>cnf</c> — never selectable here.</summary>
-        Unusable,
+        /// <summary>No readable <c>cnf</c> — a legacy credential; keeps its Phase-1 device-signed behaviour.</summary>
+        Unbound,
+
+        /// <summary>A different device's copy (cnf matches neither key) — never selectable here.</summary>
+        Foreign,
+
+        /// <summary>Bound to SOMETHING that is not this device, and no holder thumbprint to compare —
+        /// root and foreign copy cannot be told apart. Selection fails closed, never guesses.</summary>
+        Unknown,
     }
 
     /// <summary>
-    /// Classify a cached credential's key binding relative to THIS device. The this-device
-    /// discrimination reuses <see cref="DeviceBindingService.TryGetCnfJwkThumbprint"/> (the Task 6
-    /// helper) — a match on the RFC 7638 thumbprint means this device can device-sign it. Otherwise the
-    /// holder-<c>cnf</c> root is told apart from a DIFFERENT device's copy by its <c>cnf.jwk.kty</c>: the
-    /// citizen's server-custodied holder key is Ed25519 (OKP) by design (see
-    /// <see cref="ComputeJwkThumbprint"/>), whereas device keys are EC P-256. Anything else is unusable
-    /// here — the guard for the recorded trap (device-signing the root, or signing a foreign device's
-    /// copy, yields a KB-JWT that fails verification with no local error).
+    /// Classify a cached credential's key binding relative to THIS device. Discrimination is purely by
+    /// RFC 7638 <c>cnf.jwk</c> thumbprint (via <see cref="DeviceBindingService.TryGetCnfJwkThumbprint"/>,
+    /// the Task 6 helper) against BOTH the device key and the holder key — the same rule the Task 5
+    /// server-side policy uses. Key-TYPE discrimination is deliberately absent: a P-256 wallet's holder
+    /// key (and therefore its root's <c>cnf</c>) is EC, indistinguishable from a device key by type.
+    /// This layer guards the recorded trap: device-signing the root, or signing a foreign device's copy,
+    /// yields a KB-JWT that fails verification downstream with no local error.
     /// </summary>
-    internal static CredentialBinding ClassifyBinding(string rawSdJwt, string? deviceThumbprint)
+    internal static CredentialBinding ClassifyBinding(
+        string rawSdJwt, string? deviceThumbprint, string? holderThumbprint)
     {
         if (!DeviceBindingService.TryGetCnfJwkThumbprint(rawSdJwt, out var cnfThumbprint))
-            return CredentialBinding.Unusable;
+            return CredentialBinding.Unbound;
 
         if (!string.IsNullOrEmpty(deviceThumbprint) &&
             string.Equals(cnfThumbprint, deviceThumbprint, StringComparison.Ordinal))
             return CredentialBinding.ThisDevice;
 
-        return string.Equals(CnfKeyType(rawSdJwt), "OKP", StringComparison.Ordinal)
-            ? CredentialBinding.HolderRoot
-            : CredentialBinding.Unusable;
-    }
+        if (string.IsNullOrEmpty(holderThumbprint))
+            return CredentialBinding.Unknown;
 
-    /// <summary>Reads <c>cnf.jwk.kty</c> from an SD-JWT credential's payload, or null when absent.</summary>
-    private static string? CnfKeyType(string rawSdJwt)
-    {
-        if (string.IsNullOrWhiteSpace(rawSdJwt)) return null;
-        try
-        {
-            var parts = rawSdJwt.Split('~')[0].Split('.');
-            if (parts.Length < 2) return null;
-            using var payload = JsonDocument.Parse(Base64Url.DecodeFromChars(parts[1]));
-            return payload.RootElement.TryGetProperty("cnf", out var cnf) &&
-                   cnf.ValueKind == JsonValueKind.Object &&
-                   cnf.TryGetProperty("jwk", out var jwk) &&
-                   jwk.ValueKind == JsonValueKind.Object &&
-                   jwk.TryGetProperty("kty", out var kty)
-                ? kty.GetString()
-                : null;
-        }
-        catch
-        {
-            return null;
-        }
+        return string.Equals(cnfThumbprint, holderThumbprint, StringComparison.Ordinal)
+            ? CredentialBinding.HolderRoot
+            : CredentialBinding.Foreign;
     }
 
     /// <summary>The JOSE alg for a signing key's public JWK: OKP/Ed25519 → EdDSA; EC P-256 → ES256.</summary>

--- a/src/Apps/Sorcha.Wallet.Pwa/Services/Presentation/PresentationEngine.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Services/Presentation/PresentationEngine.cs
@@ -334,6 +334,8 @@ public sealed class PresentationEngine : IPresentationEngine
         ParsedPresentationRequest request,
         JsonElement deviceJwk,
         Func<byte[], CancellationToken, Task<byte[]>> deviceSigner,
+        JsonElement? holderJwk = null,
+        Func<byte[], CancellationToken, Task<byte[]>>? holderSigner = null,
         CancellationToken ct = default)
     {
         ArgumentNullException.ThrowIfNull(consented);
@@ -343,7 +345,10 @@ public sealed class PresentationEngine : IPresentationEngine
             throw new InvalidOperationException("A presentation must carry at least one consented query.");
         }
 
-        // One SD-JWT presentation per query, each validated against its own required-claim set.
+        // One SD-JWT presentation per query, each validated against its own required-claim set and
+        // signed under ITS OWN mode (#1195 Phase 2, Task 7 fix round 2). Mixed modes compose: every
+        // presentation carries an independent KB-JWT and the verifier validates each against its own
+        // credential's cnf — there is no envelope-level signature.
         var presentations = new Dictionary<string, IReadOnlyList<string>>(StringComparer.Ordinal);
         foreach (var c in consented)
         {
@@ -351,8 +356,34 @@ public sealed class PresentationEngine : IPresentationEngine
             {
                 throw new InvalidOperationException($"Duplicate query id '{c.QueryId}' in the consented set.");
             }
+
+            JsonElement jwk;
+            Func<byte[], CancellationToken, Task<byte[]>> signer;
+            if (c.SigningMode == PresentationSigningMode.ServerCustody)
+            {
+                // FAIL LOUD, never fall back: a device-signed holder-cnf root is the recorded trap —
+                // it fails verification downstream with no local error.
+                if (holderJwk is null || holderSigner is null)
+                {
+                    throw new InvalidOperationException(
+                        $"Query '{c.QueryId}' requires server-custody signing but no holder signer was provided.");
+                }
+                jwk = holderJwk.Value;
+                signer = holderSigner;
+            }
+            else
+            {
+                if (deviceJwk.ValueKind == JsonValueKind.Undefined)
+                {
+                    throw new InvalidOperationException(
+                        $"Query '{c.QueryId}' requires device signing but no device key was provided.");
+                }
+                jwk = deviceJwk;
+                signer = deviceSigner;
+            }
+
             var vp = await BuildSinglePresentationAsync(
-                c.Match, c.ApprovedClaims, c.RequiredClaims, request, deviceJwk, deviceSigner, ct);
+                c.Match, c.ApprovedClaims, c.RequiredClaims, request, jwk, signer, ct);
             presentations[c.QueryId] = [vp];
         }
 
@@ -533,7 +564,7 @@ public sealed class PresentationEngine : IPresentationEngine
         // (never selectable here), or unclassifiable (bound, but no holder thumbprint to compare).
         CredentialMatch? deviceCopy = null;
         CredentialMatch? root = null;
-        CredentialMatch? unbound = null;
+        var unbound = new List<CredentialMatch>();
         var sawUnknown = false;
         foreach (var candidate in Match(request, credentials))
         {
@@ -546,7 +577,7 @@ public sealed class PresentationEngine : IPresentationEngine
                     root ??= candidate;
                     break;
                 case CredentialBinding.Unbound:
-                    unbound ??= candidate;
+                    unbound.Add(candidate);
                     break;
                 case CredentialBinding.Unknown:
                     sawUnknown = true;
@@ -555,42 +586,47 @@ public sealed class PresentationEngine : IPresentationEngine
             }
         }
 
-        switch (surface)
+        // The root + this-device copy are ONE credential family — one identity, two bindings — so
+        // they collapse to a single per-surface representative and never offer a picker between
+        // themselves. Every legacy unbound credential is a genuinely DISTINCT candidate.
+        PresentationCandidate? boundRepresentative = surface switch
         {
-            // In person / offline: device-signed only. A device-cnf copy first; a legacy unbound
-            // credential still device-signs (nothing for the verifier to check it against). A root
-            // WITHOUT a copy ⇒ the distinct bind-first outcome (route to the Task 6 button); never
-            // the root itself (device-signing it cannot verify), never a doomed present.
-            case PresentationSurface.InPerson:
-                if (deviceCopy is not null)
-                    return PresentationSelection.Selected(deviceCopy, PresentationSigningMode.Device);
-                if (unbound is not null)
-                    return PresentationSelection.Selected(unbound, PresentationSigningMode.Device);
-                if (root is not null)
-                    return PresentationSelection.BindFirst(root);
-                return sawUnknown ? PresentationSelection.HolderKeyUnavailable : PresentationSelection.None;
+            // In person / offline: device-signed only. The root itself is never presentable here —
+            // device-signing it produces a KB-JWT that fails verification with no local error.
+            PresentationSurface.InPerson => deviceCopy is not null
+                ? new PresentationCandidate(deviceCopy, PresentationSigningMode.Device)
+                : null,
 
-            // Web / remote: the holder-cnf root, server custody. Without a root, a this-device copy or
-            // a legacy unbound credential stands in (device-signed — still verifies).
-            case PresentationSurface.Remote:
-                if (root is not null)
-                    return PresentationSelection.Selected(root, PresentationSigningMode.ServerCustody);
-                if (deviceCopy is not null)
-                    return PresentationSelection.Selected(deviceCopy, PresentationSigningMode.Device);
-                if (unbound is not null)
-                    return PresentationSelection.Selected(unbound, PresentationSigningMode.Device);
-                return sawUnknown ? PresentationSelection.HolderKeyUnavailable : PresentationSelection.None;
+            // Web / remote: the root (server custody) first; a this-device copy stands in without one.
+            PresentationSurface.Remote => root is not null
+                ? new PresentationCandidate(root, PresentationSigningMode.ServerCustody)
+                : deviceCopy is not null
+                    ? new PresentationCandidate(deviceCopy, PresentationSigningMode.Device)
+                    : null,
 
-            // Auto (default): prefer a device copy this device can sign for, else the root, else legacy.
-            default:
-                if (deviceCopy is not null)
-                    return PresentationSelection.Selected(deviceCopy, PresentationSigningMode.Device);
-                if (root is not null)
-                    return PresentationSelection.Selected(root, PresentationSigningMode.ServerCustody);
-                if (unbound is not null)
-                    return PresentationSelection.Selected(unbound, PresentationSigningMode.Device);
-                return sawUnknown ? PresentationSelection.HolderKeyUnavailable : PresentationSelection.None;
-        }
+            // Auto (default): prefer the copy this device can sign for, else the root.
+            _ => deviceCopy is not null
+                ? new PresentationCandidate(deviceCopy, PresentationSigningMode.Device)
+                : root is not null
+                    ? new PresentationCandidate(root, PresentationSigningMode.ServerCustody)
+                    : null,
+        };
+
+        var candidates = new List<PresentationCandidate>(1 + unbound.Count);
+        if (boundRepresentative is not null) candidates.Add(boundRepresentative);
+        candidates.AddRange(unbound.Select(u => new PresentationCandidate(u, PresentationSigningMode.Device)));
+
+        if (candidates.Count == 1)
+            return PresentationSelection.Selected(candidates[0].Match, candidates[0].SigningMode);
+        if (candidates.Count > 1)
+            return PresentationSelection.Choice(candidates);
+
+        // Nothing presentable. In person, a root that COULD satisfy the ask is the distinct
+        // bind-first outcome (route to the Task 6 button) — never a doomed present. Otherwise an
+        // unclassifiable bound candidate fails closed; an empty field is a plain no-match.
+        if (surface == PresentationSurface.InPerson && root is not null)
+            return PresentationSelection.BindFirst(root);
+        return sawUnknown ? PresentationSelection.HolderKeyUnavailable : PresentationSelection.None;
     }
 
     /// <summary>The key binding of a cached credential relative to THIS device (#1195 Phase 2, Task 7).</summary>

--- a/src/Common/Sorcha.CitizenWallet.Abstractions/Models/KbJwtSignModels.cs
+++ b/src/Common/Sorcha.CitizenWallet.Abstractions/Models/KbJwtSignModels.cs
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+namespace Sorcha.CitizenWallet.Abstractions.Models;
+
+/// <summary>
+/// Request body of <c>POST /api/v1/wallet/presentations/sign-kb</c> (#1195 Phase 2, Task 6a —
+/// server-custody KB-JWT signing for holder-<c>cnf</c> presentations). Carries ONLY the JWS
+/// signing input; the holder key that signs is always resolved from the authenticated caller's
+/// JWT — there is deliberately no wallet-address field, so a citizen can only ever sign under
+/// their OWN holder key.
+/// </summary>
+public sealed record KbJwtSignRequest
+{
+    /// <summary>
+    /// The compact JWS signing input — <c>base64url(header).base64url(payload)</c> of the
+    /// KB-JWT to sign. The decoded header MUST carry <c>typ: "kb+jwt"</c>; the endpoint refuses
+    /// anything else (the holder key also signs device delegation credentials, so it must not
+    /// become a general-purpose signing oracle).
+    /// </summary>
+    public required string SigningInput { get; init; }
+}
+
+/// <summary>
+/// Response body of <c>POST /api/v1/wallet/presentations/sign-kb</c>.
+/// </summary>
+public sealed record KbJwtSignResponse
+{
+    /// <summary>The raw signature over the ASCII bytes of the signing input, base64url-encoded — ready to append as the KB-JWT's third segment.</summary>
+    public required string Signature { get; init; }
+
+    /// <summary>The JOSE algorithm the holder key signed with (<c>ES256</c> or <c>EdDSA</c>). Matches the header's <c>alg</c> (a mismatch is refused with 400).</summary>
+    public required string Algorithm { get; init; }
+}

--- a/src/Common/Sorcha.CitizenWallet.Abstractions/Validators/KbJwtSignRequestValidator.cs
+++ b/src/Common/Sorcha.CitizenWallet.Abstractions/Validators/KbJwtSignRequestValidator.cs
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Text.RegularExpressions;
+using FluentValidation;
+using Sorcha.CitizenWallet.Abstractions.Models;
+
+namespace Sorcha.CitizenWallet.Abstractions.Validators;
+
+/// <summary>
+/// Validates a KB-JWT signing request (#1195 Phase 2, Task 6a). Shape-level checks only —
+/// the endpoint separately decodes the header and enforces <c>typ: "kb+jwt"</c> (the
+/// signing-oracle guard) because that requires base64url + JSON work FluentValidation
+/// shouldn't own.
+/// </summary>
+public sealed partial class KbJwtSignRequestValidator : AbstractValidator<KbJwtSignRequest>
+{
+    /// <summary>Two non-empty base64url segments joined by a single dot (a compact JWS signing input).</summary>
+    [GeneratedRegex("^[A-Za-z0-9_-]+\\.[A-Za-z0-9_-]+$")]
+    private static partial Regex SigningInputShape();
+
+    /// <summary>Initialise validation rules.</summary>
+    public KbJwtSignRequestValidator()
+    {
+        RuleFor(x => x.SigningInput)
+            .NotEmpty()
+            .MaximumLength(16384)
+            .Matches(SigningInputShape())
+            .WithMessage("SigningInput must be a compact JWS signing input: base64url(header).base64url(payload).");
+    }
+}

--- a/src/Common/Sorcha.PresentationLifecycle.Abstractions/IPresentationConsumer.cs
+++ b/src/Common/Sorcha.PresentationLifecycle.Abstractions/IPresentationConsumer.cs
@@ -17,7 +17,11 @@ namespace Sorcha.PresentationLifecycle.Abstractions;
 ///   <item><description><see cref="VerifyAsync"/> is synchronous w.r.t. the caller's await — no background processing after return.</description></item>
 ///   <item><description>Consumers MUST NOT write to the register directly; they return an outcome, the lifecycle service writes it.</description></item>
 ///   <item><description>Consumer-level idempotency is NOT required; the lifecycle service guards via a Redis sentinel.</description></item>
-///   <item><description>VerifiedClaims MUST be filtered to the claims the blueprint's requiredClaims asked for — minimal disclosure.</description></item>
+///   <item><description>VerifiedClaims MUST contain only claims from the VERIFIED presentation
+///   (issuer-committed, digest-anchored) and MUST cover every requiredClaim (the gate). Claims
+///   beyond the required set MAY be included when the citizen consented to disclose them —
+///   minimal disclosure is enforced at the wallet's consent, not by server-side truncation
+///   (#1195 Phase 2: the full-disclosure bind gate copies exactly what the root carries).</description></item>
 ///   <item><description>VerifierDiagnostics format is consumer-defined; SHOULD NOT contain PII.</description></item>
 /// </list>
 /// </remarks>

--- a/src/Common/Sorcha.PresentationLifecycle.Abstractions/PresentationInitiationContext.cs
+++ b/src/Common/Sorcha.PresentationLifecycle.Abstractions/PresentationInitiationContext.cs
@@ -44,6 +44,15 @@ namespace Sorcha.PresentationLifecycle.Abstractions;
 /// <paramref name="RequiredClaimNames"/> (back-compatible with pre-US2 callers).
 /// Carried as JSON to keep this abstractions assembly free of a DCQL model
 /// dependency.</param>
+/// <param name="Nonce">#1195 Phase 2 (Task 6b, T032) — the nonce the consumer's
+/// initiation embedded in the request object. Persisted on pending state at
+/// initiation and carried back on the callback so the consumer can rebuild the
+/// verifier session (the KB-JWT must echo this nonce). Null on legacy pending
+/// entries written before the session wiring.</param>
+/// <param name="ExpiresAt">#1195 Phase 2 (Task 6b, T032) — when the pending
+/// attempt's validity window closes (CreatedAt + validity window). Lets the
+/// consumer refuse a late outcome with a NAMED session-expired decline instead
+/// of an opaque failure. Null on legacy pending entries.</param>
 public sealed record PresentationInitiationContext(
     Guid PresentationRequestId,
     Guid InstanceId,
@@ -57,4 +66,6 @@ public sealed record PresentationInitiationContext(
     string? CredentialType = null,
     IReadOnlyList<string>? RequiredClaimNames = null,
     string? PublicBaseUrl = null,
-    string? DeclaredDcqlQueryJson = null);
+    string? DeclaredDcqlQueryJson = null,
+    string? Nonce = null,
+    DateTimeOffset? ExpiresAt = null);

--- a/src/Common/Sorcha.ServiceClients.Http/CitizenWallet/CitizenWalletClient.cs
+++ b/src/Common/Sorcha.ServiceClients.Http/CitizenWallet/CitizenWalletClient.cs
@@ -174,6 +174,21 @@ public sealed class CitizenWalletClient : ICitizenWalletClient
     }
 
     /// <inheritdoc />
+    public async Task<KbJwtSignResponse> SignKbJwtAsync(
+        KbJwtSignRequest request, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var response = await _httpClient.PostAsJsonAsync(
+            "api/v1/wallet/presentations/sign-kb", request, JsonOptions, ct);
+        response.EnsureSuccessStatusCode();
+
+        return await response.Content.ReadFromJsonAsync<KbJwtSignResponse>(SorchaJson.Options, ct)
+            ?? throw new InvalidOperationException(
+                "Wallet Service returned an empty body for /presentations/sign-kb.");
+    }
+
+    /// <inheritdoc />
     public async Task<PendingApplicationResponse> GetPendingApplicationAsync(CancellationToken ct = default)
     {
         var response = await _httpClient.GetAsync("api/v1/wallet/pending-applications", ct);

--- a/src/Common/Sorcha.ServiceClients.Http/CitizenWallet/ICitizenWalletClient.cs
+++ b/src/Common/Sorcha.ServiceClients.Http/CitizenWallet/ICitizenWalletClient.cs
@@ -102,4 +102,15 @@ public interface ICitizenWalletClient
     /// in flight. Scoped to the calling citizen by the platform via the forwarded JWT.
     /// </summary>
     Task<PendingApplicationResponse> GetPendingApplicationAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Signs a KB-JWT signing input with the authenticated citizen's server-custodied holder
+    /// key (#1195 Phase 2, Task 6a). Calls <c>POST /api/v1/wallet/presentations/sign-kb</c>.
+    /// Used by the wallet PWA to present a holder-<c>cnf</c> credential (e.g. the
+    /// AssuredIdentityCredential root) — the holder private key never leaves the server.
+    /// The header must carry <c>typ: "kb+jwt"</c> and an <c>alg</c> matching the holder JWK's
+    /// algorithm; the server refuses anything else with a named 400.
+    /// </summary>
+    Task<KbJwtSignResponse> SignKbJwtAsync(
+        KbJwtSignRequest request, CancellationToken ct = default);
 }

--- a/src/Common/Sorcha.Verifier.Engine/VerifiablePresentationValidator.cs
+++ b/src/Common/Sorcha.Verifier.Engine/VerifiablePresentationValidator.cs
@@ -20,9 +20,13 @@ namespace Sorcha.Verifier.Engine;
 /// <list type="number">
 ///   <item>Parse the SD-JWT VC compact form (<c>credential.disclosure1.disclosureN.kbjwt</c>).</item>
 ///   <item>Extract the holder JWK from the credential's <c>cnf.jwk</c> claim.</item>
-///   <item>Verify the device delegation credential's signature with that holder JWK,
-///         extract the device JWK from its <c>cnf.jwk</c>, and check its status-list bit.</item>
-///   <item>Verify the KB-JWT signature with the device JWK.</item>
+///   <item>When a device delegation credential is supplied, verify its signature with that
+///         holder JWK, extract the device JWK from its <c>cnf.jwk</c>, and check its status-list bit;
+///         the KB-JWT is then verified with the device JWK. When NO delegation is supplied
+///         (server-custody, #1195 Phase 2) the KB-JWT is verified directly against the credential's
+///         own <c>cnf.jwk</c> holder key — a legitimate server-side wallet holds cnf and signs.</item>
+///   <item>Verify the KB-JWT signature with the delegation device JWK (delegation model) or the
+///         credential's own holder JWK (server-custody model).</item>
 ///   <item>Verify KB-JWT <c>nonce</c> + <c>aud</c> match the verifier session.</item>
 ///   <item>Verify required claim names appear in the disclosed claim set.</item>
 /// </list>
@@ -156,10 +160,27 @@ public sealed class VerifiablePresentationValidator : IVerifiablePresentationVal
             // ES256-only verifier reject Ed25519-holder presentations, so it's the first thing to surface.
             layerState.HolderKey = DescribeJwk(holderJwk);
 
-            // ── 4. Validate holder→device delegation credential ───────────────────
-            JsonElement deviceJwk = default;
+            // ── 4. Establish the KB-JWT signing key (two custody models) ──────────
+            //   The presentation carries its custody model implicitly, in whether a device
+            //   delegation credential accompanies it:
+            //
+            //   • DELEGATION model (F114/F127 device-bound wallets, the desk/doorstep verifiers):
+            //     the holder key signs a device delegation credential whose cnf is the device key,
+            //     and the KB-JWT is device-signed. The delegation's signature (holder key), expiry,
+            //     and status-list bit are all verified here. Behaviour is unchanged when a
+            //     delegation credential is supplied.
+            //
+            //   • SERVER-CUSTODY model (#1195 Phase 2, design §2): NO delegation. A legitimate
+            //     server-side wallet holds the credential's own cnf holder key and signs the KB-JWT
+            //     directly with it — there is no device key and nothing to delegate. The KB-JWT is
+            //     verified straight against the credential's cnf.jwk (same semantics as
+            //     SdJwtService.VerifyPresentationAsync on the HAIP path). This is what the Task-6
+            //     "bind to device" flow posts (holder-signed vp_token, no delegation).
+            JsonElement kbSigningKey;
+            bool serverCustody;
             if (!string.IsNullOrWhiteSpace(delegationCredential))
             {
+                serverCustody = false;
                 layerState.DelegationAlg = HeaderAlg(delegationCredential);
 
                 var delegationErrors = await ValidateDelegationAsync(
@@ -172,17 +193,23 @@ public sealed class VerifiablePresentationValidator : IVerifiablePresentationVal
 
                 var delegationPayload = TryParseJwtPayload(delegationCredential);
                 if (delegationPayload is null
-                    || !TryExtractCnfJwk(delegationPayload.Value, out deviceJwk))
+                    || !TryExtractCnfJwk(delegationPayload.Value, out var deviceJwk))
                 {
                     errors.Add("Delegation credential is missing cnf.jwk (device key).");
                     return Failure(errors, BuildLayers(false));
                 }
                 layerState.DeviceKey = DescribeJwk(deviceJwk);
+                kbSigningKey = deviceJwk;
             }
             else
             {
-                errors.Add("Delegation credential is required for citizen wallet presentations.");
-                return Failure(errors, BuildLayers(false));
+                // Server-custody: the KB-JWT MUST be signed by the credential's own cnf holder key
+                // (extracted at step 3). The missing-cnf case already rejected loudly above with
+                // "Credential is missing cnf.jwk (holder key binding)" — so reaching here with no
+                // delegation guarantees a holder key to verify against.
+                serverCustody = true;
+                layerState.ServerCustody = true;
+                kbSigningKey = holderJwk;
             }
 
             // ── 4b. Verify the credential's issuer signature ──────────────────────
@@ -235,10 +262,18 @@ public sealed class VerifiablePresentationValidator : IVerifiablePresentationVal
                 layerState.IssuerSignature = IssuerLayer.UnresolvedNotRequired;
             }
 
-            // ── 5. Verify KB-JWT signature with the device key ────────────────────
-            if (!VerifyJwsSignature(kbJwt, deviceJwk, out var kbPayload))
+            // ── 5. Verify KB-JWT signature ────────────────────────────────────────
+            //   Delegation model → the delegation's device key; server-custody → the credential's
+            //   own cnf holder key. VerifyJwsSignature dispatches on the KB-JWT header alg
+            //   (ES256 via ECDsa, EdDSA via BouncyCastle, ES256K), so an Ed25519 holder key — the
+            //   default Sorcha wallet, signing its own KB-JWT under server-custody — verifies just
+            //   as a P-256 device or holder key does. The two custody models raise DISTINCT named
+            //   errors so the verdict never conflates "wrong device key" with "holder key mismatch".
+            if (!VerifyJwsSignature(kbJwt, kbSigningKey, out var kbPayload))
             {
-                errors.Add("KB-JWT signature verification failed against device key.");
+                errors.Add(serverCustody
+                    ? "Key binding mismatch: KB-JWT not signed by the credential's cnf key."
+                    : "KB-JWT signature verification failed against device key.");
                 return Failure(errors, BuildLayers(false));
             }
 
@@ -898,6 +933,7 @@ internal sealed class LayerState
     public string? HolderKey;     // credential cnf.jwk "kty / crv" (e.g. "OKP / Ed25519")
     public string? DelegationAlg; // device-delegation JWS header alg (e.g. "EdDSA")
     public string? DeviceKey;     // delegation cnf.jwk "kty / crv" (always "EC / P-256" today)
+    public bool ServerCustody;    // #1195 Phase 2 — no delegation; the credential's holder key signs the KB-JWT directly
 
     // IssuerSignature
     public IssuerLayer IssuerSignature = IssuerLayer.NotChecked;
@@ -941,7 +977,13 @@ internal sealed class LayerState
             // the diagnostic that explains Ed25519-vs-P-256 behaviour (the default Sorcha wallet is
             // Ed25519, so its credential cnf.jwk is OKP / Ed25519 and the delegation is EdDSA-signed).
             if (!string.IsNullOrEmpty(HolderKey)) detail["holder-key"] = HolderKey;
-            if (!string.IsNullOrEmpty(DelegationAlg) || !string.IsNullOrEmpty(DeviceKey))
+            if (ServerCustody)
+            {
+                // Honest verdict trail — there is genuinely no delegation in server-custody. Say so
+                // rather than fabricate a delegation line; the holder key (above) signed the KB-JWT.
+                detail["delegation"] = "server-custody (none) · holder cnf signs KB-JWT";
+            }
+            else if (!string.IsNullOrEmpty(DelegationAlg) || !string.IsNullOrEmpty(DeviceKey))
             {
                 detail["delegation"] =
                     $"{DelegationAlg ?? "?"} · device key {DeviceKey ?? "?"}";

--- a/src/Common/Sorcha.Verifier.Engine/VerifiablePresentationValidator.cs
+++ b/src/Common/Sorcha.Verifier.Engine/VerifiablePresentationValidator.cs
@@ -308,11 +308,31 @@ public sealed class VerifiablePresentationValidator : IVerifiablePresentationVal
             // ── 7. Anchor disclosures, extract disclosed claims, check required set ──
             // #1195 Phase 2 (Task 6 fix round) — RFC 9901 disclosure anchoring: every
             // disclosure segment MUST be committed by the credential (its SHA-256 digest in an
-            // _sd array of the payload, or of an already-accepted disclosure's value — nested
-            // SD). Without this, a presenter could append fabricated [salt, name, value]
-            // segments — or OVERRIDE a legitimate claim's value with a forged duplicate — and
-            // have them emitted as verified claims. The KB-JWT cannot protect against this:
-            // its signer IS the presenter. Tampering rejects the whole presentation, loudly.
+            // _sd array or an array-element {"...": digest} marker of the payload, or of an
+            // already-accepted disclosure's value — nested SD). Without this, a presenter could
+            // append fabricated [salt, name, value] segments — or OVERRIDE a legitimate claim's
+            // value with a forged duplicate — and have them emitted as verified claims. The
+            // KB-JWT cannot protect against this: its signer IS the presenter. Tampering
+            // rejects the whole presentation, loudly.
+            //
+            // Fix round 2 — honour the payload's _sd_alg (RFC 9901 §4.1.1): sha-256 is the
+            // default and the only supported algorithm. Any OTHER declared value is its own
+            // DISTINCT rejection — digests computed under an unknown algorithm can never
+            // anchor, and reporting that as "unanchored disclosure" would accuse a legitimate
+            // credential of forgery. The error must tell the truth about why.
+            if (disclosureSegments.Count > 0)
+            {
+                var sdAlg = TryGetString(credentialPayload.Value, "_sd_alg");
+                if (sdAlg is not null && !string.Equals(sdAlg, "sha-256", StringComparison.OrdinalIgnoreCase))
+                {
+                    errors.Add(
+                        $"Unsupported _sd_alg '{sdAlg}' — this verifier supports sha-256 only; " +
+                        "disclosure anchoring cannot be evaluated.");
+                    layerState.LivePresentationFailed = true;
+                    return Failure(errors, BuildLayers(false));
+                }
+            }
+
             var unanchored = FindUnanchoredDisclosures(credentialPayload.Value, disclosureSegments);
             if (unanchored.Count > 0)
             {
@@ -451,9 +471,10 @@ public sealed class VerifiablePresentationValidator : IVerifiablePresentationVal
     }
 
     /// <summary>
-    /// RFC 9901 disclosure anchoring (#1195 Phase 2, Task 6 fix round). Returns the display
-    /// names of every disclosure segment whose SHA-256 digest is NOT committed by the
-    /// credential — i.e. not present in any <c>_sd</c> array of the credential payload or of an
+    /// RFC 9901 disclosure anchoring (#1195 Phase 2, Task 6 fix rounds 1+2). Returns the
+    /// display names of every disclosure segment whose SHA-256 digest is NOT committed by the
+    /// credential — i.e. not present in any <c>_sd</c> array OR any array-element
+    /// <c>{"...": "&lt;digest&gt;"}</c> marker of the credential payload or of an
     /// already-anchored disclosure's value (nested selective disclosure). Runs to fixpoint so
     /// nested disclosures anchor regardless of segment order. An empty result means every
     /// presented disclosure is issuer-committed.
@@ -510,7 +531,13 @@ public sealed class VerifiablePresentationValidator : IVerifiablePresentationVal
         return unanchoredNames;
     }
 
-    /// <summary>Recursively collect every string entry of every <c>_sd</c> array in <paramref name="element"/>.</summary>
+    /// <summary>
+    /// Recursively collect every digest the credential commits: string entries of <c>_sd</c>
+    /// arrays (object-property SD) and the values of <c>{"...": "&lt;digest&gt;"}</c>
+    /// array-element markers (RFC 9901 array SD — fix round 2). Harvesting a marker anywhere
+    /// in an anchored subtree is deliberate lenience: digests are unguessable SHA-256 values,
+    /// so over-collection can never anchor a forged disclosure.
+    /// </summary>
     private static void CollectSdDigests(JsonElement element, HashSet<string> sink)
     {
         switch (element.ValueKind)
@@ -527,6 +554,12 @@ public sealed class VerifiablePresentationValidator : IVerifiablePresentationVal
                                 sink.Add(digest.GetString()!);
                             }
                         }
+                    }
+                    else if (property.NameEquals("...") && property.Value.ValueKind == JsonValueKind.String)
+                    {
+                        // RFC 9901 array-element marker: {"...": "<digest>"} commits a
+                        // 2-element [salt, value] disclosure for that array position.
+                        sink.Add(property.Value.GetString()!);
                     }
                     else
                     {

--- a/src/Common/Sorcha.Verifier.Engine/VerifiablePresentationValidator.cs
+++ b/src/Common/Sorcha.Verifier.Engine/VerifiablePresentationValidator.cs
@@ -305,7 +305,27 @@ public sealed class VerifiablePresentationValidator : IVerifiablePresentationVal
                 layerState.LivePresentationFailed = true;
             }
 
-            // ── 7. Extract disclosed claims and check required set ────────────────
+            // ── 7. Anchor disclosures, extract disclosed claims, check required set ──
+            // #1195 Phase 2 (Task 6 fix round) — RFC 9901 disclosure anchoring: every
+            // disclosure segment MUST be committed by the credential (its SHA-256 digest in an
+            // _sd array of the payload, or of an already-accepted disclosure's value — nested
+            // SD). Without this, a presenter could append fabricated [salt, name, value]
+            // segments — or OVERRIDE a legitimate claim's value with a forged duplicate — and
+            // have them emitted as verified claims. The KB-JWT cannot protect against this:
+            // its signer IS the presenter. Tampering rejects the whole presentation, loudly.
+            var unanchored = FindUnanchoredDisclosures(credentialPayload.Value, disclosureSegments);
+            if (unanchored.Count > 0)
+            {
+                foreach (var name in unanchored)
+                {
+                    errors.Add(
+                        $"Disclosure '{name}' is not committed by the credential " +
+                        "(no matching _sd digest) — the presentation is tampered or malformed.");
+                }
+                layerState.LivePresentationFailed = true;
+                return Failure(errors, BuildLayers(false));
+            }
+
             disclosed = ParseDisclosures(disclosureSegments);
             foreach (var required in session.RequiredClaims)
             {
@@ -428,6 +448,119 @@ public sealed class VerifiablePresentationValidator : IVerifiablePresentationVal
         if (inner.ValueKind != JsonValueKind.Object) return false;
         jwk = inner;
         return true;
+    }
+
+    /// <summary>
+    /// RFC 9901 disclosure anchoring (#1195 Phase 2, Task 6 fix round). Returns the display
+    /// names of every disclosure segment whose SHA-256 digest is NOT committed by the
+    /// credential — i.e. not present in any <c>_sd</c> array of the credential payload or of an
+    /// already-anchored disclosure's value (nested selective disclosure). Runs to fixpoint so
+    /// nested disclosures anchor regardless of segment order. An empty result means every
+    /// presented disclosure is issuer-committed.
+    /// </summary>
+    internal static IReadOnlyList<string> FindUnanchoredDisclosures(
+        JsonElement credentialPayload,
+        IReadOnlyList<string> segments)
+    {
+        if (segments.Count == 0) return [];
+
+        var committed = new HashSet<string>(StringComparer.Ordinal);
+        CollectSdDigests(credentialPayload, committed);
+
+        var anchored = new bool[segments.Count];
+        bool progressed = true;
+        while (progressed)
+        {
+            progressed = false;
+            for (var i = 0; i < segments.Count; i++)
+            {
+                if (anchored[i]) continue;
+                var digest = Base64Url.EncodeToString(
+                    SHA256.HashData(Encoding.ASCII.GetBytes(segments[i])));
+                if (!committed.Contains(digest)) continue;
+
+                anchored[i] = true;
+                progressed = true;
+
+                // Nested SD: the disclosed value may itself carry _sd arrays that commit
+                // further disclosures (e.g. address sub-fields).
+                try
+                {
+                    using var doc = JsonDocument.Parse(Base64Url.DecodeFromChars(segments[i]));
+                    if (doc.RootElement.ValueKind == JsonValueKind.Array &&
+                        doc.RootElement.GetArrayLength() is 2 or 3)
+                    {
+                        CollectSdDigests(doc.RootElement[doc.RootElement.GetArrayLength() - 1], committed);
+                    }
+                }
+                catch
+                {
+                    // A segment that anchors but doesn't parse contributes no nested digests;
+                    // ParseDisclosures drops it downstream.
+                }
+            }
+        }
+
+        var unanchoredNames = new List<string>();
+        for (var i = 0; i < segments.Count; i++)
+        {
+            if (anchored[i]) continue;
+            unanchoredNames.Add(ReadDisclosureDisplayName(segments[i]));
+        }
+        return unanchoredNames;
+    }
+
+    /// <summary>Recursively collect every string entry of every <c>_sd</c> array in <paramref name="element"/>.</summary>
+    private static void CollectSdDigests(JsonElement element, HashSet<string> sink)
+    {
+        switch (element.ValueKind)
+        {
+            case JsonValueKind.Object:
+                foreach (var property in element.EnumerateObject())
+                {
+                    if (property.NameEquals("_sd") && property.Value.ValueKind == JsonValueKind.Array)
+                    {
+                        foreach (var digest in property.Value.EnumerateArray())
+                        {
+                            if (digest.ValueKind == JsonValueKind.String)
+                            {
+                                sink.Add(digest.GetString()!);
+                            }
+                        }
+                    }
+                    else
+                    {
+                        CollectSdDigests(property.Value, sink);
+                    }
+                }
+                break;
+            case JsonValueKind.Array:
+                foreach (var item in element.EnumerateArray())
+                {
+                    CollectSdDigests(item, sink);
+                }
+                break;
+        }
+    }
+
+    /// <summary>Best-effort claim name of a disclosure segment for error messages; never throws.</summary>
+    private static string ReadDisclosureDisplayName(string segment)
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(Base64Url.DecodeFromChars(segment));
+            if (doc.RootElement.ValueKind != JsonValueKind.Array) return "<malformed>";
+            return doc.RootElement.GetArrayLength() switch
+            {
+                3 => doc.RootElement[1].GetString() ?? "<unnamed>",
+                2 => doc.RootElement[0].GetString() ?? "<unnamed>",
+                _ => "<malformed>",
+            };
+        }
+        catch
+        {
+            return "<malformed>";
+        }
     }
 
     /// <summary>

--- a/src/Services/Sorcha.Blueprint.Service/Endpoints/PresentationEndpoints.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Endpoints/PresentationEndpoints.cs
@@ -90,28 +90,59 @@ public static class PresentationEndpoints
                 "scanner; no instance, register, or consumer metadata is included. " +
                 "The register's transaction stream is the authoritative history.");
 
-        app.MapPost("/callbacks/{consumerName}/{presentationRequestId:guid}", async (
+        // Shared dispatch for both callback routes below.
+        static async Task<IResult> DispatchCallbackAsync(
+            string consumerName,
+            Guid presentationRequestId,
+            JsonElement verifierPayload,
+            IPresentationLifecycleService lifecycle,
+            CancellationToken ct)
+        {
+            try
+            {
+                var result = await lifecycle.HandleOutcomeAsync(
+                    consumerName, presentationRequestId, verifierPayload, ct);
+                return Results.Ok(new PresentationCallbackResponse(
+                    Kind: result.Kind.ToString(),
+                    OutcomeTransactionId: result.OutcomeTransactionId,
+                    IdempotentReplay: result.IsIdempotentReplay,
+                    LateAfterAbandonment: result.IsLateAfterAbandonment));
+            }
+            catch (InvalidOperationException ex)
+            {
+                return Results.BadRequest(new { error = ex.Message });
+            }
+        }
+
+        // #1195 Phase 2 (Task 6b, B) — the sorcha-wallet consumer's callback IS the wallet's
+        // direct_post target (BuildInitiationAsync serves it as response_uri), and the poster
+        // is always the Citizen Wallet PWA holding a CONSUMER-tier token. The literal segment
+        // outranks the {consumerName} template in route matching, so this route takes every
+        // sorcha-wallet post; all other consumers stay on the service-tier route below.
+        app.MapPost("/callbacks/sorcha-wallet/{presentationRequestId:guid}", (
+                Guid presentationRequestId,
+                [FromBody] JsonElement verifierPayload,
+                IPresentationLifecycleService lifecycle,
+                CancellationToken ct) => DispatchCallbackAsync(
+                    Services.Implementation.SorchaWalletPresentationConsumer.ConsumerNameValue,
+                    presentationRequestId, verifierPayload, lifecycle, ct))
+            .WithName("SorchaWalletPresentationCallback")
+            .WithSummary("Citizen-wallet direct_post target for a sorcha-wallet presentation outcome")
+            .WithDescription(
+                "The Sorcha Wallet PWA posts its {vpToken} outcome payload here (this URI is the " +
+                "response_uri in the served request object). Consumer-tier: the citizen's own " +
+                "token authorises the post; verification happens server-side in the sorcha-wallet " +
+                "consumer against the session persisted at initiation. Idempotent by " +
+                "presentationRequestId; unknown/expired attempts return a named 400.")
+            .RequireAuthorization(AuthorizationPolicies.RequireConsumerAudience);
+
+        app.MapPost("/callbacks/{consumerName}/{presentationRequestId:guid}", (
                 string consumerName,
                 Guid presentationRequestId,
                 [FromBody] JsonElement verifierPayload,
                 IPresentationLifecycleService lifecycle,
-                CancellationToken ct) =>
-            {
-                try
-                {
-                    var result = await lifecycle.HandleOutcomeAsync(
-                        consumerName, presentationRequestId, verifierPayload, ct);
-                    return Results.Ok(new PresentationCallbackResponse(
-                        Kind: result.Kind.ToString(),
-                        OutcomeTransactionId: result.OutcomeTransactionId,
-                        IdempotentReplay: result.IsIdempotentReplay,
-                        LateAfterAbandonment: result.IsLateAfterAbandonment));
-                }
-                catch (InvalidOperationException ex)
-                {
-                    return Results.BadRequest(new { error = ex.Message });
-                }
-            })
+                CancellationToken ct) => DispatchCallbackAsync(
+                    consumerName, presentationRequestId, verifierPayload, lifecycle, ct))
             .WithName("PresentationCallback")
             .WithSummary("Verifier callback for a presentation outcome")
             .WithDescription(

--- a/src/Services/Sorcha.Blueprint.Service/Endpoints/PresentationEndpoints.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Endpoints/PresentationEndpoints.cs
@@ -273,8 +273,10 @@ public static class PresentationEndpoints
             .WithDescription(
                 "Feature 127 supplement to F111's presentation lifecycle. The token returned by " +
                 "InitiateAsync authenticates the caller as the council page that originated the " +
-                "flow. Single-use; consumed on first fetch. Claims are returned in plaintext, " +
-                "filtered to the requiredClaims declared on the action's credentialRequirement. " +
+                "flow. Single-use; consumed on first fetch. Claims are returned in plaintext — " +
+                "every claim the citizen consented to disclose and the validator verified " +
+                "(requiredClaims gate the presentation; they no longer truncate the emitted set — " +
+                "#1195 Phase 2 full-disclosure pass-through). " +
                 "Returns 200 + status=pending while the wallet's outcome hasn't been written; " +
                 "returns 410 on decline / abandonment / claims-expired; returns 401 when the " +
                 "token is invalid or doesn't match the path's presentationRequestId.");

--- a/src/Services/Sorcha.Blueprint.Service/Services/Implementation/ActionExecutionService.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Services/Implementation/ActionExecutionService.cs
@@ -79,6 +79,24 @@ public class ActionExecutionService : IActionExecutionService, IPresentationRout
     /// </summary>
     private const int MaxExecutionDepth = 1000;
 
+    /// <summary>
+    /// Stable claim-source prefix for a verified credential presentation's disclosed claims
+    /// (Feature 174 / #1195 Phase 2, "one assurance, two bindings"). A
+    /// <c>credentialIssuanceConfig.claimMappings</c> entry with
+    /// <c>sourceField: "/presentedCredential/givenName"</c> resolves the <c>givenName</c> disclosed by
+    /// the verified, issuer-signed presentation captured at the action's <c>credentialRequirements</c>
+    /// gate — the mechanism by which a device-bound copy of a credential carries the assured claim set
+    /// forward from the verified root presentation (design §4.1), NOT from client-supplied payload.
+    /// <para>
+    /// SECURITY: values under this prefix are AUTHORITATIVE. They come only from a verified presentation
+    /// (the synchronous internal verifier this execution, or a prior gated action's reconstructed data)
+    /// and always take precedence over the submitted payload. A client MUST NOT be able to override or
+    /// spoof an identity claim by submitting a <c>presentedCredential</c> field — any payload-supplied
+    /// value at this key is dropped and replaced with the verified source, fail-closed.
+    /// </para>
+    /// </summary>
+    internal const string PresentedCredentialClaimSourceKey = "presentedCredential";
+
     /// <summary>Initialises a new instance of the <see cref="ActionExecutionService"/> class.</summary>
     public ActionExecutionService(
         IActionResolverService actionResolver,
@@ -269,7 +287,16 @@ public class ActionExecutionService : IActionExecutionService, IPresentationRout
             }
         }
 
-        // 4c. Verify credential presentations against action requirements
+        // 4c. Verify credential presentations against action requirements.
+        //
+        // Feature 174 / #1195 Phase 2 — the verified presentation's disclosed claims are the
+        // authoritative source for any issuance claim mapped from /presentedCredential/* (see
+        // PresentedCredentialClaimSourceKey). Captured here at the synchronous gate and threaded into
+        // the issuance source document below (step 8a-bis) so device-copy identity claims come from the
+        // verified, issuer-signed root presentation — never from client-supplied payload. Null when no
+        // synchronous presentation was verified this execution (e.g. an async SorchaWallet gate, or no
+        // credential requirement at all).
+        Dictionary<string, object>? verifiedPresentationClaims = null;
         var haipRequirement = actionDef.CredentialRequirements?
             .FirstOrDefault(r => r.PresentationSource == PresentationSource.HaipExternalWallet);
         if (actionDef.CredentialRequirements?.Any() == true)
@@ -362,6 +389,25 @@ public class ActionExecutionService : IActionExecutionService, IPresentationRout
                 _logger.LogInformation(
                     "Credential verification passed for action {ActionId}: {Count} credential(s) verified",
                     actionId, credentialResult.VerifiedCredentials.Count);
+
+                // Feature 174 / #1195 Phase 2 — capture the disclosed claims from the verified
+                // presentation(s) so they can be exposed under /presentedCredential/* at issuance
+                // (step 8a-bis). Merge across all verified credentials (a single root credential in
+                // the AIAS device-binding flow). Previously this result was dropped after logging,
+                // which meant a claim mapped from /presentedCredential/* fell through to whatever the
+                // client submitted — the vulnerability this closes.
+                if (credentialResult.VerifiedCredentials.Count > 0)
+                {
+                    var captured = new Dictionary<string, object>(StringComparer.Ordinal);
+                    foreach (var verified in credentialResult.VerifiedCredentials)
+                    {
+                        foreach (var claim in verified.VerifiedClaims)
+                        {
+                            captured[claim.Key] = claim.Value;
+                        }
+                    }
+                    verifiedPresentationClaims = captured;
+                }
             }
         }
 
@@ -521,6 +567,15 @@ public class ActionExecutionService : IActionExecutionService, IPresentationRout
             ? flattenedState.Where(kvp => kvp.Value != null).ToDictionary(kvp => kvp.Key, kvp => kvp.Value!)
             : new Dictionary<string, object>(instance.AccumulatedData);
 
+        // Feature 174 / #1195 Phase 2 — snapshot any /presentedCredential source carried forward from a
+        // prior gated action's reconstructed data BEFORE the payload overlay, so a client-supplied
+        // `presentedCredential` field can never masquerade as the verified source. Reinstated with
+        // precedence at step 8a-bis. See PresentedCredentialClaimSourceKey.
+        var reconstructedPresentedCredential =
+            mergedData.TryGetValue(PresentedCredentialClaimSourceKey, out var reconstructedPc)
+                ? reconstructedPc
+                : null;
+
         foreach (var kvp in request.PayloadData)
         {
             mergedData[kvp.Key] = kvp.Value;
@@ -548,6 +603,29 @@ public class ActionExecutionService : IActionExecutionService, IPresentationRout
         {
             ["registerId"] = instance.RegisterId
         };
+
+        // 8a-bis. Feature 174 / #1195 Phase 2 — expose the verified presentation's disclosed claims
+        //     under the stable /presentedCredential/* claim-source prefix (see
+        //     PresentedCredentialClaimSourceKey) and give them PRECEDENCE over client payload. A
+        //     claimMappings entry with sourceField "/presentedCredential/givenName" resolves the
+        //     givenName disclosed by the verified, issuer-signed root presentation — the device-copy's
+        //     identity claims are carried forward from that verified presentation (design §4.1), never
+        //     from client-supplied payload. Two supply routes: (a) this execution's synchronous gate
+        //     (verifiedPresentationClaims), (b) a prior gated action's reconstructed data
+        //     (reconstructedPresentedCredential, snapshotted pre-overlay at step 7). Whichever is
+        //     present is written here AFTER the payload overlay, so any payload-supplied
+        //     `presentedCredential` field is dropped. When neither is present the key is removed
+        //     outright — a client value must never be able to pose as a verified presentation
+        //     (fail-closed; /presentedCredential/* then resolves to nothing and the claim is dropped).
+        var trustedPresentedCredential = (object?)verifiedPresentationClaims ?? reconstructedPresentedCredential;
+        if (trustedPresentedCredential is not null)
+        {
+            mergedData[PresentedCredentialClaimSourceKey] = trustedPresentedCredential;
+        }
+        else
+        {
+            mergedData.Remove(PresentedCredentialClaimSourceKey);
+        }
 
         // 8b. HAIP credential mint (Feature 097 + Feature 104 wave 14b).
         //     Moved to run BEFORE routing so the minted offer data can be

--- a/src/Services/Sorcha.Blueprint.Service/Services/Implementation/ActionExecutionService.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Services/Implementation/ActionExecutionService.cs
@@ -297,8 +297,14 @@ public class ActionExecutionService : IActionExecutionService, IPresentationRout
         // synchronous presentation was verified this execution (e.g. an async SorchaWallet gate, or no
         // credential requirement at all).
         Dictionary<string, object>? verifiedPresentationClaims = null;
+        // #1195 Phase 2 (Task 6b, A) — the F111 async lifecycle fires for BOTH external-wallet
+        // presentation sources. HAIP keeps first pick (byte-identical behaviour for existing
+        // blueprints); a SorchaWallet requirement now also initiates instead of falling through
+        // to the internal synchronous verifier (which could never satisfy an async wallet gate).
         var haipRequirement = actionDef.CredentialRequirements?
-            .FirstOrDefault(r => r.PresentationSource == PresentationSource.HaipExternalWallet);
+            .FirstOrDefault(r => r.PresentationSource == PresentationSource.HaipExternalWallet)
+            ?? actionDef.CredentialRequirements?
+            .FirstOrDefault(r => r.PresentationSource == PresentationSource.SorchaWallet);
         if (actionDef.CredentialRequirements?.Any() == true)
         {
             var hasSubmittedPresentations = request.CredentialPresentations is { Count: > 0 };
@@ -364,10 +370,11 @@ public class ActionExecutionService : IActionExecutionService, IPresentationRout
             {
                 // Deployment-configuration error: this branch is only reachable when
                 // IPresentationLifecycleService is not registered. Fail fast rather
-                // than silently skipping the HAIP requirement.
+                // than silently skipping the presentation requirement.
                 throw new InvalidOperationException(
-                    "HAIP presentation requested but IPresentationLifecycleService is not registered. " +
-                    "Ensure PresentationLifecycleOptions and related services are wired in the DI container.");
+                    $"An external-wallet presentation ({haipRequirement.PresentationSource}) was requested " +
+                    "but IPresentationLifecycleService is not registered. Ensure PresentationLifecycleOptions " +
+                    "and related services are wired in the DI container.");
             }
             else if (_credentialVerifier != null)
             {

--- a/src/Services/Sorcha.Blueprint.Service/Services/Implementation/PresentationLifecycleService.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Services/Implementation/PresentationLifecycleService.cs
@@ -157,6 +157,10 @@ public sealed class PresentationLifecycleService : IPresentationLifecycleService
         //    HAIP delegates to its external service; non-HAIP consumers use the
         //    F127 BuildInitiationAsync extension on IPresentationConsumer.
         InitiationDescriptor descriptor;
+        // #1195 Phase 2 (Task 6b) — hoisted so the pending record can persist the verifier
+        // client_id the request object was served with (session reconstruction at callback
+        // time). Stays null on the HAIP path (HAIP owns its own session state).
+        string? verifierClientId = null;
         if (consumerName == "haip")
         {
             if (_haipClient is null)
@@ -206,7 +210,6 @@ public sealed class PresentationLifecycleService : IPresentationLifecycleService
             // emit a real client_id instead of did:sorcha:org:UNKNOWN. Best-effort:
             // a null result (no org id, unpublished DID doc, or transport failure)
             // leaves the consumer's placeholder fallback intact and never blocks the gate.
-            string? verifierClientId = null;
             if (_orgDidClient is not null
                 && !string.IsNullOrWhiteSpace(blueprint.OrganizationId)
                 && Guid.TryParse(blueprint.OrganizationId, out var orgGuid))
@@ -284,7 +287,16 @@ public sealed class PresentationLifecycleService : IPresentationLifecycleService
             OutcomeDetailLevel = (config.OutcomeDetailLevel ?? OutcomeDetailLevel.Minimal)
                 .ToString().ToLowerInvariant(),
             ValidityWindowSeconds = validityWindow,
-            CreatedAt = DateTimeOffset.UtcNow
+            CreatedAt = DateTimeOffset.UtcNow,
+            // #1195 Phase 2 (Task 6b, T032) — persist the verifier-session fields so the
+            // callback can rebuild the VerifierSession (nonce echo, vct/claim checks,
+            // KB-JWT audience). The pending row is the session record: single-use
+            // (deleted post-outcome) and TTL-bound (validity window).
+            Nonce = descriptor.Nonce,
+            VerifierClientId = verifierClientId,
+            CredentialType = credentialRequirement.Type,
+            RequiredClaimNames = credentialRequirement.RequiredClaims?
+                .Select(c => c.ClaimName).ToList()
         };
         await _pendingStore.StoreAsync(pending, cancellationToken);
 
@@ -464,7 +476,15 @@ public sealed class PresentationLifecycleService : IPresentationLifecycleService
             BlueprintId: pending.BlueprintId,
             SubmitterWallet: pending.SubmitterWallet,
             RequirementsDigest: Convert.FromHexString(pending.CredentialRequirementDigestHex),
-            InitiatedAt: pending.CreatedAt);
+            InitiatedAt: pending.CreatedAt,
+            // #1195 Phase 2 (Task 6b, T032) — the verifier-session fields persisted at
+            // initiation ride back to the consumer so it can rebuild the VerifierSession.
+            // Null on legacy pending entries ⇒ the consumer keeps its session-missing decline.
+            VerifierClientId: pending.VerifierClientId,
+            CredentialType: pending.CredentialType,
+            RequiredClaimNames: pending.RequiredClaimNames,
+            Nonce: pending.Nonce,
+            ExpiresAt: pending.CreatedAt.AddSeconds(pending.ValidityWindowSeconds));
 
         var outcome = await consumer.VerifyAsync(context, verifierPayload, cancellationToken);
 

--- a/src/Services/Sorcha.Blueprint.Service/Services/Implementation/SorchaWalletPresentationConsumer.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Services/Implementation/SorchaWalletPresentationConsumer.cs
@@ -192,20 +192,21 @@ public sealed class SorchaWalletPresentationConsumer : IPresentationConsumer
                 PresentationSubmissionHash: null);
         }
 
-        // Filter disclosed claims to the verifier-session's required set. Minimal
-        // disclosure invariant — the consumer surfaces only what the blueprint
-        // asked for. The wallet may include more in the VP; what crosses the
-        // boundary into F111's outcome record is the strict required subset.
+        // Task 6 fix round (#1195 Phase 2) — requiredClaims act as the GATE, and the emitted
+        // VerifiedClaims are the FULL verified disclosure set (design §4.1 full-disclosure
+        // bind: the device copy mirrors exactly what the root carries; optional claims like
+        // middleName degrade gracefully instead of refusing citizens who don't have one).
+        // Minimal disclosure is enforced where it belongs: at the wallet's consent sheet
+        // (only consented disclosures enter the vp_token) and by the validator's RFC 9901
+        // digest anchoring (only issuer-committed disclosures reach DisclosedClaims) — so
+        // nothing here is client-controlled beyond what the issuer signed and the citizen
+        // chose to disclose.
         var requiredClaimSet = new HashSet<string>(session.RequiredClaims, StringComparer.Ordinal);
-        var filteredClaims = outcome.DisclosedClaims
-            .Where(kv => requiredClaimSet.Contains(kv.Key))
-            .ToDictionary(
-                kv => kv.Key,
-                kv => (object)(kv.Value ?? string.Empty),
-                StringComparer.Ordinal);
 
-        // Are any required claims missing? Decline with SchemaMismatch.
-        var missing = requiredClaimSet.Except(filteredClaims.Keys).ToList();
+        // The gate: every required claim must be present in the verified disclosure set.
+        var missing = requiredClaimSet
+            .Where(r => !outcome.DisclosedClaims.ContainsKey(r))
+            .ToList();
         if (missing.Count > 0)
         {
             _logger.LogWarning(
@@ -222,10 +223,16 @@ public sealed class SorchaWalletPresentationConsumer : IPresentationConsumer
                 PresentationSubmissionHash: null);
         }
 
-        var submissionHash = ComputePresentationHash(session, filteredClaims);
+        // The pass-through: everything the validator verified, verbatim.
+        var verifiedClaims = outcome.DisclosedClaims.ToDictionary(
+            kv => kv.Key,
+            kv => (object)(kv.Value ?? string.Empty),
+            StringComparer.Ordinal);
+
+        var submissionHash = ComputePresentationHash(session, verifiedClaims);
         return new PresentationOutcome(
             Kind: PresentationOutcomeKind.Success,
-            VerifiedClaims: filteredClaims,
+            VerifiedClaims: verifiedClaims,
             Reason: null,
             VerifierDiagnostics: null,
             PresentationSubmissionHash: $"sha256:{submissionHash}");

--- a/src/Services/Sorcha.Blueprint.Service/Services/Implementation/SorchaWalletPresentationConsumer.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Services/Implementation/SorchaWalletPresentationConsumer.cs
@@ -90,34 +90,73 @@ public sealed class SorchaWalletPresentationConsumer : IPresentationConsumer
                 PresentationSubmissionHash: null);
         }
 
-        if (payload.Session is null)
+        // #1195 Phase 2 (Task 6b) — T032 landed: when the caller supplies no session (the
+        // wallet posts only {vpToken}), rebuild the VerifierSession from the pending-state
+        // fields the lifecycle persisted at initiation. Every refusal here is NAMED and
+        // distinct — wrong nonce (validator: "KB-JWT nonce does not match session"),
+        // expired session, and genuinely-unknown session are three different answers.
+        var session = payload.Session;
+        if (session is null)
         {
-            // The lifecycle service (T032) is expected to populate
-            // payload.Session from the pending state + blueprint metadata
-            // before dispatching here. Until that wiring lands, this branch
-            // surfaces a clear, debuggable error rather than fabricating a
-            // session that wouldn't match what the wallet signed against.
-            _logger.LogWarning(
-                "Sorcha-wallet consumer received payload without a VerifierSession (requestId={RequestId}); " +
-                "T032 lifecycle dispatch must populate Session from pending state.",
-                context.PresentationRequestId);
-            return new PresentationOutcome(
-                Kind: PresentationOutcomeKind.Decline,
-                VerifiedClaims: null,
-                Reason: PresentationDeclineReason.VerifierError,
-                VerifierDiagnostics: new Dictionary<string, object>
-                {
-                    ["error"] = "session-missing",
-                    ["requestId"] = context.PresentationRequestId
-                },
-                PresentationSubmissionHash: null);
+            if (string.IsNullOrEmpty(context.Nonce) || string.IsNullOrEmpty(context.CredentialType))
+            {
+                // Legacy pending entry (pre-session-wiring) or a caller that never initiated —
+                // no nonce means nothing the KB-JWT could be verified against. Named decline.
+                _logger.LogWarning(
+                    "Sorcha-wallet consumer cannot rebuild a VerifierSession for requestId={RequestId}: " +
+                    "the pending state carries no nonce/credentialType (pre-T032 entry?).",
+                    context.PresentationRequestId);
+                return new PresentationOutcome(
+                    Kind: PresentationOutcomeKind.Decline,
+                    VerifiedClaims: null,
+                    Reason: PresentationDeclineReason.VerifierError,
+                    VerifierDiagnostics: new Dictionary<string, object>
+                    {
+                        ["error"] = "session-missing",
+                        ["requestId"] = context.PresentationRequestId
+                    },
+                    PresentationSubmissionHash: null);
+            }
+
+            var expiresAt = context.ExpiresAt ?? context.InitiatedAt.AddMinutes(5);
+            if (DateTimeOffset.UtcNow > expiresAt)
+            {
+                _logger.LogWarning(
+                    "Sorcha-wallet outcome for requestId={RequestId} arrived after the session expired at {ExpiresAt:O}.",
+                    context.PresentationRequestId, expiresAt);
+                return new PresentationOutcome(
+                    Kind: PresentationOutcomeKind.Decline,
+                    VerifiedClaims: null,
+                    Reason: PresentationDeclineReason.VerifierError,
+                    VerifierDiagnostics: new Dictionary<string, object>
+                    {
+                        ["error"] = "session-expired",
+                        ["requestId"] = context.PresentationRequestId,
+                        ["expiresAt"] = expiresAt
+                    },
+                    PresentationSubmissionHash: null);
+            }
+
+            session = new VerifierSession
+            {
+                SessionId = context.PresentationRequestId.ToString("N"),
+                // MUST match the client_id the request object was served with — the wallet's
+                // KB-JWT binds aud to it. Same resolution rule as BuildInitiationAsync.
+                ClientId = ResolveClientId(context),
+                Nonce = context.Nonce,
+                RequiredVct = context.CredentialType,
+                RequiredClaims = context.RequiredClaimNames ?? [],
+                Purpose = "credential-gate",
+                CreatedAt = context.InitiatedAt,
+                ExpiresAt = expiresAt
+            };
         }
 
         VerificationOutcome outcome;
         try
         {
             outcome = await _validator.ValidateAsync(
-                payload.Session,
+                session,
                 payload.VpToken,
                 payload.DelegationCredential,
                 cancellationToken);
@@ -157,7 +196,7 @@ public sealed class SorchaWalletPresentationConsumer : IPresentationConsumer
         // disclosure invariant — the consumer surfaces only what the blueprint
         // asked for. The wallet may include more in the VP; what crosses the
         // boundary into F111's outcome record is the strict required subset.
-        var requiredClaimSet = new HashSet<string>(payload.Session.RequiredClaims, StringComparer.Ordinal);
+        var requiredClaimSet = new HashSet<string>(session.RequiredClaims, StringComparer.Ordinal);
         var filteredClaims = outcome.DisclosedClaims
             .Where(kv => requiredClaimSet.Contains(kv.Key))
             .ToDictionary(
@@ -183,7 +222,7 @@ public sealed class SorchaWalletPresentationConsumer : IPresentationConsumer
                 PresentationSubmissionHash: null);
         }
 
-        var submissionHash = ComputePresentationHash(payload.Session, filteredClaims);
+        var submissionHash = ComputePresentationHash(session, filteredClaims);
         return new PresentationOutcome(
             Kind: PresentationOutcomeKind.Success,
             VerifiedClaims: filteredClaims,
@@ -208,7 +247,7 @@ public sealed class SorchaWalletPresentationConsumer : IPresentationConsumer
         // gate. The request object is unsigned in this flow (alg "none"), so client_id
         // is a display identity; US6 (Feature 181) signs it with the verifier
         // certificate and makes it cryptographically load-bearing.
-        var clientId = context.VerifierClientId ?? "did:sorcha:org:UNKNOWN";
+        var clientId = ResolveClientId(context);
 
         // Feature 181 (T014) — the ask is expressed in DCQL inside a SERVED request
         // object (the request_uri form every Sorcha producer converges on), built via
@@ -305,6 +344,15 @@ public sealed class SorchaWalletPresentationConsumer : IPresentationConsumer
         var body = JsonSerializer.SerializeToUtf8Bytes(payload);
         return $"{B64Url(header)}.{B64Url(body)}.";
     }
+
+    /// <summary>
+    /// The ONE client_id resolution rule, shared by <see cref="BuildInitiationAsync"/> (what the
+    /// request object serves) and the Task 6b session reconstruction (what the KB-JWT's <c>aud</c>
+    /// is verified against). A drift between the two would make every wallet presentation fail
+    /// the audience check.
+    /// </summary>
+    private static string ResolveClientId(PresentationInitiationContext context)
+        => context.VerifierClientId ?? "did:sorcha:org:UNKNOWN";
 
     private static PresentationDeclineReason MapDeclineReason(IReadOnlyList<string> errors)
     {

--- a/src/Services/Sorcha.Blueprint.Service/Services/Implementation/StateReconstructionService.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Services/Implementation/StateReconstructionService.cs
@@ -119,6 +119,16 @@ public class StateReconstructionService : IStateReconstructionService
         // loop's timestamp ordering gives latest-sealed-wins for free).
         var presentedCredentialByAction = new Dictionary<string, JsonElement>();
 
+        // Feature 174 / #1195 Phase 2 (continuation) — the gated action's own submitted payload.
+        // On the async presentation path NO regular Action tx is ever sealed for the gated action
+        // (execution returns AwaitingPresentation before any tx build; the outcome path writes only
+        // the lifecycle tx; the projector/advance only touch instance state). The outcome tx's
+        // `actionPayload` is therefore the ONLY durable record of what the citizen submitted (e.g.
+        // the deviceKey that a later issuance action's holderKeySourceField resolves). Contributed
+        // as the gated action's data AFTER the loop, and only as a FALLBACK — an ordinary Action tx
+        // for the same action stays authoritative so no existing flow changes.
+        var outcomeActionPayloadByAction = new Dictionary<string, (JsonElement Payload, string TxId)>();
+
         foreach (var tx in transactions.OrderBy(t => t.TimeStamp))
         {
             // Track the chain head on every instance tx — including rejections and
@@ -155,10 +165,16 @@ public class StateReconstructionService : IStateReconstructionService
             // from a lifecycle tx feeds reconstructed action data.
             if (tx.MetaData?.TransactionType == Sorcha.Register.Models.Enums.TransactionType.PresentationOutcome)
             {
-                var verifiedClaims = TryExtractVerifiedClaimsFromOutcome(tx);
-                if (verifiedClaims.HasValue)
+                var contribution = TryExtractOutcomeContributions(tx);
+                if (contribution is not null)
                 {
-                    presentedCredentialByAction[txActionId.Value.ToString()] = verifiedClaims.Value;
+                    var gatedActionKey = txActionId.Value.ToString();
+                    presentedCredentialByAction[gatedActionKey] = contribution.Value.VerifiedClaims;
+                    if (contribution.Value.ActionPayload.HasValue)
+                    {
+                        outcomeActionPayloadByAction[gatedActionKey] =
+                            (contribution.Value.ActionPayload.Value, tx.TxId);
+                    }
                 }
                 continue;
             }
@@ -186,11 +202,25 @@ public class StateReconstructionService : IStateReconstructionService
             }
         }
 
+        // Feature 174 / #1195 Phase 2 (continuation) — fall back to the outcome tx's actionPayload
+        // as the gated action's data when no ordinary Action tx supplied any (the async-path case).
+        // The actionPayload is the CITIZEN's client-supplied draft submission, so the reserved-key
+        // strip applies to it exactly as to a regular Action tx's payload — `presentedCredential`
+        // remains populated only from verifiedClaims (folded below, after this).
+        foreach (var (gatedActionKey, (outcomePayload, outcomeTxId)) in outcomeActionPayloadByAction)
+        {
+            if (!actionData.ContainsKey(gatedActionKey))
+            {
+                actionData[gatedActionKey] = StripReservedPresentedCredential(outcomePayload, outcomeTxId);
+            }
+        }
+
         // Feature 174 / #1195 Phase 2 — fold the verified-presentation claims into the gated
         // action's reconstructed data under the reserved `presentedCredential` key. Merging AFTER
-        // the loop means an Action tx for the same action (regardless of seal order) can never
-        // clobber the verified contribution, and the key ends up at the data root so
-        // AccumulatedState.GetFlattenedData surfaces it for the issuance source document.
+        // the loop (and after the actionPayload fallback above) means neither an Action tx nor the
+        // client-supplied actionPayload can ever clobber the verified contribution, and the key
+        // ends up at the data root so AccumulatedState.GetFlattenedData surfaces it for the
+        // issuance source document.
         foreach (var (gatedActionKey, verifiedClaims) in presentedCredentialByAction)
         {
             actionData[gatedActionKey] = MergePresentedCredentialIntoActionData(
@@ -629,14 +659,23 @@ public class StateReconstructionService : IStateReconstructionService
     }
 
     /// <summary>
-    /// Feature 174 / #1195 Phase 2 — extracts the <c>verifiedClaims</c> object from a sealed
-    /// <c>PresentationOutcome</c> transaction's plaintext payload
-    /// (<c>ITransactionBuilderService.BuildPresentationOutcomeAsync</c> shape: the validator seals
-    /// the outcome's canonical JSON into <c>Payloads[0].Data</c> base64url-encoded). Returns null —
-    /// contributing nothing, fail closed — unless the payload parses, carries
-    /// <c>kind == "success"</c>, and has an object-valued <c>verifiedClaims</c>.
+    /// Feature 174 / #1195 Phase 2 — the reconstruction-relevant parts of a sealed
+    /// <c>PresentationOutcome</c> success transaction: the verifier-produced disclosed claims
+    /// (always present when the contribution is non-null) and the citizen's draft action payload
+    /// (present only when the outcome recorded one).
     /// </summary>
-    private JsonElement? TryExtractVerifiedClaimsFromOutcome(Sorcha.Register.Models.TransactionModel transaction)
+    private readonly record struct OutcomeContribution(JsonElement VerifiedClaims, JsonElement? ActionPayload);
+
+    /// <summary>
+    /// Feature 174 / #1195 Phase 2 — extracts the <c>verifiedClaims</c> object (and, when present,
+    /// the <c>actionPayload</c> object) from a sealed <c>PresentationOutcome</c> transaction's
+    /// plaintext payload (<c>ITransactionBuilderService.BuildPresentationOutcomeAsync</c> shape: the
+    /// validator seals the outcome's canonical JSON into <c>Payloads[0].Data</c> base64url-encoded).
+    /// Returns null — contributing nothing, fail closed — unless the payload parses, carries
+    /// <c>kind == "success"</c>, and has an object-valued <c>verifiedClaims</c>. A missing or
+    /// non-object <c>actionPayload</c> is simply omitted (the claims contribution stands alone).
+    /// </summary>
+    private OutcomeContribution? TryExtractOutcomeContributions(Sorcha.Register.Models.TransactionModel transaction)
     {
         try
         {
@@ -670,7 +709,14 @@ public class StateReconstructionService : IStateReconstructionService
                 return null;
             }
 
-            return claimsEl.Clone();
+            JsonElement? actionPayload = null;
+            if (root.TryGetProperty("actionPayload", out var actionPayloadEl)
+                && actionPayloadEl.ValueKind == JsonValueKind.Object)
+            {
+                actionPayload = actionPayloadEl.Clone();
+            }
+
+            return new OutcomeContribution(claimsEl.Clone(), actionPayload);
         }
         catch (Exception ex)
         {

--- a/src/Services/Sorcha.Blueprint.Service/Services/Implementation/StateReconstructionService.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Services/Implementation/StateReconstructionService.cs
@@ -112,6 +112,13 @@ public class StateReconstructionService : IStateReconstructionService
         var branchStates = new Dictionary<string, BranchState>();
         string? previousTransactionId = null;
 
+        // Feature 174 / #1195 Phase 2 — verified-presentation claims contributed by sealed
+        // PresentationOutcome success transactions, keyed by the gated action id. Folded into
+        // that action's reconstructed data under the reserved `presentedCredential` key after
+        // the main loop (so an Action tx for the same action can never clobber it, and the
+        // loop's timestamp ordering gives latest-sealed-wins for free).
+        var presentedCredentialByAction = new Dictionary<string, JsonElement>();
+
         foreach (var tx in transactions.OrderBy(t => t.TimeStamp))
         {
             // Track the chain head on every instance tx — including rejections and
@@ -136,13 +143,39 @@ public class StateReconstructionService : IStateReconstructionService
                 continue;
             }
 
+            // Feature 174 / #1195 Phase 2 — async SorchaWallet gate. A sealed PresentationOutcome
+            // lifecycle tx for a required prior action contributes ONLY its verifiedClaims, surfaced
+            // under the reserved `presentedCredential` key so a later issuance action's claim
+            // mappings resolve /presentedCredential/* from the verified presentation. Trust posture:
+            // the outcome tx is written by the lifecycle service only AFTER verification, is sealed
+            // on the register, and is read here exactly like F145's RoutingDecision — the same
+            // tamper-evidence as any other sealed transaction. Guards: only kind=success outcomes
+            // contribute; malformed/missing verifiedClaims contribute nothing (fail closed); the
+            // loop's timestamp ordering means the latest sealed success outcome wins. Nothing else
+            // from a lifecycle tx feeds reconstructed action data.
+            if (tx.MetaData?.TransactionType == Sorcha.Register.Models.Enums.TransactionType.PresentationOutcome)
+            {
+                var verifiedClaims = TryExtractVerifiedClaimsFromOutcome(tx);
+                if (verifiedClaims.HasValue)
+                {
+                    presentedCredentialByAction[txActionId.Value.ToString()] = verifiedClaims.Value;
+                }
+                continue;
+            }
+
             // Decrypt the payload using delegated access (or read plaintext for DevMode registers)
             var decryptedData = await DecryptTransactionPayloadAsync(
                 tx, delegationToken, participantWallets, registerDevMode, cancellationToken);
 
             if (decryptedData.HasValue)
             {
-                actionData[txActionId.Value.ToString()] = decryptedData.Value;
+                // Feature 174 / #1195 Phase 2 — `presentedCredential` is a RESERVED key that only a
+                // sealed PresentationOutcome success tx (above) may populate. Strip it from regular
+                // action-tx payloads so a client can never smuggle a spoofed presentedCredential
+                // through a prior action's submitted data and have it surface as the verified source
+                // at issuance (fail closed).
+                actionData[txActionId.Value.ToString()] =
+                    StripReservedPresentedCredential(decryptedData.Value, tx.TxId);
             }
 
             // Track branch states if present
@@ -151,6 +184,18 @@ public class StateReconstructionService : IStateReconstructionService
             {
                 branchStates[branchId] = BranchState.Active;
             }
+        }
+
+        // Feature 174 / #1195 Phase 2 — fold the verified-presentation claims into the gated
+        // action's reconstructed data under the reserved `presentedCredential` key. Merging AFTER
+        // the loop means an Action tx for the same action (regardless of seal order) can never
+        // clobber the verified contribution, and the key ends up at the data root so
+        // AccumulatedState.GetFlattenedData surfaces it for the issuance source document.
+        foreach (var (gatedActionKey, verifiedClaims) in presentedCredentialByAction)
+        {
+            actionData[gatedActionKey] = MergePresentedCredentialIntoActionData(
+                actionData.TryGetValue(gatedActionKey, out var existing) ? existing : (JsonElement?)null,
+                verifiedClaims);
         }
 
         var state = new AccumulatedState
@@ -581,5 +626,115 @@ public class StateReconstructionService : IStateReconstructionService
         }
 
         return null;
+    }
+
+    /// <summary>
+    /// Feature 174 / #1195 Phase 2 — extracts the <c>verifiedClaims</c> object from a sealed
+    /// <c>PresentationOutcome</c> transaction's plaintext payload
+    /// (<c>ITransactionBuilderService.BuildPresentationOutcomeAsync</c> shape: the validator seals
+    /// the outcome's canonical JSON into <c>Payloads[0].Data</c> base64url-encoded). Returns null —
+    /// contributing nothing, fail closed — unless the payload parses, carries
+    /// <c>kind == "success"</c>, and has an object-valued <c>verifiedClaims</c>.
+    /// </summary>
+    private JsonElement? TryExtractVerifiedClaimsFromOutcome(Sorcha.Register.Models.TransactionModel transaction)
+    {
+        try
+        {
+            var payload = transaction.Payloads?.FirstOrDefault();
+            if (payload == null || string.IsNullOrEmpty(payload.Data))
+            {
+                return null;
+            }
+
+            var payloadBytes = Sorcha.TransactionHandler.Services.ContentEncodings.DecodeBase64Auto(payload.Data);
+            using var doc = JsonDocument.Parse(payloadBytes);
+            var root = doc.RootElement;
+            if (root.ValueKind != JsonValueKind.Object)
+            {
+                return null;
+            }
+
+            if (!root.TryGetProperty("kind", out var kindEl)
+                || kindEl.ValueKind != JsonValueKind.String
+                || !string.Equals(kindEl.GetString(), "success", StringComparison.OrdinalIgnoreCase))
+            {
+                return null;
+            }
+
+            if (!root.TryGetProperty("verifiedClaims", out var claimsEl)
+                || claimsEl.ValueKind != JsonValueKind.Object)
+            {
+                _logger.LogWarning(
+                    "PresentationOutcome tx {TxId} has kind=success but missing/malformed verifiedClaims — contributing nothing (fail closed)",
+                    transaction.TxId);
+                return null;
+            }
+
+            return claimsEl.Clone();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "Failed to read verifiedClaims from PresentationOutcome tx {TxId} — contributing nothing (fail closed)",
+                transaction.TxId);
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Feature 174 / #1195 Phase 2 — removes the reserved <c>presentedCredential</c> root property
+    /// from a regular action transaction's reconstructed payload. Only a sealed
+    /// <c>PresentationOutcome</c> success tx may populate that key (via
+    /// <see cref="TryExtractVerifiedClaimsFromOutcome"/>); a client-submitted field of the same name
+    /// sealed inside an Action tx must never surface as the verified claim source at issuance.
+    /// See <c>ActionExecutionService.PresentedCredentialClaimSourceKey</c> for the prefix contract.
+    /// </summary>
+    private JsonElement StripReservedPresentedCredential(JsonElement data, string txId)
+    {
+        if (data.ValueKind != JsonValueKind.Object
+            || !data.TryGetProperty(ActionExecutionService.PresentedCredentialClaimSourceKey, out _))
+        {
+            return data;
+        }
+
+        _logger.LogWarning(
+            "Action tx {TxId} payload carried the reserved '{ReservedKey}' key — stripped during reconstruction " +
+            "(only a sealed PresentationOutcome success tx may populate it)",
+            txId, ActionExecutionService.PresentedCredentialClaimSourceKey);
+
+        var rebuilt = new JsonObject();
+        foreach (var property in data.EnumerateObject())
+        {
+            if (!string.Equals(property.Name, ActionExecutionService.PresentedCredentialClaimSourceKey, StringComparison.Ordinal))
+            {
+                rebuilt[property.Name] = JsonNode.Parse(property.Value.GetRawText());
+            }
+        }
+
+        using var doc = JsonDocument.Parse(rebuilt.ToJsonString());
+        return doc.RootElement.Clone();
+    }
+
+    /// <summary>
+    /// Feature 174 / #1195 Phase 2 — folds the verified-presentation claims into the gated action's
+    /// reconstructed data as <c>{ ..., "presentedCredential": { ...claims } }</c>, overwriting any
+    /// same-named property (the verified source always wins) and creating the action-data object
+    /// when the outcome tx is the action's only data-bearing transaction.
+    /// </summary>
+    private static JsonElement MergePresentedCredentialIntoActionData(JsonElement? existing, JsonElement verifiedClaims)
+    {
+        var merged = new JsonObject();
+        if (existing is { ValueKind: JsonValueKind.Object } existingObj)
+        {
+            foreach (var property in existingObj.EnumerateObject())
+            {
+                merged[property.Name] = JsonNode.Parse(property.Value.GetRawText());
+            }
+        }
+
+        merged[ActionExecutionService.PresentedCredentialClaimSourceKey] = JsonNode.Parse(verifiedClaims.GetRawText());
+
+        using var doc = JsonDocument.Parse(merged.ToJsonString());
+        return doc.RootElement.Clone();
     }
 }

--- a/src/Services/Sorcha.Blueprint.Service/Storage/Presentations/IPendingPresentationStore.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Storage/Presentations/IPendingPresentationStore.cs
@@ -118,4 +118,24 @@ public sealed record PendingPresentation
     /// register. Set after the initiated tx is submitted.
     /// </summary>
     public string? InitiatedTransactionId { get; init; }
+
+    // ── #1195 Phase 2 (Task 6b, T032) — verifier-session fields ─────────────────────────
+    // Persisted at initiation so the callback path can rebuild the VerifierSession the
+    // sorcha-wallet consumer's validator needs (nonce echo, vct + required-claim checks,
+    // KB-JWT audience binding). All nullable: legacy pending entries written before the
+    // session wiring deserialize with nulls and keep their previous behaviour
+    // (session-missing decline). Single-use + TTL-bound by construction — the pending row
+    // IS the session record (deleted post-outcome; Redis TTL = validity window).
+
+    /// <summary>The nonce the consumer embedded in the request object; the KB-JWT must echo it.</summary>
+    public string? Nonce { get; init; }
+
+    /// <summary>The verifier client_id served in the request object (null ⇒ the consumer's placeholder fallback).</summary>
+    public string? VerifierClientId { get; init; }
+
+    /// <summary>Required credential type (vct) from the gating requirement.</summary>
+    public string? CredentialType { get; init; }
+
+    /// <summary>Required claim names from the gating requirement.</summary>
+    public List<string>? RequiredClaimNames { get; init; }
 }

--- a/src/Services/Sorcha.Wallet.Service/Endpoints/CitizenWalletEndpoints.cs
+++ b/src/Services/Sorcha.Wallet.Service/Endpoints/CitizenWalletEndpoints.cs
@@ -1,7 +1,10 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Sorcha Contributors
 
+using System.Buffers.Text;
 using System.Security.Claims;
+using System.Text;
+using System.Text.Json;
 using FluentValidation;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.SignalR;
@@ -158,6 +161,25 @@ public static class CitizenWalletEndpoints
             .ProducesValidationProblem()
             .Produces(StatusCodes.Status401Unauthorized);
 
+        group.MapPost("/presentations/sign-kb", SignKbJwt)
+            .WithName("SignCitizenKbJwt")
+            .WithSummary("Sign a KB-JWT signing input with the caller's holder key (server custody)")
+            .WithDescription(
+                "#1195 Phase 2 (Task 6a). Signs the supplied compact JWS signing input " +
+                "(base64url(header).base64url(payload)) with the AUTHENTICATED citizen's slot-108 " +
+                "holder key, so the wallet PWA can present a holder-cnf credential (e.g. the " +
+                "AssuredIdentityCredential root) without the holder private key ever leaving " +
+                "server custody. The decoded header MUST carry typ 'kb+jwt' — the endpoint " +
+                "refuses to sign anything else (the same key signs device delegations, so it " +
+                "must never act as a general-purpose signing oracle). The header alg must match " +
+                "the holder key's real algorithm; a mismatch is a named 400, never a signature " +
+                "that silently fails downstream verification. The signing wallet is resolved " +
+                "from the JWT only — the body carries no wallet address. Rate-limited (Strict).")
+            .Produces<KbJwtSignResponse>(StatusCodes.Status200OK)
+            .ProducesValidationProblem()
+            .Produces(StatusCodes.Status401Unauthorized)
+            .Produces(StatusCodes.Status404NotFound);
+
         group.MapGet("/presentations", ListPresentations)
             .WithName("ListCitizenPresentations")
             .WithSummary("List the citizen's presentation history (US5)")
@@ -210,6 +232,143 @@ public static class CitizenWalletEndpoints
         await store.DeleteAsync(platformUserId.Value, id, ct);
         return Results.NoContent();
     }
+
+    /// <summary>
+    /// #1195 Phase 2 (Task 6a) — server-custody KB-JWT signing. Signs the ASCII bytes of the
+    /// supplied compact JWS signing input with the authenticated caller's slot-108 holder key
+    /// (<see cref="IHolderKeyService.SignAsync"/>). Security invariants: (1) the signing wallet is
+    /// resolved from the caller's JWT only — the body has no wallet field; (2) only a
+    /// <c>typ: "kb+jwt"</c> header is ever signed (oracle guard — the same key signs device
+    /// delegation credentials); (3) a header <c>alg</c> that cannot match the holder key's real
+    /// algorithm is a named 400 (never-silent: an unusable signature would otherwise surface as an
+    /// inexplicable downstream verification failure).
+    /// </summary>
+    private static async Task<IResult> SignKbJwt(
+        [FromBody] KbJwtSignRequest request,
+        HttpContext context,
+        IValidator<KbJwtSignRequest> validator,
+        IHolderKeyService holderKeys,
+        IWalletRepository walletRepository,
+        ILogger<Program> logger,
+        CancellationToken ct)
+    {
+        var validation = await validator.ValidateAsync(request, ct);
+        if (!validation.IsValid)
+        {
+            return Results.ValidationProblem(validation.ToDictionary());
+        }
+
+        if (!TryReadKbJwtHeaderAlg(request.SigningInput, out var headerAlg, out var refusal))
+        {
+            return Results.Problem(
+                title: "Not a KB-JWT signing input",
+                detail: refusal,
+                statusCode: StatusCodes.Status400BadRequest);
+        }
+
+        var (platformUserId, citizenWallet, _) = await ResolveCitizenContextAsync(context, walletRepository, ct);
+        if (platformUserId is null || citizenWallet is null) return Results.Unauthorized();
+
+        try
+        {
+            var (signature, algorithm) = await holderKeys.SignAsync(
+                citizenWallet, Encoding.ASCII.GetBytes(request.SigningInput), ct);
+
+            var joseAlg = ToJoseAlgorithm(algorithm);
+            if (!string.Equals(headerAlg, joseAlg, StringComparison.Ordinal))
+            {
+                logger.LogWarning(
+                    "KB-JWT sign refused for wallet {Wallet}: header alg {HeaderAlg} does not match holder key alg {KeyAlg}",
+                    citizenWallet, headerAlg, joseAlg);
+                return Results.Problem(
+                    title: "KB-JWT alg mismatch",
+                    detail: $"The KB-JWT header declares alg '{headerAlg}' but the holder key signs '{joseAlg}'. " +
+                            "Build the header with the holder JWK's algorithm (EC P-256 → ES256, OKP Ed25519 → EdDSA).",
+                    statusCode: StatusCodes.Status400BadRequest);
+            }
+
+            return Results.Ok(new KbJwtSignResponse
+            {
+                Signature = Base64Url.EncodeToString(signature),
+                Algorithm = joseAlg
+            });
+        }
+        catch (KeyNotFoundException)
+        {
+            // No wallet resolvable for the caller — 404, indistinguishable from
+            // non-existence (matches the rest of the citizen surface).
+            return Results.NotFound();
+        }
+        catch (NotSupportedException ex)
+        {
+            logger.LogWarning(ex,
+                "KB-JWT sign for wallet {Wallet} rejected — unsupported holder key algorithm.", citizenWallet);
+            return Results.Problem(
+                title: "Unsupported holder key algorithm",
+                detail: ex.Message,
+                statusCode: StatusCodes.Status400BadRequest);
+        }
+    }
+
+    /// <summary>
+    /// Decode the header segment of a compact JWS signing input and enforce the KB-JWT oracle
+    /// guard: <c>typ</c> MUST be <c>"kb+jwt"</c> and <c>alg</c> MUST be present. Returns the
+    /// declared <c>alg</c> on success; a human-readable refusal reason otherwise.
+    /// </summary>
+    private static bool TryReadKbJwtHeaderAlg(string signingInput, out string headerAlg, out string refusal)
+    {
+        headerAlg = string.Empty;
+        refusal = string.Empty;
+
+        var dot = signingInput.IndexOf('.');
+        if (dot <= 0 || dot == signingInput.Length - 1 || signingInput.IndexOf('.', dot + 1) >= 0)
+        {
+            refusal = "SigningInput must be exactly base64url(header).base64url(payload).";
+            return false;
+        }
+
+        try
+        {
+            using var header = JsonDocument.Parse(Base64Url.DecodeFromChars(signingInput.AsSpan(0, dot)));
+            var root = header.RootElement;
+
+            if (!root.TryGetProperty("typ", out var typ) || typ.ValueKind != JsonValueKind.String ||
+                !string.Equals(typ.GetString(), "kb+jwt", StringComparison.Ordinal))
+            {
+                refusal = "The header typ must be 'kb+jwt' — this endpoint signs Key Binding JWTs only.";
+                return false;
+            }
+
+            if (!root.TryGetProperty("alg", out var alg) || alg.ValueKind != JsonValueKind.String ||
+                string.IsNullOrEmpty(alg.GetString()))
+            {
+                refusal = "The header must declare alg.";
+                return false;
+            }
+
+            headerAlg = alg.GetString()!;
+            return true;
+        }
+        catch (Exception ex) when (ex is FormatException or JsonException)
+        {
+            refusal = "The header segment does not decode to JSON.";
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Normalise a wallet-style algorithm name (what <see cref="IHolderKeyService.SignAsync"/>
+    /// returns, e.g. <c>ED25519</c>) to the JOSE identifier used in JWS headers. Token sets mirror
+    /// <c>HolderKeyService</c>'s own JWK-building dispatch.
+    /// </summary>
+    private static string ToJoseAlgorithm(string walletAlgorithm) =>
+        walletAlgorithm.ToUpperInvariant() switch
+        {
+            "ED25519" or "EDDSA" => "EdDSA",
+            "ES256" or "P-256" or "P256" or "NIST-P256" or "NISTP256" or "ECDSA-P256" or "SECP256R1" => "ES256",
+            _ => throw new NotSupportedException(
+                $"Holder key algorithm '{walletAlgorithm}' has no JOSE mapping (only Ed25519 and P-256 are supported).")
+        };
 
     private static async Task<IResult> ReportPresentationLog(
         [FromBody] PresentationLogReportRequest request,

--- a/src/Services/Sorcha.Wallet.Service/Endpoints/CredentialEndpoints.cs
+++ b/src/Services/Sorcha.Wallet.Service/Endpoints/CredentialEndpoints.cs
@@ -741,16 +741,31 @@ public static class CredentialEndpoints
                 deviceBoundPlan = await deviceBoundCoordinator.PrepareAsync(
                     request.RecipientWallet, vct, request.HolderJwk.Value, deviceBoundOrgId, cancellationToken);
             }
-            catch (Exception ex)
+            catch (DeviceBoundPolicyRefusalException ex)
             {
+                // Policy REFUSAL — the cap could not be honoured (eviction/replacement revoke
+                // failed). 409: retrying as-is won't help until the copy state changes.
                 logger.LogWarning(ex,
-                    "Device-bound copy policy aborted issuance of '{Vct}' for recipient {Recipient} — no credential issued",
+                    "Device-bound copy policy refused issuance of '{Vct}' for recipient {Recipient} — no credential issued",
                     vct, request.RecipientWallet);
                 return Results.Problem(
                     title: "Device-bound credential policy failed",
                     detail: "The device-bound credential copy could not be issued: the eviction policy "
                         + "could not revoke an existing copy. No credential was issued.",
                     statusCode: StatusCodes.Status409Conflict);
+            }
+            catch (Exception ex)
+            {
+                // Infrastructure FAULT (holder-key resolution, status-slot allocation, …) —
+                // transient and retryable, so 503. Generic detail: never leak internals.
+                logger.LogError(ex,
+                    "Device-bound copy coordination faulted issuing '{Vct}' for recipient {Recipient} — no credential issued",
+                    vct, request.RecipientWallet);
+                return Results.Problem(
+                    title: "Credential issuance temporarily unavailable",
+                    detail: "The credential could not be issued right now. Please retry shortly. "
+                        + "No credential was issued.",
+                    statusCode: StatusCodes.Status503ServiceUnavailable);
             }
 
             if (deviceBoundPlan is not null)

--- a/src/Services/Sorcha.Wallet.Service/Endpoints/CredentialEndpoints.cs
+++ b/src/Services/Sorcha.Wallet.Service/Endpoints/CredentialEndpoints.cs
@@ -770,6 +770,15 @@ public static class CredentialEndpoints
 
             if (deviceBoundPlan is not null)
             {
+                // M-3 (#1195 Phase 2) — eviction-then-mint-failure window: PrepareAsync ran the
+                // LRU policy and may already have EVICTED (revoked) the oldest copy before we reach
+                // the signing below. If signing then fails, the user is momentarily below the cap
+                // (e.g. 2 copies instead of 3). This is fail-safe BY DESIGN: the invariant is
+                // "never MORE than 3, never an orphaned status slot" — being temporarily under is
+                // harmless and self-heals on retry (the citizen re-binds and a fresh slot is taken).
+                // We deliberately do NOT try to "un-evict": resurrecting a revoked copy would be the
+                // more dangerous failure mode.
+                //
                 // Override any engine-supplied allocation with the wallet-owned F114 slot so
                 // the citizen status-list publisher can flip it on eviction. F114 lists are
                 // IETF Token Status List (statuslist+jwt), so force the IETF claim shape.

--- a/src/Services/Sorcha.Wallet.Service/Endpoints/CredentialEndpoints.cs
+++ b/src/Services/Sorcha.Wallet.Service/Endpoints/CredentialEndpoints.cs
@@ -19,6 +19,7 @@ using Sorcha.Wallet.Core.Repositories.Interfaces;
 using Sorcha.Wallet.Core.Services.Interfaces;
 using Sorcha.Wallet.Service.Credentials;
 using Sorcha.Wallet.Service.Services.Implementation;
+using Sorcha.Wallet.Service.Services.Interfaces;
 
 using StackExchange.Redis;
 
@@ -577,6 +578,7 @@ public static class CredentialEndpoints
         Sorcha.Wallet.Service.Services.Implementation.IWalletInboxWriter inboxWriter,
         Sorcha.Wallet.Service.Services.Interfaces.IIssuanceKeyService? issuanceKeyService = null,
         IOrgCertChainProvider? orgCertChainProvider = null,
+        Sorcha.Wallet.Service.Services.Interfaces.IDeviceBoundCopyIssuanceCoordinator? deviceBoundCoordinator = null,
         CancellationToken cancellationToken = default)
     {
         // 1. Get the issuer wallet
@@ -719,7 +721,50 @@ public static class CredentialEndpoints
             ? null
             : JsonSerializer.Serialize(new CredentialDisplayConfig { CredentialName = request.DisplayName });
 
-        if (!string.IsNullOrEmpty(request.StatusListUrl) && request.StatusListIndex.HasValue)
+        // Feature 1195 Phase 2 — device-bound copy cap + eviction. A device-bound AIAS copy
+        // carries a cnf that is NOT the recipient's holder key; the coordinator detects this,
+        // runs the max-3 LRU policy BEFORE signing, and allocates a wallet-owned (F114)
+        // status-list slot so the copy is revocable. The holder-bound web root, a non-citizen
+        // recipient, and unbound mints return null → issuance proceeds unchanged. A thrown
+        // reconcile (eviction revoke failed) aborts the mint — no credential is signed or stored.
+        var effectiveStatusListUrl = request.StatusListUrl;
+        var effectiveStatusListIndex = request.StatusListIndex;
+        var effectiveStatusForm = request.StatusClaimForm;
+
+        if (deviceBoundCoordinator is not null
+            && request.HolderJwk.HasValue
+            && Guid.TryParse(request.TenantId, out var deviceBoundOrgId))
+        {
+            DeviceBoundMintPlan? deviceBoundPlan;
+            try
+            {
+                deviceBoundPlan = await deviceBoundCoordinator.PrepareAsync(
+                    request.RecipientWallet, vct, request.HolderJwk.Value, deviceBoundOrgId, cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex,
+                    "Device-bound copy policy aborted issuance of '{Vct}' for recipient {Recipient} — no credential issued",
+                    vct, request.RecipientWallet);
+                return Results.Problem(
+                    title: "Device-bound credential policy failed",
+                    detail: "The device-bound credential copy could not be issued: the eviction policy "
+                        + "could not revoke an existing copy. No credential was issued.",
+                    statusCode: StatusCodes.Status409Conflict);
+            }
+
+            if (deviceBoundPlan is not null)
+            {
+                // Override any engine-supplied allocation with the wallet-owned F114 slot so
+                // the citizen status-list publisher can flip it on eviction. F114 lists are
+                // IETF Token Status List (statuslist+jwt), so force the IETF claim shape.
+                effectiveStatusListUrl = deviceBoundPlan.StatusListUrl;
+                effectiveStatusListIndex = deviceBoundPlan.StatusListIndex;
+                effectiveStatusForm = Sorcha.Wallet.Service.Models.StatusClaimForm.IetfTokenStatusList;
+            }
+        }
+
+        if (!string.IsNullOrEmpty(effectiveStatusListUrl) && effectiveStatusListIndex.HasValue)
         {
             var purpose = string.IsNullOrWhiteSpace(request.StatusListPurpose)
                 ? "revocation"
@@ -729,14 +774,14 @@ public static class CredentialEndpoints
             // wallets can read status via IETF Token Status List semantics; internal
             // callers keep the W3C shape to preserve spec 093 behaviour. Exactly one
             // shape is embedded per credential — callers cannot opt into both.
-            if (request.StatusClaimForm == Sorcha.Wallet.Service.Models.StatusClaimForm.IetfTokenStatusList)
+            if (effectiveStatusForm == Sorcha.Wallet.Service.Models.StatusClaimForm.IetfTokenStatusList)
             {
                 claims["status"] = new Dictionary<string, object>
                 {
                     ["status_list"] = new Dictionary<string, object>
                     {
-                        ["uri"] = request.StatusListUrl!,
-                        ["idx"] = request.StatusListIndex.Value,
+                        ["uri"] = effectiveStatusListUrl!,
+                        ["idx"] = effectiveStatusListIndex.Value,
                     },
                 };
             }
@@ -744,11 +789,11 @@ public static class CredentialEndpoints
             {
                 claims["credentialStatus"] = new Dictionary<string, object>
                 {
-                    ["id"] = $"{request.StatusListUrl}#{request.StatusListIndex.Value}",
+                    ["id"] = $"{effectiveStatusListUrl}#{effectiveStatusListIndex.Value}",
                     ["type"] = "BitstringStatusListEntry",
                     ["statusPurpose"] = purpose,
-                    ["statusListIndex"] = request.StatusListIndex.Value.ToString(),
-                    ["statusListCredential"] = request.StatusListUrl!
+                    ["statusListIndex"] = effectiveStatusListIndex.Value.ToString(),
+                    ["statusListCredential"] = effectiveStatusListUrl!
                 };
             }
         }
@@ -827,8 +872,8 @@ public static class CredentialEndpoints
             IssuerOrgName = request.IssuerOrgName,
             WalletAddress = walletAddress,
             CreatedAt = DateTimeOffset.UtcNow,
-            StatusListUrl = request.StatusListUrl,
-            StatusListIndex = request.StatusListIndex,
+            StatusListUrl = effectiveStatusListUrl,
+            StatusListIndex = effectiveStatusListIndex,
             DisplayConfigJson = displayConfigJson
         };
         await store.StoreAsync(issuerEntity, cancellationToken);
@@ -857,8 +902,8 @@ public static class CredentialEndpoints
                     IssuanceBlueprintId = request.IssuanceBlueprintId,
                     WalletAddress = request.RecipientWallet,
                     CreatedAt = DateTimeOffset.UtcNow,
-                    StatusListUrl = request.StatusListUrl,
-                    StatusListIndex = request.StatusListIndex,
+                    StatusListUrl = effectiveStatusListUrl,
+                    StatusListIndex = effectiveStatusListIndex,
                     DisplayConfigJson = displayConfigJson
                 };
                 await store.StoreAsync(recipientEntity, cancellationToken);

--- a/src/Services/Sorcha.Wallet.Service/Program.cs
+++ b/src/Services/Sorcha.Wallet.Service/Program.cs
@@ -210,12 +210,7 @@ builder.Services.AddScoped<Sorcha.Wallet.Service.Services.Interfaces.IDelegation
 builder.Services.AddScoped<Sorcha.Wallet.Service.Services.Interfaces.IDeviceRevocationService,
     Sorcha.Wallet.Service.Services.Implementation.DeviceRevocationService>();
 
-// Feature 1195 (Phase 2, Task 4): device-bound credential cap + LRU eviction policy.
-// Registered here so it is DI-available; wiring into the mint path is Task 5. The
-// IDeviceBoundCredentialLookup / IDeviceBoundCredentialRevoker seams it composes are
-// supplied by Task 5 (no registration yet — this policy is not resolved until then).
-builder.Services.AddScoped<Sorcha.Wallet.Service.Services.Interfaces.IDeviceBoundCredentialPolicy,
-    Sorcha.Wallet.Service.Services.Implementation.DeviceBoundCredentialPolicy>();
+// IDeviceBoundCredentialPolicy is registered in Task 5 alongside its lookup/revoker seams — registering it earlier fails ValidateOnBuild.
 
 // Feature 114 (US5): citizen presentation-log reporting. The reporter dedupes
 // each reported entry (Redis SET-NX, 24h) and forwards new ones via the forwarder

--- a/src/Services/Sorcha.Wallet.Service/Program.cs
+++ b/src/Services/Sorcha.Wallet.Service/Program.cs
@@ -210,7 +210,20 @@ builder.Services.AddScoped<Sorcha.Wallet.Service.Services.Interfaces.IDelegation
 builder.Services.AddScoped<Sorcha.Wallet.Service.Services.Interfaces.IDeviceRevocationService,
     Sorcha.Wallet.Service.Services.Implementation.DeviceRevocationService>();
 
-// IDeviceBoundCredentialPolicy is registered in Task 5 alongside its lookup/revoker seams — registering it earlier fails ValidateOnBuild.
+// Feature 1195 (Phase 2): device-bound credential copy cap + LRU eviction. The policy and
+// its two seams (lookup + revoker) MUST be registered together — registering the policy
+// without concrete seams fails Development ValidateOnBuild at boot. The coordinator is the
+// mint-path entrypoint (CredentialEndpoints.IssueCredential) that runs the discriminator +
+// policy + F114 status-slot allocation. All scoped (they consume WalletDbContext / the
+// scoped citizen status-list + holder services).
+builder.Services.AddScoped<Sorcha.Wallet.Service.Services.Interfaces.IDeviceBoundCredentialLookup,
+    Sorcha.Wallet.Service.Services.Implementation.EfCoreDeviceBoundCredentialLookup>();
+builder.Services.AddScoped<Sorcha.Wallet.Service.Services.Interfaces.IDeviceBoundCredentialRevoker,
+    Sorcha.Wallet.Service.Services.Implementation.DeviceBoundCredentialRevoker>();
+builder.Services.AddScoped<Sorcha.Wallet.Service.Services.Interfaces.IDeviceBoundCredentialPolicy,
+    Sorcha.Wallet.Service.Services.Implementation.DeviceBoundCredentialPolicy>();
+builder.Services.AddScoped<Sorcha.Wallet.Service.Services.Interfaces.IDeviceBoundCopyIssuanceCoordinator,
+    Sorcha.Wallet.Service.Services.Implementation.DeviceBoundCopyIssuanceCoordinator>();
 
 // Feature 114 (US5): citizen presentation-log reporting. The reporter dedupes
 // each reported entry (Redis SET-NX, 24h) and forwards new ones via the forwarder

--- a/src/Services/Sorcha.Wallet.Service/Program.cs
+++ b/src/Services/Sorcha.Wallet.Service/Program.cs
@@ -210,6 +210,13 @@ builder.Services.AddScoped<Sorcha.Wallet.Service.Services.Interfaces.IDelegation
 builder.Services.AddScoped<Sorcha.Wallet.Service.Services.Interfaces.IDeviceRevocationService,
     Sorcha.Wallet.Service.Services.Implementation.DeviceRevocationService>();
 
+// Feature 1195 (Phase 2, Task 4): device-bound credential cap + LRU eviction policy.
+// Registered here so it is DI-available; wiring into the mint path is Task 5. The
+// IDeviceBoundCredentialLookup / IDeviceBoundCredentialRevoker seams it composes are
+// supplied by Task 5 (no registration yet — this policy is not resolved until then).
+builder.Services.AddScoped<Sorcha.Wallet.Service.Services.Interfaces.IDeviceBoundCredentialPolicy,
+    Sorcha.Wallet.Service.Services.Implementation.DeviceBoundCredentialPolicy>();
+
 // Feature 114 (US5): citizen presentation-log reporting. The reporter dedupes
 // each reported entry (Redis SET-NX, 24h) and forwards new ones via the forwarder
 // seam (PR2). PR3 forwards into the durable per-citizen presentation store so the

--- a/src/Services/Sorcha.Wallet.Service/README.md
+++ b/src/Services/Sorcha.Wallet.Service/README.md
@@ -207,6 +207,20 @@ OPENTELEMETRY__ZIPKINENDPOINT="https://zipkin.yourcompany.com"
 | DELETE | `/api/v1/wallets/{walletAddress}/access/{subject}` | Revoke access |
 | GET | `/api/v1/wallets/{walletAddress}/access/{subject}/check` | Check if subject has access |
 
+### Citizen Wallet — Server-Custody KB-JWT Signing (#1195 Phase 2)
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| POST | `/api/v1/wallet/presentations/sign-kb` | Sign a KB-JWT signing input with the **authenticated caller's** slot-108 holder key (consumer-tier, `Strict` rate limit) |
+
+Lets the wallet PWA present a holder-`cnf` credential (the web-issued `AssuredIdentityCredential`
+root) with the holder private key staying in server custody. The signing wallet is resolved from
+the citizen JWT only — the body carries no wallet address. The endpoint signs **only** inputs whose
+decoded header is `typ: "kb+jwt"` (never a general-purpose signing oracle — the same key signs
+device delegation credentials), and refuses with a named 400 when the header `alg` cannot match the
+holder key's real algorithm (EC P-256 → `ES256`, OKP Ed25519 → `EdDSA`). The rest of the citizen
+wallet surface (`/api/v1/wallet/*`, Feature 114) is documented in `docs/reference/API-DOCUMENTATION.md`.
+
 ### Ethereum Auxiliary Identity (Features 180 / 181)
 
 A wallet exposes an **auxiliary Ethereum identity** — a secp256k1 key derived on demand from its existing

--- a/src/Services/Sorcha.Wallet.Service/Services/Implementation/DeviceBoundCopyIssuanceCoordinator.cs
+++ b/src/Services/Sorcha.Wallet.Service/Services/Implementation/DeviceBoundCopyIssuanceCoordinator.cs
@@ -84,6 +84,11 @@ public sealed class DeviceBoundCopyIssuanceCoordinator : IDeviceBoundCopyIssuanc
             return null;
         }
 
+        // FAIL-CLOSED BY DESIGN: a holder-key resolution fault propagates and aborts the mint.
+        // Degrading here would either misclassify a device copy as the web root (minting it
+        // WITHOUT a revocable status slot — a permanently unrevocable artifact) or bypass the
+        // device cap entirely. Transient faults are retryable by the caller (the endpoint maps
+        // them to 503), and holder thumbprints are Redis-cached (24h) so faults are rare.
         var holderThumbprint = await _holderKeyService
             .GetHolderJwkThumbprintAsync(recipientWalletAddress, ct)
             .ConfigureAwait(false);
@@ -94,19 +99,33 @@ public sealed class DeviceBoundCopyIssuanceCoordinator : IDeviceBoundCopyIssuanc
             return null;
         }
 
-        // 3. It is a device-bound copy. Enforce the cap (may evict the oldest via the
-        //    status-list + inbox). A revoke failure throws — the caller aborts issuance.
-        var disposition = await _policy
-            .ReconcileAsync(platformUserId.Value, credentialVct, deviceThumbprint, ct)
-            .ConfigureAwait(false);
-
-        // 4. A ReplaceExisting disposition is an idempotent re-bind of the same device — the
-        //    policy leaves the prior same-thumbprint copy to the mint path. Revoke it so the
-        //    new copy replaces it in place (one live copy per device thumbprint).
-        if (disposition.Kind == DeviceBindKind.ReplaceExisting)
+        // 3+4. It is a device-bound copy. Enforce the cap (may evict the oldest via the
+        //      status-list + inbox); on ReplaceExisting (idempotent re-bind of the same device)
+        //      revoke the prior same-thumbprint copy so the new one replaces it in place.
+        //      Failures in this block are POLICY REFUSALS — the cap could not be honoured
+        //      (revoke failed / reconcile refused) — surfaced as the typed exception so the
+        //      endpoint maps them to 409 (vs 503 for infrastructure faults elsewhere).
+        try
         {
-            await RevokePriorCopyForThumbprintAsync(platformUserId.Value, credentialVct, deviceThumbprint, ct)
+            var disposition = await _policy
+                .ReconcileAsync(platformUserId.Value, credentialVct, deviceThumbprint, ct)
                 .ConfigureAwait(false);
+
+            if (disposition.Kind == DeviceBindKind.ReplaceExisting)
+            {
+                await RevokePriorCopyForThumbprintAsync(platformUserId.Value, credentialVct, deviceThumbprint, ct)
+                    .ConfigureAwait(false);
+            }
+
+            _logger.LogInformation(
+                "Device-bound copy reconcile: user={UserId} vct={Vct} disposition={Disposition}",
+                platformUserId.Value, credentialVct, disposition.Kind);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            throw new DeviceBoundPolicyRefusalException(
+                $"Device-bound copy policy refused the mint for user {platformUserId.Value}: " +
+                "the cap could not be honoured (eviction/replacement revoke failed).", ex);
         }
 
         // 5. Allocate a wallet-owned (F114) status-list slot so the copy is revocable. Done
@@ -118,9 +137,8 @@ public sealed class DeviceBoundCopyIssuanceCoordinator : IDeviceBoundCopyIssuanc
         var statusListUrl = _statusList.BuildStatusListUri(issuerOrgId, listId);
 
         _logger.LogInformation(
-            "Device-bound copy mint plan: user={UserId} vct={Vct} disposition={Disposition} " +
-            "statusSlot={Org}/{ListId}#{Index}",
-            platformUserId.Value, credentialVct, disposition.Kind, issuerOrgId, listId, index);
+            "Device-bound copy mint plan: user={UserId} vct={Vct} statusSlot={Org}/{ListId}#{Index}",
+            platformUserId.Value, credentialVct, issuerOrgId, listId, index);
 
         return new DeviceBoundMintPlan(statusListUrl, index);
     }

--- a/src/Services/Sorcha.Wallet.Service/Services/Implementation/DeviceBoundCopyIssuanceCoordinator.cs
+++ b/src/Services/Sorcha.Wallet.Service/Services/Implementation/DeviceBoundCopyIssuanceCoordinator.cs
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Text.Json;
+
+using Sorcha.Cryptography;
+using Sorcha.Wallet.Service.Services.Interfaces;
+
+namespace Sorcha.Wallet.Service.Services.Implementation;
+
+/// <summary>
+/// Default <see cref="IDeviceBoundCopyIssuanceCoordinator"/> (Feature 1195, Phase 2, Task 5).
+/// Runs the device-bound copy discriminator, the max-3 eviction policy, and the F114
+/// status-slot allocation at the mint entrypoint.
+/// </summary>
+public sealed class DeviceBoundCopyIssuanceCoordinator : IDeviceBoundCopyIssuanceCoordinator
+{
+    private readonly IHolderAddressLookup _holderAddressLookup;
+    private readonly IHolderKeyService _holderKeyService;
+    private readonly IDeviceBoundCredentialPolicy _policy;
+    private readonly IDeviceBoundCredentialLookup _lookup;
+    private readonly IDeviceBoundCredentialRevoker _revoker;
+    private readonly ICitizenStatusListPublisher _statusList;
+    private readonly IOrgStatusSigningWalletResolver _orgWalletResolver;
+    private readonly ILogger<DeviceBoundCopyIssuanceCoordinator> _logger;
+
+    /// <summary>Initialises a new <see cref="DeviceBoundCopyIssuanceCoordinator"/>.</summary>
+    public DeviceBoundCopyIssuanceCoordinator(
+        IHolderAddressLookup holderAddressLookup,
+        IHolderKeyService holderKeyService,
+        IDeviceBoundCredentialPolicy policy,
+        IDeviceBoundCredentialLookup lookup,
+        IDeviceBoundCredentialRevoker revoker,
+        ICitizenStatusListPublisher statusList,
+        IOrgStatusSigningWalletResolver orgWalletResolver,
+        ILogger<DeviceBoundCopyIssuanceCoordinator> logger)
+    {
+        _holderAddressLookup = holderAddressLookup ?? throw new ArgumentNullException(nameof(holderAddressLookup));
+        _holderKeyService = holderKeyService ?? throw new ArgumentNullException(nameof(holderKeyService));
+        _policy = policy ?? throw new ArgumentNullException(nameof(policy));
+        _lookup = lookup ?? throw new ArgumentNullException(nameof(lookup));
+        _revoker = revoker ?? throw new ArgumentNullException(nameof(revoker));
+        _statusList = statusList ?? throw new ArgumentNullException(nameof(statusList));
+        _orgWalletResolver = orgWalletResolver ?? throw new ArgumentNullException(nameof(orgWalletResolver));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    public async Task<DeviceBoundMintPlan?> PrepareAsync(
+        string recipientWalletAddress,
+        string credentialVct,
+        JsonElement holderJwk,
+        Guid issuerOrgId,
+        CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(recipientWalletAddress);
+        ArgumentException.ThrowIfNullOrWhiteSpace(credentialVct);
+
+        // 1. The policy applies only to citizens (a resolvable PlatformUserId). A device
+        //    copy delivered to a non-citizen recipient (e.g. an org wallet) is out of scope —
+        //    mint proceeds unchanged.
+        var platformUserId = await _holderAddressLookup
+            .ResolvePlatformUserIdAsync(recipientWalletAddress, ct)
+            .ConfigureAwait(false);
+        if (platformUserId is null)
+        {
+            return null;
+        }
+
+        // 2. Discriminate the device copy from the holder-bound web root. The root's cnf IS
+        //    the citizen's holder key, so its thumbprint equals the holder-key thumbprint; a
+        //    device copy's cnf is the phone's device key, a different thumbprint. This holds
+        //    even for P-256 wallets (whose holder key is also P-256), unlike a curve check.
+        string deviceThumbprint;
+        try
+        {
+            deviceThumbprint = JsonWebKeyThumbprint.Compute(holderJwk);
+        }
+        catch (ArgumentException ex)
+        {
+            // An unparseable cnf is not a device copy we can cap — mint unchanged.
+            _logger.LogWarning(ex,
+                "Device-bound coordinator: incoming cnf JWK is not a computable thumbprint; treating as non-device mint");
+            return null;
+        }
+
+        var holderThumbprint = await _holderKeyService
+            .GetHolderJwkThumbprintAsync(recipientWalletAddress, ct)
+            .ConfigureAwait(false);
+
+        if (string.Equals(deviceThumbprint, holderThumbprint, StringComparison.Ordinal))
+        {
+            // Holder-bound web root — NOT a device copy. Mint unchanged (no policy, no slot).
+            return null;
+        }
+
+        // 3. It is a device-bound copy. Enforce the cap (may evict the oldest via the
+        //    status-list + inbox). A revoke failure throws — the caller aborts issuance.
+        var disposition = await _policy
+            .ReconcileAsync(platformUserId.Value, credentialVct, deviceThumbprint, ct)
+            .ConfigureAwait(false);
+
+        // 4. A ReplaceExisting disposition is an idempotent re-bind of the same device — the
+        //    policy leaves the prior same-thumbprint copy to the mint path. Revoke it so the
+        //    new copy replaces it in place (one live copy per device thumbprint).
+        if (disposition.Kind == DeviceBindKind.ReplaceExisting)
+        {
+            await RevokePriorCopyForThumbprintAsync(platformUserId.Value, credentialVct, deviceThumbprint, ct)
+                .ConfigureAwait(false);
+        }
+
+        // 5. Allocate a wallet-owned (F114) status-list slot so the copy is revocable. Done
+        //    after the policy so a reconcile abort does not leak an index.
+        var signingWallet = await _orgWalletResolver.ResolveAsync(issuerOrgId, ct).ConfigureAwait(false);
+        var (listId, index) = await _statusList
+            .AllocateIndexAsync(issuerOrgId, signingWallet, ct)
+            .ConfigureAwait(false);
+        var statusListUrl = _statusList.BuildStatusListUri(issuerOrgId, listId);
+
+        _logger.LogInformation(
+            "Device-bound copy mint plan: user={UserId} vct={Vct} disposition={Disposition} " +
+            "statusSlot={Org}/{ListId}#{Index}",
+            platformUserId.Value, credentialVct, disposition.Kind, issuerOrgId, listId, index);
+
+        return new DeviceBoundMintPlan(statusListUrl, index);
+    }
+
+    private async Task RevokePriorCopyForThumbprintAsync(
+        Guid userId, string credentialVct, string deviceThumbprint, CancellationToken ct)
+    {
+        var liveCopies = await _lookup.GetLiveCopiesAsync(userId, credentialVct, ct).ConfigureAwait(false);
+        var prior = liveCopies.FirstOrDefault(
+            c => string.Equals(c.DeviceKeyThumbprint, deviceThumbprint, StringComparison.Ordinal));
+
+        if (prior is null)
+        {
+            // Nothing live to replace (raced away / already revoked) — the new copy stands alone.
+            return;
+        }
+
+        // A revoke failure propagates: aborting is safer than minting a second live copy
+        // for the same device.
+        await _revoker.RevokeAsync(userId, prior, ct).ConfigureAwait(false);
+    }
+}

--- a/src/Services/Sorcha.Wallet.Service/Services/Implementation/DeviceBoundCredentialPolicy.cs
+++ b/src/Services/Sorcha.Wallet.Service/Services/Implementation/DeviceBoundCredentialPolicy.cs
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using Sorcha.Wallet.Service.Services.Interfaces;
+
+namespace Sorcha.Wallet.Service.Services.Implementation;
+
+/// <summary>
+/// Issuer-side policy enforcing at most <see cref="MaxDevices"/> live device-bound credential
+/// copies per <c>(user, credentialType)</c>, keyed on the device key JWK thumbprint (RFC 7638),
+/// with least-recently-issued (LRU) eviction (Feature 1195, Phase 2).
+/// </summary>
+/// <remarks>
+/// Pure orchestration over injected seams — no HTTP, no database, no SD-JWT parsing — so it is
+/// fully unit-testable. Wiring into the mint path is Task 5.
+/// <para>
+/// Eviction ordering is by <see cref="DeviceBoundCredentialCopy.IssuedAt"/> (smallest = oldest),
+/// so no wall-clock is needed. Revoke happens BEFORE the disposition is returned; a revoke
+/// failure propagates so the caller aborts issuance and no partial state is created (no inbox
+/// write, no disposition). The inbox notification follows the established non-fatal pattern — a
+/// notify failure is logged and swallowed and never aborts issuance.
+/// </para>
+/// </remarks>
+public sealed class DeviceBoundCredentialPolicy : IDeviceBoundCredentialPolicy
+{
+    /// <summary>Maximum number of live device-bound copies permitted per (user, credentialType).</summary>
+    public const int MaxDevices = 3;
+
+    private readonly IDeviceBoundCredentialLookup _lookup;
+    private readonly IDeviceBoundCredentialRevoker _revoker;
+    private readonly ICitizenDeviceInboxWriter _inbox;
+    private readonly ILogger<DeviceBoundCredentialPolicy> _logger;
+
+    /// <summary>Initialises a new <see cref="DeviceBoundCredentialPolicy"/>.</summary>
+    public DeviceBoundCredentialPolicy(
+        IDeviceBoundCredentialLookup lookup,
+        IDeviceBoundCredentialRevoker revoker,
+        ICitizenDeviceInboxWriter inbox,
+        ILogger<DeviceBoundCredentialPolicy> logger)
+    {
+        _lookup = lookup ?? throw new ArgumentNullException(nameof(lookup));
+        _revoker = revoker ?? throw new ArgumentNullException(nameof(revoker));
+        _inbox = inbox ?? throw new ArgumentNullException(nameof(inbox));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    public async Task<DeviceBindDisposition> ReconcileAsync(
+        Guid userId, string credentialType, string deviceKeyThumbprint, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(credentialType))
+            throw new ArgumentException("Credential type is required.", nameof(credentialType));
+        if (string.IsNullOrWhiteSpace(deviceKeyThumbprint))
+            throw new ArgumentException("Device key thumbprint is required.", nameof(deviceKeyThumbprint));
+
+        var liveCopies = await _lookup.GetLiveCopiesAsync(userId, credentialType, ct).ConfigureAwait(false);
+
+        // Same device re-binding — idempotent replace, no eviction, count unchanged.
+        // Thumbprints are base64url (RFC 7638), so compare ordinal (case-sensitive).
+        if (liveCopies.Any(c => string.Equals(c.DeviceKeyThumbprint, deviceKeyThumbprint, StringComparison.Ordinal)))
+        {
+            _logger.LogDebug(
+                "Device-bound reconcile: thumbprint match — ReplaceExisting. UserId={UserId} Type={Type}",
+                userId, credentialType);
+            return new DeviceBindDisposition(DeviceBindKind.ReplaceExisting, EvictedCredentialId: null);
+        }
+
+        // New device within the cap — mint freely.
+        if (liveCopies.Count < MaxDevices)
+        {
+            _logger.LogDebug(
+                "Device-bound reconcile: {Count}/{Max} — NewWithinCap. UserId={UserId} Type={Type}",
+                liveCopies.Count, MaxDevices, userId, credentialType);
+            return new DeviceBindDisposition(DeviceBindKind.NewWithinCap, EvictedCredentialId: null);
+        }
+
+        // Cap reached — evict the oldest (least-recently-issued) live copy to make room.
+        var oldest = liveCopies.OrderBy(c => c.IssuedAt).First();
+
+        // Revoke BEFORE returning. A revoke failure propagates so issuance aborts — no inbox
+        // write, no disposition. This must run before the (non-fatal) inbox notification.
+        await _revoker.RevokeAsync(userId, oldest, ct).ConfigureAwait(false);
+
+        // Inbox notify is non-fatal — a notify outage must not abort issuance after the copy
+        // has already been revoked. Mirrors the try/log/swallow pattern of the inbox writers.
+        try
+        {
+            await _inbox.WriteDeviceRevokedAsync(userId, oldest.DeviceId, oldest.DeviceLabel, ct).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "Device-bound eviction: inbox notify failed (non-fatal). UserId={UserId} CredentialId={CredentialId} DeviceId={DeviceId}",
+                userId, oldest.CredentialId, oldest.DeviceId);
+        }
+
+        _logger.LogInformation(
+            "Device-bound reconcile: cap {Max} reached — evicted oldest copy {CredentialId} (issued {IssuedAt:o}). UserId={UserId} Type={Type}",
+            MaxDevices, oldest.CredentialId, oldest.IssuedAt, userId, credentialType);
+
+        return new DeviceBindDisposition(DeviceBindKind.NewWithEviction, oldest.CredentialId);
+    }
+}

--- a/src/Services/Sorcha.Wallet.Service/Services/Implementation/DeviceBoundCredentialPolicy.cs
+++ b/src/Services/Sorcha.Wallet.Service/Services/Implementation/DeviceBoundCredentialPolicy.cs
@@ -75,7 +75,7 @@ public sealed class DeviceBoundCredentialPolicy : IDeviceBoundCredentialPolicy
         }
 
         // Cap reached — evict the oldest (least-recently-issued) live copy to make room.
-        var oldest = liveCopies.OrderBy(c => c.IssuedAt).First();
+        var oldest = liveCopies.OrderBy(c => c.IssuedAt).ThenBy(c => c.CredentialId).First();
 
         // Revoke BEFORE returning. A revoke failure propagates so issuance aborts — no inbox
         // write, no disposition. This must run before the (non-fatal) inbox notification.

--- a/src/Services/Sorcha.Wallet.Service/Services/Implementation/DeviceBoundCredentialRevoker.cs
+++ b/src/Services/Sorcha.Wallet.Service/Services/Implementation/DeviceBoundCredentialRevoker.cs
@@ -1,0 +1,200 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Buffers.Text;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+
+using Microsoft.EntityFrameworkCore;
+
+using Sorcha.Wallet.Core.Domain.Entities;
+using Sorcha.Wallet.Core.Data;
+using Sorcha.Wallet.Service.Credentials;
+using Sorcha.Wallet.Service.Services.Interfaces;
+
+namespace Sorcha.Wallet.Service.Services.Implementation;
+
+/// <summary>
+/// Revokes an evicted (or replaced) device-bound credential copy by flipping its
+/// IETF Token Status List bit via the Feature 114 citizen status-list publisher, then
+/// marking the stored copy <see cref="CredentialStatus.Revoked"/> so it no longer counts
+/// as a live copy (Feature 1195, Phase 2, Task 5).
+/// </summary>
+/// <remarks>
+/// Credential-copy revocation is distinct from device-delegation revocation
+/// (<see cref="DeviceRevocationService"/>): here the status slot is read from the copy's
+/// own <c>StatusListUrl</c>/<c>StatusListIndex</c> (allocated at device-copy mint time),
+/// not from a device registry row. A revoke failure throws so the caller aborts issuance —
+/// never leaving more than the cap of live copies.
+/// </remarks>
+public sealed partial class DeviceBoundCredentialRevoker : IDeviceBoundCredentialRevoker
+{
+    private readonly WalletDbContext _db;
+    private readonly ICredentialStore _store;
+    private readonly ICitizenStatusListPublisher _statusList;
+    private readonly IOrgStatusSigningWalletResolver _orgWalletResolver;
+    private readonly ILogger<DeviceBoundCredentialRevoker> _logger;
+
+    /// <summary>Initialises a new <see cref="DeviceBoundCredentialRevoker"/>.</summary>
+    public DeviceBoundCredentialRevoker(
+        WalletDbContext db,
+        ICredentialStore store,
+        ICitizenStatusListPublisher statusList,
+        IOrgStatusSigningWalletResolver orgWalletResolver,
+        ILogger<DeviceBoundCredentialRevoker> logger)
+    {
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+        _store = store ?? throw new ArgumentNullException(nameof(store));
+        _statusList = statusList ?? throw new ArgumentNullException(nameof(statusList));
+        _orgWalletResolver = orgWalletResolver ?? throw new ArgumentNullException(nameof(orgWalletResolver));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    public async Task RevokeAsync(Guid userId, DeviceBoundCredentialCopy copy, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(copy);
+
+        // Locate the stored copy under the citizen's holder wallet(s) so we can read its
+        // status-list allocation. Credential ids are not globally unique (issuer + holder
+        // rows), so scope the read to the citizen's own wallet.
+        var walletAddresses = await _db.CitizenHolderIndex
+            .AsNoTracking()
+            .Where(e => e.PlatformUserId == userId)
+            .Select(e => e.WalletAddress)
+            .ToListAsync(ct)
+            .ConfigureAwait(false);
+
+        CredentialEntity? entity = null;
+        string? entityWallet = null;
+        foreach (var walletAddress in walletAddresses)
+        {
+            entity = await _store.GetByIdForWalletAsync(copy.CredentialId, walletAddress, ct).ConfigureAwait(false);
+            if (entity is not null)
+            {
+                entityWallet = walletAddress;
+                break;
+            }
+        }
+
+        if (entity is null || entityWallet is null)
+        {
+            throw new InvalidOperationException(
+                $"Cannot revoke device-bound copy {copy.CredentialId}: no stored copy found for user {userId}.");
+        }
+
+        // Prefer the IETF status claim embedded in the signed token: a register-delivered
+        // citizen copy (SorchaLocalWallet) arrives via InboundCredentialDetector, which does
+        // not populate the StatusListUrl/StatusListIndex columns — but the signed body always
+        // carries status.status_list.{uri,idx}. Fall back to the columns for the issuer copy.
+        var (statusListUrl, statusListIndex) = ResolveStatusAllocation(entity);
+
+        if (string.IsNullOrWhiteSpace(statusListUrl) || !statusListIndex.HasValue)
+        {
+            throw new InvalidOperationException(
+                $"Cannot revoke device-bound copy {copy.CredentialId}: it has no status-list allocation " +
+                "(neither an embedded IETF status claim nor StatusListUrl/StatusListIndex). " +
+                "A device copy must be minted with a revocable slot.");
+        }
+
+        if (!TryParseCitizenStatusListUri(statusListUrl, out var organizationId, out var listId))
+        {
+            throw new InvalidOperationException(
+                $"Cannot revoke device-bound copy {copy.CredentialId}: status-list URL '{statusListUrl}' " +
+                "is not a recognised citizen-device status list.");
+        }
+
+        // Flip the revoked bit FIRST (this is what external verifiers honour). A failure
+        // propagates so issuance aborts.
+        var signingWallet = await _orgWalletResolver.ResolveAsync(organizationId, ct).ConfigureAwait(false);
+        await _statusList.FlipAsync(organizationId, listId, statusListIndex.Value, signingWallet, ct)
+            .ConfigureAwait(false);
+
+        // Mark the stored copy Revoked so the live-copy lookup excludes it immediately.
+        await _store.UpdateStatusAsync(copy.CredentialId, entityWallet, CredentialStatus.Revoked, ct)
+            .ConfigureAwait(false);
+
+        _logger.LogInformation(
+            "Revoked device-bound credential copy {CredentialId} for user {UserId} " +
+            "(org={OrgId} list={ListId}#{Index})",
+            copy.CredentialId, userId, organizationId, listId, statusListIndex.Value);
+    }
+
+    /// <summary>
+    /// Resolves the copy's status-list allocation, preferring the IETF <c>status.status_list</c>
+    /// claim in the signed token (populated on every device copy) and falling back to the
+    /// <c>StatusListUrl</c>/<c>StatusListIndex</c> columns (populated on the issuer's copy).
+    /// </summary>
+    private static (string? Url, int? Index) ResolveStatusAllocation(CredentialEntity entity)
+    {
+        if (TryReadIetfStatusClaim(entity.RawToken, out var url, out var idx))
+        {
+            return (url, idx);
+        }
+
+        return (entity.StatusListUrl, entity.StatusListIndex);
+    }
+
+    private static bool TryReadIetfStatusClaim(string? rawToken, out string? uri, out int? idx)
+    {
+        uri = null;
+        idx = null;
+        if (string.IsNullOrWhiteSpace(rawToken))
+        {
+            return false;
+        }
+
+        try
+        {
+            var jwt = rawToken.Split('~')[0];
+            var parts = jwt.Split('.');
+            if (parts.Length < 2)
+            {
+                return false;
+            }
+
+            using var doc = JsonDocument.Parse(Base64Url.DecodeFromChars(parts[1]));
+            if (doc.RootElement.ValueKind != JsonValueKind.Object
+                || !doc.RootElement.TryGetProperty("status", out var status)
+                || !status.TryGetProperty("status_list", out var statusList)
+                || !statusList.TryGetProperty("uri", out var uriEl)
+                || !statusList.TryGetProperty("idx", out var idxEl)
+                || uriEl.ValueKind != JsonValueKind.String
+                || idxEl.ValueKind != JsonValueKind.Number)
+            {
+                return false;
+            }
+
+            uri = uriEl.GetString();
+            idx = idxEl.GetInt32();
+            return !string.IsNullOrWhiteSpace(uri);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Parses the org id and list id out of a citizen-device status-list URI of the form
+    /// <c>.../status/{orgId:N}/citizen-devices/{listId}.statuslist+jwt</c>
+    /// (see <c>CitizenStatusListPublisher.BuildStatusListUri</c>).
+    /// </summary>
+    private static bool TryParseCitizenStatusListUri(string url, out Guid organizationId, out int listId)
+    {
+        organizationId = Guid.Empty;
+        listId = -1;
+
+        var match = CitizenStatusListUriRegex().Match(url);
+        if (!match.Success)
+        {
+            return false;
+        }
+
+        return Guid.TryParseExact(match.Groups["org"].Value, "N", out organizationId)
+            && int.TryParse(match.Groups["list"].Value, out listId);
+    }
+
+    [GeneratedRegex(@"/status/(?<org>[0-9a-fA-F]{32})/citizen-devices/(?<list>\d+)\.statuslist\+jwt$")]
+    private static partial Regex CitizenStatusListUriRegex();
+}

--- a/src/Services/Sorcha.Wallet.Service/Services/Implementation/EfCoreDeviceBoundCredentialLookup.cs
+++ b/src/Services/Sorcha.Wallet.Service/Services/Implementation/EfCoreDeviceBoundCredentialLookup.cs
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Buffers.Text;
+using System.Text.Json;
+
+using Microsoft.EntityFrameworkCore;
+
+using Sorcha.Cryptography;
+using Sorcha.Wallet.Core.Data;
+using Sorcha.Wallet.Core.Domain.Entities;
+using Sorcha.Wallet.Service.Credentials;
+using Sorcha.Wallet.Service.Services.Interfaces;
+
+namespace Sorcha.Wallet.Service.Services.Implementation;
+
+/// <summary>
+/// EF Core-backed <see cref="IDeviceBoundCredentialLookup"/>. Projects the live
+/// device-bound copies of a credential type held by a citizen from the wallet
+/// credential store (Feature 1195, Phase 2, Task 5).
+/// </summary>
+/// <remarks>
+/// A credential is a <em>device-bound copy</em> when its <c>cnf</c> key is NOT the
+/// citizen's holder key — the holder-bound web root shares the same <c>(user, vct)</c>
+/// but its <c>cnf</c> thumbprint equals the holder-key thumbprint, so it is excluded
+/// here and never counts against the device cap. Only <see cref="CredentialStatus.Active"/>
+/// (presentable) copies are returned.
+/// </remarks>
+public sealed class EfCoreDeviceBoundCredentialLookup : IDeviceBoundCredentialLookup
+{
+    private readonly WalletDbContext _db;
+    private readonly ICredentialStore _store;
+    private readonly IHolderKeyService _holderKeyService;
+    private readonly ILogger<EfCoreDeviceBoundCredentialLookup> _logger;
+
+    /// <summary>Initialises a new <see cref="EfCoreDeviceBoundCredentialLookup"/>.</summary>
+    public EfCoreDeviceBoundCredentialLookup(
+        WalletDbContext db,
+        ICredentialStore store,
+        IHolderKeyService holderKeyService,
+        ILogger<EfCoreDeviceBoundCredentialLookup> logger)
+    {
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+        _store = store ?? throw new ArgumentNullException(nameof(store));
+        _holderKeyService = holderKeyService ?? throw new ArgumentNullException(nameof(holderKeyService));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<DeviceBoundCredentialCopy>> GetLiveCopiesAsync(
+        Guid userId, string credentialType, CancellationToken ct = default)
+    {
+        // Reverse the F114 holder index (userId → holder wallet address(es)). A citizen
+        // normally holds one holder address; the loop tolerates re-enrolment rows.
+        var walletAddresses = await _db.CitizenHolderIndex
+            .AsNoTracking()
+            .Where(e => e.PlatformUserId == userId)
+            .Select(e => e.WalletAddress)
+            .ToListAsync(ct)
+            .ConfigureAwait(false);
+
+        if (walletAddresses.Count == 0)
+        {
+            return Array.Empty<DeviceBoundCredentialCopy>();
+        }
+
+        var copies = new List<DeviceBoundCredentialCopy>();
+
+        foreach (var walletAddress in walletAddresses)
+        {
+            // The holder-key thumbprint distinguishes the web root (cnf == holder key)
+            // from a device copy (cnf == device key). Resolve once per wallet.
+            string holderThumbprint;
+            try
+            {
+                holderThumbprint = await _holderKeyService
+                    .GetHolderJwkThumbprintAsync(walletAddress, ct)
+                    .ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                // Without the holder thumbprint we cannot exclude the root, so we would
+                // risk counting it against the cap. Skip this wallet rather than guess.
+                _logger.LogWarning(ex,
+                    "Device-bound lookup: could not resolve holder thumbprint for wallet {Address}; skipping",
+                    walletAddress);
+                continue;
+            }
+
+            var stored = await _store.GetByWalletAsync(walletAddress, ct).ConfigureAwait(false);
+
+            foreach (var credential in stored)
+            {
+                if (credential.Status != CredentialStatus.Active)
+                {
+                    continue; // revoked/expired/declined copies must not count against the cap
+                }
+
+                if (!string.Equals(credential.Type, credentialType, StringComparison.Ordinal))
+                {
+                    continue; // the cap is per credential type (vct)
+                }
+
+                var thumbprint = TryComputeCnfThumbprint(credential.RawToken);
+                if (thumbprint is null)
+                {
+                    continue; // no cnf → not a bound copy
+                }
+
+                if (string.Equals(thumbprint, holderThumbprint, StringComparison.Ordinal))
+                {
+                    continue; // this is the holder-bound web root, not a device copy
+                }
+
+                copies.Add(new DeviceBoundCredentialCopy(
+                    CredentialId: credential.Id,
+                    DeviceKeyThumbprint: thumbprint,
+                    IssuedAt: credential.IssuedAt,
+                    // The stored credential carries no device linkage — device id/label are
+                    // resolved cross-service (Tenant registry) which is out of scope here.
+                    // The F118 eviction notice degrades to a no-op (non-fatal) without them.
+                    DeviceId: Guid.Empty,
+                    DeviceLabel: null));
+            }
+        }
+
+        return copies;
+    }
+
+    /// <summary>
+    /// Extracts the RFC 7638 thumbprint of the credential's non-disclosable <c>cnf</c>
+    /// key from the SD-JWT body, or <c>null</c> if the token has no <c>cnf.jwk</c>.
+    /// </summary>
+    private static string? TryComputeCnfThumbprint(string? rawToken)
+    {
+        if (string.IsNullOrWhiteSpace(rawToken))
+        {
+            return null;
+        }
+
+        try
+        {
+            // cnf lives in the issuer-signed JWT body (before the first '~'), never in a
+            // disclosure — it is always non-disclosable.
+            var jwt = rawToken.Split('~')[0];
+            var parts = jwt.Split('.');
+            if (parts.Length < 2)
+            {
+                return null;
+            }
+
+            var bodyBytes = Base64Url.DecodeFromChars(parts[1]);
+            using var doc = JsonDocument.Parse(bodyBytes);
+            if (doc.RootElement.ValueKind != JsonValueKind.Object
+                || !doc.RootElement.TryGetProperty("cnf", out var cnf)
+                || cnf.ValueKind != JsonValueKind.Object
+                || !cnf.TryGetProperty("jwk", out var jwk)
+                || jwk.ValueKind != JsonValueKind.Object)
+            {
+                return null;
+            }
+
+            return JsonWebKeyThumbprint.Compute(jwk);
+        }
+        catch
+        {
+            // Malformed token / unsupported key — not a countable device copy.
+            return null;
+        }
+    }
+}

--- a/src/Services/Sorcha.Wallet.Service/Services/Implementation/EfCoreDeviceBoundCredentialLookup.cs
+++ b/src/Services/Sorcha.Wallet.Service/Services/Implementation/EfCoreDeviceBoundCredentialLookup.cs
@@ -7,6 +7,7 @@ using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 
 using Sorcha.Cryptography;
+using Sorcha.ServiceClients.PlatformUserDevice;
 using Sorcha.Wallet.Core.Data;
 using Sorcha.Wallet.Core.Domain.Entities;
 using Sorcha.Wallet.Service.Credentials;
@@ -31,6 +32,7 @@ public sealed class EfCoreDeviceBoundCredentialLookup : IDeviceBoundCredentialLo
     private readonly WalletDbContext _db;
     private readonly ICredentialStore _store;
     private readonly IHolderKeyService _holderKeyService;
+    private readonly IPlatformUserDeviceClient _deviceClient;
     private readonly ILogger<EfCoreDeviceBoundCredentialLookup> _logger;
 
     /// <summary>Initialises a new <see cref="EfCoreDeviceBoundCredentialLookup"/>.</summary>
@@ -38,11 +40,13 @@ public sealed class EfCoreDeviceBoundCredentialLookup : IDeviceBoundCredentialLo
         WalletDbContext db,
         ICredentialStore store,
         IHolderKeyService holderKeyService,
+        IPlatformUserDeviceClient deviceClient,
         ILogger<EfCoreDeviceBoundCredentialLookup> logger)
     {
         _db = db ?? throw new ArgumentNullException(nameof(db));
         _store = store ?? throw new ArgumentNullException(nameof(store));
         _holderKeyService = holderKeyService ?? throw new ArgumentNullException(nameof(holderKeyService));
+        _deviceClient = deviceClient ?? throw new ArgumentNullException(nameof(deviceClient));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -63,6 +67,29 @@ public sealed class EfCoreDeviceBoundCredentialLookup : IDeviceBoundCredentialLo
         {
             return Array.Empty<DeviceBoundCredentialCopy>();
         }
+
+        // Fix round 1 (eviction notify): the copy's cnf thumbprint IS the device's Tenant
+        // registry identity — PlatformUserDevice.DevicePublicJwkThumbprint is the same RFC 7638
+        // thumbprint. Resolve the registry once so each copy carries a real DeviceId/Label for
+        // the F118 eviction notice. Non-fatal: a Tenant outage must never block the mint (only
+        // the revoke is fatal), so failure degrades to the deterministic-fallback path below.
+        IReadOnlyList<PlatformUserDeviceLookupResult> registeredDevices;
+        try
+        {
+            registeredDevices = await _deviceClient.ListAsync(userId, ct).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "Device-bound lookup: Tenant device registry unavailable for user {UserId} — " +
+                "eviction notices will degrade to thumbprint-derived device ids (no label)",
+                userId);
+            registeredDevices = Array.Empty<PlatformUserDeviceLookupResult>();
+        }
+
+        var devicesByThumbprint = registeredDevices
+            .GroupBy(d => d.DevicePublicJwkThumbprint, StringComparer.Ordinal)
+            .ToDictionary(g => g.Key, g => g.First(), StringComparer.Ordinal);
 
         var copies = new List<DeviceBoundCredentialCopy>();
 
@@ -112,19 +139,44 @@ public sealed class EfCoreDeviceBoundCredentialLookup : IDeviceBoundCredentialLo
                     continue; // this is the holder-bound web root, not a device copy
                 }
 
+                // Device id/label from the Tenant registry via the thumbprint link. When the
+                // registry has no match (or was unavailable), fall back to a DETERMINISTIC
+                // thumbprint-derived Guid so the F118 eviction notice still fires —
+                // CitizenDeviceInboxWriter short-circuits Guid.Empty into silence, and an
+                // eviction notice without a device label ("your device") beats no notice.
+                // Determinism preserves the writer's (userId, deviceId) idempotency key.
+                var (deviceId, deviceLabel) =
+                    devicesByThumbprint.TryGetValue(thumbprint, out var registered)
+                        ? (registered.DeviceId, (string?)registered.Label)
+                        : (DeterministicDeviceId(thumbprint), null);
+
                 copies.Add(new DeviceBoundCredentialCopy(
                     CredentialId: credential.Id,
                     DeviceKeyThumbprint: thumbprint,
                     IssuedAt: credential.IssuedAt,
-                    // The stored credential carries no device linkage — device id/label are
-                    // resolved cross-service (Tenant registry) which is out of scope here.
-                    // The F118 eviction notice degrades to a no-op (non-fatal) without them.
-                    DeviceId: Guid.Empty,
-                    DeviceLabel: null));
+                    DeviceId: deviceId,
+                    DeviceLabel: deviceLabel));
             }
         }
 
         return copies;
+    }
+
+    /// <summary>
+    /// Deterministic (version-5-style) Guid derived from the device-key thumbprint. Used when
+    /// the Tenant device registry has no row for the thumbprint (or is unreachable) so the
+    /// F118 eviction notice still fires with a stable, dedupable device identity. Mirrors the
+    /// hash-to-Guid shape of <c>CitizenDeviceInboxWriter.DeterministicSourceEventId</c>.
+    /// </summary>
+    private static Guid DeterministicDeviceId(string deviceKeyThumbprint)
+    {
+        var input = $"sorcha.device-bound.device-id:{deviceKeyThumbprint}";
+        var bytes = System.Security.Cryptography.SHA256.HashData(System.Text.Encoding.UTF8.GetBytes(input));
+        var guidBytes = new byte[16];
+        Array.Copy(bytes, guidBytes, 16);
+        guidBytes[6] = (byte)((guidBytes[6] & 0x0F) | 0x50);
+        guidBytes[8] = (byte)((guidBytes[8] & 0x3F) | 0x80);
+        return new Guid(guidBytes);
     }
 
     /// <summary>

--- a/src/Services/Sorcha.Wallet.Service/Services/Interfaces/IDeviceBoundCopyIssuanceCoordinator.cs
+++ b/src/Services/Sorcha.Wallet.Service/Services/Interfaces/IDeviceBoundCopyIssuanceCoordinator.cs
@@ -17,6 +17,22 @@ namespace Sorcha.Wallet.Service.Services.Interfaces;
 public sealed record DeviceBoundMintPlan(string StatusListUrl, int StatusListIndex);
 
 /// <summary>
+/// The device-bound copy policy REFUSED the mint: the cap could not be honoured because the
+/// eviction/replacement revoke failed (or the reconcile itself refused). Distinct from an
+/// infrastructure fault so the endpoint can map refusal → 409 (not retryable as-is) and
+/// anything else → 503 (transient, retryable). Carries the causing exception as
+/// <see cref="Exception.InnerException"/>; the message never reaches the client.
+/// </summary>
+public sealed class DeviceBoundPolicyRefusalException : Exception
+{
+    /// <summary>Initialises a new <see cref="DeviceBoundPolicyRefusalException"/>.</summary>
+    public DeviceBoundPolicyRefusalException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+}
+
+/// <summary>
 /// Runs the device-bound credential copy policy (Feature 1195, Phase 2) at the mint
 /// entrypoint. Detects whether an incoming issuance is a <em>device-bound copy</em>
 /// (vs the holder-bound web root), enforces the max-3 cap with LRU eviction via

--- a/src/Services/Sorcha.Wallet.Service/Services/Interfaces/IDeviceBoundCopyIssuanceCoordinator.cs
+++ b/src/Services/Sorcha.Wallet.Service/Services/Interfaces/IDeviceBoundCopyIssuanceCoordinator.cs
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Text.Json;
+
+namespace Sorcha.Wallet.Service.Services.Interfaces;
+
+/// <summary>
+/// The Token Status List slot a device-bound credential copy must embed so it is
+/// revocable by the citizen status-list publisher (Feature 114). Returned by
+/// <see cref="IDeviceBoundCopyIssuanceCoordinator.PrepareAsync"/> when the mint is a
+/// device-bound copy; the issuance path embeds it as the IETF <c>status.status_list</c>
+/// claim and records it on the stored <c>CredentialEntity</c>.
+/// </summary>
+/// <param name="StatusListUrl">The F114 citizen-device status-list URI (<c>statuslist+jwt</c>).</param>
+/// <param name="StatusListIndex">The allocated bit index within that list.</param>
+public sealed record DeviceBoundMintPlan(string StatusListUrl, int StatusListIndex);
+
+/// <summary>
+/// Runs the device-bound credential copy policy (Feature 1195, Phase 2) at the mint
+/// entrypoint. Detects whether an incoming issuance is a <em>device-bound copy</em>
+/// (vs the holder-bound web root), enforces the max-3 cap with LRU eviction via
+/// <see cref="IDeviceBoundCredentialPolicy"/>, and allocates a wallet-owned
+/// (F114) status-list slot so the copy can later be revoked.
+/// </summary>
+/// <remarks>
+/// Encapsulates the mint-path wiring so the <c>IssueCredential</c> endpoint gains a
+/// single seam rather than five discrete dependencies, and so the discriminator +
+/// policy + allocation are unit-testable in isolation.
+/// <para>
+/// <b>Discriminator.</b> A device-bound copy is one whose <c>cnf</c> key is NOT the
+/// recipient's citizen holder key (slot 108). The web root is bound to the holder key
+/// itself, so its <c>cnf</c> thumbprint equals the recipient's holder-key thumbprint;
+/// a device copy is bound to the phone's device key, a different thumbprint. Comparing
+/// thumbprints (rather than <c>cnf</c> curve) is robust even for P-256 wallets, whose
+/// holder key is also P-256.
+/// </para>
+/// </remarks>
+public interface IDeviceBoundCopyIssuanceCoordinator
+{
+    /// <summary>
+    /// Called BEFORE signing a credential. Returns <c>null</c> when the mint is not a
+    /// device-bound copy (the holder-bound web root, a non-citizen recipient, or an
+    /// unbound credential) — the caller mints unchanged. Otherwise runs the eviction
+    /// policy and returns the status-list slot the copy must embed.
+    /// </summary>
+    /// <param name="recipientWalletAddress">The credential recipient's wallet address.</param>
+    /// <param name="credentialVct">The resolved credential type / <c>vct</c> (the cap key).</param>
+    /// <param name="holderJwk">The incoming <c>cnf</c> key (device key for a device copy).</param>
+    /// <param name="issuerOrgId">The issuing organisation id (owns the F114 status list).</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The status-list slot for a device-bound copy, or <c>null</c> to mint unchanged.</returns>
+    /// <exception cref="Exception">
+    /// Propagated from <see cref="IDeviceBoundCredentialPolicy.ReconcileAsync"/> when
+    /// eviction (revoke-oldest) fails — the caller MUST abort issuance.
+    /// </exception>
+    Task<DeviceBoundMintPlan?> PrepareAsync(
+        string recipientWalletAddress,
+        string credentialVct,
+        JsonElement holderJwk,
+        Guid issuerOrgId,
+        CancellationToken ct = default);
+}

--- a/src/Services/Sorcha.Wallet.Service/Services/Interfaces/IDeviceBoundCredentialPolicy.cs
+++ b/src/Services/Sorcha.Wallet.Service/Services/Interfaces/IDeviceBoundCredentialPolicy.cs
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+namespace Sorcha.Wallet.Service.Services.Interfaces;
+
+/// <summary>
+/// Outcome kind returned by <see cref="IDeviceBoundCredentialPolicy.ReconcileAsync"/>
+/// describing how a device-bound credential copy request relates to the live copies
+/// already held for the same <c>(user, credentialType)</c>.
+/// </summary>
+public enum DeviceBindKind
+{
+    /// <summary>The device is new and the live-copy count is still below the cap — mint freely.</summary>
+    NewWithinCap,
+
+    /// <summary>
+    /// The device key thumbprint matches an existing live copy — the mint is an idempotent
+    /// re-issue for the same device. No eviction; the live-copy count is unchanged.
+    /// </summary>
+    ReplaceExisting,
+
+    /// <summary>
+    /// The device is new and the cap is already reached — the oldest live copy has been
+    /// evicted (status-list revoke + inbox notify) to make room. See
+    /// <see cref="DeviceBindDisposition.EvictedCredentialId"/>.
+    /// </summary>
+    NewWithEviction
+}
+
+/// <summary>
+/// Result of reconciling a device-bound credential copy request against the live copies.
+/// </summary>
+/// <param name="Kind">How the request relates to the existing live copies.</param>
+/// <param name="EvictedCredentialId">
+/// The credential id of the copy evicted to honour the cap, or <c>null</c> when no
+/// eviction occurred (<see cref="DeviceBindKind.NewWithinCap"/> /
+/// <see cref="DeviceBindKind.ReplaceExisting"/>).
+/// </param>
+public sealed record DeviceBindDisposition(DeviceBindKind Kind, string? EvictedCredentialId);
+
+/// <summary>
+/// A live device-bound credential copy as seen by the eviction policy. Projected from the
+/// wallet credential store by an <see cref="IDeviceBoundCredentialLookup"/> implementation
+/// (Task 5) so the policy stays a pure orchestration over data, free of SD-JWT parsing.
+/// </summary>
+/// <param name="CredentialId">The stored credential's id (returned as the evicted id).</param>
+/// <param name="DeviceKeyThumbprint">RFC 7638 thumbprint of the copy's device <c>cnf</c> key.</param>
+/// <param name="IssuedAt">When the copy was issued — the LRU ordering key (oldest = smallest).</param>
+/// <param name="DeviceId">The bound device's id, used for the F118 inbox notification.</param>
+/// <param name="DeviceLabel">Human-readable device label for the inbox entry, or <c>null</c>.</param>
+public sealed record DeviceBoundCredentialCopy(
+    string CredentialId,
+    string DeviceKeyThumbprint,
+    DateTimeOffset IssuedAt,
+    Guid DeviceId,
+    string? DeviceLabel);
+
+/// <summary>
+/// Loads the live (presentable) device-bound credential copies for a citizen and credential
+/// type. Task 5 supplies the concrete implementation over the wallet credential store; the
+/// policy consumes this seam so it can be unit-tested without a database or SD-JWT decoding.
+/// </summary>
+public interface IDeviceBoundCredentialLookup
+{
+    /// <summary>
+    /// Returns every live device-bound copy of <paramref name="credentialType"/> currently held
+    /// by <paramref name="userId"/>. Copies whose status is no longer presentable (revoked,
+    /// expired, declined) MUST be excluded so they do not count against the device cap.
+    /// </summary>
+    Task<IReadOnlyList<DeviceBoundCredentialCopy>> GetLiveCopiesAsync(
+        Guid userId, string credentialType, CancellationToken ct = default);
+}
+
+/// <summary>
+/// Revokes a single evicted device-bound credential copy (flips its status-list bit).
+/// Split out as its own seam because credential-level status-list revocation is distinct from
+/// device-delegation revocation (Feature 114); Task 5 supplies the concrete revoker. Revocation
+/// failure MUST propagate — the caller aborts issuance rather than leave partial state.
+/// </summary>
+public interface IDeviceBoundCredentialRevoker
+{
+    /// <summary>
+    /// Revokes the supplied <paramref name="copy"/> for <paramref name="userId"/>. Throwing
+    /// aborts the reconcile (no inbox write, no disposition returned).
+    /// </summary>
+    Task RevokeAsync(Guid userId, DeviceBoundCredentialCopy copy, CancellationToken ct = default);
+}
+
+/// <summary>
+/// Issuer-side business policy enforcing at most <c>MAX_DEVICES</c> live device-bound copies of a
+/// credential per citizen, keyed on the device key JWK thumbprint (RFC 7638), with LRU eviction
+/// (Feature 1195, Phase 2).
+/// </summary>
+public interface IDeviceBoundCredentialPolicy
+{
+    /// <summary>
+    /// Called BEFORE minting a device-bound copy. Enforces max-3 per <c>(user, credentialType)</c>
+    /// keyed on device-key JWK thumbprint. Returns the disposition; performs eviction
+    /// (status-list revoke + inbox notify) as a side-effect when a NEW device exceeds the cap.
+    /// </summary>
+    /// <param name="userId">The citizen (platform user) requesting the device-bound copy.</param>
+    /// <param name="credentialType">The credential type being bound (the cap is per type).</param>
+    /// <param name="deviceKeyThumbprint">RFC 7638 thumbprint of the requesting device's <c>cnf</c> key.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The disposition. On revoke failure the task faults (issuance must abort).</returns>
+    Task<DeviceBindDisposition> ReconcileAsync(
+        Guid userId, string credentialType, string deviceKeyThumbprint, CancellationToken ct = default);
+}

--- a/src/Services/Sorcha.Wallet.Service/Services/Interfaces/IDeviceBoundCredentialPolicy.cs
+++ b/src/Services/Sorcha.Wallet.Service/Services/Interfaces/IDeviceBoundCredentialPolicy.cs
@@ -16,6 +16,8 @@ public enum DeviceBindKind
     /// <summary>
     /// The device key thumbprint matches an existing live copy — the mint is an idempotent
     /// re-issue for the same device. No eviction; the live-copy count is unchanged.
+    /// The policy does NOT revoke the prior same-thumbprint copy — replacing the stored
+    /// copy is the caller's (the mint path's) responsibility.
     /// </summary>
     ReplaceExisting,
 

--- a/tests/Sorcha.Blueprint.Service.Tests/AiasDeviceRegistrationBlueprintTests.cs
+++ b/tests/Sorcha.Blueprint.Service.Tests/AiasDeviceRegistrationBlueprintTests.cs
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Sorcha.Blueprint.Service.Services;
+using Sorcha.Blueprint.Service.Storage;
+using BlueprintModel = Sorcha.Blueprint.Models.Blueprint;
+
+namespace Sorcha.Blueprint.Service.Tests;
+
+/// <summary>
+/// Publish/validate coverage for the AIAS device-registration blueprint
+/// (<c>demos/AIAS/blueprints/aias-device-registration.template.json</c>, #1195 Phase 2 —
+/// "one assurance, two bindings"). Loads the real shipped template, deserializes its
+/// <c>template</c> body into the <see cref="BlueprintModel"/>, and drives it through the same
+/// <see cref="PublishService.ValidateAsync"/> publish-time gate that guards production publishes.
+///
+/// The blueprint's starting action gates on PRESENTING the web-issued
+/// <c>AssuredIdentityCredential</c> (entitlement proof) and captures the phone's device public
+/// JWK; its issuance action mints a device-<c>cnf</c> copy bound to that key. These tests pin the
+/// shape the runtime relies on and prove the template publishes clean (no <c>VAL_BP_*</c> errors,
+/// open citizen participant accepted).
+/// </summary>
+public class AiasDeviceRegistrationBlueprintTests
+{
+    private const string ExpectedVct = "https://sorcha.dev/vc/assured-identity/v1";
+
+    private static readonly JsonSerializerOptions DeserializeOptions =
+        new() { PropertyNameCaseInsensitive = true };
+
+    private static BlueprintModel LoadDeviceRegistrationBlueprint()
+    {
+        var repoRoot = FindRepoRoot(AppContext.BaseDirectory);
+        var file = Path.Combine(
+            repoRoot, "demos", "AIAS", "blueprints", "aias-device-registration.template.json");
+        File.Exists(file).Should().BeTrue($"the device-registration template must ship at {file}");
+
+        var root = JsonNode.Parse(File.ReadAllText(file))!.AsObject();
+
+        // Templates are wrapped: the workflow body lives under "template" (mirrors the sibling
+        // aias-assured-identity.template.json and the walkthrough loader's wrapped/flat handling).
+        var templateNode = root["template"];
+        templateNode.Should().NotBeNull("the AIAS template must carry its blueprint under a 'template' property");
+
+        var blueprint = templateNode.Deserialize<BlueprintModel>(DeserializeOptions);
+        blueprint.Should().NotBeNull("the template body must deserialize into the Blueprint model");
+        return blueprint!;
+    }
+
+    private static PublishService BuildValidatingService(BlueprintModel blueprint)
+    {
+        var blueprintStore = new Mock<IBlueprintStore>();
+        var publishedStore = new Mock<IPublishedBlueprintStore>();
+        blueprintStore.Setup(s => s.GetAsync(blueprint.Id)).ReturnsAsync(blueprint);
+        return new PublishService(blueprintStore.Object, publishedStore.Object);
+    }
+
+    [Fact]
+    public async Task Validate_DeviceRegistrationBlueprint_PublishesWithoutValidationErrors()
+    {
+        var blueprint = LoadDeviceRegistrationBlueprint();
+        var service = BuildValidatingService(blueprint);
+
+        var result = await service.ValidateAsync(blueprint.Id);
+
+        result.IsValid.Should().BeTrue(
+            "the shipped device-registration blueprint must pass the publish-time gate: "
+            + string.Join(" | ", result.ValidationResults.Select(i => i.Message)));
+        result.ValidationResults.Should().NotContain(
+            i => i.Message.Contains("VAL_BP_", StringComparison.Ordinal),
+            "no publish-time guardrail (VAL_BP_*) may fire");
+    }
+
+    [Fact]
+    public void DeviceRegistrationBlueprint_CitizenIsOpenParticipant_WalletAddressOmitted()
+    {
+        var blueprint = LoadDeviceRegistrationBlueprint();
+
+        var citizen = blueprint.Participants.Should().ContainSingle(p => p.Id == "citizen").Subject;
+        citizen.WalletAddress.Should().BeNullOrWhiteSpace(
+            "citizen is the sender of the open starting action and must late-bind (VAL_BP_010)");
+    }
+
+    [Fact]
+    public void DeviceRegistrationBlueprint_StartingAction_GatesOnAssuredIdentityPresentation()
+    {
+        var blueprint = LoadDeviceRegistrationBlueprint();
+
+        var start = blueprint.Actions.Should().ContainSingle(a => a.IsStartingAction).Subject;
+        start.Sender.Should().Be("citizen");
+
+        var requirement = start.CredentialRequirements.Should()
+            .ContainSingle("the starting action gates on a single credential presentation").Subject;
+
+        // Canonical VCT URI (case-sensitive) — matches VctUris.AssuredIdentityV1 and the corpus
+        // convention (walkthroughs/.../driving-licence.json). A bare type name would fail the
+        // BlueprintVctConformanceTests sweep that walks demos/.
+        requirement.Type.Should().Be(ExpectedVct);
+        requirement.PresentationSource.Should()
+            .Be(Sorcha.Blueprint.Models.Credentials.PresentationSource.SorchaWallet,
+                "the citizen presents from their on-device Sorcha Wallet PWA (F127), not HAIP");
+        requirement.RequiredClaims.Should().NotBeNull();
+        requirement.RequiredClaims!.Select(c => c.ClaimName).Should()
+            .Contain(new[] { "givenName", "familyName", "dateOfBirth" });
+    }
+
+    [Fact]
+    public void DeviceRegistrationBlueprint_StartingAction_CapturesDevicePublicKey()
+    {
+        var blueprint = LoadDeviceRegistrationBlueprint();
+
+        var start = blueprint.Actions.Single(a => a.IsStartingAction);
+        var schema = start.DataSchemas.Should().ContainSingle().Subject;
+
+        using var doc = schema; // JsonDocument
+        var deviceKey = doc.RootElement.GetProperty("properties").GetProperty("deviceKey");
+        deviceKey.GetProperty("format").GetString().Should().Be("sorcha-device-key");
+        deviceKey.GetProperty("x-device-key").GetProperty("required").GetBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void DeviceRegistrationBlueprint_IssuanceAction_MintsDeviceCnfCopy()
+    {
+        var blueprint = LoadDeviceRegistrationBlueprint();
+
+        var issuance = blueprint.Actions.Should()
+            .ContainSingle(a => a.CredentialIssuanceConfig != null).Subject;
+        issuance.Sender.Should().Be("aias-issuer");
+        issuance.RequiredPriorActions.Should().Contain(1);
+        issuance.Routes.Should().ContainSingle().Which.NextActionIds.Should()
+            .BeEmpty("the issuance action is terminal");
+
+        var config = issuance.CredentialIssuanceConfig!;
+        config.CredentialType.Should().Be("AssuredIdentityCredential");
+        config.Vct.Should().Be(ExpectedVct);
+        config.RecipientParticipantId.Should().Be("citizen");
+        config.HolderKeySourceField.Should().Be("/deviceKey/holderJwk",
+            "the device copy is bound (cnf) to the captured device key");
+        config.ClaimMappings.Select(m => m.SourceField).Should()
+            .OnlyContain(s => s!.StartsWith("/presentedCredential/", StringComparison.Ordinal),
+                "the full assured claim set is carried from the verified presentation");
+    }
+
+    [Fact]
+    public void DeviceRegistrationBlueprint_DoesNotBakeRegisterId()
+    {
+        // Register selection is left to the AIAS publish/deploy tooling (same register as the
+        // apply blueprint). The apply template bakes no registerId; neither may this one.
+        var blueprint = LoadDeviceRegistrationBlueprint();
+        foreach (var action in blueprint.Actions)
+        {
+            action.CredentialIssuanceConfig?.RegisterId.Should().BeNullOrEmpty(
+                "the device-registration blueprint must not target a register — the deploy tooling picks it");
+        }
+    }
+
+    private static string FindRepoRoot(string startDir)
+    {
+        var dir = startDir;
+        while (dir is not null)
+        {
+            if (File.Exists(Path.Combine(dir, "Sorcha.sln")))
+            {
+                return dir;
+            }
+
+            dir = Directory.GetParent(dir)?.FullName;
+        }
+
+        throw new DirectoryNotFoundException(
+            $"Could not locate repo root (dir containing Sorcha.sln) walking up from '{startDir}'.");
+    }
+}

--- a/tests/Sorcha.Blueprint.Service.Tests/AiasDeviceRegistrationBlueprintTests.cs
+++ b/tests/Sorcha.Blueprint.Service.Tests/AiasDeviceRegistrationBlueprintTests.cs
@@ -101,13 +101,14 @@ public class AiasDeviceRegistrationBlueprintTests
             .Be(Sorcha.Blueprint.Models.Credentials.PresentationSource.SorchaWallet,
                 "the citizen presents from their on-device Sorcha Wallet PWA (F127), not HAIP");
         requirement.RequiredClaims.Should().NotBeNull();
-        // Task 6b (D) — FULL disclosure for the bind gate (design §4.1): the consumer filters
-        // disclosed claims to the gate's requiredClaims, so the gate must require the COMPLETE
-        // assured claim set the apply blueprint issues (its claimMappings are the source of
-        // truth) or the device copy is minted with holes (no email/address/portrait).
+        // Task 6 fix round — optional-claim gate semantics. The gate requires ONLY the
+        // mandatory identity core every root provably carries. middleName/fullName/portrait
+        // are OPTIONAL at apply time (claim mappings skip missing sources), so requiring them
+        // would refuse the bind to every citizen without a middle name. Full disclosure of the
+        // copy comes from the consumer's PASS-THROUGH of all verified disclosed claims
+        // (design §4.1), not from this list — the requiredClaims are the entitlement gate.
         requirement.RequiredClaims!.Select(c => c.ClaimName).Should().BeEquivalentTo(
-            "givenName", "middleName", "familyName", "fullName",
-            "dateOfBirth", "email", "address", "portrait");
+            "givenName", "familyName", "dateOfBirth");
     }
 
     [Fact]

--- a/tests/Sorcha.Blueprint.Service.Tests/AiasDeviceRegistrationBlueprintTests.cs
+++ b/tests/Sorcha.Blueprint.Service.Tests/AiasDeviceRegistrationBlueprintTests.cs
@@ -101,8 +101,13 @@ public class AiasDeviceRegistrationBlueprintTests
             .Be(Sorcha.Blueprint.Models.Credentials.PresentationSource.SorchaWallet,
                 "the citizen presents from their on-device Sorcha Wallet PWA (F127), not HAIP");
         requirement.RequiredClaims.Should().NotBeNull();
-        requirement.RequiredClaims!.Select(c => c.ClaimName).Should()
-            .Contain(new[] { "givenName", "familyName", "dateOfBirth" });
+        // Task 6b (D) — FULL disclosure for the bind gate (design §4.1): the consumer filters
+        // disclosed claims to the gate's requiredClaims, so the gate must require the COMPLETE
+        // assured claim set the apply blueprint issues (its claimMappings are the source of
+        // truth) or the device copy is minted with holes (no email/address/portrait).
+        requirement.RequiredClaims!.Select(c => c.ClaimName).Should().BeEquivalentTo(
+            "givenName", "middleName", "familyName", "fullName",
+            "dateOfBirth", "email", "address", "portrait");
     }
 
     [Fact]

--- a/tests/Sorcha.Blueprint.Service.Tests/Integration/PresentationLifecycleWebApplicationFactory.cs
+++ b/tests/Sorcha.Blueprint.Service.Tests/Integration/PresentationLifecycleWebApplicationFactory.cs
@@ -230,6 +230,18 @@ public sealed class PresentationLifecycleWebApplicationFactory : BlueprintServic
             services.RemoveAll<IPendingPresentationStore>();
             services.AddSingleton<IPendingPresentationStore>(PendingStore);
 
+            // #1195 Phase 2 (Task 6b) — the sorcha-wallet initiation path (first exercised by
+            // SorchaWalletExecuteIntegrationTests) mints a ClaimsFetchToken and stashes the
+            // served request object; the outcome path stashes disclosed claims. The production
+            // Redis stores dereference the base factory's null GetDatabase() and NRE (same
+            // reason the seal coordinator is replaced above) — swap in in-memory doubles.
+            services.RemoveAll<IClaimsFetchTokenStore>();
+            services.AddSingleton<IClaimsFetchTokenStore, InMemoryClaimsFetchTokenStore>();
+            services.RemoveAll<IRequestObjectStore>();
+            services.AddSingleton<IRequestObjectStore, InMemoryRequestObjectStore>();
+            services.RemoveAll<IDisclosedClaimsStore>();
+            services.AddSingleton<IDisclosedClaimsStore, InMemoryDisclosedClaimsStore>();
+
             services.RemoveAll<IPresentationRateLimiter>();
             services.AddSingleton<IPresentationRateLimiter>(RateLimiter);
 
@@ -277,6 +289,51 @@ internal sealed class NoOpPresentationSealCoordinator : IPresentationSealCoordin
 
     public Task<SweepResult> RunRecoverySweepAsync(CancellationToken cancellationToken = default)
         => Task.FromResult(new SweepResult(0, 0));
+}
+
+/// <summary>In-memory test double for <see cref="IClaimsFetchTokenStore"/> (no TTL enforcement).</summary>
+internal sealed class InMemoryClaimsFetchTokenStore : IClaimsFetchTokenStore
+{
+    private readonly ConcurrentDictionary<string, Guid> _tokens = new();
+
+    public Task StoreAsync(string token, Guid presentationRequestId, TimeSpan ttl, CancellationToken ct = default)
+    {
+        _tokens[token] = presentationRequestId;
+        return Task.CompletedTask;
+    }
+
+    public Task<Guid?> GetAndRemoveAsync(string token, CancellationToken ct = default)
+        => Task.FromResult<Guid?>(_tokens.TryRemove(token, out var id) ? id : null);
+}
+
+/// <summary>In-memory test double for <see cref="IRequestObjectStore"/> (no TTL enforcement).</summary>
+internal sealed class InMemoryRequestObjectStore : IRequestObjectStore
+{
+    private readonly ConcurrentDictionary<Guid, string> _objects = new();
+
+    public Task StoreAsync(Guid presentationRequestId, string requestObjectJwt, TimeSpan ttl, CancellationToken ct = default)
+    {
+        _objects[presentationRequestId] = requestObjectJwt;
+        return Task.CompletedTask;
+    }
+
+    public Task<string?> GetAsync(Guid presentationRequestId, CancellationToken ct = default)
+        => Task.FromResult(_objects.GetValueOrDefault(presentationRequestId));
+}
+
+/// <summary>In-memory test double for <see cref="IDisclosedClaimsStore"/> (no TTL enforcement).</summary>
+internal sealed class InMemoryDisclosedClaimsStore : IDisclosedClaimsStore
+{
+    private readonly ConcurrentDictionary<Guid, IReadOnlyDictionary<string, object>> _claims = new();
+
+    public Task StoreAsync(Guid presentationRequestId, IReadOnlyDictionary<string, object> claims, TimeSpan ttl, CancellationToken ct = default)
+    {
+        _claims[presentationRequestId] = claims;
+        return Task.CompletedTask;
+    }
+
+    public Task<IReadOnlyDictionary<string, object>?> GetAsync(Guid presentationRequestId, CancellationToken ct = default)
+        => Task.FromResult(_claims.GetValueOrDefault(presentationRequestId));
 }
 
 /// <summary>

--- a/tests/Sorcha.Blueprint.Service.Tests/Integration/SorchaWalletExecuteIntegrationTests.cs
+++ b/tests/Sorcha.Blueprint.Service.Tests/Integration/SorchaWalletExecuteIntegrationTests.cs
@@ -1,0 +1,257 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Sorcha.Blueprint.Models.Credentials;
+using Sorcha.Blueprint.Service.Models.Requests;
+using Sorcha.Blueprint.Service.Models.Responses;
+using Sorcha.PresentationLifecycle.Abstractions;
+using Xunit;
+using ActionModel = Sorcha.Blueprint.Models.Action;
+using BlueprintModel = Sorcha.Blueprint.Models.Blueprint;
+using ParticipantModel = Sorcha.Blueprint.Models.Participant;
+
+namespace Sorcha.Blueprint.Service.Tests.Integration;
+
+/// <summary>
+/// #1195 Phase 2 / Task 6b (A + B) — integration coverage for the SorchaWallet presentation
+/// rail: a starting action gated with <c>presentationSource: SorchaWallet</c> must initiate the
+/// F111 lifecycle from <c>/execute</c> exactly like the HAIP source does (202 +
+/// AwaitingPresentation + pending state under consumer <c>sorcha-wallet</c>), and the wallet's
+/// direct_post target <c>POST /api/presentations/callbacks/sorcha-wallet/{id}</c> must be
+/// reachable with a consumer-tier token (route-metadata assertion) and dispatch to the
+/// sorcha-wallet consumer.
+/// </summary>
+public class SorchaWalletExecuteIntegrationTests : IAsyncLifetime
+{
+    private readonly PresentationLifecycleWebApplicationFactory _factory;
+    private readonly TestSorchaWalletConsumer _sorchaWalletConsumer = new();
+    private HttpClient _client = null!;
+    private const string TestRegister = "reg-sw-execute";
+    private const string CitizenWallet = "ws1qcitizen-sw";
+
+    public SorchaWalletExecuteIntegrationTests()
+    {
+        _factory = new PresentationLifecycleWebApplicationFactory();
+        // Must land in Consumers BEFORE the host starts (CreateClient) — the factory
+        // registers extras during ConfigureWebHost only.
+        _factory.Consumers.Add(_sorchaWalletConsumer);
+    }
+
+    public ValueTask InitializeAsync()
+    {
+        _client = _factory.CreateClient();
+        _factory.ResetMocksAndState();
+        _client.DefaultRequestHeaders.Add("X-Delegation-Token", "test-delegation-token");
+        return ValueTask.CompletedTask;
+    }
+
+    public async ValueTask DisposeAsync() => await _factory.DisposeAsync();
+
+    private async Task<(string InstanceId, string BlueprintId)> SeedSorchaWalletInstanceAsync()
+    {
+        var blueprint = new BlueprintModel
+        {
+            Id = $"bp-sw-{Guid.NewGuid():N}",
+            Title = "SorchaWallet-gated blueprint",
+            Description = "Citizen presents from the Sorcha Wallet PWA",
+            Version = 1,
+            Participants = new List<ParticipantModel>
+            {
+                new() { Id = "citizen", Name = "Citizen" },
+                new() { Id = "issuer", Name = "Issuer" }
+            },
+            Actions = new List<ActionModel>
+            {
+                new()
+                {
+                    Id = 1,
+                    Title = "Bind your identity to this device",
+                    Sender = "citizen",
+                    IsStartingAction = true,
+                    CredentialRequirements = new List<CredentialRequirement>
+                    {
+                        new()
+                        {
+                            Type = "https://sorcha.dev/vc/assured-identity/v1",
+                            PresentationSource = PresentationSource.SorchaWallet,
+                            RequiredClaims =
+                            [
+                                new ClaimConstraint { ClaimName = "givenName" },
+                                new ClaimConstraint { ClaimName = "familyName" }
+                            ]
+                        }
+                    }
+                }
+            }
+        };
+
+        var create = await _client.PostAsJsonAsync("/api/blueprints", blueprint);
+        create.EnsureSuccessStatusCode();
+        var created = await create.Content.ReadFromJsonAsync<BlueprintModel>();
+
+        var publish = await _client.PostAsync(
+            $"/api/blueprints/{created!.Id}/publish",
+            JsonContent.Create(new { registerId = TestRegister }));
+        publish.EnsureSuccessStatusCode();
+
+        var instanceResp = await _client.PostAsJsonAsync("/api/instances", new
+        {
+            blueprintId = created.Id,
+            registerId = TestRegister,
+            tenantId = "test-tenant-789"
+        });
+        instanceResp.StatusCode.Should().Be(HttpStatusCode.Created);
+        using var doc = JsonDocument.Parse(await instanceResp.Content.ReadAsStringAsync());
+        return (doc.RootElement.GetProperty("id").GetString()!, created.Id);
+    }
+
+    [Fact]
+    public async Task Execute_SorchaWalletRequired_Returns202_WithAwaitingPresentation_AndSorchaWalletPending()
+    {
+        var (instanceId, blueprintId) = await SeedSorchaWalletInstanceAsync();
+
+        var response = await _client.PostAsJsonAsync(
+            $"/api/instances/{instanceId}/actions/1/execute",
+            new ActionSubmissionRequest
+            {
+                BlueprintId = blueprintId,
+                ActionId = "1",
+                SenderWallet = CitizenWallet,
+                RegisterAddress = TestRegister,
+                PayloadData = new Dictionary<string, object>
+                {
+                    ["deviceKey"] = new Dictionary<string, object>
+                    {
+                        ["holderJwk"] = new { kty = "EC", crv = "P-256", x = "devX", y = "devY" }
+                    }
+                }
+            });
+
+        var raw = await response.Content.ReadAsStringAsync();
+        response.StatusCode.Should().Be(HttpStatusCode.Accepted,
+            $"a SorchaWallet-gated starting action must initiate the F111 lifecycle, not fall into internal verification (body: {raw})");
+
+        var body = await response.Content.ReadFromJsonAsync<ActionSubmissionResponse>();
+        body!.AwaitingPresentation.Should().BeTrue();
+        body.PresentationRequest.Should().NotBeNull();
+        body.PresentationRequest!.PresentationRequestUri.Should().StartWith("openid4vp://",
+            "the wallet drives the presentation from this authorization request URI");
+
+        var pending = await _factory.PendingStore.GetAsync(body.PresentationRequest.RequestId);
+        pending.Should().NotBeNull();
+        pending!.ConsumerName.Should().Be("sorcha-wallet");
+        pending.SubmitterWallet.Should().Be(CitizenWallet);
+        pending.Nonce.Should().Be(TestSorchaWalletConsumer.TestNonce,
+            "Task 6b (C): the initiation nonce must be persisted so the callback can rebuild the verifier session");
+        pending.CredentialType.Should().Be("https://sorcha.dev/vc/assured-identity/v1");
+        pending.RequiredClaimNames.Should().BeEquivalentTo(["givenName", "familyName"]);
+    }
+
+    [Fact]
+    public async Task Execute_ThenSorchaWalletCallback_DispatchesToTheSorchaWalletConsumer_WithSessionContext()
+    {
+        var (instanceId, blueprintId) = await SeedSorchaWalletInstanceAsync();
+
+        var execute = await _client.PostAsJsonAsync(
+            $"/api/instances/{instanceId}/actions/1/execute",
+            new ActionSubmissionRequest
+            {
+                BlueprintId = blueprintId,
+                ActionId = "1",
+                SenderWallet = CitizenWallet,
+                RegisterAddress = TestRegister,
+                PayloadData = new Dictionary<string, object> { ["note"] = "bind" }
+            });
+        execute.StatusCode.Should().Be(HttpStatusCode.Accepted);
+        var body = await execute.Content.ReadFromJsonAsync<ActionSubmissionResponse>();
+        var requestId = body!.PresentationRequest!.RequestId;
+
+        // The wallet's direct_post: JSON {vpToken} to the sorcha-wallet callback route.
+        var callback = await _client.PostAsJsonAsync(
+            $"/api/presentations/callbacks/sorcha-wallet/{requestId}",
+            new { vpToken = "vp-compact~kb" });
+
+        callback.StatusCode.Should().Be(HttpStatusCode.OK,
+            "the wallet-reachable callback route must dispatch the outcome");
+        _sorchaWalletConsumer.InvokedContexts.Should().ContainSingle();
+
+        var ctx = _sorchaWalletConsumer.InvokedContexts[0];
+        ctx.PresentationRequestId.Should().Be(requestId);
+        // Task 6b (C) — the session fields persisted at initiation must reach the consumer.
+        ctx.Nonce.Should().Be(TestSorchaWalletConsumer.TestNonce);
+        ctx.CredentialType.Should().Be("https://sorcha.dev/vc/assured-identity/v1");
+        ctx.RequiredClaimNames.Should().BeEquivalentTo(["givenName", "familyName"]);
+        ctx.ExpiresAt.Should().NotBeNull("the callback path must know the session's expiry");
+    }
+
+    [Fact]
+    public void CallbackRoutes_SorchaWalletIsConsumerTier_GenericStaysServiceTier()
+    {
+        // Task 6b (B) — the policy split: the wallet posts with a CITIZEN token, so the
+        // sorcha-wallet callback route carries RequireConsumerAudience; every other
+        // consumer's callback stays service-to-service.
+        var endpoints = _factory.Services.GetRequiredService<EndpointDataSource>().Endpoints
+            .OfType<RouteEndpoint>()
+            .ToList();
+
+        var sorchaWalletRoute = endpoints.Should().ContainSingle(e =>
+                e.RoutePattern.RawText != null &&
+                e.RoutePattern.RawText.Contains("callbacks/sorcha-wallet/", StringComparison.Ordinal))
+            .Subject;
+        sorchaWalletRoute.Metadata.GetOrderedMetadata<IAuthorizeData>()
+            .Should().Contain(a => a.Policy == "RequireConsumerAudience",
+                "the Sorcha wallet PWA posts the outcome with a consumer-tier citizen token");
+
+        var genericRoute = endpoints.Should().ContainSingle(e =>
+                e.RoutePattern.RawText != null &&
+                e.RoutePattern.RawText.Contains("callbacks/{consumerName}/", StringComparison.Ordinal))
+            .Subject;
+        genericRoute.Metadata.GetOrderedMetadata<IAuthorizeData>()
+            .Should().Contain(a => a.Policy == "RequireService",
+                "other consumers (HAIP relay) remain service-to-service");
+    }
+}
+
+/// <summary>
+/// Controllable sorcha-wallet consumer for the Task 6b integration tests: implements
+/// <see cref="IPresentationConsumer.BuildInitiationAsync"/> (the F127 generic initiation
+/// dispatch) and records every <see cref="VerifyAsync"/> context.
+/// </summary>
+public sealed class TestSorchaWalletConsumer : IPresentationConsumer
+{
+    public const string TestNonce = "sw-test-nonce-1";
+
+    public string ConsumerName => "sorcha-wallet";
+
+    public List<PresentationInitiationContext> InvokedContexts { get; } = new();
+
+    public PresentationOutcome NextOutcome { get; set; } = new(
+        Kind: PresentationOutcomeKind.Success,
+        VerifiedClaims: new Dictionary<string, object> { ["givenName"] = "Sarah" },
+        Reason: null,
+        VerifierDiagnostics: null,
+        PresentationSubmissionHash: "sha256:sw-test");
+
+    public Task<PresentationOutcome> VerifyAsync(
+        PresentationInitiationContext context, object verifierPayload, CancellationToken cancellationToken)
+    {
+        InvokedContexts.Add(context);
+        return Task.FromResult(NextOutcome);
+    }
+
+    public Task<ConsumerInitiationDescriptor> BuildInitiationAsync(
+        PresentationInitiationContext context, CancellationToken cancellationToken)
+        => Task.FromResult(new ConsumerInitiationDescriptor(
+            AuthorizationRequestUri:
+                $"openid4vp://authorize?client_id=did%3Asorcha%3Aorg%3Atest&request_uri=https%3A%2F%2Fgw.test%2Fapi%2Fpresentations%2F{context.PresentationRequestId:N}%2Frequest-object",
+            RequestUri: $"https://gw.test/api/presentations/{context.PresentationRequestId:N}/request-object",
+            Nonce: TestNonce,
+            RequestObjectJwt: null));
+}

--- a/tests/Sorcha.Blueprint.Service.Tests/Services/ActionExecutionPresentedCredentialSourceTests.cs
+++ b/tests/Sorcha.Blueprint.Service.Tests/Services/ActionExecutionPresentedCredentialSourceTests.cs
@@ -1,0 +1,224 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Text.Json.Nodes;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Sorcha.ServiceClients.Haip;
+using Sorcha.ServiceClients.Participant;
+using Sorcha.ServiceClients.Register;
+using Sorcha.ServiceClients.Register.Models;
+using Sorcha.ServiceClients.Validator;
+using Sorcha.ServiceClients.Wallet;
+using Sorcha.Blueprint.Engine.Credentials;
+using Sorcha.Blueprint.Engine.Implementation;
+using Sorcha.Blueprint.Engine.Interfaces;
+using Sorcha.Blueprint.Models.Credentials;
+using Sorcha.Blueprint.Service.Models;
+using Sorcha.Blueprint.Service.Models.Requests;
+using Sorcha.Blueprint.Service.Services.Implementation;
+using Sorcha.Blueprint.Service.Services.Interfaces;
+using Sorcha.Blueprint.Service.Storage;
+using BlueprintModel = Sorcha.Blueprint.Models.Blueprint;
+using ActionModel = Sorcha.Blueprint.Models.Action;
+using ParticipantModel = Sorcha.Blueprint.Models.Participant;
+using RouteModel = Sorcha.Blueprint.Models.Route;
+
+namespace Sorcha.Blueprint.Service.Tests.Services;
+
+/// <summary>
+/// Feature 174 / #1195 Phase 2 ("one assurance, two bindings") — the verified presentation's
+/// disclosed claims from an action's credential-requirement gate must be exposed in the issuance
+/// source document under the stable <c>/presentedCredential/*</c> claim-source prefix, and they
+/// MUST take precedence over client-supplied payload for those claims. This is the SECURITY
+/// property of design §4.1: the device-bound copy's identity claims come from the verified,
+/// issuer-signed root presentation (tamper-evident) — never from client-supplied payload. A
+/// submitted payload that names <c>givenName</c> (or even a spoofed <c>presentedCredential</c>
+/// object) can never override the value disclosed by the verified presentation.
+/// </summary>
+public class ActionExecutionPresentedCredentialSourceTests
+{
+    private const string PresentedGivenName = "Alice-from-verified-presentation";
+    private const string PayloadSpoofGivenName = "Attacker-supplied-payload";
+    private const string CredentialType = "https://sorcha.dev/vc/assured-identity/v1";
+
+    private readonly Mock<IActionResolverService> _actionResolver = new();
+    private readonly Mock<IStateReconstructionService> _stateReconstruction = new();
+    private readonly Mock<ITransactionBuilderService> _transactionBuilder = new();
+    private readonly Mock<IRegisterServiceClient> _registerClient = new();
+    private readonly Mock<IValidatorServiceClient> _validatorClient = new();
+    private readonly Mock<IWalletServiceClient> _walletClient = new();
+    private readonly Mock<IParticipantServiceClient> _participantClient = new();
+    private readonly Mock<INotificationService> _notificationService = new();
+    private readonly Mock<IInstanceStore> _instanceStore = new();
+    private readonly Mock<IActionStore> _actionStore = new();
+    private readonly Mock<IExecutionEngine> _executionEngine = new();
+    private readonly Mock<IHaipServiceClient> _haipClient = new();
+    private readonly Mock<ICredentialVerifier> _credentialVerifier = new();
+
+    // Captures the claims dictionary the HAIP path builds from claimMappings + the issuance source doc.
+    private Dictionary<string, object>? _capturedOfferClaims;
+
+    private ActionExecutionService CreateService() => new(
+        _actionResolver.Object, _stateReconstruction.Object, _transactionBuilder.Object,
+        _registerClient.Object, _validatorClient.Object, _walletClient.Object,
+        _participantClient.Object, _notificationService.Object, _instanceStore.Object,
+        _actionStore.Object, _executionEngine.Object,
+        new Mock<ILogger<ActionExecutionService>>().Object, new ConfigurationBuilder().Build(),
+        credentialVerifier: _credentialVerifier.Object,
+        haipClient: _haipClient.Object,
+        jsonLogicEvaluator: new JsonLogicEvaluator());
+
+    private static Instance TestInstance() => new()
+    {
+        Id = "inst-1", BlueprintId = "bp-1", BlueprintVersion = 1, RegisterId = "reg-1",
+        TenantId = "t-1", State = InstanceState.Active, CurrentActionIds = [1],
+        ParticipantWallets = new Dictionary<string, string> { ["citizen"] = "wallet-citizen" },
+    };
+
+    // A single action that BOTH gates on presenting a credential AND issues one whose givenName is
+    // mapped from the verified presentation via the /presentedCredential/* prefix.
+    private static BlueprintModel GateAndIssueBlueprint() => new()
+    {
+        Id = "bp-1",
+        Title = "AIAS device binding (single-action test shape)",
+        Participants = [new ParticipantModel { Id = "citizen", Name = "Holder", WalletAddress = "wallet-citizen" }],
+        Actions =
+        [
+            new ActionModel
+            {
+                Id = 1, Title = "Bind identity to device", Sender = "citizen", IsStartingAction = true,
+                CredentialRequirements =
+                [
+                    new CredentialRequirement
+                    {
+                        Type = CredentialType,
+                        PresentationSource = PresentationSource.SorchaInternal,
+                        RequiredClaims = [new ClaimConstraint { ClaimName = "givenName" }],
+                    },
+                ],
+                CredentialIssuanceConfig = new CredentialIssuanceConfig
+                {
+                    CredentialType = "AssuredIdentityCredential",
+                    Vct = CredentialType,
+                    TargetAudience = TargetAudience.HaipExternalWallet,
+                    RecipientParticipantId = "citizen",
+                    ClaimMappings =
+                    [
+                        new ClaimMapping { ClaimName = "givenName", SourceField = "/presentedCredential/givenName" },
+                    ],
+                },
+                Routes = [new RouteModel { NextActionIds = [] }],
+            },
+        ],
+    };
+
+    private static ActionSubmissionRequest RequestWithPayloadSpoof() => new()
+    {
+        BlueprintId = "bp-1", ActionId = "1", SenderWallet = "wallet-citizen", RegisterAddress = "reg-1",
+        // A submitted presentation satisfies the internal verifier gate (the mock returns the verified claims).
+        CredentialPresentations =
+        [
+            new CredentialPresentation
+            {
+                CredentialId = "did:sorcha:credential:root",
+                RawPresentation = "eyJ.presentation.token",
+                DisclosedClaims = new Dictionary<string, object> { ["givenName"] = PresentedGivenName },
+            },
+        ],
+        // The client tries to override the identity claim two ways: a root givenName AND a spoofed
+        // presentedCredential object. Neither may win.
+        PayloadData = new Dictionary<string, object>
+        {
+            ["givenName"] = PayloadSpoofGivenName,
+            ["presentedCredential"] = new Dictionary<string, object> { ["givenName"] = PayloadSpoofGivenName },
+        },
+    };
+
+    private void SetupFlow(BlueprintModel blueprint)
+    {
+        var instance = TestInstance();
+        var action = blueprint.Actions!.First();
+
+        _instanceStore.Setup(x => x.GetAsync("inst-1", It.IsAny<CancellationToken>())).ReturnsAsync(instance);
+        _actionResolver.Setup(x => x.GetBlueprintAsync("bp-1", It.IsAny<CancellationToken>())).ReturnsAsync(blueprint);
+        _actionResolver.Setup(x => x.GetActionDefinition(blueprint, "1")).Returns(action);
+        _actionStore.Setup(s => s.GetByIdempotencyKeyAsync(It.IsAny<string>())).ReturnsAsync((string?)null);
+
+        // The verified presentation discloses givenName — this is the authoritative source.
+        _credentialVerifier.Setup(x => x.VerifyAsync(
+                It.IsAny<IEnumerable<CredentialRequirement>>(),
+                It.IsAny<IEnumerable<CredentialPresentation>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new CredentialValidationResult
+            {
+                IsValid = true,
+                VerifiedCredentials =
+                [
+                    new VerifiedCredentialDetail
+                    {
+                        CredentialId = "did:sorcha:credential:root",
+                        Type = CredentialType,
+                        IssuerDid = "did:sorcha:aias",
+                        SignatureValid = true,
+                        VerifiedClaims = new Dictionary<string, object> { ["givenName"] = PresentedGivenName },
+                    },
+                ],
+            });
+
+        _stateReconstruction.Setup(x => x.ReconstructAsync(
+                It.IsAny<BlueprintModel>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string>(),
+                It.IsAny<string>(), It.IsAny<Dictionary<string, string>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AccumulatedState());
+
+        _executionEngine.Setup(x => x.ValidateAsync(It.IsAny<Dictionary<string, object>>(), action, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Sorcha.Blueprint.Engine.Models.ValidationResult.Valid());
+        _executionEngine.Setup(x => x.ApplyCalculationsAsync(It.IsAny<Dictionary<string, object>>(), action, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<string, object>());
+        _executionEngine.Setup(x => x.DetermineRoutingWithMappingAsync(
+                blueprint, action, It.IsAny<Dictionary<string, object>>(), It.IsAny<JsonObject?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Sorcha.Blueprint.Engine.Models.RoutingResult.Complete());
+        _executionEngine.Setup(x => x.ApplyDisclosures(It.IsAny<Dictionary<string, object>>(), action))
+            .Returns(new List<Sorcha.Blueprint.Engine.Models.DisclosureResult>());
+
+        _registerClient.Setup(x => x.GetRegisterAsync("reg-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Sorcha.Register.Models.Register { Id = "reg-1", Name = "Dev", DevMode = true });
+        _registerClient.Setup(x => x.ResolvePublicKeysBatchAsync(It.IsAny<string>(), It.IsAny<BatchPublicKeyRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new BatchPublicKeyResponse { Resolved = new(), NotFound = [], Revoked = [] });
+
+        _walletClient.Setup(x => x.SignTransactionAsync(It.IsAny<string>(), It.IsAny<byte[]>(), It.IsAny<string?>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new WalletSignResult { Signature = new byte[64], PublicKey = new byte[32], SignedBy = "wallet-citizen", Algorithm = "ED25519" });
+        _validatorClient.Setup(x => x.SubmitTransactionAsync(It.IsAny<TransactionSubmission>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new TransactionSubmissionResult { Success = true, TransactionId = new string('a', 64) });
+        _registerClient.Setup(x => x.GetTransactionAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Sorcha.Register.Models.TransactionModel { TxId = new string('a', 64), DocketNumber = 1 });
+        _instanceStore.Setup(x => x.UpdateAsync(It.IsAny<Instance>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Instance i, CancellationToken _) => i);
+
+        _haipClient.Setup(x => x.CreateCredentialOfferAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Dictionary<string, object>>(),
+                It.IsAny<List<string>?>(), It.IsAny<CancellationToken>()))
+            .Callback<string, string, string, Dictionary<string, object>, List<string>?, CancellationToken>(
+                (_, _, _, claims, _, _) => _capturedOfferClaims = claims)
+            .ReturnsAsync(new CreateOfferResult(Guid.NewGuid(), "openid-credential-offer://x", "pac", DateTimeOffset.UtcNow.AddHours(1)));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ClaimMappingSourcesPresentedCredential_UsesVerifiedValueNotPayload()
+    {
+        var blueprint = GateAndIssueBlueprint();
+        SetupFlow(blueprint);
+
+        await CreateService().ExecuteAsync("inst-1", 1, RequestWithPayloadSpoof(), "delg-token");
+
+        _capturedOfferClaims.Should().NotBeNull(
+            "the HAIP issuance path must have built claims from the /presentedCredential/* source");
+        _capturedOfferClaims!.Should().ContainKey("givenName");
+        _capturedOfferClaims["givenName"].Should().Be(
+            PresentedGivenName,
+            "the issued givenName MUST come from the verified, issuer-signed presentation (design §4.1) — " +
+            "a client-supplied payload value can never override an identity claim sourced from the verified presentation");
+        _capturedOfferClaims["givenName"].Should().NotBe(
+            PayloadSpoofGivenName, "the payload spoof must not win");
+    }
+}

--- a/tests/Sorcha.Blueprint.Service.Tests/Services/ActionExecutionPresentedCredentialSourceTests.cs
+++ b/tests/Sorcha.Blueprint.Service.Tests/Services/ActionExecutionPresentedCredentialSourceTests.cs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Sorcha Contributors
 
+using System.Text.Json;
 using System.Text.Json.Nodes;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
@@ -220,5 +221,48 @@ public class ActionExecutionPresentedCredentialSourceTests
             "a client-supplied payload value can never override an identity claim sourced from the verified presentation");
         _capturedOfferClaims["givenName"].Should().NotBe(
             PayloadSpoofGivenName, "the payload spoof must not win");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_PresentedCredentialFromReconstructedPriorAction_FeedsIssuanceOverPayload()
+    {
+        // Async SorchaWallet path (two-action shape): the gated prior action's verified claims arrive
+        // at the issuance action via state reconstruction (StateReconstructionService surfaces the
+        // sealed PresentationOutcome's verifiedClaims under the reserved presentedCredential key).
+        // The issuance action has NO synchronous gate of its own — the reconstructed source must feed
+        // the claim mapping and beat a payload spoof.
+        var blueprint = GateAndIssueBlueprint();
+        // Remove the synchronous gate from the executing action — claims come from reconstruction only.
+        blueprint.Actions!.First().CredentialRequirements = null;
+        SetupFlow(blueprint);
+
+        // Reconstructed prior-action data carries the verified presentation under presentedCredential.
+        var priorActionData = JsonSerializer.Deserialize<JsonElement>(
+            $$"""{ "presentedCredential": { "givenName": "{{PresentedGivenName}}" } }""");
+        _stateReconstruction.Setup(x => x.ReconstructAsync(
+                It.IsAny<BlueprintModel>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string>(),
+                It.IsAny<string>(), It.IsAny<Dictionary<string, string>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AccumulatedState
+            {
+                ActionData = new Dictionary<string, JsonElement> { ["1"] = priorActionData }
+            });
+
+        var request = new ActionSubmissionRequest
+        {
+            BlueprintId = "bp-1", ActionId = "1", SenderWallet = "wallet-citizen", RegisterAddress = "reg-1",
+            PayloadData = new Dictionary<string, object>
+            {
+                ["presentedCredential"] = new Dictionary<string, object> { ["givenName"] = PayloadSpoofGivenName },
+            },
+        };
+
+        await CreateService().ExecuteAsync("inst-1", 1, request, "delg-token");
+
+        _capturedOfferClaims.Should().NotBeNull();
+        _capturedOfferClaims!.Should().ContainKey("givenName");
+        _capturedOfferClaims["givenName"]!.ToString().Should().Be(
+            PresentedGivenName,
+            "the reconstructed verified presentation (sealed outcome tx) must feed the issuance claim, " +
+            "and a payload spoof must never override it");
     }
 }

--- a/tests/Sorcha.Blueprint.Service.Tests/Services/SorchaWalletPresentationConsumerTests.cs
+++ b/tests/Sorcha.Blueprint.Service.Tests/Services/SorchaWalletPresentationConsumerTests.cs
@@ -202,6 +202,128 @@ public sealed class SorchaWalletPresentationConsumerTests
         outcome.VerifierDiagnostics!["error"].Should().Be("session-missing");
     }
 
+    // ── #1195 Phase 2 / Task 6b (C) — session reconstruction from pending context (T032) ──
+
+    /// <summary>A context carrying the session fields the lifecycle now persists on pending state.</summary>
+    private static PresentationInitiationContext ContextWithSession(
+        string? verifierClientId = null,
+        DateTimeOffset? expiresAt = null) => new(
+        PresentationRequestId: Guid.Parse("11111111-1111-1111-1111-111111111111"),
+        InstanceId: Guid.Parse("22222222-2222-2222-2222-222222222222"),
+        ActionId: 1,
+        RegisterId: "reg-test",
+        BlueprintId: "bp-test",
+        SubmitterWallet: "ws11qqtest",
+        RequirementsDigest: new byte[32],
+        InitiatedAt: DateTimeOffset.UtcNow.AddMinutes(-1),
+        VerifierClientId: verifierClientId,
+        CredentialType: "https://sorcha.dev/vc/assured-identity/v1",
+        RequiredClaimNames: ["givenName", "familyName"],
+        PublicBaseUrl: "https://gateway.example",
+        Nonce: "ctx-nonce-1",
+        ExpiresAt: expiresAt ?? DateTimeOffset.UtcNow.AddMinutes(5));
+
+    [Fact]
+    public async Task VerifyAsync_NoPayloadSession_ReconstructsSessionFromContext()
+    {
+        // The wallet posts only {vpToken} — the session the validator needs is rebuilt
+        // from the pending-presentation context (nonce, vct, required claims, client id).
+        VerifierSession? seen = null;
+        _validator
+            .Setup(v => v.ValidateAsync(It.IsAny<VerifierSession>(), "vp-token", null, It.IsAny<CancellationToken>()))
+            .Callback((VerifierSession s, string _, string? _, CancellationToken _) => seen = s)
+            .ReturnsAsync(new VerificationOutcome
+            {
+                Accepted = true,
+                DisclosedClaims = new Dictionary<string, object?>
+                {
+                    ["givenName"] = "Sarah",
+                    ["familyName"] = "Example"
+                },
+                Errors = [],
+                CompletedAt = DateTimeOffset.UtcNow
+            });
+
+        var outcome = await _sut.VerifyAsync(
+            ContextWithSession(verifierClientId: "did:sorcha:org:aias"),
+            new SorchaWalletVerificationPayload { VpToken = "vp-token", Session = null },
+            CancellationToken.None);
+
+        outcome.Kind.Should().Be(PresentationOutcomeKind.Success);
+        seen.Should().NotBeNull("the consumer must rebuild the VerifierSession from the context");
+        seen!.Nonce.Should().Be("ctx-nonce-1", "the KB-JWT nonce check binds to the initiation nonce");
+        seen.RequiredVct.Should().Be("https://sorcha.dev/vc/assured-identity/v1");
+        seen.RequiredClaims.Should().BeEquivalentTo(["givenName", "familyName"]);
+        seen.ClientId.Should().Be("did:sorcha:org:aias",
+            "the KB-JWT aud check must bind to the SAME client_id the request object carried");
+    }
+
+    [Fact]
+    public async Task VerifyAsync_ReconstructedSession_ClientIdFallback_MatchesTheRequestObjectPlaceholder()
+    {
+        // BuildInitiationAsync serves client_id 'did:sorcha:org:UNKNOWN' when no verifier DID
+        // resolves; the reconstructed session must use the SAME fallback or the wallet's
+        // aud-bound KB-JWT can never verify.
+        VerifierSession? seen = null;
+        _validator
+            .Setup(v => v.ValidateAsync(It.IsAny<VerifierSession>(), It.IsAny<string>(), null, It.IsAny<CancellationToken>()))
+            .Callback((VerifierSession s, string _, string? _, CancellationToken _) => seen = s)
+            .ReturnsAsync(new VerificationOutcome
+            {
+                Accepted = true,
+                DisclosedClaims = new Dictionary<string, object?>
+                {
+                    ["givenName"] = "S",
+                    ["familyName"] = "E"
+                },
+                Errors = [],
+                CompletedAt = DateTimeOffset.UtcNow
+            });
+
+        await _sut.VerifyAsync(
+            ContextWithSession(verifierClientId: null),
+            new SorchaWalletVerificationPayload { VpToken = "vp", Session = null },
+            CancellationToken.None);
+
+        var descriptor = await _sut.BuildInitiationAsync(
+            ContextWithSession(verifierClientId: null), CancellationToken.None);
+        var servedClientId = System.Web.HttpUtility.ParseQueryString(
+            new Uri(descriptor.AuthorizationRequestUri.Replace("openid4vp://authorize", "https://x/a")).Query)["client_id"];
+
+        seen!.ClientId.Should().Be(servedClientId,
+            "session ClientId and request-object client_id must come from the same resolution rule");
+    }
+
+    [Fact]
+    public async Task VerifyAsync_ContextSessionExpired_DeclinesNamed_AndNeverValidates()
+    {
+        var outcome = await _sut.VerifyAsync(
+            ContextWithSession(expiresAt: DateTimeOffset.UtcNow.AddMinutes(-2)),
+            new SorchaWalletVerificationPayload { VpToken = "vp", Session = null },
+            CancellationToken.None);
+
+        outcome.Kind.Should().Be(PresentationOutcomeKind.Decline);
+        outcome.VerifierDiagnostics.Should().NotBeNull();
+        outcome.VerifierDiagnostics!["error"].Should().Be("session-expired",
+            "an expired session must be distinguishable from an unknown one");
+        _validator.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task VerifyAsync_ContextWithoutNonce_StaysSessionMissing()
+    {
+        // A context that predates the session wiring (no nonce persisted) cannot form a
+        // verifiable session — the named session-missing decline is preserved.
+        var outcome = await _sut.VerifyAsync(
+            NewContext(),
+            new SorchaWalletVerificationPayload { VpToken = "vp", Session = null },
+            CancellationToken.None);
+
+        outcome.Kind.Should().Be(PresentationOutcomeKind.Decline);
+        outcome.VerifierDiagnostics!["error"].Should().Be("session-missing");
+        _validator.VerifyNoOtherCalls();
+    }
+
     [Fact]
     public async Task VerifyAsync_ReturnsVerifierError_WhenPayloadTypeIsUnexpected()
     {

--- a/tests/Sorcha.Blueprint.Service.Tests/Services/SorchaWalletPresentationConsumerTests.cs
+++ b/tests/Sorcha.Blueprint.Service.Tests/Services/SorchaWalletPresentationConsumerTests.cs
@@ -110,11 +110,14 @@ public sealed class SorchaWalletPresentationConsumerTests
     }
 
     [Fact]
-    public async Task VerifyAsync_FiltersClaimsToRequiredSet_MinimalDisclosure()
+    public async Task VerifyAsync_EmitsAllVerifiedDisclosedClaims_RequiredClaimsActOnlyAsGate()
     {
-        // Validator returns more claims than asked for; the consumer must
-        // filter to the strict required set per the IPresentationConsumer
-        // contract's minimal-disclosure invariant.
+        // Task 6 fix round — full-disclosure pass-through (design §4.1): requiredClaims GATE
+        // the presentation (must all be present), but VerifiedClaims carries EVERY claim the
+        // validator verified from the citizen's consented disclosure. Minimal disclosure is
+        // enforced at the wallet's consent sheet (what enters the vp_token) and by the
+        // validator's digest anchoring (only issuer-committed disclosures verify) — not by a
+        // server-side truncation that would mint device copies with holes.
         var session = NewSession("givenName");
         _validator
             .Setup(v => v.ValidateAsync(session, It.IsAny<string>(), null, It.IsAny<CancellationToken>()))
@@ -124,8 +127,9 @@ public sealed class SorchaWalletPresentationConsumerTests
                 DisclosedClaims = new Dictionary<string, object?>
                 {
                     ["givenName"] = "Sarah",
-                    ["familyName"] = "Example",  // not in required — must be filtered out
-                    ["secretClaim"] = "private"  // not in required — must be filtered out
+                    ["familyName"] = "Example",
+                    ["email"] = "sarah@example.org",
+                    ["portrait"] = "base64…"
                 },
                 Errors = [],
                 CompletedAt = DateTimeOffset.UtcNow
@@ -136,7 +140,44 @@ public sealed class SorchaWalletPresentationConsumerTests
             CancellationToken.None);
 
         outcome.Kind.Should().Be(PresentationOutcomeKind.Success);
-        outcome.VerifiedClaims!.Keys.Should().BeEquivalentTo(new[] { "givenName" });
+        outcome.VerifiedClaims!.Keys.Should().BeEquivalentTo(
+            new[] { "givenName", "familyName", "email", "portrait" },
+            "every verified disclosed claim passes through — the copy mirrors the root");
+    }
+
+    [Fact]
+    public async Task VerifyAsync_RootWithoutOptionalClaim_PassesGate_AndCopiesOnlyWhatTheRootCarries()
+    {
+        // A citizen with no middle name: the root never carried the claim, the gate requires
+        // only the core, and the emitted set gracefully omits it — no failure, no hole.
+        var session = NewSession("givenName", "familyName", "dateOfBirth");
+        _validator
+            .Setup(v => v.ValidateAsync(session, It.IsAny<string>(), null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new VerificationOutcome
+            {
+                Accepted = true,
+                DisclosedClaims = new Dictionary<string, object?>
+                {
+                    ["givenName"] = "Sarah",
+                    ["familyName"] = "Example",
+                    ["dateOfBirth"] = "1968-04-12",
+                    ["email"] = "sarah@example.org",
+                    ["address"] = "12 Brae Road"
+                    // no middleName, no fullName, no portrait — the root never carried them
+                },
+                Errors = [],
+                CompletedAt = DateTimeOffset.UtcNow
+            });
+
+        var outcome = await _sut.VerifyAsync(NewContext(),
+            new SorchaWalletVerificationPayload { VpToken = "vp", Session = session },
+            CancellationToken.None);
+
+        outcome.Kind.Should().Be(PresentationOutcomeKind.Success,
+            "an absent OPTIONAL claim must never fail the bind");
+        outcome.VerifiedClaims!.Keys.Should().BeEquivalentTo(
+            new[] { "givenName", "familyName", "dateOfBirth", "email", "address" });
+        outcome.VerifiedClaims!.Should().NotContainKey("middleName");
     }
 
     [Fact]

--- a/tests/Sorcha.Blueprint.Service.Tests/Services/SorchaWalletServerCustodyE2ETests.cs
+++ b/tests/Sorcha.Blueprint.Service.Tests/Services/SorchaWalletServerCustodyE2ETests.cs
@@ -1,0 +1,191 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Buffers.Text;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Sorcha.Blueprint.Service.Services.Implementation;
+using Sorcha.PresentationLifecycle.Abstractions;
+using Sorcha.Verifier.Engine;
+using Sorcha.Verifier.Engine.Models;
+using Xunit;
+
+namespace Sorcha.Blueprint.Service.Tests.Services;
+
+/// <summary>
+/// #1195 Phase 2 (final review C-1) — the end-to-end proof the prior tests mocked past. Drives the
+/// REAL <see cref="SorchaWalletPresentationConsumer"/> over the REAL
+/// <see cref="VerifiablePresentationValidator"/> (no mock at that boundary) with a delegation-free,
+/// SERVER-CUSTODY presentation: a holder-<c>cnf</c> credential whose KB-JWT is signed directly by the
+/// credential's own holder key, exactly as the Task-6 "bind to device" flow posts it. This is the
+/// bind-gate path that must pass for device-bound re-issuance to work.
+/// </summary>
+public sealed class SorchaWalletServerCustodyE2ETests
+{
+    private const string Vct = "https://sorcha.dev/vc/assured-identity/v1";
+    private const string ClientId = "did:sorcha:org:aias";
+    private const string Nonce = "server-custody-nonce-1";
+
+    /// <summary>The REAL validator — offline v1 posture (opt-out issuer resolver, no require-issuer).</summary>
+    private static VerifiablePresentationValidator RealValidator()
+    {
+        var statusList = new Mock<IStatusListCache>();
+        statusList
+            .Setup(s => s.CheckAsync(
+                It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(StatusListVerdict.Active);
+
+        return new VerifiablePresentationValidator(
+            statusList.Object,
+            new OptOutIssuerKeyResolver(),
+            TimeProvider.System,
+            NullLogger<VerifiablePresentationValidator>.Instance,
+            requireIssuerSignature: false);
+    }
+
+    private static VerifierSession Session() => new()
+    {
+        SessionId = "sess-server-custody",
+        ClientId = ClientId,
+        Nonce = Nonce,
+        RequiredVct = Vct,
+        RequiredClaims = ["givenName"],
+        Purpose = "credential-gate",
+        CreatedAt = DateTimeOffset.UtcNow,
+        ExpiresAt = DateTimeOffset.UtcNow.AddMinutes(5),
+    };
+
+    private static PresentationInitiationContext Context() => new(
+        PresentationRequestId: Guid.Parse("33333333-3333-3333-3333-333333333333"),
+        InstanceId: Guid.Parse("44444444-4444-4444-4444-444444444444"),
+        ActionId: 1,
+        RegisterId: "reg-test",
+        BlueprintId: "bp-test",
+        SubmitterWallet: "ws11qqtest",
+        RequirementsDigest: new byte[32],
+        InitiatedAt: DateTimeOffset.UtcNow,
+        VerifierClientId: ClientId,
+        CredentialType: Vct,
+        RequiredClaimNames: ["givenName"],
+        PublicBaseUrl: "https://gateway.example");
+
+    [Fact]
+    public async Task VerifyAsync_ServerCustody_HolderSignedNoDelegation_Succeeds_AndEmitsClaims()
+    {
+        // Holder-signed, delegation-free vp_token through the real validator → Success + claims.
+        // Success here IS the "HolderKeyVerified == true" signal at the consumer boundary (the
+        // consumer's PresentationOutcome exposes no separate layer field).
+        var vpToken = MintServerCustodyVp(kbSignedByHolder: true);
+        var consumer = new SorchaWalletPresentationConsumer(
+            RealValidator(), NullLogger<SorchaWalletPresentationConsumer>.Instance);
+
+        var outcome = await consumer.VerifyAsync(
+            Context(),
+            new SorchaWalletVerificationPayload { VpToken = vpToken, DelegationCredential = null, Session = Session() },
+            CancellationToken.None);
+
+        outcome.Kind.Should().Be(PresentationOutcomeKind.Success);
+        outcome.VerifiedClaims.Should().NotBeNull();
+        outcome.VerifiedClaims!.Should().ContainKey("givenName");
+        outcome.PresentationSubmissionHash.Should().StartWith("sha256:");
+    }
+
+    [Fact]
+    public async Task VerifyAsync_ServerCustody_DeviceSignedNoDelegation_Declines_WithNoClaims()
+    {
+        // The wrong-key negative on the real path: cnf is the holder key, the KB-JWT is signed by a
+        // DIFFERENT device key, no delegation. The real validator raises the named key-binding
+        // mismatch → the consumer maps it to SignatureInvalid and emits zero claims.
+        var vpToken = MintServerCustodyVp(kbSignedByHolder: false);
+        var consumer = new SorchaWalletPresentationConsumer(
+            RealValidator(), NullLogger<SorchaWalletPresentationConsumer>.Instance);
+
+        var outcome = await consumer.VerifyAsync(
+            Context(),
+            new SorchaWalletVerificationPayload { VpToken = vpToken, DelegationCredential = null, Session = Session() },
+            CancellationToken.None);
+
+        outcome.Kind.Should().Be(PresentationOutcomeKind.Decline);
+        outcome.Reason.Should().Be(PresentationDeclineReason.SignatureInvalid);
+        outcome.VerifiedClaims.Should().BeNull();
+    }
+
+    // ─────────────────────────── self-contained SD-JWT minter ───────────────────────────────────
+    //   Mirrors the on-the-wire shape a server-custody wallet produces: SD-JWT VC (issuer-signed,
+    //   cnf = holder P-256 key) + a KB-JWT signed by the holder key itself (no delegation). This test
+    //   project cannot see Verifier.Tests' TestVpFactory, so it mints locally with the BCL only.
+
+    private static string MintServerCustodyVp(bool kbSignedByHolder)
+    {
+        using var issuer = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        using var holder = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+
+        var (disclosure, hash) = MintDisclosure("givenName", "Sarah");
+
+        var credentialPayload = new Dictionary<string, object>
+        {
+            ["iss"] = "did:sorcha:org:test",
+            ["iat"] = DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
+            ["vct"] = Vct,
+            ["_sd"] = new[] { hash },
+            ["_sd_alg"] = "sha-256",
+            ["cnf"] = new Dictionary<string, object> { ["jwk"] = Jwk(holder) },
+        };
+        var credentialJwt = SignEs256(
+            new Dictionary<string, object> { ["alg"] = "ES256", ["typ"] = "dc+sd-jwt" },
+            credentialPayload, issuer);
+
+        var kbPayload = new Dictionary<string, object>
+        {
+            ["iat"] = DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
+            ["exp"] = DateTimeOffset.UtcNow.AddSeconds(120).ToUnixTimeSeconds(),
+            ["aud"] = ClientId,
+            ["nonce"] = Nonce,
+            ["sd_hash"] = "placeholder",
+        };
+        using var wrongDevice = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        var kbSigner = kbSignedByHolder ? holder : wrongDevice;
+        var kbJwt = SignEs256(
+            new Dictionary<string, object> { ["alg"] = "ES256", ["typ"] = "kb+jwt" },
+            kbPayload, kbSigner);
+
+        return $"{credentialJwt}~{disclosure}~{kbJwt}";
+    }
+
+    private static (string Segment, string Hash) MintDisclosure(string name, string value)
+    {
+        Span<byte> salt = stackalloc byte[16];
+        RandomNumberGenerator.Fill(salt);
+        var segment = Base64Url.EncodeToString(JsonSerializer.SerializeToUtf8Bytes(
+            new object[] { Base64Url.EncodeToString(salt), name, value }));
+        var hash = Base64Url.EncodeToString(SHA256.HashData(Encoding.ASCII.GetBytes(segment)));
+        return (segment, hash);
+    }
+
+    private static JsonElement Jwk(ECDsa ecdsa)
+    {
+        var p = ecdsa.ExportParameters(false);
+        var json = JsonSerializer.Serialize(new
+        {
+            kty = "EC",
+            crv = "P-256",
+            x = Base64Url.EncodeToString(p.Q.X!),
+            y = Base64Url.EncodeToString(p.Q.Y!),
+        });
+        return JsonDocument.Parse(json).RootElement.Clone();
+    }
+
+    private static string SignEs256(Dictionary<string, object> header, Dictionary<string, object> payload, ECDsa signer)
+    {
+        var headerSeg = Base64Url.EncodeToString(JsonSerializer.SerializeToUtf8Bytes(header));
+        var payloadSeg = Base64Url.EncodeToString(JsonSerializer.SerializeToUtf8Bytes(payload));
+        var signingInput = Encoding.ASCII.GetBytes($"{headerSeg}.{payloadSeg}");
+        var sig = signer.SignData(signingInput, HashAlgorithmName.SHA256);
+        return $"{headerSeg}.{payloadSeg}.{Base64Url.EncodeToString(sig)}";
+    }
+}

--- a/tests/Sorcha.Blueprint.Service.Tests/Services/StateReconstructionPresentedCredentialTests.cs
+++ b/tests/Sorcha.Blueprint.Service.Tests/Services/StateReconstructionPresentedCredentialTests.cs
@@ -84,7 +84,8 @@ public class StateReconstructionPresentedCredentialTests
         DateTime timeStamp,
         string kind = "success",
         object? verifiedClaims = null,
-        bool omitVerifiedClaims = false)
+        bool omitVerifiedClaims = false,
+        object? actionPayload = null)
     {
         // Shape mirrors ITransactionBuilderService.BuildPresentationOutcomeAsync's plaintext
         // transactionPayload, as sealed by the validator (Payloads[0].Data = base64url(JSON)).
@@ -103,6 +104,10 @@ public class StateReconstructionPresentedCredentialTests
         if (!omitVerifiedClaims)
         {
             payload["verifiedClaims"] = verifiedClaims ?? new Dictionary<string, object> { ["givenName"] = VerifiedGivenName };
+        }
+        if (actionPayload is not null)
+        {
+            payload["actionPayload"] = actionPayload;
         }
 
         return new TransactionModel
@@ -251,6 +256,77 @@ public class StateReconstructionPresentedCredentialTests
         result.ActionData["1"].GetProperty("presentedCredential").GetProperty("givenName").GetString()
             .Should().Be(VerifiedGivenName,
                 "the payload-smuggled presentedCredential must be stripped and the sealed verified outcome must win");
+    }
+
+    [Fact]
+    public async Task ReconstructAsync_SuccessOutcomeWithActionPayload_ContributesGatedActionPayload()
+    {
+        // Async SorchaWallet path — the gated action's submitted payload (e.g. the deviceKey the
+        // AIAS issuance action's holderKeySourceField "/deviceKey/holderJwk" resolves) is sealed
+        // ONLY inside the outcome tx's actionPayload (no regular Action tx is ever written for a
+        // presentation-gated action). Reconstruction must surface it as the gated action's data.
+        SetupRegister(
+        [
+            OutcomeTx("tx-out-1", DateTime.UtcNow.AddMinutes(-5),
+                actionPayload: new { deviceKey = new { holderJwk = "the-device-jwk" } })
+        ]);
+
+        var result = await ReconstructForIssuanceActionAsync();
+
+        result.ActionData.Should().ContainKey("1");
+        result.ActionData["1"].GetProperty("deviceKey").GetProperty("holderJwk").GetString()
+            .Should().Be("the-device-jwk",
+                "the outcome tx's actionPayload is the only durable record of the gated action's submitted payload");
+        result.ActionData["1"].GetProperty("presentedCredential").GetProperty("givenName").GetString()
+            .Should().Be(VerifiedGivenName, "verified claims still surface alongside the action payload");
+    }
+
+    [Fact]
+    public async Task ReconstructAsync_OutcomeActionPayloadSmugglesPresentedCredential_ReservedKeyStaysVerified()
+    {
+        // The actionPayload is the CITIZEN's draft submission — client-supplied. A presentedCredential
+        // field smuggled inside it must be stripped; the reserved key carries verifiedClaims only.
+        SetupRegister(
+        [
+            OutcomeTx("tx-out-1", DateTime.UtcNow.AddMinutes(-5),
+                actionPayload: new
+                {
+                    deviceKey = new { holderJwk = "the-device-jwk" },
+                    presentedCredential = new { givenName = SpoofGivenName }
+                })
+        ]);
+
+        var result = await ReconstructForIssuanceActionAsync();
+
+        result.ActionData["1"].GetProperty("deviceKey").GetProperty("holderJwk").GetString()
+            .Should().Be("the-device-jwk");
+        result.ActionData["1"].GetProperty("presentedCredential").GetProperty("givenName").GetString()
+            .Should().Be(VerifiedGivenName,
+                "a presentedCredential smuggled inside the client-supplied actionPayload must never win over verifiedClaims");
+    }
+
+    [Fact]
+    public async Task ReconstructAsync_OrdinaryActionTxPresent_ActionTxWinsOverOutcomeActionPayload()
+    {
+        // When a regular Action tx exists for the same action, it stays authoritative for action
+        // data — the outcome's actionPayload contribution is a fallback only, so no existing flow
+        // changes. The verified presentedCredential still folds on top.
+        SetupRegister(
+        [
+            DevModeActionTx("tx-act-1", DateTime.UtcNow.AddMinutes(-10), new
+            {
+                deviceKey = new { holderJwk = "from-action-tx" }
+            }),
+            OutcomeTx("tx-out-1", DateTime.UtcNow.AddMinutes(-5),
+                actionPayload: new { deviceKey = new { holderJwk = "from-outcome" } })
+        ], devMode: true);
+
+        var result = await ReconstructForIssuanceActionAsync();
+
+        result.ActionData["1"].GetProperty("deviceKey").GetProperty("holderJwk").GetString()
+            .Should().Be("from-action-tx", "an ordinary Action tx wins for action data; the outcome contribution is the fallback");
+        result.ActionData["1"].GetProperty("presentedCredential").GetProperty("givenName").GetString()
+            .Should().Be(VerifiedGivenName);
     }
 
     [Fact]

--- a/tests/Sorcha.Blueprint.Service.Tests/Services/StateReconstructionPresentedCredentialTests.cs
+++ b/tests/Sorcha.Blueprint.Service.Tests/Services/StateReconstructionPresentedCredentialTests.cs
@@ -1,0 +1,274 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using Microsoft.Extensions.Logging;
+using Sorcha.ServiceClients.Wallet;
+using Sorcha.ServiceClients.Register;
+using Sorcha.Blueprint.Service.Services.Implementation;
+using Sorcha.Register.Models;
+using System.Text.Json;
+using BlueprintModel = Sorcha.Blueprint.Models.Blueprint;
+using ActionModel = Sorcha.Blueprint.Models.Action;
+using ParticipantModel = Sorcha.Blueprint.Models.Participant;
+using RouteModel = Sorcha.Blueprint.Models.Route;
+
+namespace Sorcha.Blueprint.Service.Tests.Services;
+
+/// <summary>
+/// Feature 174 / #1195 Phase 2 ("one assurance, two bindings") — async SorchaWallet path. A sealed
+/// <c>PresentationOutcome</c> lifecycle transaction with kind=success for a required prior action
+/// contributes its <c>verifiedClaims</c> into that action's reconstructed data under the reserved
+/// <c>presentedCredential</c> key, so a later issuance action's claim mappings can resolve
+/// <c>/presentedCredential/*</c> from the verified, sealed presentation. Guards: only kind=success
+/// contributes; malformed/missing verifiedClaims contribute nothing (fail closed); when multiple
+/// success outcomes exist the latest sealed wins; and the reserved key is STRIPPED from regular
+/// action-tx payloads so a client can never smuggle a spoofed <c>presentedCredential</c> through a
+/// prior action's submitted data.
+/// </summary>
+public class StateReconstructionPresentedCredentialTests
+{
+    private const string VerifiedGivenName = "Alice-from-sealed-outcome";
+    private const string SpoofGivenName = "Attacker-via-prior-action-payload";
+
+    private readonly Mock<IRegisterServiceClient> _mockRegisterClient = new();
+    private readonly Mock<IWalletServiceClient> _mockWalletClient = new();
+    private readonly Mock<Sorcha.Cryptography.Interfaces.ISymmetricCrypto> _mockSymmetricCrypto = new();
+    private readonly StateReconstructionService _service;
+
+    private const string InstanceId = "test-instance";
+    private const string RegisterId = "test-register";
+    private const string DelegationToken = "test-delegation-token";
+
+    private static readonly Dictionary<string, string> ParticipantWallets = new()
+    {
+        ["citizen"] = "wallet-citizen",
+        ["issuer"] = "wallet-issuer"
+    };
+
+    public StateReconstructionPresentedCredentialTests()
+    {
+        _service = new StateReconstructionService(
+            _mockRegisterClient.Object,
+            _mockWalletClient.Object,
+            _mockSymmetricCrypto.Object,
+            new Mock<ILogger<StateReconstructionService>>().Object);
+    }
+
+    /// <summary>Two-action blueprint mirroring the AIAS device-binding shape: gated action 1 → issuance action 2.</summary>
+    private static BlueprintModel GatedThenIssueBlueprint() => new()
+    {
+        Id = "bp-device",
+        Title = "Gate then issue",
+        Participants =
+        [
+            new ParticipantModel { Id = "citizen", Name = "Citizen", WalletAddress = "wallet-citizen" },
+            new ParticipantModel { Id = "issuer", Name = "Issuer", WalletAddress = "wallet-issuer" }
+        ],
+        Actions =
+        [
+            new ActionModel
+            {
+                Id = 1, Title = "Present credential", Sender = "citizen",
+                Routes = [new RouteModel { NextActionIds = [2] }]
+            },
+            new ActionModel
+            {
+                Id = 2, Title = "Issue device-bound copy", Sender = "issuer",
+                RequiredPriorActions = [1]
+            }
+        ]
+    };
+
+    private static TransactionModel OutcomeTx(
+        string txId,
+        DateTime timeStamp,
+        string kind = "success",
+        object? verifiedClaims = null,
+        bool omitVerifiedClaims = false)
+    {
+        // Shape mirrors ITransactionBuilderService.BuildPresentationOutcomeAsync's plaintext
+        // transactionPayload, as sealed by the validator (Payloads[0].Data = base64url(JSON)).
+        var payload = new Dictionary<string, object?>
+        {
+            ["type"] = "presentation-outcome",
+            ["kind"] = kind,
+            ["blueprintId"] = "bp-device",
+            ["actionId"] = 1,
+            ["instanceId"] = InstanceId,
+            ["presentationRequestId"] = Guid.NewGuid(),
+            ["consumerName"] = "SorchaWallet",
+            ["submitterWallet"] = "wallet-citizen",
+            ["timestamp"] = DateTimeOffset.UtcNow
+        };
+        if (!omitVerifiedClaims)
+        {
+            payload["verifiedClaims"] = verifiedClaims ?? new Dictionary<string, object> { ["givenName"] = VerifiedGivenName };
+        }
+
+        return new TransactionModel
+        {
+            TxId = txId,
+            RegisterId = RegisterId,
+            TimeStamp = timeStamp,
+            MetaData = new TransactionMetaData
+            {
+                ActionId = 1,
+                TransactionType = Sorcha.Register.Models.Enums.TransactionType.PresentationOutcome,
+                TrackingData = new Dictionary<string, string> { ["outcomeKind"] = kind }
+            },
+            Payloads =
+            [
+                new PayloadModel
+                {
+                    Data = Convert.ToBase64String(JsonSerializer.SerializeToUtf8Bytes(payload)),
+                    WalletAccess = Array.Empty<string>()
+                }
+            ]
+        };
+    }
+
+    /// <summary>A regular DevMode-plaintext Action tx for action 1 carrying the given fields.</summary>
+    private static TransactionModel DevModeActionTx(string txId, DateTime timeStamp, object fields)
+    {
+        var envelope = new
+        {
+            type = "action",
+            blueprintId = "bp-device",
+            actionId = 1,
+            instanceId = InstanceId,
+            payloads = new Dictionary<string, object> { ["wallet-citizen"] = fields }
+        };
+        return new TransactionModel
+        {
+            TxId = txId,
+            RegisterId = RegisterId,
+            TimeStamp = timeStamp,
+            MetaData = new TransactionMetaData
+            {
+                ActionId = 1,
+                TransactionType = Sorcha.Register.Models.Enums.TransactionType.Action
+            },
+            Payloads =
+            [
+                new PayloadModel
+                {
+                    Data = Convert.ToBase64String(JsonSerializer.SerializeToUtf8Bytes(envelope)),
+                    WalletAccess = Array.Empty<string>()
+                }
+            ]
+        };
+    }
+
+    private void SetupRegister(List<TransactionModel> transactions, bool devMode = false)
+    {
+        _mockRegisterClient
+            .Setup(x => x.GetTransactionsByInstanceIdAsync(RegisterId, InstanceId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(transactions);
+        _mockRegisterClient
+            .Setup(x => x.GetRegisterAsync(RegisterId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Sorcha.Register.Models.Register { Id = RegisterId, Name = "Test", DevMode = devMode });
+    }
+
+    private Task<Sorcha.Blueprint.Service.Models.AccumulatedState> ReconstructForIssuanceActionAsync() =>
+        _service.ReconstructAsync(
+            GatedThenIssueBlueprint(), InstanceId, currentActionId: 2, RegisterId,
+            DelegationToken, ParticipantWallets);
+
+    [Fact]
+    public async Task ReconstructAsync_SuccessOutcomeForPriorAction_SurfacesVerifiedClaimsUnderPresentedCredential()
+    {
+        SetupRegister([OutcomeTx("tx-out-1", DateTime.UtcNow.AddMinutes(-5))]);
+
+        var result = await ReconstructForIssuanceActionAsync();
+
+        result.ActionData.Should().ContainKey("1",
+            "the sealed success outcome for gated action 1 must contribute reconstructed data");
+        result.ActionData["1"].GetProperty("presentedCredential").GetProperty("givenName").GetString()
+            .Should().Be(VerifiedGivenName,
+                "the verified presentation's disclosed claims must surface under the reserved presentedCredential key");
+    }
+
+    [Fact]
+    public async Task ReconstructAsync_DeclineOutcome_ContributesNothing()
+    {
+        SetupRegister([OutcomeTx("tx-out-1", DateTime.UtcNow.AddMinutes(-5), kind: "decline")]);
+
+        var result = await ReconstructForIssuanceActionAsync();
+
+        result.ActionData.Should().NotContainKey("1", "only kind=success outcomes contribute verified claims");
+    }
+
+    [Fact]
+    public async Task ReconstructAsync_SuccessOutcomeWithMissingVerifiedClaims_ContributesNothing()
+    {
+        SetupRegister([OutcomeTx("tx-out-1", DateTime.UtcNow.AddMinutes(-5), omitVerifiedClaims: true)]);
+
+        var result = await ReconstructForIssuanceActionAsync();
+
+        result.ActionData.Should().NotContainKey("1",
+            "a success outcome with missing/malformed verifiedClaims must contribute nothing (fail closed)");
+    }
+
+    [Fact]
+    public async Task ReconstructAsync_MultipleSuccessOutcomes_LatestSealedWins()
+    {
+        SetupRegister(
+        [
+            OutcomeTx("tx-out-1", DateTime.UtcNow.AddMinutes(-10),
+                verifiedClaims: new Dictionary<string, object> { ["givenName"] = "Stale-earlier-outcome" }),
+            OutcomeTx("tx-out-2", DateTime.UtcNow.AddMinutes(-5),
+                verifiedClaims: new Dictionary<string, object> { ["givenName"] = VerifiedGivenName })
+        ]);
+
+        var result = await ReconstructForIssuanceActionAsync();
+
+        result.ActionData["1"].GetProperty("presentedCredential").GetProperty("givenName").GetString()
+            .Should().Be(VerifiedGivenName, "when multiple success outcomes exist the latest sealed wins");
+    }
+
+    [Fact]
+    public async Task ReconstructAsync_ActionPayloadPresentedCredential_IsStrippedAndVerifiedOutcomeWins()
+    {
+        // SECURITY — a client that smuggles a `presentedCredential` field into a PRIOR action's
+        // submitted payload must not have it surface as the trusted verified source at issuance.
+        // The reserved key is stripped from regular action-tx data; only the sealed success
+        // outcome may populate it.
+        SetupRegister(
+        [
+            DevModeActionTx("tx-act-1", DateTime.UtcNow.AddMinutes(-10), new
+            {
+                deviceKey = new { holderJwk = "the-device-jwk" },
+                presentedCredential = new { givenName = SpoofGivenName }
+            }),
+            OutcomeTx("tx-out-1", DateTime.UtcNow.AddMinutes(-5))
+        ], devMode: true);
+
+        var result = await ReconstructForIssuanceActionAsync();
+
+        result.ActionData.Should().ContainKey("1");
+        result.ActionData["1"].GetProperty("deviceKey").GetProperty("holderJwk").GetString()
+            .Should().Be("the-device-jwk", "legitimate action-payload fields are preserved");
+        result.ActionData["1"].GetProperty("presentedCredential").GetProperty("givenName").GetString()
+            .Should().Be(VerifiedGivenName,
+                "the payload-smuggled presentedCredential must be stripped and the sealed verified outcome must win");
+    }
+
+    [Fact]
+    public async Task ReconstructAsync_ActionPayloadPresentedCredential_NoOutcome_IsStripped()
+    {
+        SetupRegister(
+        [
+            DevModeActionTx("tx-act-1", DateTime.UtcNow.AddMinutes(-10), new
+            {
+                deviceKey = new { holderJwk = "the-device-jwk" },
+                presentedCredential = new { givenName = SpoofGivenName }
+            })
+        ], devMode: true);
+
+        var result = await ReconstructForIssuanceActionAsync();
+
+        result.ActionData.Should().ContainKey("1");
+        result.ActionData["1"].TryGetProperty("presentedCredential", out _).Should().BeFalse(
+            "with no verified outcome, a payload-smuggled presentedCredential is stripped and never surfaces (fail closed)");
+    }
+}

--- a/tests/Sorcha.Haip.Service.Tests/DeviceCnfPresentationFactory.cs
+++ b/tests/Sorcha.Haip.Service.Tests/DeviceCnfPresentationFactory.cs
@@ -92,4 +92,120 @@ internal static class DeviceCnfPresentationFactory
 
         return (presentation.RawPresentation, rootCertDer);
     }
+
+    // --- #1195 Phase 2: the REAL AIAS credential shape + holder/device binding parity ------------
+
+    /// <summary>
+    /// The Assured Identity credential type URI (<c>VctUris.AssuredIdentityV1</c>, case-sensitive).
+    /// Carried as a plaintext <c>vct</c> claim, exactly as the live issuance path emits it.
+    /// </summary>
+    internal const string AiasVct = "https://sorcha.dev/vc/assured-identity/v1";
+
+    /// <summary>The disclosed AIAS assured claim set — givenName / familyName / dateOfBirth.</summary>
+    internal static readonly string[] AiasDisclosedClaims = ["givenName", "familyName", "dateOfBirth"];
+
+    /// <summary>
+    /// Which of the two independent P-256 keys plays a role in a presentation. The two keys are
+    /// cryptographically indistinguishable to the verifier — the names document intent only:
+    /// <see cref="Device"/> is a device-bound copy's on-device key; <see cref="Holder"/> is the
+    /// web-root's holder key (whose private half the wallet service holds for server-custody signing).
+    /// </summary>
+    internal enum Binding
+    {
+        /// <summary>The device-bound copy's on-device P-256 key.</summary>
+        Device,
+
+        /// <summary>The web-root's holder P-256 key (server-custody signer).</summary>
+        Holder,
+    }
+
+    /// <summary>
+    /// Builds a REAL AIAS SD-JWT VC presentation (vct <see cref="AiasVct"/> + the assured claim set),
+    /// x5c-chained to a test root, with independent control over which key is the credential's
+    /// <c>cnf.jwk</c> (<paramref name="cnf"/>) and which key signs the KB-JWT
+    /// (<paramref name="kbSigner"/>, defaulting to a correct match with <paramref name="cnf"/>).
+    ///
+    /// Correct-binding cases (<paramref name="kbSigner"/> == <paramref name="cnf"/>) prove holder /
+    /// device custody parity; mismatched cases (device key over a holder-cnf root, or vice versa)
+    /// drive the loud, named key-binding failure the whole phase guards against.
+    /// </summary>
+    internal static async Task<(string Presentation, byte[] RootCertDer)> CreateAiasAsync(
+        ISdJwtService sdJwtService, string audience, string nonce,
+        Binding cnf = Binding.Device, Binding? kbSigner = null)
+    {
+        var signerRole = kbSigner ?? cnf;
+
+        var (rootCertDer, rootPrivateKey, _) = X509CertificateBuilder.BuildSelfSignedRoot("ES256", "CN=Test Root CA");
+
+        using var issuerEcdsa = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        var issuerPublicKey = issuerEcdsa.ExportSubjectPublicKeyInfo();
+        var issuerPrivateKey = issuerEcdsa.ExportECPrivateKey();
+
+        var (orgCertDer, _) = X509CertificateBuilder.BuildOrgCert(
+            rootCertDer, rootPrivateKey, issuerPublicKey, "CN=Test Org", "did:sorcha:org:ws1qtest");
+
+        // Two independent P-256 keys — one stands in for the on-device key, one for the web-root
+        // holder key. The verifier cannot tell them apart; only which one signed the KB-JWT matters.
+        using var deviceEcdsa = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        using var holderEcdsa = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+
+        ECDsa KeyFor(Binding role) => role == Binding.Device ? deviceEcdsa : holderEcdsa;
+
+        var cnfParams = KeyFor(cnf).ExportParameters(includePrivateParameters: false);
+        var cnfJwk = JsonSerializer.Deserialize<JsonElement>(JsonSerializer.Serialize(new Dictionary<string, string>
+        {
+            ["kty"] = "EC",
+            ["crv"] = "P-256",
+            ["x"] = System.Buffers.Text.Base64Url.EncodeToString(cnfParams.Q.X!),
+            ["y"] = System.Buffers.Text.Base64Url.EncodeToString(cnfParams.Q.Y!)
+        }));
+
+        // The live AIAS credential: plaintext vct + the assured identity claim set.
+        var token = await sdJwtService.CreateTokenAsync(
+            new Dictionary<string, object>
+            {
+                ["vct"] = AiasVct,
+                ["givenName"] = "Ada",
+                ["familyName"] = "Lovelace",
+                ["dateOfBirth"] = "1815-12-10",
+            },
+            disclosableClaims: AiasDisclosedClaims,
+            issuer: "did:sorcha:org:ws1qtest",
+            subject: "did:sorcha:w:holder1",
+            signingKey: issuerPrivateKey,
+            algorithm: "ES256",
+            holderJwk: cnfJwk);
+
+        // Inject the x5c chain into the header and re-sign (mirrors the credential endpoint output).
+        var rawParts = token.RawToken.TrimEnd('~').Split('~');
+        var jwtSegments = rawParts[0].Split('.');
+        var headerBytes = System.Buffers.Text.Base64Url.DecodeFromChars(jwtSegments[0]);
+        var header = JsonSerializer.Deserialize<Dictionary<string, object>>(headerBytes)!;
+        header["x5c"] = new[] { Convert.ToBase64String(orgCertDer), Convert.ToBase64String(rootCertDer) };
+
+        var newHeaderB64 = System.Buffers.Text.Base64Url.EncodeToString(JsonSerializer.SerializeToUtf8Bytes(header));
+        var signingInput = System.Text.Encoding.UTF8.GetBytes($"{newHeaderB64}.{jwtSegments[1]}");
+        var signature = issuerEcdsa.SignData(signingInput, HashAlgorithmName.SHA256);
+        var signatureB64 = System.Buffers.Text.Base64Url.EncodeToString(signature);
+        var newRawToken = $"{newHeaderB64}.{jwtSegments[1]}.{signatureB64}~{string.Join("~", rawParts[1..])}~";
+
+        // Export the KB-signing private key up front so the delegate captures a byte[] (the ECDsa
+        // instances are disposed with the method, but the signing runs synchronously within scope).
+        var kbPrivate = KeyFor(signerRole).ExportECPrivateKey();
+
+        var presentation = await sdJwtService.CreatePresentationAsync(
+            newRawToken,
+            claimsToDisclose: AiasDisclosedClaims,
+            kbJwtSigner: (data, _token) =>
+            {
+                using var ecdsa = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+                ecdsa.ImportECPrivateKey(kbPrivate, out _);
+                return Task.FromResult(ecdsa.SignData(data, HashAlgorithmName.SHA256));
+            },
+            holderAlgorithm: "ES256",
+            audience: audience,
+            nonce: nonce);
+
+        return (presentation.RawPresentation, rootCertDer);
+    }
 }

--- a/tests/Sorcha.Haip.Service.Tests/Endpoints/VerifierEndpointTests.cs
+++ b/tests/Sorcha.Haip.Service.Tests/Endpoints/VerifierEndpointTests.cs
@@ -471,6 +471,121 @@ public class VerifierEndpointTests
         stored.PresentationSubmission.Should().BeNull("no PE dialect, and no delegation artefact, on the wire");
     }
 
+    // --- #1195 Phase 2: AIAS holder/device custody parity + wrong-key negatives ----------------
+    //
+    // The model under test: ONE assured identity, TWO bindings that share the AIAS vct. A holder-cnf
+    // web root (server-custody: the wallet service signs the KB-JWT with the holder key) and a
+    // device-cnf copy (the on-device P-256 key signs the KB-JWT in person) must BOTH verify through
+    // the identical standard OID4VP path — the verifier cannot, and must not, tell them apart. The
+    // trap the phase guards against is a KB-JWT signed by the WRONG key: it must fail loudly with a
+    // named key-binding error and emit no verified claims.
+
+    /// <summary>Executes an object-keyed AIAS presentation through the real HandleDirectPost.</summary>
+    private async Task<(int Status, string Body, PresentationRequest Stored)> PostAiasAsync(
+        DeviceCnfPresentationFactory.Binding cnf, DeviceCnfPresentationFactory.Binding? kbSigner)
+    {
+        // Require the full assured claim set so the endpoint proves the AIAS claims actually flowed.
+        var request = await CreateRequestAsync(
+            requiredClaims: [.. DeviceCnfPresentationFactory.AiasDisclosedClaims]);
+
+        var (presentation, rootCertDer) = await DeviceCnfPresentationFactory.CreateAiasAsync(
+            new SdJwtService(), audience: request.ClientId, nonce: request.Nonce, cnf: cnf, kbSigner: kbSigner);
+
+        var envelope = JsonSerializer.Serialize(
+            new Dictionary<string, string[]> { [VerifierEndpoints.DefaultQueryId] = [presentation] });
+
+        var (status, body) = await ExecuteAsync(await InvokeDirectPostAsync(
+            request.Id, vpToken: envelope, state: request.Id.ToString(),
+            sdJwtVerifier: BuildSdJwtVerifier(trustedRoot: rootCertDer)));
+
+        var stored = (await _store.GetAsync(request.Id))!;
+        return (status, body, stored);
+    }
+
+    [Fact]
+    public async Task HandleDirectPost_DeviceCnf_AiasCopy_DeviceSignedKb_Verifies()
+    {
+        // Step 1 — a device-bound AIAS copy: cnf.jwk is the on-device key, KB-JWT device-signed.
+        var (status, body, stored) = await PostAiasAsync(
+            cnf: DeviceCnfPresentationFactory.Binding.Device, kbSigner: null);
+
+        status.Should().Be(200, "a device-signed KB-JWT over a device-cnf AIAS copy must verify: {0}", body);
+        stored.State.Should().Be(PresentationRequestState.Verified);
+        stored.Result.Should().NotBeNull();
+        stored.Result!.IsValid.Should().BeTrue();
+        stored.Result.HolderKeyVerified.Should().BeTrue("the KB-JWT was signed by the private half of the device cnf key");
+        stored.Result.X5cChainValid.Should().BeTrue();
+        // The real AIAS assured claim set flowed end-to-end.
+        stored.Result.VerifiedClaims.Should().ContainKeys("givenName", "familyName", "dateOfBirth");
+        // The AIAS vct is surfaced but NOT gated against the request's declared type (#1198, pre-existing).
+        // Verified-claim values are JsonElement; compare the string form.
+        stored.Result.VerifiedClaims.Should().ContainKey("vct");
+        stored.Result.VerifiedClaims["vct"].ToString().Should().Be(DeviceCnfPresentationFactory.AiasVct);
+    }
+
+    [Fact]
+    public async Task HandleDirectPost_HolderCnf_AiasRoot_ServerCustodySignedKb_Verifies()
+    {
+        // Step 2 — the web root presented server-custody: cnf.jwk is the holder key, and the KB-JWT is
+        // signed by that same holder key (what the wallet service does when it signs on the holder's
+        // behalf). It must verify through the IDENTICAL path as the device copy — proving custody parity.
+        var (status, body, stored) = await PostAiasAsync(
+            cnf: DeviceCnfPresentationFactory.Binding.Holder, kbSigner: null);
+
+        status.Should().Be(200, "a holder-key-signed KB-JWT over a holder-cnf AIAS root must verify: {0}", body);
+        stored.State.Should().Be(PresentationRequestState.Verified);
+        stored.Result.Should().NotBeNull();
+        stored.Result!.IsValid.Should().BeTrue();
+        stored.Result.HolderKeyVerified.Should().BeTrue("the KB-JWT was signed by the private half of the holder cnf key");
+        stored.Result.X5cChainValid.Should().BeTrue();
+        stored.Result.VerifiedClaims.Should().ContainKeys("givenName", "familyName", "dateOfBirth");
+    }
+
+    [Fact]
+    public async Task HandleDirectPost_DeviceKeySignsHolderCnfRoot_FailsWithNamedKeyBindingError()
+    {
+        // NEGATIVE (the trap) — a device key signs a KB-JWT over a holder-cnf root. The KB signature
+        // does not verify against the credential's cnf (holder) key → a loud, NAMED key-binding failure.
+        var (status, body, stored) = await PostAiasAsync(
+            cnf: DeviceCnfPresentationFactory.Binding.Holder,
+            kbSigner: DeviceCnfPresentationFactory.Binding.Device);
+
+        status.Should().Be(400, "a wrong-key KB-JWT must be rejected, not silently accepted");
+        var json = ParseJson(body);
+        json.GetProperty("error").GetString().Should().Be("invalid_presentation");
+        json.GetProperty("error_description").GetString().Should().Contain(
+            "Key binding mismatch", "the failure must name the key-binding mismatch, not a generic error");
+
+        // Nothing downstream may treat this as success.
+        stored.State.Should().Be(PresentationRequestState.Denied);
+        stored.Result.Should().NotBeNull();
+        stored.Result!.IsValid.Should().BeFalse();
+        stored.Result.HolderKeyVerified.Should().BeFalse();
+        stored.Result.VerifiedClaims.Should().BeEmpty("no claims may be emitted from a key-binding failure");
+    }
+
+    [Fact]
+    public async Task HandleDirectPost_HolderKeySignsDeviceCnfCopy_FailsWithNamedKeyBindingError()
+    {
+        // NEGATIVE (mirror) — a holder key signs a KB-JWT over a device-cnf copy. Same explicit shape:
+        // the KB signature does not verify against the copy's cnf (device) key.
+        var (status, body, stored) = await PostAiasAsync(
+            cnf: DeviceCnfPresentationFactory.Binding.Device,
+            kbSigner: DeviceCnfPresentationFactory.Binding.Holder);
+
+        status.Should().Be(400, "a wrong-key KB-JWT must be rejected, not silently accepted");
+        var json = ParseJson(body);
+        json.GetProperty("error").GetString().Should().Be("invalid_presentation");
+        json.GetProperty("error_description").GetString().Should().Contain(
+            "Key binding mismatch", "the failure must name the key-binding mismatch, not a generic error");
+
+        stored.State.Should().Be(PresentationRequestState.Denied);
+        stored.Result.Should().NotBeNull();
+        stored.Result!.IsValid.Should().BeFalse();
+        stored.Result.HolderKeyVerified.Should().BeFalse();
+        stored.Result.VerifiedClaims.Should().BeEmpty("no claims may be emitted from a key-binding failure");
+    }
+
     /// <summary>
     /// Mints a self-signed mdoc DeviceResponse bound to the request's OpenID4VP session
     /// (client_id / nonce / response_uri) so the endpoint's mdoc path verifies for real.

--- a/tests/Sorcha.Verifier.Tests/Services/DisclosureAnchoringTests.cs
+++ b/tests/Sorcha.Verifier.Tests/Services/DisclosureAnchoringTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Buffers.Text;
+using System.Collections.Generic;
 using System.Text.Json;
 using System.Threading.Tasks;
 using FluentAssertions;
@@ -90,5 +91,94 @@ public sealed class DisclosureAnchoringTests
 
         outcome.Accepted.Should().BeTrue(string.Join(", ", outcome.Errors));
         outcome.DisclosedClaims.Should().ContainKeys("givenName", "familyName");
+    }
+
+    // ── Fix round 2: RFC 9901 anchoring completeness ─────────────────────────────
+
+    /// <summary>Mint an RFC 9901 array-element disclosure: base64url(JSON [salt, value]). Returns (segment, digest).</summary>
+    private static (string Segment, string Digest) MintArrayElementDisclosure(string salt, string value)
+    {
+        var segment = Base64Url.EncodeToString(JsonSerializer.SerializeToUtf8Bytes(
+            new object[] { salt, value }));
+        var digest = Base64Url.EncodeToString(
+            System.Security.Cryptography.SHA256.HashData(System.Text.Encoding.ASCII.GetBytes(segment)));
+        return (segment, digest);
+    }
+
+    [Fact]
+    public async Task ValidateAsync_LegitimateArrayElementDisclosure_AnchorsAndVerifies()
+    {
+        // RFC 9901 array SD: the payload carries an array whose selectively-disclosable
+        // element is the {"...": "<digest>"} marker; the matching 2-element [salt, value]
+        // disclosure rides in the vp_token. A legitimate credential using this shape must
+        // anchor cleanly — reporting it as "unanchored" (forgery) was the fix-round-2 gap.
+        var (segment, digest) = MintArrayElementDisclosure("elem-salt-1", "GB");
+        var bundle = TestVpFactory.Mint(Vct,
+            VpValidatorTestHarness.Claims(("givenName", "Stuart")),
+            VpValidatorTestHarness.ClientId, VpValidatorTestHarness.Nonce,
+            extraPayloadClaims: new Dictionary<string, object>
+            {
+                ["nationalities"] = new object[]
+                {
+                    new Dictionary<string, object> { ["..."] = digest },
+                    "IE", // non-disclosable sibling element stays inline
+                },
+            },
+            extraDisclosureSegments: [segment]);
+
+        var validator = VpValidatorTestHarness.BuildValidator();
+        var outcome = await validator.ValidateAsync(
+            VpValidatorTestHarness.Session(), bundle.VpToken, bundle.Delegation);
+
+        outcome.Accepted.Should().BeTrue(
+            "an issuer-committed array-element disclosure is legitimate, not forgery: " +
+            string.Join(", ", outcome.Errors));
+        outcome.DisclosedClaims.Should().ContainKey("givenName");
+    }
+
+    [Fact]
+    public async Task ValidateAsync_ForgedArrayElementDisclosure_IsRejected_WithNamedError()
+    {
+        // A 2-element [salt, value] disclosure whose digest appears in NO marker and no _sd
+        // array is still a forgery and must reject, naming the segment.
+        var (forgedSegment, _) = MintArrayElementDisclosure("forged-elem-salt", "attacker-value");
+        var bundle = TestVpFactory.Mint(Vct,
+            VpValidatorTestHarness.Claims(("givenName", "Stuart")),
+            VpValidatorTestHarness.ClientId, VpValidatorTestHarness.Nonce,
+            extraDisclosureSegments: [forgedSegment]);
+
+        var validator = VpValidatorTestHarness.BuildValidator();
+        var outcome = await validator.ValidateAsync(
+            VpValidatorTestHarness.Session(), bundle.VpToken, bundle.Delegation);
+
+        outcome.Accepted.Should().BeFalse("an uncommitted array-element disclosure is a forgery");
+        outcome.Errors.Should().Contain(e =>
+                e.Contains("not committed", StringComparison.OrdinalIgnoreCase) &&
+                e.Contains("forged-elem-salt"),
+            "the refusal must identify the forged segment — never silent");
+    }
+
+    [Fact]
+    public async Task ValidateAsync_UnsupportedSdAlg_RejectsWithDistinctNamedError_NotUnanchored()
+    {
+        // _sd_alg other than sha-256: digests computed under an unknown algorithm can never
+        // anchor here — but calling that "unanchored disclosure" would accuse a legitimate
+        // credential of forgery. The rejection must be its own named reason.
+        var bundle = TestVpFactory.Mint(Vct,
+            VpValidatorTestHarness.Claims(("givenName", "Stuart")),
+            VpValidatorTestHarness.ClientId, VpValidatorTestHarness.Nonce,
+            extraPayloadClaims: new Dictionary<string, object> { ["_sd_alg"] = "sha-384" });
+
+        var validator = VpValidatorTestHarness.BuildValidator();
+        var outcome = await validator.ValidateAsync(
+            VpValidatorTestHarness.Session(), bundle.VpToken, bundle.Delegation);
+
+        outcome.Accepted.Should().BeFalse("sha-256 is the only supported _sd_alg — fail closed");
+        outcome.Errors.Should().Contain(e =>
+                e.Contains("_sd_alg", StringComparison.OrdinalIgnoreCase) &&
+                e.Contains("sha-384"),
+            "the error must name the unsupported algorithm");
+        outcome.Errors.Should().NotContain(e => e.Contains("not committed", StringComparison.OrdinalIgnoreCase),
+            "an unsupported algorithm must NOT be misclassified as a forged/unanchored disclosure");
     }
 }

--- a/tests/Sorcha.Verifier.Tests/Services/DisclosureAnchoringTests.cs
+++ b/tests/Sorcha.Verifier.Tests/Services/DisclosureAnchoringTests.cs
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System;
+using System.Buffers.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Xunit;
+
+namespace Sorcha.Verifier.Tests.Services;
+
+/// <summary>
+/// #1195 Phase 2 (Task 6 fix round) — RFC 9901 disclosure anchoring. Every disclosure
+/// segment in a presented SD-JWT MUST be committed by the credential: its SHA-256 digest
+/// must appear in an <c>_sd</c> array of the (issuer-signed) payload, or of an
+/// already-accepted disclosure's value (nested SD). Without this check a presenter could
+/// append fabricated <c>[salt, name, value]</c> segments — or OVERRIDE a legitimate
+/// claim's value with a forged duplicate — and have them emitted as verified claims.
+/// The KB-JWT does not protect against this (its signer IS the presenter).
+/// </summary>
+public sealed class DisclosureAnchoringTests
+{
+    private const string Vct = VpValidatorTestHarness.Vct;
+
+    private static string ForgedDisclosure(string name, string value) =>
+        Base64Url.EncodeToString(JsonSerializer.SerializeToUtf8Bytes(
+            new object[] { "forged-salt", name, value }));
+
+    /// <summary>Insert a disclosure segment immediately before the trailing KB-JWT.</summary>
+    private static string InjectDisclosure(string vpToken, string segment)
+    {
+        var lastTilde = vpToken.LastIndexOf('~');
+        return vpToken[..(lastTilde + 1)] + segment + "~" + vpToken[(lastTilde + 1)..];
+    }
+
+    [Fact]
+    public async Task ValidateAsync_ForgedAppendedDisclosure_IsRejected_WithNamedError()
+    {
+        // A legitimate presentation with a fabricated extra claim appended: the forged
+        // segment's digest appears in no _sd array, so the presentation must be REJECTED
+        // (RFC 9901 — an unanchored disclosure invalidates the SD-JWT), never silently
+        // accepted with the forged claim in the disclosed set.
+        var bundle = TestVpFactory.Mint(Vct,
+            VpValidatorTestHarness.Claims(("givenName", "Stuart")),
+            VpValidatorTestHarness.ClientId, VpValidatorTestHarness.Nonce);
+        var tampered = InjectDisclosure(bundle.VpToken, ForgedDisclosure("email", "attacker@evil.example"));
+
+        var validator = VpValidatorTestHarness.BuildValidator();
+        var outcome = await validator.ValidateAsync(
+            VpValidatorTestHarness.Session(), tampered, bundle.Delegation);
+
+        outcome.Accepted.Should().BeFalse("a disclosure the issuer never committed must invalidate the presentation");
+        outcome.Errors.Should().Contain(e => e.Contains("email") && e.Contains("not committed", StringComparison.OrdinalIgnoreCase),
+            "the refusal must NAME the forged claim — never silent");
+        outcome.DisclosedClaims.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ValidateAsync_ForgedDuplicateOfLegitimateClaim_IsRejected_NotOverridden()
+    {
+        // The value-override attack: the credential legitimately discloses givenName, and the
+        // presenter appends a SECOND, forged givenName segment. Dictionary parse order would let
+        // the forged value win — anchoring must reject the presentation outright instead.
+        var bundle = TestVpFactory.Mint(Vct,
+            VpValidatorTestHarness.Claims(("givenName", "Stuart")),
+            VpValidatorTestHarness.ClientId, VpValidatorTestHarness.Nonce);
+        var tampered = InjectDisclosure(bundle.VpToken, ForgedDisclosure("givenName", "Mallory"));
+
+        var validator = VpValidatorTestHarness.BuildValidator();
+        var outcome = await validator.ValidateAsync(
+            VpValidatorTestHarness.Session(), tampered, bundle.Delegation);
+
+        outcome.Accepted.Should().BeFalse("a forged duplicate must never override the issuer-committed value");
+        outcome.Errors.Should().Contain(e => e.Contains("givenName") && e.Contains("not committed", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task ValidateAsync_AllDisclosuresAnchored_StillAccepts()
+    {
+        // Regression guard: the untampered fixture (digest-anchored per RFC 9901 by
+        // TestVpFactory) continues to verify after the anchoring check lands.
+        var bundle = TestVpFactory.Mint(Vct,
+            VpValidatorTestHarness.Claims(("givenName", "Stuart"), ("familyName", "Fraser")),
+            VpValidatorTestHarness.ClientId, VpValidatorTestHarness.Nonce);
+
+        var validator = VpValidatorTestHarness.BuildValidator();
+        var outcome = await validator.ValidateAsync(
+            VpValidatorTestHarness.Session(), bundle.VpToken, bundle.Delegation);
+
+        outcome.Accepted.Should().BeTrue(string.Join(", ", outcome.Errors));
+        outcome.DisclosedClaims.Should().ContainKeys("givenName", "familyName");
+    }
+}

--- a/tests/Sorcha.Verifier.Tests/Services/ServerCustodyPresentationTests.cs
+++ b/tests/Sorcha.Verifier.Tests/Services/ServerCustodyPresentationTests.cs
@@ -1,0 +1,225 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System;
+using System.Buffers.Text;
+using System.Collections.Generic;
+using System.Security.Cryptography;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Sorcha.Verifier.Engine;
+using Sorcha.Verifier.Engine.Models;
+using Xunit;
+
+namespace Sorcha.Verifier.Tests.Services;
+
+/// <summary>
+/// #1195 Phase 2 (final review C-1 / I-2). The verifier engine must accept a delegation-free
+/// SERVER-CUSTODY presentation — a holder-<c>cnf</c> credential whose KB-JWT is signed directly by
+/// the credential's own holder key, with NO device delegation credential (design §2). This is what
+/// the Task-6 "bind to device" flow posts. The delegation model (F114/F127) stays byte-identical and
+/// is covered by <see cref="DisclosureAnchoringTests"/> and the Feature 138 replay suite.
+/// </summary>
+public sealed class ServerCustodyPresentationTests
+{
+    private const string Vct = VpValidatorTestHarness.Vct;
+
+    /// <summary>
+    /// A validator with a stub status-list cache (never consulted on the server-custody path — there
+    /// is no delegation and therefore no status_list block) and a caller-supplied issuer resolver +
+    /// RequireIssuerSignature policy. Defaults reproduce the offline v1 contract (opt-out resolver,
+    /// requireIssuerSignature false).
+    /// </summary>
+    private static VerifiablePresentationValidator BuildValidator(
+        IIssuerKeyResolver? issuerKeys = null,
+        bool requireIssuerSignature = false)
+    {
+        var statusList = new Mock<IStatusListCache>();
+        statusList
+            .Setup(s => s.CheckAsync(
+                It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(StatusListVerdict.Active);
+
+        return new VerifiablePresentationValidator(
+            statusList.Object,
+            issuerKeys ?? new OptOutIssuerKeyResolver(),
+            TimeProvider.System,
+            NullLogger<VerifiablePresentationValidator>.Instance,
+            requireIssuerSignature: requireIssuerSignature);
+    }
+
+    // ─────────────────────────── C-1: server-custody accept / reject ─────────────────────────────
+
+    [Fact]
+    public async Task ValidateAsync_ServerCustody_HolderSignedNoDelegation_Accepts_WithClaimsAndLiveLayer()
+    {
+        // The delegation-free, HOLDER-signed present (P-256 holder). BEFORE the C-1 fix this failed
+        // with "Delegation credential is required for citizen wallet presentations" — that is the
+        // reproduction of the review finding.
+        var bundle = TestVpFactory.MintServerCustodyP256(
+            Vct, VpValidatorTestHarness.Claims(("givenName", "Sarah")),
+            VpValidatorTestHarness.ClientId, VpValidatorTestHarness.Nonce);
+
+        var outcome = await BuildValidator().ValidateAsync(
+            VpValidatorTestHarness.Session(), bundle.VpToken, delegationCredential: null);
+
+        outcome.Accepted.Should().BeTrue(string.Join(", ", outcome.Errors));
+        outcome.DisclosedClaims.Should().ContainKey("givenName");
+
+        // The holder-key binding verified — the LivePresentation layer passes and its verdict trail
+        // records server-custody honestly (no fabricated delegation). This layer Pass IS the
+        // "HolderKeyVerified == true" signal (VerificationOutcome exposes no separate flag).
+        var live = outcome.Layers.Should().ContainSingle(l => l.Layer == ValidationLayer.LivePresentation).Subject;
+        live.Status.Should().Be(LayerStatus.Pass);
+        live.Detail.Should().ContainKey("delegation")
+            .WhoseValue.Should().Contain("server-custody (none)");
+    }
+
+    [Fact]
+    public async Task ValidateAsync_ServerCustody_Ed25519HolderSigned_Accepts()
+    {
+        // The realistic default-wallet path: an Ed25519 holder key signs its own KB-JWT (EdDSA).
+        // Verified via BouncyCastle through the same alg-dispatched VerifyJwsSignature.
+        var bundle = TestVpFactory.MintServerCustodyEd25519(
+            Vct, VpValidatorTestHarness.Claims(("givenName", "Sarah")),
+            VpValidatorTestHarness.ClientId, VpValidatorTestHarness.Nonce);
+
+        var outcome = await BuildValidator().ValidateAsync(
+            VpValidatorTestHarness.Session(), bundle.VpToken, delegationCredential: null);
+
+        outcome.Accepted.Should().BeTrue(string.Join(", ", outcome.Errors));
+        outcome.DisclosedClaims.Should().ContainKey("givenName");
+    }
+
+    [Fact]
+    public async Task ValidateAsync_ServerCustody_DeviceSignedNoDelegation_RejectsNamed_KeyBindingMismatch()
+    {
+        // The wrong-key negative on the REAL path: cnf is the holder key but the KB-JWT was signed
+        // by a DIFFERENT device key with no delegation to legitimise it. Must reject LOUDLY with a
+        // named error DISTINCT from the delegation-model errors, and emit zero claims.
+        var bundle = TestVpFactory.MintServerCustodyP256(
+            Vct, VpValidatorTestHarness.Claims(("givenName", "Sarah")),
+            VpValidatorTestHarness.ClientId, VpValidatorTestHarness.Nonce,
+            kbSignedByHolder: false);
+
+        var outcome = await BuildValidator().ValidateAsync(
+            VpValidatorTestHarness.Session(), bundle.VpToken, delegationCredential: null);
+
+        outcome.Accepted.Should().BeFalse();
+        outcome.Errors.Should().Contain(e =>
+                e.Contains("Key binding mismatch", StringComparison.Ordinal) &&
+                e.Contains("cnf key", StringComparison.Ordinal),
+            "a KB-JWT not signed by the credential's cnf key must be named, not conflated with device-key errors");
+        outcome.Errors.Should().NotContain(e => e.Contains("device key", StringComparison.OrdinalIgnoreCase),
+            "server-custody has no device key — the error must not blame one");
+        outcome.DisclosedClaims.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ValidateAsync_ServerCustody_Ed25519DeviceSigned_RejectsNamed_KeyBindingMismatch()
+    {
+        // Same negative on the Ed25519-holder path: holder cnf is OKP, KB-JWT signed by a P-256
+        // device key. Reject named, zero claims.
+        var bundle = TestVpFactory.MintServerCustodyEd25519(
+            Vct, VpValidatorTestHarness.Claims(("givenName", "Sarah")),
+            VpValidatorTestHarness.ClientId, VpValidatorTestHarness.Nonce,
+            kbSignedByHolder: false);
+
+        var outcome = await BuildValidator().ValidateAsync(
+            VpValidatorTestHarness.Session(), bundle.VpToken, delegationCredential: null);
+
+        outcome.Accepted.Should().BeFalse();
+        outcome.Errors.Should().Contain(e => e.Contains("Key binding mismatch", StringComparison.Ordinal));
+        outcome.DisclosedClaims.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ValidateAsync_ServerCustody_MissingCnf_NoDelegation_RejectsNamed()
+    {
+        // LOUD failure: a credential with no cnf.jwk presented server-custody (no delegation) has no
+        // holder key to bind the KB-JWT to. Rejected by name at the cnf-extraction step.
+        var issuer = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        var (disclosure, hash) = TestVpFactory.MintDisclosure(
+            "givenName", JsonSerializer.SerializeToElement("Sarah"));
+        var credentialPayload = new Dictionary<string, object>
+        {
+            ["iss"] = "did:sorcha:org:test",
+            ["iat"] = DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
+            ["vct"] = Vct,
+            ["_sd"] = new[] { hash },
+            ["_sd_alg"] = "sha-256",
+            // no cnf
+        };
+        var credentialJwt = TestVpFactory.SignEs256(
+            new Dictionary<string, object> { ["alg"] = "ES256", ["typ"] = "dc+sd-jwt" },
+            credentialPayload, issuer);
+        // A syntactically-valid KB-JWT (its signer is irrelevant — cnf extraction rejects first).
+        var kbJwt = TestVpFactory.SignEs256(
+            new Dictionary<string, object> { ["alg"] = "ES256", ["typ"] = "kb+jwt" },
+            new Dictionary<string, object>
+            {
+                ["iat"] = DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
+                ["exp"] = DateTimeOffset.UtcNow.AddSeconds(120).ToUnixTimeSeconds(),
+                ["aud"] = VpValidatorTestHarness.ClientId,
+                ["nonce"] = VpValidatorTestHarness.Nonce,
+            },
+            ECDsa.Create(ECCurve.NamedCurves.nistP256));
+        var vpToken = $"{credentialJwt}~{disclosure}~{kbJwt}";
+
+        var outcome = await BuildValidator().ValidateAsync(
+            VpValidatorTestHarness.Session(), vpToken, delegationCredential: null);
+
+        outcome.Accepted.Should().BeFalse();
+        outcome.Errors.Should().Contain(e => e.Contains("cnf.jwk", StringComparison.OrdinalIgnoreCase),
+            "a credential missing its holder binding must be named, never silently accepted");
+        outcome.DisclosedClaims.Should().BeEmpty();
+    }
+
+    // ─────────────────────────── I-2: the issuer-signature leg ───────────────────────────────────
+
+    [Fact]
+    public async Task ValidateAsync_ServerCustody_IssuerKeyResolves_RequireIssuerSignature_Accepts_IssuerVerified()
+    {
+        // I-2 (a): with RequireIssuerSignature ON and the issuer key RESOLVABLE, a holder-signed
+        // delegation-free present passes both gates and reports the issuer signature verified.
+        var bundle = TestVpFactory.MintServerCustodyP256(
+            Vct, VpValidatorTestHarness.Claims(("givenName", "Sarah")),
+            VpValidatorTestHarness.ClientId, VpValidatorTestHarness.Nonce);
+
+        var registry = new JwkRegistryIssuerKeyResolver();
+        registry.Register(
+            bundle.Issuer,
+            JsonDocument.Parse(TestVpFactory.ToJwk(bundle.IssuerKey)).RootElement);
+
+        var outcome = await BuildValidator(registry, requireIssuerSignature: true)
+            .ValidateAsync(VpValidatorTestHarness.Session(), bundle.VpToken, delegationCredential: null);
+
+        outcome.Accepted.Should().BeTrue(string.Join(", ", outcome.Errors));
+        outcome.IssuerSignature.Should().Be(IssuerSignatureStatus.Verified);
+        outcome.Layers.Should().Contain(l =>
+            l.Layer == ValidationLayer.IssuerSignature && l.Status == LayerStatus.Pass);
+    }
+
+    [Fact]
+    public async Task ValidateAsync_ServerCustody_IssuerKeyUnresolved_RequireIssuerSignature_RejectsNamed()
+    {
+        // I-2 (b): with RequireIssuerSignature ON but NO resolvable issuer key, the second gate must
+        // reject LOUDLY, naming the requirement — proving the issuer leg is enforced, not silent.
+        var bundle = TestVpFactory.MintServerCustodyP256(
+            Vct, VpValidatorTestHarness.Claims(("givenName", "Sarah")),
+            VpValidatorTestHarness.ClientId, VpValidatorTestHarness.Nonce);
+
+        var outcome = await BuildValidator(new OptOutIssuerKeyResolver(), requireIssuerSignature: true)
+            .ValidateAsync(VpValidatorTestHarness.Session(), bundle.VpToken, delegationCredential: null);
+
+        outcome.Accepted.Should().BeFalse();
+        outcome.Errors.Should().Contain(e => e.Contains("RequireIssuerSignature", StringComparison.Ordinal),
+            "an unresolved issuer key under RequireIssuerSignature must name the requirement it failed");
+        outcome.Layers.Should().Contain(l =>
+            l.Layer == ValidationLayer.IssuerSignature && l.Status == LayerStatus.Fail);
+    }
+}

--- a/tests/Sorcha.Verifier.Tests/Services/TestVpFactory.cs
+++ b/tests/Sorcha.Verifier.Tests/Services/TestVpFactory.cs
@@ -44,7 +44,9 @@ internal static class TestVpFactory
         DateTimeOffset? kbJwtIssuedAt = null,
         DateTimeOffset? kbJwtExpiresAt = null,
         bool omitKbJwtExp = false,
-        string credentialTyp = "dc+sd-jwt")
+        string credentialTyp = "dc+sd-jwt",
+        Dictionary<string, object>? extraPayloadClaims = null,
+        IEnumerable<string>? extraDisclosureSegments = null)
     {
         var issuer = ECDsa.Create(ECCurve.NamedCurves.nistP256);
         var holder = ECDsa.Create(ECCurve.NamedCurves.nistP256);
@@ -76,6 +78,19 @@ internal static class TestVpFactory
             ["_sd_alg"] = "sha-256",
             ["cnf"] = new Dictionary<string, object> { ["jwk"] = JsonDocument.Parse(holderJwk).RootElement },
         };
+        // Fix round 2 (anchoring completeness) — lets tests add payload claims (e.g. an
+        // array carrying {"...": digest} markers) or OVERRIDE defaults (e.g. _sd_alg).
+        if (extraPayloadClaims is not null)
+        {
+            foreach (var (name, value) in extraPayloadClaims)
+            {
+                credentialPayload[name] = value;
+            }
+        }
+        if (extraDisclosureSegments is not null)
+        {
+            disclosures.AddRange(extraDisclosureSegments);
+        }
         var credentialJwt = SignEs256(
             new Dictionary<string, object> { ["alg"] = "ES256", ["typ"] = credentialTyp },
             credentialPayload, issuer);

--- a/tests/Sorcha.Verifier.Tests/Services/TestVpFactory.cs
+++ b/tests/Sorcha.Verifier.Tests/Services/TestVpFactory.cs
@@ -254,6 +254,129 @@ internal static class TestVpFactory
         string StatusListUri,
         int StatusListIndex);
 
+    /// <summary>
+    /// A delegation-free SERVER-CUSTODY presentation (#1195 Phase 2). The vp_token carries an
+    /// SD-JWT VC with <c>cnf</c> = the holder key and a KB-JWT the holder key itself signed —
+    /// there is NO delegation credential. Exposes the issuer key (for issuer-signature tests)
+    /// and the holder's public JWK.
+    /// </summary>
+    public sealed record ServerCustodyBundle(
+        string VpToken,
+        ECDsa IssuerKey,
+        JsonElement HolderJwk,
+        string Issuer);
+
+    private const string TestIssuer = "did:sorcha:org:test";
+
+    private static (string CredentialJwt, List<string> Disclosures) BuildCredential(
+        string vct, Dictionary<string, JsonElement> disclosedClaims, string holderJwkJson, ECDsa issuer)
+    {
+        var disclosures = new List<string>();
+        var sdHashes = new List<string>();
+        foreach (var (name, value) in disclosedClaims)
+        {
+            var (segment, hash) = MintDisclosure(name, value);
+            disclosures.Add(segment);
+            sdHashes.Add(hash);
+        }
+
+        var credentialPayload = new Dictionary<string, object>
+        {
+            ["iss"] = TestIssuer,
+            ["iat"] = DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
+            ["vct"] = vct,
+            ["_sd"] = sdHashes,
+            ["_sd_alg"] = "sha-256",
+            ["cnf"] = new Dictionary<string, object> { ["jwk"] = JsonDocument.Parse(holderJwkJson).RootElement },
+        };
+        var credentialJwt = SignEs256(
+            new Dictionary<string, object> { ["alg"] = "ES256", ["typ"] = "dc+sd-jwt" },
+            credentialPayload, issuer);
+        return (credentialJwt, disclosures);
+    }
+
+    private static Dictionary<string, object> KbPayload(string verifierClientId, string verifierNonce) => new()
+    {
+        ["iat"] = DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
+        ["exp"] = DateTimeOffset.UtcNow.AddSeconds(120).ToUnixTimeSeconds(),
+        ["aud"] = verifierClientId,
+        ["nonce"] = verifierNonce,
+        ["sd_hash"] = "placeholder",
+    };
+
+    /// <summary>
+    /// Mint a server-custody presentation with a P-256 (EC) holder key. When
+    /// <paramref name="kbSignedByHolder"/> is true the KB-JWT is signed by the holder key (the
+    /// legitimate server-custody case); when false it is signed by an UNRELATED P-256 device key
+    /// while <c>cnf</c> stays the holder — the wrong-key negative that must reject as a key-binding
+    /// mismatch.
+    /// </summary>
+    public static ServerCustodyBundle MintServerCustodyP256(
+        string vct,
+        Dictionary<string, JsonElement> disclosedClaims,
+        string verifierClientId,
+        string verifierNonce,
+        bool kbSignedByHolder = true)
+    {
+        var issuer = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        var holder = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        var holderJwkJson = ToJwk(holder);
+
+        var (credentialJwt, disclosures) = BuildCredential(vct, disclosedClaims, holderJwkJson, issuer);
+
+        var kbSigner = kbSignedByHolder ? holder : ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        var kbJwt = SignEs256(
+            new Dictionary<string, object> { ["alg"] = "ES256", ["typ"] = "kb+jwt" },
+            KbPayload(verifierClientId, verifierNonce), kbSigner);
+
+        var vpToken = $"{credentialJwt}{string.Concat(disclosures.Select(d => "~" + d))}~{kbJwt}";
+        return new ServerCustodyBundle(
+            vpToken, issuer, JsonDocument.Parse(holderJwkJson).RootElement.Clone(), TestIssuer);
+    }
+
+    /// <summary>
+    /// Mint a server-custody presentation with an <b>Ed25519</b> (OKP) holder key — the default
+    /// Sorcha wallet algorithm. When <paramref name="kbSignedByHolder"/> is true the KB-JWT is an
+    /// honest EdDSA signature by the holder key; when false it is signed by an unrelated P-256
+    /// device key (the wrong-key negative on the EdDSA-holder path).
+    /// </summary>
+    public static ServerCustodyBundle MintServerCustodyEd25519(
+        string vct,
+        Dictionary<string, JsonElement> disclosedClaims,
+        string verifierClientId,
+        string verifierNonce,
+        bool kbSignedByHolder = true)
+    {
+        var issuer = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+
+        var gen = new Ed25519KeyPairGenerator();
+        gen.Init(new Ed25519KeyGenerationParameters(new SecureRandom()));
+        var pair = gen.GenerateKeyPair();
+        var priv = (Ed25519PrivateKeyParameters)pair.Private;
+        var pub = (Ed25519PublicKeyParameters)pair.Public;
+        var holderJwkJson = ToOkpJwk(pub);
+
+        var (credentialJwt, disclosures) = BuildCredential(vct, disclosedClaims, holderJwkJson, issuer);
+
+        string kbJwt;
+        if (kbSignedByHolder)
+        {
+            kbJwt = SignEdDsa(
+                new Dictionary<string, object> { ["alg"] = "EdDSA", ["typ"] = "kb+jwt" },
+                KbPayload(verifierClientId, verifierNonce), priv);
+        }
+        else
+        {
+            kbJwt = SignEs256(
+                new Dictionary<string, object> { ["alg"] = "ES256", ["typ"] = "kb+jwt" },
+                KbPayload(verifierClientId, verifierNonce), ECDsa.Create(ECCurve.NamedCurves.nistP256));
+        }
+
+        var vpToken = $"{credentialJwt}{string.Concat(disclosures.Select(d => "~" + d))}~{kbJwt}";
+        return new ServerCustodyBundle(
+            vpToken, issuer, JsonDocument.Parse(holderJwkJson).RootElement.Clone(), TestIssuer);
+    }
+
     public static string SignEdDsa(Dictionary<string, object> header, Dictionary<string, object> payload, Ed25519PrivateKeyParameters signer)
     {
         var headerSeg = Base64Url.EncodeToString(JsonSerializer.SerializeToUtf8Bytes(header));

--- a/tests/Sorcha.Verifier.Tests/Services/VerifiablePresentationValidatorTests.cs
+++ b/tests/Sorcha.Verifier.Tests/Services/VerifiablePresentationValidatorTests.cs
@@ -143,14 +143,20 @@ public sealed class VerifiablePresentationValidatorTests
     }
 
     [Fact]
-    public async Task ValidateAsync_MissingDelegation_Rejected()
+    public async Task ValidateAsync_NoDelegation_DeviceSignedKbJwt_RejectedAsKeyBindingMismatch()
     {
+        // #1195 Phase 2 (C-1): a delegation-free present is now VALID under server-custody — but only
+        // when the KB-JWT is signed by the credential's OWN cnf holder key. The Mint bundle's KB-JWT
+        // is DEVICE-signed (it is built for the delegation model), so presenting it with no delegation
+        // is the wrong-key case: it must reject with the NAMED key-binding-mismatch error, distinct
+        // from the delegation-model errors. (The legitimate holder-signed server-custody path is
+        // covered by ServerCustodyPresentationTests.)
         var bundle = TestVpFactory.Mint(Vct, Claims(("givenName", "Stuart")), ClientId, Nonce);
 
         var outcome = await _validator.ValidateAsync(Session(), bundle.VpToken, null);
 
         outcome.Accepted.Should().BeFalse();
-        outcome.Errors.Should().Contain(e => e.Contains("Delegation credential is required", StringComparison.Ordinal));
+        outcome.Errors.Should().Contain(e => e.Contains("Key binding mismatch", StringComparison.Ordinal));
     }
 
     [Fact]

--- a/tests/Sorcha.Wallet.Pwa.Tests/Pages/CredentialDetailTests.cs
+++ b/tests/Sorcha.Wallet.Pwa.Tests/Pages/CredentialDetailTests.cs
@@ -30,8 +30,17 @@ namespace Sorcha.Wallet.Pwa.Tests.Pages;
 public sealed class CredentialDetailTests : ComponentTestFixture
 {
     private readonly Mock<ICredentialCache> _cache = new();
+    private readonly Mock<IDeviceBindingService> _binding = new();
+    private readonly Mock<Sorcha.UI.Core.Services.Feedback.IInlineFeedback> _feedback = new();
 
-    public CredentialDetailTests() => Services.AddSingleton(_cache.Object);
+    public CredentialDetailTests()
+    {
+        Services.AddSingleton(_cache.Object);
+        Services.AddSingleton(_binding.Object);
+        Services.AddSingleton(_feedback.Object);
+        // Default: not bindable (non-AIAS credentials, uninitialised device, …).
+        _binding.Setup(b => b.CanBind(It.IsAny<CachedCredential>())).Returns(false);
+    }
 
     // The detail page uses MudExpansionPanels, which asserts a MudPopoverProvider
     // in the tree (provided by MainLayout in the app).
@@ -110,5 +119,37 @@ public sealed class CredentialDetailTests : ComponentTestFixture
         var cut = Render(PageWithProvider(Guid.NewGuid()));
 
         cut.Markup.Should().Contain("Credential not found");
+    }
+
+    // ── #1195 Phase 2 — "Bind to device" visibility per CanBind ──────────────
+
+    [Fact]
+    public void BindButton_CanBindTrue_IsVisible()
+    {
+        var id = Guid.NewGuid();
+        _cache.Setup(c => c.ListAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<CachedCredential> { CredWithClaims(id) });
+        _binding.Setup(b => b.CanBind(It.Is<CachedCredential>(c => c.Id == id))).Returns(true);
+
+        var cut = Render(PageWithProvider(id));
+
+        cut.FindAll("[data-testid=credential-detail-bind-button]").Should().ContainSingle();
+        _binding.Verify(b => b.InitializeAsync(It.IsAny<CancellationToken>()), Times.Once,
+            "the page must prime the binding service before asking CanBind");
+    }
+
+    [Fact]
+    public void BindButton_CanBindFalse_IsAbsent()
+    {
+        var id = Guid.NewGuid();
+        _cache.Setup(c => c.ListAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<CachedCredential> { CredWithClaims(id) });
+        _binding.Setup(b => b.CanBind(It.IsAny<CachedCredential>())).Returns(false);
+
+        var cut = Render(PageWithProvider(id));
+
+        cut.FindAll("[data-testid=credential-detail-bind-button]").Should().BeEmpty();
+        // The rest of the page is unaffected — the Present affordance stays.
+        cut.FindAll("[data-testid=credential-detail-present-button]").Should().ContainSingle();
     }
 }

--- a/tests/Sorcha.Wallet.Pwa.Tests/Pages/PresentIntakeLayoutTests.cs
+++ b/tests/Sorcha.Wallet.Pwa.Tests/Pages/PresentIntakeLayoutTests.cs
@@ -9,7 +9,9 @@ using Bunit;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;
+using Sorcha.ServiceClients.CitizenWallet;
 using Sorcha.UI.Core.Models.Presentation;
+using Sorcha.UI.Core.Services.HolderKeys;
 using Sorcha.Verifier.Engine.Dcql;
 using Sorcha.UI.Testing;
 using Sorcha.Wallet.Pwa.Models.Device;
@@ -44,6 +46,9 @@ public sealed class PresentIntakeLayoutTests : ComponentTestFixture
         Services.AddSingleton(_delegation.Object);
         Services.AddSingleton(_statusList.Object);
         Services.AddSingleton(_log.Object);
+        // Task 7 wiring — the page resolves the selection inputs (holder + wallet clients).
+        Services.AddSingleton(new Mock<ICitizenWalletClient>().Object);
+        Services.AddSingleton(new Mock<IHolderKeyClient>().Object);
         Services.AddSingleton<Microsoft.Extensions.Logging.ILogger<PresentPage>>(
             Microsoft.Extensions.Logging.Abstractions.NullLogger<PresentPage>.Instance);
         Services.AddScoped<System.Net.Http.HttpClient>(_ =>

--- a/tests/Sorcha.Wallet.Pwa.Tests/Pages/PresentSelectionWiringTests.cs
+++ b/tests/Sorcha.Wallet.Pwa.Tests/Pages/PresentSelectionWiringTests.cs
@@ -1,0 +1,322 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System;
+using System.Buffers.Text;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Bunit;
+using FluentAssertions;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Sorcha.CitizenWallet.Abstractions.Models;
+using Sorcha.ServiceClients.CitizenWallet;
+using Sorcha.UI.Core.Models.Presentation;
+using Sorcha.UI.Core.Services.HolderKeys;
+using Sorcha.UI.Testing;
+using Sorcha.Verifier.Engine.Dcql;
+using Sorcha.Wallet.Pwa.Models.Device;
+using Sorcha.Wallet.Pwa.Services;
+using Sorcha.Wallet.Pwa.Services.Device;
+using Sorcha.Wallet.Pwa.Services.Presentation;
+using Xunit;
+using PresentPage = Sorcha.Wallet.Pwa.Pages.Present;
+
+namespace Sorcha.Wallet.Pwa.Tests.Pages;
+
+/// <summary>
+/// #1195 Phase 2 (Task 7, fix round 1) — the Present page's remote/web flow routes through
+/// <see cref="IPresentationEngine.Select"/> and honours the outcome: the holder-<c>cnf</c> root
+/// presents via the SERVER-CUSTODY signing leg (Task 6a endpoint), a this-device copy via the
+/// device-sign leg, <c>BindDeviceFirst</c> renders an explicit bind CTA (never a doomed present),
+/// and <c>NoMatch</c> keeps the existing no-matching-credential UX.
+/// </summary>
+public sealed class PresentSelectionWiringTests : ComponentTestFixture
+{
+    private const string Vct = "https://sorcha.dev/vc/test/v1";
+
+    private readonly Mock<IPresentationEngine> _engine = new();
+    private readonly Mock<ICredentialCache> _credentials = new();
+    private readonly Mock<IDeviceKeyService> _deviceKey = new();
+    private readonly Mock<IStatusListService> _statusList = new();
+    private readonly Mock<IPresentationLog> _log = new();
+    private readonly Mock<ICitizenWalletClient> _walletClient = new();
+    private readonly Mock<IHolderKeyClient> _holderKeys = new();
+    private readonly StubHttpHandler _http = new();
+
+    private static readonly JsonElement HolderJwk = JsonSerializer.Deserialize<JsonElement>(
+        """{"kty":"OKP","crv":"Ed25519","x":"holderX"}""");
+    private static readonly string HolderThumbprint = PresentationEngine.ComputeJwkThumbprint(HolderJwk);
+    private static readonly JsonElement DeviceJwk = JsonSerializer.Deserialize<JsonElement>(
+        """{"kty":"EC","crv":"P-256","x":"dx","y":"dy"}""");
+
+    public PresentSelectionWiringTests()
+    {
+        Services.AddSingleton(_engine.Object);
+        Services.AddSingleton(_credentials.Object);
+        Services.AddSingleton(_deviceKey.Object);
+        Services.AddSingleton(_statusList.Object);
+        Services.AddSingleton(_log.Object);
+        Services.AddSingleton(_walletClient.Object);
+        Services.AddSingleton(_holderKeys.Object);
+        Services.AddScoped(_ => new HttpClient(_http));
+
+        // PasteOnly intake — the paste field renders immediately, no camera interop.
+        var probe = new Mock<IDeviceProfileProbe>();
+        probe.Setup(p => p.GetProfileAsync(It.IsAny<CancellationToken>()))
+             .ReturnsAsync(new DeviceProfile(DeviceFormFactor.Desktop, CameraAvailability.Unavailable));
+        Services.AddScoped<IDeviceProfileProbe>(_ => probe.Object);
+
+        _deviceKey.Setup(d => d.GetThumbprintAsync(It.IsAny<CancellationToken>()))
+                  .ReturnsAsync("device-thumbprint");
+        _deviceKey.Setup(d => d.GetPublicJwkAsync(It.IsAny<CancellationToken>()))
+                  .ReturnsAsync(DeviceJwk);
+        _holderKeys.Setup(h => h.GetHolderKeysAsync(It.IsAny<CancellationToken>()))
+                   .ReturnsAsync(new HolderKeysView { HolderJwk = HolderJwk });
+        _credentials.Setup(c => c.ListAsync(It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(new List<CachedCredential> { MakeCredential(), MakeCredential() });
+        _engine.Setup(e => e.ParseAsync(
+                It.IsAny<string>(),
+                It.IsAny<Func<string, CancellationToken, Task<string>>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeRequest());
+    }
+
+    // ────────────────────────── outcomes ──────────────────────────
+
+    [Fact]
+    public async Task Continue_RemoteFlow_RoutesThroughSelectWithRemoteSurfaceAndBothThumbprints()
+    {
+        var rootMatch = MakeMatch();
+        _engine.Setup(e => e.Select(
+                It.IsAny<ParsedPresentationRequest>(), It.IsAny<IReadOnlyList<CachedCredential>>(),
+                It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<PresentationSurface>()))
+            .Returns(Selected(rootMatch, PresentationSigningMode.ServerCustody));
+
+        var cut = await ContinueAsync();
+
+        cut.WaitForAssertion(() =>
+            cut.FindAll("[data-testid=consent-sheet]").Should().ContainSingle(
+                "a Selected outcome lands on the consent surface"));
+
+        _engine.Verify(e => e.Select(
+                It.IsAny<ParsedPresentationRequest>(), It.IsAny<IReadOnlyList<CachedCredential>>(),
+                "device-thumbprint", HolderThumbprint, PresentationSurface.Remote),
+            Times.Once,
+            "the web present page is the REMOTE surface and must hand Select both key thumbprints");
+    }
+
+    [Fact]
+    public async Task Confirm_ServerCustodySelection_SignsViaWalletServiceWithHolderJwk_NeverDeviceKey()
+    {
+        var rootMatch = MakeMatch();
+        _engine.Setup(e => e.Select(
+                It.IsAny<ParsedPresentationRequest>(), It.IsAny<IReadOnlyList<CachedCredential>>(),
+                It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<PresentationSurface>()))
+            .Returns(Selected(rootMatch, PresentationSigningMode.ServerCustody));
+
+        JsonElement? jwkPassedToBuild = null;
+        SetupBuildVpToken(jwk => jwkPassedToBuild = jwk);
+        _walletClient.Setup(w => w.SignKbJwtAsync(It.IsAny<KbJwtSignRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new KbJwtSignResponse
+            {
+                Signature = Base64Url.EncodeToString(new byte[] { 9, 9 }),
+                Algorithm = "EdDSA",
+            });
+
+        var cut = await ContinueAsync();
+        await cut.InvokeAsync(() => cut.Find("[data-testid=consent-confirm]").Click());
+
+        cut.WaitForAssertion(() =>
+        {
+            // The KB-JWT is signed by the WALLET SERVICE under the holder key — never this device.
+            _walletClient.Verify(w => w.SignKbJwtAsync(
+                It.IsAny<KbJwtSignRequest>(), It.IsAny<CancellationToken>()), Times.Once);
+            _deviceKey.Verify(d => d.SignAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()), Times.Never,
+                "device-signing the holder-cnf root produces a KB-JWT that fails verification downstream");
+            jwkPassedToBuild.Should().NotBeNull();
+            jwkPassedToBuild!.Value.GetRawText().Should().Be(HolderJwk.GetRawText(),
+                "the KB-JWT header must carry the HOLDER key's thumbprint, not the device key's");
+        });
+    }
+
+    [Fact]
+    public async Task Confirm_DeviceSelection_SignsWithDeviceKey_NeverWalletService()
+    {
+        var copyMatch = MakeMatch();
+        _engine.Setup(e => e.Select(
+                It.IsAny<ParsedPresentationRequest>(), It.IsAny<IReadOnlyList<CachedCredential>>(),
+                It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<PresentationSurface>()))
+            .Returns(Selected(copyMatch, PresentationSigningMode.Device));
+
+        SetupBuildVpToken(_ => { });
+        _deviceKey.Setup(d => d.SignAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+                  .ReturnsAsync(new byte[] { 7 });
+
+        var cut = await ContinueAsync();
+        await cut.InvokeAsync(() => cut.Find("[data-testid=consent-confirm]").Click());
+
+        cut.WaitForAssertion(() =>
+        {
+            _deviceKey.Verify(d => d.SignAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()), Times.Once);
+            _walletClient.Verify(w => w.SignKbJwtAsync(
+                It.IsAny<KbJwtSignRequest>(), It.IsAny<CancellationToken>()), Times.Never);
+        });
+    }
+
+    [Fact]
+    public async Task Continue_BindDeviceFirst_RendersBindCtaAndNeverAttemptsPresent()
+    {
+        var rootMatch = MakeMatch();
+        _engine.Setup(e => e.Select(
+                It.IsAny<ParsedPresentationRequest>(), It.IsAny<IReadOnlyList<CachedCredential>>(),
+                It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<PresentationSurface>()))
+            .Returns(BindFirst(rootMatch));
+
+        var cut = await ContinueAsync();
+
+        cut.WaitForAssertion(() =>
+        {
+            cut.FindAll("[data-testid=present-bind-first]").Should().ContainSingle(
+                "a bind-first outcome renders explicit copy, never silence");
+            cut.FindAll("[data-testid=present-bind-cta]").Should().ContainSingle(
+                "the citizen is routed to the bind action, not left at a dead end");
+            cut.FindAll("[data-testid=consent-sheet]").Should().BeEmpty(
+                "a doomed present must never be offered");
+        });
+        _engine.Verify(e => e.BuildVpTokenAsync(
+                It.IsAny<CredentialMatch>(), It.IsAny<IReadOnlyList<string>>(),
+                It.IsAny<ParsedPresentationRequest>(), It.IsAny<JsonElement>(),
+                It.IsAny<Func<byte[], CancellationToken, Task<byte[]>>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+
+        // The CTA deep-links the root's credential card — the Task 6 "Bind to device" surface.
+        await cut.InvokeAsync(() => cut.Find("[data-testid=present-bind-cta]").Click());
+        Services.GetRequiredService<NavigationManager>().Uri
+            .Should().EndWith($"credentials/{rootMatch.Credential.Id}");
+    }
+
+    [Fact]
+    public async Task Continue_HolderKeyUnavailable_ShowsNamedInlineError_NoConsent()
+    {
+        _engine.Setup(e => e.Select(
+                It.IsAny<ParsedPresentationRequest>(), It.IsAny<IReadOnlyList<CachedCredential>>(),
+                It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<PresentationSurface>()))
+            .Returns(HolderKeyUnavailable());
+
+        var cut = await ContinueAsync();
+
+        cut.WaitForAssertion(() =>
+        {
+            var error = cut.FindAll("[data-testid=present-error]");
+            error.Should().ContainSingle("fail-closed selection must surface a named error, never silence");
+            error[0].TextContent.Should().Contain("holder key",
+                "the citizen must be told WHAT is unavailable so a retry makes sense");
+            cut.FindAll("[data-testid=consent-sheet]").Should().BeEmpty();
+        });
+    }
+
+    [Fact]
+    public async Task Continue_NoMatch_KeepsExistingNoMatchingCredentialUx()
+    {
+        _engine.Setup(e => e.Select(
+                It.IsAny<ParsedPresentationRequest>(), It.IsAny<IReadOnlyList<CachedCredential>>(),
+                It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<PresentationSurface>()))
+            .Returns(NoMatch());
+
+        var cut = await ContinueAsync();
+
+        cut.WaitForAssertion(() =>
+            cut.Markup.Should().Contain("None of your credentials match",
+                "a NoMatch outcome keeps the existing no-matching-credential dialog"));
+    }
+
+    // ────────────────────────── helpers ──────────────────────────
+
+    /// <summary>Render the page, paste a deep link, and press Continue.</summary>
+    private async Task<IRenderedComponent<PresentPage>> ContinueAsync()
+    {
+        var cut = Render<PresentPage>();
+        await cut.InvokeAsync(() =>
+            cut.Find("[data-testid=present-paste-field]").Change("openid4vp://request"));
+        await cut.InvokeAsync(() => cut.Find("[data-testid=present-continue]").Click());
+        return cut;
+    }
+
+    /// <summary>Mock BuildVpTokenAsync to capture the signer JWK and drive the signer delegate once.</summary>
+    private void SetupBuildVpToken(Action<JsonElement> onJwk)
+    {
+        _engine.Setup(e => e.BuildVpTokenAsync(
+                It.IsAny<CredentialMatch>(), It.IsAny<IReadOnlyList<string>>(),
+                It.IsAny<ParsedPresentationRequest>(), It.IsAny<JsonElement>(),
+                It.IsAny<Func<byte[], CancellationToken, Task<byte[]>>>(), It.IsAny<CancellationToken>()))
+            .Returns(async (CredentialMatch _, IReadOnlyList<string> _, ParsedPresentationRequest _,
+                JsonElement jwk, Func<byte[], CancellationToken, Task<byte[]>> signer, CancellationToken ct) =>
+            {
+                onJwk(jwk);
+                await signer(new byte[] { 1, 2, 3 }, ct);
+                return "vp";
+            });
+    }
+
+    private static ParsedPresentationRequest MakeRequest() => new()
+    {
+        ClientId = "did:sorcha:verifier:1",
+        ResponseUri = "https://verify.test/r/x/response",
+        Nonce = "n",
+        State = "s",
+        Query = new DcqlQuery
+        {
+            Credentials = [new DcqlCredentialQuery
+            {
+                Id = "credential",
+                Format = DcqlFormats.SdJwtVc,
+                Meta = new DcqlCredentialMeta { VctValues = [Vct] },
+            }],
+        },
+        RequiredVct = Vct,
+        RequiredClaims = ["givenName"],
+        OptionalClaims = [],
+    };
+
+    private static CachedCredential MakeCredential() => new()
+    {
+        Id = Guid.NewGuid(),
+        Vct = Vct,
+        RawSdJwt = "h.p.s",
+        AvailableClaimNames = ["givenName"],
+    };
+
+    private static CredentialMatch MakeMatch() => new()
+    {
+        Credential = MakeCredential(),
+        SatisfiedRequired = ["givenName"],
+        AvailableOptional = [],
+    };
+
+    // PresentationSelection factories are internal to the PWA assembly; build results directly.
+    private static PresentationSelection Selected(CredentialMatch match, PresentationSigningMode mode) =>
+        new() { Outcome = PresentationSelectionOutcome.Selected, Match = match, SigningMode = mode };
+
+    private static PresentationSelection BindFirst(CredentialMatch root) =>
+        new() { Outcome = PresentationSelectionOutcome.BindDeviceFirst, RootToBind = root };
+
+    private static PresentationSelection HolderKeyUnavailable() =>
+        new() { Outcome = PresentationSelectionOutcome.HolderKeyUnavailable };
+
+    private static PresentationSelection NoMatch() =>
+        new() { Outcome = PresentationSelectionOutcome.NoMatch };
+
+    /// <summary>Always-200 handler so ConfirmAsync's direct_post never touches the network.</summary>
+    private sealed class StubHttpHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken) =>
+            Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+    }
+}

--- a/tests/Sorcha.Wallet.Pwa.Tests/Pages/PresentSelectionWiringTests.cs
+++ b/tests/Sorcha.Wallet.Pwa.Tests/Pages/PresentSelectionWiringTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Buffers.Text;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Text.Json;
@@ -236,6 +237,138 @@ public sealed class PresentSelectionWiringTests : ComponentTestFixture
                 "a NoMatch outcome keeps the existing no-matching-credential dialog"));
     }
 
+    [Fact]
+    public async Task Continue_ChoiceRequired_ShowsPickerAndChosenCandidateKeepsItsSigningMode()
+    {
+        // Fix round 2 — genuinely distinct candidates restore the picker, and the chosen
+        // credential keeps the signing mode its candidate carried (never re-derived).
+        var rootMatch = MakeMatch();
+        var legacyMatch = MakeMatch();
+        _engine.Setup(e => e.Select(
+                It.IsAny<ParsedPresentationRequest>(), It.IsAny<IReadOnlyList<CachedCredential>>(),
+                It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<PresentationSurface>()))
+            .Returns(Choice(
+            [
+                new PresentationCandidate(rootMatch, PresentationSigningMode.ServerCustody),
+                new PresentationCandidate(legacyMatch, PresentationSigningMode.Device),
+            ]));
+
+        JsonElement? jwkPassedToBuild = null;
+        SetupBuildVpToken(jwk => jwkPassedToBuild = jwk);
+        _walletClient.Setup(w => w.SignKbJwtAsync(It.IsAny<KbJwtSignRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new KbJwtSignResponse
+            {
+                Signature = Base64Url.EncodeToString(new byte[] { 9, 9 }),
+                Algorithm = "EdDSA",
+            });
+
+        var cut = await ContinueAsync();
+
+        // The picker is offered with both distinct candidates.
+        cut.WaitForAssertion(() =>
+            cut.FindAll("[data-testid=credential-picker-candidate]").Should().HaveCount(2,
+                "distinct candidates must offer the citizen a pick, exactly as before Task 7"));
+
+        // Choose the FIRST candidate — the server-custody root.
+        await cut.InvokeAsync(() =>
+            cut.FindAll("[data-testid=credential-picker-candidate]")[0].Click());
+        cut.WaitForAssertion(() =>
+            cut.FindAll("[data-testid=consent-sheet]").Should().ContainSingle());
+
+        await cut.InvokeAsync(() => cut.Find("[data-testid=consent-confirm]").Click());
+
+        cut.WaitForAssertion(() =>
+        {
+            // The chosen ROOT candidate carried ServerCustody — the wallet service signs, never the device.
+            _walletClient.Verify(w => w.SignKbJwtAsync(
+                It.IsAny<KbJwtSignRequest>(), It.IsAny<CancellationToken>()), Times.Once);
+            _deviceKey.Verify(d => d.SignAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()), Times.Never);
+            jwkPassedToBuild!.Value.GetRawText().Should().Be(HolderJwk.GetRawText());
+        });
+    }
+
+    [Fact]
+    public async Task ConfirmMulti_RootQueryIsServerCustodySigned_CopyQueryDeviceSigned_NeverDeviceSignedRoot()
+    {
+        // Fix round 2 — the multi-credential (F181 US2) flow classifies EACH consented query by cnf
+        // thumbprint: the holder-cnf root goes server-custody, the device-cnf copy device-signs.
+        // A device-signed root is the recorded silent-verification-failure trap.
+        const string AddressVct = "https://sorcha.dev/vc/address/v1";
+        var deviceThumbprint = PresentationEngine.ComputeJwkThumbprint(DeviceJwk);
+        _deviceKey.Setup(d => d.GetThumbprintAsync(It.IsAny<CancellationToken>()))
+                  .ReturnsAsync(deviceThumbprint);
+
+        var rootCred = MakeCnfCredential(Vct, HolderJwk);           // cnf = holder key → root
+        var copyCred = MakeCnfCredential(AddressVct, DeviceJwk);    // cnf = THIS device → copy
+
+        var request = MakeMultiRequest(("identity", Vct), ("address", AddressVct));
+        _engine.Setup(e => e.ParseAsync(
+                It.IsAny<string>(), It.IsAny<Func<string, CancellationToken, Task<string>>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(request);
+        _engine.Setup(e => e.MatchQuery(
+                It.IsAny<ParsedPresentationRequest>(), It.IsAny<IReadOnlyList<CachedCredential>>()))
+            .Returns(new DcqlMatchResult
+            {
+                Satisfiable = true,
+                PerQuery =
+                [
+                    MakeQueryMatch("identity", Vct, rootCred),
+                    MakeQueryMatch("address", AddressVct, copyCred),
+                ],
+                UnsatisfiedRequiredQueryIds = [],
+                SetChoices = [],
+            });
+
+        IReadOnlyList<ConsentedQuery>? capturedConsented = null;
+        JsonElement? capturedHolderJwk = null;
+        Func<byte[], CancellationToken, Task<byte[]>>? capturedHolderSigner = null;
+        _engine.Setup(e => e.BuildVpTokenEnvelopeAsync(
+                It.IsAny<IReadOnlyList<ConsentedQuery>>(), It.IsAny<ParsedPresentationRequest>(),
+                It.IsAny<JsonElement>(), It.IsAny<Func<byte[], CancellationToken, Task<byte[]>>>(),
+                It.IsAny<JsonElement?>(), It.IsAny<Func<byte[], CancellationToken, Task<byte[]>>?>(),
+                It.IsAny<CancellationToken>()))
+            .Callback((IReadOnlyList<ConsentedQuery> consented, ParsedPresentationRequest _,
+                JsonElement _, Func<byte[], CancellationToken, Task<byte[]>> _,
+                JsonElement? holderJwk, Func<byte[], CancellationToken, Task<byte[]>>? holderSigner,
+                CancellationToken _) =>
+            {
+                capturedConsented = consented;
+                capturedHolderJwk = holderJwk;
+                capturedHolderSigner = holderSigner;
+            })
+            .ReturnsAsync("""{"identity":["vp"],"address":["vp"]}""");
+        _walletClient.Setup(w => w.SignKbJwtAsync(It.IsAny<KbJwtSignRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new KbJwtSignResponse
+            {
+                Signature = Base64Url.EncodeToString(new byte[] { 9 }),
+                Algorithm = "EdDSA",
+            });
+
+        var cut = await ContinueAsync();
+        cut.WaitForAssertion(() =>
+            cut.FindAll("[data-testid=consent-sheet]").Should().ContainSingle());
+        await cut.InvokeAsync(() => cut.Find("[data-testid=consent-confirm]").Click());
+
+        cut.WaitForAssertion(() => capturedConsented.Should().NotBeNull());
+
+        // The root's query is server-custody; the copy's is device-signed. NEVER a device-signed root.
+        capturedConsented!.Single(c => c.QueryId == "identity").SigningMode
+            .Should().Be(PresentationSigningMode.ServerCustody,
+                "device-signing the holder-cnf root fails verification downstream with no local error");
+        capturedConsented.Single(c => c.QueryId == "address").SigningMode
+            .Should().Be(PresentationSigningMode.Device);
+
+        // The page supplied the holder signing leg for the server-custody entry.
+        capturedHolderJwk.Should().NotBeNull();
+        capturedHolderJwk!.Value.GetRawText().Should().Be(HolderJwk.GetRawText());
+        capturedHolderSigner.Should().NotBeNull();
+        await capturedHolderSigner!(new byte[] { 1, 2 }, CancellationToken.None);
+        _walletClient.Verify(w => w.SignKbJwtAsync(
+            It.IsAny<KbJwtSignRequest>(), It.IsAny<CancellationToken>()), Times.Once,
+            "the holder signer must round-trip the Task 6a sign-kb endpoint");
+    }
+
     // ────────────────────────── helpers ──────────────────────────
 
     /// <summary>Render the page, paste a deep link, and press Continue.</summary>
@@ -299,9 +432,61 @@ public sealed class PresentSelectionWiringTests : ComponentTestFixture
         AvailableOptional = [],
     };
 
+    /// <summary>A two-query DCQL request so the page takes the multi-credential (F181 US2) path.</summary>
+    private static ParsedPresentationRequest MakeMultiRequest(params (string Id, string Vct)[] queries) => new()
+    {
+        ClientId = "did:sorcha:verifier:1",
+        ResponseUri = "https://verify.test/r/x/response",
+        Nonce = "n",
+        State = "s",
+        Query = new DcqlQuery
+        {
+            Credentials = queries.Select(q => new DcqlCredentialQuery
+            {
+                Id = q.Id,
+                Format = DcqlFormats.SdJwtVc,
+                Meta = new DcqlCredentialMeta { VctValues = [q.Vct] },
+            }).ToList(),
+        },
+        RequiredVct = queries[0].Vct,
+        RequiredClaims = [],
+        OptionalClaims = [],
+    };
+
+    private static DcqlQueryMatch MakeQueryMatch(string queryId, string vct, CachedCredential credential) => new()
+    {
+        QueryId = queryId,
+        Vct = vct,
+        RequiredClaims = [],
+        OptionalClaims = [],
+        Candidates =
+        [
+            new CredentialMatch { Credential = credential, SatisfiedRequired = [], AvailableOptional = [] },
+        ],
+    };
+
+    /// <summary>A cached SD-JWT whose payload carries the given cnf.jwk — classified by REAL thumbprint logic.</summary>
+    private static CachedCredential MakeCnfCredential(string vct, JsonElement cnfJwk)
+    {
+        var headerSeg = Base64Url.EncodeToString(
+            JsonSerializer.SerializeToUtf8Bytes(new { alg = "ES256", typ = "dc+sd-jwt" }));
+        var payloadSeg = Base64Url.EncodeToString(JsonSerializer.SerializeToUtf8Bytes(
+            new Dictionary<string, object> { ["vct"] = vct, ["cnf"] = new Dictionary<string, object> { ["jwk"] = cnfJwk } }));
+        return new CachedCredential
+        {
+            Id = Guid.NewGuid(),
+            Vct = vct,
+            RawSdJwt = $"{headerSeg}.{payloadSeg}.sig",
+            AvailableClaimNames = [],
+        };
+    }
+
     // PresentationSelection factories are internal to the PWA assembly; build results directly.
     private static PresentationSelection Selected(CredentialMatch match, PresentationSigningMode mode) =>
         new() { Outcome = PresentationSelectionOutcome.Selected, Match = match, SigningMode = mode };
+
+    private static PresentationSelection Choice(IReadOnlyList<PresentationCandidate> candidates) =>
+        new() { Outcome = PresentationSelectionOutcome.ChoiceRequired, Candidates = candidates };
 
     private static PresentationSelection BindFirst(CredentialMatch root) =>
         new() { Outcome = PresentationSelectionOutcome.BindDeviceFirst, RootToBind = root };

--- a/tests/Sorcha.Wallet.Pwa.Tests/Pages/ProximityAffordanceTests.cs
+++ b/tests/Sorcha.Wallet.Pwa.Tests/Pages/ProximityAffordanceTests.cs
@@ -54,6 +54,9 @@ public sealed class ProximityAffordanceTests : ComponentTestFixture
         Services.AddSingleton(_delegation.Object);
         Services.AddSingleton(_statusList.Object);
         Services.AddSingleton(_log.Object);
+        // Task 7 wiring — the page resolves the selection inputs (holder + wallet clients).
+        Services.AddSingleton(new Mock<Sorcha.ServiceClients.CitizenWallet.ICitizenWalletClient>().Object);
+        Services.AddSingleton(new Mock<Sorcha.UI.Core.Services.HolderKeys.IHolderKeyClient>().Object);
         Services.AddSingleton<Microsoft.Extensions.Logging.ILogger<PresentPage>>(
             Microsoft.Extensions.Logging.Abstractions.NullLogger<PresentPage>.Instance);
         Services.AddScoped<System.Net.Http.HttpClient>(_ => new System.Net.Http.HttpClient());

--- a/tests/Sorcha.Wallet.Pwa.Tests/Services/DeviceBindingServiceTests.cs
+++ b/tests/Sorcha.Wallet.Pwa.Tests/Services/DeviceBindingServiceTests.cs
@@ -1,0 +1,587 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System;
+using System.Buffers.Text;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Sorcha.CitizenWallet.Abstractions.Constants;
+using Sorcha.CitizenWallet.Abstractions.Models;
+using Sorcha.ServiceClients.CitizenWallet;
+using Sorcha.UI.Core.Models.Presentation;
+using Sorcha.UI.Core.Services.HolderKeys;
+using Sorcha.Verifier.Engine.Dcql;
+using Sorcha.Wallet.Pwa.Services;
+using Sorcha.Wallet.Pwa.Services.Applications;
+using Sorcha.Wallet.Pwa.Services.Catalogue;
+using Sorcha.Wallet.Pwa.Services.Presentation;
+using Xunit;
+using BlueprintAction = Sorcha.Blueprint.Models.Action;
+
+namespace Sorcha.Wallet.Pwa.Tests.Services;
+
+/// <summary>
+/// Tests for <see cref="DeviceBindingService"/> (#1195 Phase 2, Task 6 — the PWA
+/// "Bind to device" flow). CanBind is the root/copy discriminator (holder-cnf AIAS
+/// root, no live device copy on this device); BindToThisDeviceAsync orchestrates
+/// capture → submit (gated starting action) → present (server-custody root) →
+/// bounded wait for the device-cnf copy via sync. Failures must be loud and
+/// distinguishable — never silent, never cached.
+/// </summary>
+public sealed class DeviceBindingServiceTests
+{
+    private const string AiasVct = "https://sorcha.dev/vc/assured-identity/v1";
+    private const string BlueprintId = "aias-device-registration-20260716120000";
+    private const string RegisterId = "reg-1";
+
+    // ── fixed keys ────────────────────────────────────────────────────────────
+
+    /// <summary>This device's P-256 public JWK (what IDeviceKeyService reports).</summary>
+    private static readonly JsonElement DeviceJwk = JsonSerializer.Deserialize<JsonElement>(
+        """{"kty":"EC","crv":"P-256","x":"devX","y":"devY"}""");
+
+    /// <summary>The citizen's server-custodied holder JWK (Ed25519 — the root's cnf key).</summary>
+    private static readonly JsonElement HolderJwk = JsonSerializer.Deserialize<JsonElement>(
+        """{"kty":"OKP","crv":"Ed25519","x":"holderX"}""");
+
+    private static string Rfc7638(JsonElement jwk)
+    {
+        var kty = jwk.GetProperty("kty").GetString();
+        var crv = jwk.GetProperty("crv").GetString();
+        var x = jwk.GetProperty("x").GetString();
+        var canonical = kty == "OKP"
+            ? $"{{\"crv\":\"{crv}\",\"kty\":\"OKP\",\"x\":\"{x}\"}}"
+            : $"{{\"crv\":\"{crv}\",\"kty\":\"EC\",\"x\":\"{x}\",\"y\":\"{jwk.GetProperty("y").GetString()}\"}}";
+        return Base64Url.EncodeToString(SHA256.HashData(Encoding.UTF8.GetBytes(canonical)));
+    }
+
+    private static string DeviceThumbprint => Rfc7638(DeviceJwk);
+
+    // ── credential builders ───────────────────────────────────────────────────
+
+    /// <summary>An SD-JWT whose payload carries cnf.jwk = the given key.</summary>
+    private static string SdJwtWithCnf(JsonElement cnfJwk)
+    {
+        var payload = Base64Url.EncodeToString(JsonSerializer.SerializeToUtf8Bytes(new
+        {
+            vct = AiasVct,
+            cnf = new { jwk = cnfJwk },
+        }));
+        return $"eyJhbGciOiJFZERTQSJ9.{payload}.sig~";
+    }
+
+    private static CachedCredential Root(Guid? id = null) => new()
+    {
+        Id = id ?? Guid.NewGuid(),
+        Vct = AiasVct,
+        RawSdJwt = SdJwtWithCnf(HolderJwk),
+        AvailableClaimNames = ["givenName", "familyName", "dateOfBirth", "email"],
+    };
+
+    private static CachedCredential DeviceCopy(Guid? id = null) => new()
+    {
+        Id = id ?? Guid.NewGuid(),
+        Vct = AiasVct,
+        RawSdJwt = SdJwtWithCnf(DeviceJwk),
+        AvailableClaimNames = ["givenName", "familyName", "dateOfBirth"],
+    };
+
+    // ── mocks / harness ───────────────────────────────────────────────────────
+
+    private readonly Mock<IDeviceKeyService> _deviceKeys = new();
+    private readonly Mock<ICatalogueClient> _catalogue = new();
+    private readonly Mock<IApplicationActionClient> _actions = new();
+    private readonly Mock<IPresentationEngine> _engine = new();
+    private readonly Mock<IHolderKeyClient> _holderKeys = new();
+    private readonly Mock<ICitizenWalletClient> _walletClient = new();
+    private readonly Mock<ICredentialCache> _cache = new();
+    private readonly Mock<ISyncService> _sync = new();
+    private readonly RecordingHttpHandler _http = new();
+    private readonly List<string> _callLog = [];
+
+    private DeviceBindingService CreateService(DeviceBindingOptions? options = null) => new(
+        _deviceKeys.Object,
+        _catalogue.Object,
+        _actions.Object,
+        _engine.Object,
+        _holderKeys.Object,
+        _walletClient.Object,
+        _cache.Object,
+        _sync.Object,
+        new HttpClient(_http) { BaseAddress = new Uri("https://gateway.test/") },
+        TimeProvider.System,
+        NullLogger<DeviceBindingService>.Instance,
+        options ?? new DeviceBindingOptions
+        {
+            PollInterval = TimeSpan.FromMilliseconds(1),
+            DeliveryTimeout = TimeSpan.FromMilliseconds(250),
+        });
+
+    public DeviceBindingServiceTests()
+    {
+        _deviceKeys.Setup(d => d.GetPublicJwkAsync(It.IsAny<CancellationToken>()))
+            .Callback(() => _callLog.Add("capture"))
+            .ReturnsAsync(DeviceJwk);
+        _deviceKeys.Setup(d => d.GetThumbprintAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(DeviceThumbprint);
+    }
+
+    private void SetupHappyPath(CachedCredential root, CachedCredential copy)
+    {
+        var instanceId = Guid.NewGuid();
+
+        _catalogue.Setup(c => c.GetServicesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync([new CatalogueItem(BlueprintId, "AIAS Bind Identity to Device", null, RegisterId)]);
+        _catalogue.Setup(c => c.StartAsync(It.IsAny<CatalogueItem>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(instanceId.ToString("N"));
+
+        _actions.Setup(a => a.LoadFormAsync(instanceId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ApplicationFormLoadResult.Success(FormContext(instanceId)));
+        _actions.Setup(a => a.SubmitAsync(
+                It.IsAny<ApplicationFormContext>(),
+                It.IsAny<IReadOnlyDictionary<string, object?>>(),
+                It.IsAny<CancellationToken>()))
+            .Callback(() => _callLog.Add("submit"))
+            .ReturnsAsync(SubmitAccepted());
+
+        _engine.Setup(e => e.ParseAsync(
+                "openid4vp://authorize?client_id=x&request_uri=y",
+                It.IsAny<Func<string, CancellationToken, Task<string>>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Request());
+        _engine.Setup(e => e.Match(It.IsAny<ParsedPresentationRequest>(), It.IsAny<IReadOnlyList<CachedCredential>>()))
+            .Returns([new CredentialMatch
+            {
+                Credential = root,
+                SatisfiedRequired = ["givenName", "familyName", "dateOfBirth"],
+                AvailableOptional = [],
+            }]);
+        _engine.Setup(e => e.BuildVpTokenAsync(
+                It.IsAny<CredentialMatch>(),
+                It.IsAny<IReadOnlyList<string>>(),
+                It.IsAny<ParsedPresentationRequest>(),
+                It.IsAny<JsonElement>(),
+                It.IsAny<Func<byte[], CancellationToken, Task<byte[]>>>(),
+                It.IsAny<CancellationToken>()))
+            .Callback(() => _callLog.Add("present"))
+            .ReturnsAsync("vp-token~kb");
+
+        _holderKeys.Setup(h => h.GetHolderKeysAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new HolderKeysView { HolderJwk = HolderJwk, WalletAddress = "ws1qcitizen" });
+
+        _sync.Setup(s => s.SyncAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SyncOutcome(SyncMode.Delta, 1, 0, 0, []));
+
+        // First list (initialize) has only the root; after the presentation the copy appears.
+        _cache.SetupSequence(c => c.ListAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync([root])
+            .ReturnsAsync([root, copy]);
+    }
+
+    private static ApplicationFormContext FormContext(Guid instanceId) => new(
+        InstanceId: instanceId,
+        Action: new BlueprintAction { Id = 1, Title = "Bind your identity to this device" },
+        BlueprintId: BlueprintId,
+        RegisterId: RegisterId,
+        SenderWallet: "ws1qcitizen",
+        ActionId: 1,
+        Title: "AIAS Bind Identity to Device");
+
+    private static ApplicationSubmissionResult SubmitAccepted() => new(
+        ApplicationSubmissionStatus.Success,
+        InstanceId: null,
+        ErrorCode: null,
+        ErrorDetail: null,
+        AwaitingPresentation: true,
+        PresentationRequestId: Guid.NewGuid(),
+        PresentationRequestUri: "openid4vp://authorize?client_id=x&request_uri=y");
+
+    private static ParsedPresentationRequest Request() => new()
+    {
+        ClientId = "did:sorcha:org:aias",
+        ResponseUri = "https://gateway.test/api/presentations/callbacks/sorcha-wallet/00000000000000000000000000000001",
+        Nonce = "nonce-1",
+        State = "state-1",
+        Query = new DcqlQuery
+        {
+            Credentials = [new DcqlCredentialQuery
+            {
+                Id = "credential",
+                Format = DcqlFormats.SdJwtVc,
+                Meta = new DcqlCredentialMeta { VctValues = [AiasVct] },
+            }],
+        },
+        RequiredVct = AiasVct,
+        RequiredClaims = ["givenName", "familyName", "dateOfBirth"],
+        OptionalClaims = [],
+    };
+
+    // ── CanBind matrix ────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task CanBind_AiasHolderCnfRootWithNoDeviceCopy_ReturnsTrue()
+    {
+        var root = Root();
+        _cache.Setup(c => c.ListAsync(It.IsAny<CancellationToken>())).ReturnsAsync([root]);
+
+        var service = CreateService();
+        await service.InitializeAsync();
+
+        service.CanBind(root).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task CanBind_DeviceBoundCopyOnThisDevice_ReturnsFalse()
+    {
+        // A copy whose cnf IS this device's key is not a root — nothing to bind.
+        var copy = DeviceCopy();
+        _cache.Setup(c => c.ListAsync(It.IsAny<CancellationToken>())).ReturnsAsync([copy]);
+
+        var service = CreateService();
+        await service.InitializeAsync();
+
+        service.CanBind(copy).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task CanBind_RootButDeviceCopyAlreadyHeld_ReturnsFalse()
+    {
+        var root = Root();
+        var copy = DeviceCopy();
+        _cache.Setup(c => c.ListAsync(It.IsAny<CancellationToken>())).ReturnsAsync([root, copy]);
+
+        var service = CreateService();
+        await service.InitializeAsync();
+
+        service.CanBind(root).Should().BeFalse("this device already holds a live device-cnf copy");
+    }
+
+    [Fact]
+    public async Task CanBind_NonAiasVct_ReturnsFalse()
+    {
+        var other = new CachedCredential
+        {
+            Id = Guid.NewGuid(),
+            Vct = "https://sorcha.dev/vc/driving-licence/v1",
+            RawSdJwt = SdJwtWithCnf(HolderJwk),
+            AvailableClaimNames = ["licenceNumber"],
+        };
+        _cache.Setup(c => c.ListAsync(It.IsAny<CancellationToken>())).ReturnsAsync([other]);
+
+        var service = CreateService();
+        await service.InitializeAsync();
+
+        service.CanBind(other).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task CanBind_CaseVariantVct_ReturnsFalse()
+    {
+        // vct matching is case-sensitive Ordinal — a case-variant URI is a different type.
+        var variant = new CachedCredential
+        {
+            Id = Guid.NewGuid(),
+            Vct = AiasVct.ToUpperInvariant(),
+            RawSdJwt = SdJwtWithCnf(HolderJwk),
+            AvailableClaimNames = ["givenName"],
+        };
+        _cache.Setup(c => c.ListAsync(It.IsAny<CancellationToken>())).ReturnsAsync([variant]);
+
+        var service = CreateService();
+        await service.InitializeAsync();
+
+        service.CanBind(variant).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task CanBind_CredentialWithoutCnf_ReturnsFalse()
+    {
+        var noCnf = new CachedCredential
+        {
+            Id = Guid.NewGuid(),
+            Vct = AiasVct,
+            RawSdJwt = "eyJhbGciOiJFZERTQSJ9." +
+                Base64Url.EncodeToString(JsonSerializer.SerializeToUtf8Bytes(new { vct = AiasVct })) + ".sig~",
+            AvailableClaimNames = ["givenName"],
+        };
+        _cache.Setup(c => c.ListAsync(It.IsAny<CancellationToken>())).ReturnsAsync([noCnf]);
+
+        var service = CreateService();
+        await service.InitializeAsync();
+
+        service.CanBind(noCnf).Should().BeFalse();
+    }
+
+    [Fact]
+    public void CanBind_BeforeInitialize_ReturnsFalse()
+    {
+        var service = CreateService();
+        service.CanBind(Root()).Should().BeFalse("the device thumbprint is unknown until initialized");
+    }
+
+    [Fact]
+    public async Task CanBind_DeviceKeyUnavailable_ReturnsFalse()
+    {
+        // Non-PWA host / bridge failure: device binding is unavailable, never a crash.
+        _deviceKeys.Setup(d => d.GetThumbprintAsync(It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("no webcrypto bridge"));
+        _cache.Setup(c => c.ListAsync(It.IsAny<CancellationToken>())).ReturnsAsync([Root()]);
+
+        var service = CreateService();
+        await service.InitializeAsync();
+
+        service.CanBind(Root()).Should().BeFalse();
+    }
+
+    // ── BindToThisDeviceAsync ─────────────────────────────────────────────────
+
+    [Fact]
+    public async Task BindToThisDeviceAsync_HappyPath_RunsLegsInOrder_AndReturnsTheCachedDeviceCopy()
+    {
+        var root = Root();
+        var copy = DeviceCopy();
+        SetupHappyPath(root, copy);
+
+        var service = CreateService();
+        var result = await service.BindToThisDeviceAsync(root, CancellationToken.None);
+
+        result.Should().BeSameAs(copy, "the device-cnf copy delivered via sync is the result");
+
+        // The F127 gate defines the order: the device key is captured first, the gated
+        // starting action is SUBMITTED (that mints the presentation request), and only
+        // then is the root PRESENTED. (Design §4.2 lists present-then-submit, but the
+        // shipped F127 machinery mints the request AT submission — submit precedes present.)
+        _callLog.Should().ContainInOrder("capture", "submit", "present");
+
+        // The direct_post left the building: exactly one POST to the request's response_uri
+        // carrying the vp token in the documented {vpToken} JSON shape.
+        _http.Requests.Should().ContainSingle();
+        _http.Requests[0].Method.Should().Be(HttpMethod.Post);
+        _http.Requests[0].RequestUri!.ToString().Should().Contain("/api/presentations/callbacks/sorcha-wallet/");
+        _http.RequestBodies[0].Should().Contain("\"vpToken\"").And.Contain("vp-token~kb");
+    }
+
+    [Fact]
+    public async Task BindToThisDeviceAsync_SubmitsDeviceJwkAtTheBlueprintSlot()
+    {
+        var root = Root();
+        SetupHappyPath(root, DeviceCopy());
+        IReadOnlyDictionary<string, object?>? submitted = null;
+        _actions.Setup(a => a.SubmitAsync(
+                It.IsAny<ApplicationFormContext>(),
+                It.IsAny<IReadOnlyDictionary<string, object?>>(),
+                It.IsAny<CancellationToken>()))
+            .Callback((ApplicationFormContext _, IReadOnlyDictionary<string, object?> data, CancellationToken _) =>
+                submitted = data)
+            .ReturnsAsync(SubmitAccepted());
+
+        var service = CreateService();
+        await service.BindToThisDeviceAsync(root, CancellationToken.None);
+
+        submitted.Should().NotBeNull();
+        submitted!.Keys.Should().Contain("/deviceKey/holderJwk",
+            "the blueprint's issuance action reads the device JWK from /deviceKey/holderJwk");
+    }
+
+    [Fact]
+    public async Task BindToThisDeviceAsync_HolderSignerDelegate_RoundTripsTheSignKbEndpoint()
+    {
+        var root = Root();
+        SetupHappyPath(root, DeviceCopy());
+
+        Func<byte[], CancellationToken, Task<byte[]>>? capturedSigner = null;
+        _engine.Setup(e => e.BuildVpTokenAsync(
+                It.IsAny<CredentialMatch>(),
+                It.IsAny<IReadOnlyList<string>>(),
+                It.IsAny<ParsedPresentationRequest>(),
+                It.IsAny<JsonElement>(),
+                It.IsAny<Func<byte[], CancellationToken, Task<byte[]>>>(),
+                It.IsAny<CancellationToken>()))
+            .Callback((CredentialMatch _, IReadOnlyList<string> _, ParsedPresentationRequest _,
+                       JsonElement jwk, Func<byte[], CancellationToken, Task<byte[]>> signer, CancellationToken _) =>
+            {
+                jwk.GetProperty("kty").GetString().Should().Be("OKP", "the ROOT presents under the holder JWK, not the device key");
+                capturedSigner = signer;
+            })
+            .ReturnsAsync("vp-token~kb");
+
+        var signatureBytes = new byte[] { 7, 7, 7 };
+        _walletClient.Setup(w => w.SignKbJwtAsync(
+                It.Is<KbJwtSignRequest>(r => r.SigningInput == "hdr.payload"),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new KbJwtSignResponse
+            {
+                Signature = Base64Url.EncodeToString(signatureBytes),
+                Algorithm = "EdDSA",
+            });
+
+        var service = CreateService();
+        await service.BindToThisDeviceAsync(root, CancellationToken.None);
+
+        capturedSigner.Should().NotBeNull("the engine must receive the server-custody signer");
+        var produced = await capturedSigner!(Encoding.ASCII.GetBytes("hdr.payload"), CancellationToken.None);
+        produced.Should().Equal(signatureBytes, "the delegate signs via POST /api/v1/wallet/presentations/sign-kb");
+    }
+
+    [Fact]
+    public async Task BindToThisDeviceAsync_PresentationLegFails_ThrowsDistinguishableError_AndCachesNothing()
+    {
+        var root = Root();
+        SetupHappyPath(root, DeviceCopy());
+        _engine.Setup(e => e.ParseAsync(
+                It.IsAny<string>(),
+                It.IsAny<Func<string, CancellationToken, Task<string>>>(),
+                It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new FormatException("bad request object"));
+
+        var service = CreateService();
+        var act = () => service.BindToThisDeviceAsync(root, CancellationToken.None);
+
+        var ex = (await act.Should().ThrowAsync<DeviceBindingException>()).Which;
+        ex.Failure.Should().Be(DeviceBindingFailure.PresentationRequestInvalid);
+        ex.Message.Should().Contain("identity check", "the presentation-leg failure must be nameable by the citizen");
+
+        _sync.Verify(s => s.SyncAsync(It.IsAny<CancellationToken>()), Times.Never,
+            "a failed presentation must not trigger any delivery wait");
+        _cache.Verify(c => c.UpsertAsync(It.IsAny<CachedCredential>(), It.IsAny<CancellationToken>()), Times.Never,
+            "nothing may be cached on a failed bind");
+    }
+
+    [Fact]
+    public async Task BindToThisDeviceAsync_DirectPostRejected_ThrowsWithStatus_AndCachesNothing()
+    {
+        var root = Root();
+        SetupHappyPath(root, DeviceCopy());
+        _http.RespondWith = _ => new HttpResponseMessage(HttpStatusCode.Forbidden);
+
+        var service = CreateService();
+        var act = () => service.BindToThisDeviceAsync(root, CancellationToken.None);
+
+        var ex = (await act.Should().ThrowAsync<DeviceBindingException>()).Which;
+        ex.Failure.Should().Be(DeviceBindingFailure.PresentationSubmitRejected);
+        ex.Message.Should().Contain("403", "the submit-leg failure must carry the refusing status");
+        ex.Retryable.Should().BeFalse();
+        _sync.Verify(s => s.SyncAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task BindToThisDeviceAsync_DirectPost503_IsRetryable()
+    {
+        var root = Root();
+        SetupHappyPath(root, DeviceCopy());
+        _http.RespondWith = _ => new HttpResponseMessage(HttpStatusCode.ServiceUnavailable);
+
+        var service = CreateService();
+        var act = () => service.BindToThisDeviceAsync(root, CancellationToken.None);
+
+        var ex = (await act.Should().ThrowAsync<DeviceBindingException>()).Which;
+        ex.Failure.Should().Be(DeviceBindingFailure.PresentationSubmitRejected);
+        ex.Retryable.Should().BeTrue("503 is a transient infrastructure fault");
+    }
+
+    [Fact]
+    public async Task BindToThisDeviceAsync_Submit409_IsPolicyRefusal_NotRetryable()
+    {
+        var root = Root();
+        SetupHappyPath(root, DeviceCopy());
+        _actions.Setup(a => a.SubmitAsync(
+                It.IsAny<ApplicationFormContext>(),
+                It.IsAny<IReadOnlyDictionary<string, object?>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ApplicationSubmissionResult(
+                ApplicationSubmissionStatus.ValidationFailed, null, "HTTP_409", "conflict"));
+
+        var service = CreateService();
+        var act = () => service.BindToThisDeviceAsync(root, CancellationToken.None);
+
+        var ex = (await act.Should().ThrowAsync<DeviceBindingException>()).Which;
+        ex.Failure.Should().Be(DeviceBindingFailure.PolicyRefused);
+        ex.Retryable.Should().BeFalse("the policy ran and said no — retrying cannot change the answer");
+    }
+
+    [Fact]
+    public async Task BindToThisDeviceAsync_SubmitAcceptedWithoutPresentation_ThrowsNamedServerGap()
+    {
+        // Never-silent: if the server accepts the action but doesn't start the identity
+        // check (SorchaWallet initiation not wired on /execute), the citizen must see a
+        // named failure — not a success, not an eternal spinner.
+        var root = Root();
+        SetupHappyPath(root, DeviceCopy());
+        _actions.Setup(a => a.SubmitAsync(
+                It.IsAny<ApplicationFormContext>(),
+                It.IsAny<IReadOnlyDictionary<string, object?>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ApplicationSubmissionResult(
+                ApplicationSubmissionStatus.Success, null, null, null));
+
+        var service = CreateService();
+        var act = () => service.BindToThisDeviceAsync(root, CancellationToken.None);
+
+        var ex = (await act.Should().ThrowAsync<DeviceBindingException>()).Which;
+        ex.Failure.Should().Be(DeviceBindingFailure.PresentationNotInitiated);
+        _engine.Verify(e => e.ParseAsync(It.IsAny<string>(),
+            It.IsAny<Func<string, CancellationToken, Task<string>>>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task BindToThisDeviceAsync_CopyNeverArrives_ThrowsDeliveryTimeout_AsExplicitPendingOutcome()
+    {
+        var root = Root();
+        SetupHappyPath(root, DeviceCopy());
+        // Sync runs, but the copy never lands in the cache.
+        _cache.Setup(c => c.ListAsync(It.IsAny<CancellationToken>())).ReturnsAsync([root]);
+
+        var service = CreateService();
+        var act = () => service.BindToThisDeviceAsync(root, CancellationToken.None);
+
+        var ex = (await act.Should().ThrowAsync<DeviceBindingException>()).Which;
+        ex.Failure.Should().Be(DeviceBindingFailure.DeliveryTimeout);
+        ex.Message.Should().Contain("still", "a timeout is a PENDING outcome, and must read as one — not as a generic error");
+        _sync.Verify(s => s.SyncAsync(It.IsAny<CancellationToken>()), Times.AtLeastOnce);
+    }
+
+    [Fact]
+    public async Task BindToThisDeviceAsync_BlueprintNotPublished_ThrowsBlueprintNotFound()
+    {
+        var root = Root();
+        _catalogue.Setup(c => c.GetServicesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync([new CatalogueItem("some-other-service", "Fishing Licence", null, RegisterId)]);
+
+        var service = CreateService();
+        var act = () => service.BindToThisDeviceAsync(root, CancellationToken.None);
+
+        var ex = (await act.Should().ThrowAsync<DeviceBindingException>()).Which;
+        ex.Failure.Should().Be(DeviceBindingFailure.BlueprintNotFound);
+    }
+
+    // ── HTTP stub ─────────────────────────────────────────────────────────────
+
+    /// <summary>Records outbound requests and answers with a configurable response (200 OK default).</summary>
+    private sealed class RecordingHttpHandler : HttpMessageHandler
+    {
+        public List<HttpRequestMessage> Requests { get; } = [];
+        public List<string> RequestBodies { get; } = [];
+        public Func<HttpRequestMessage, HttpResponseMessage> RespondWith { get; set; } =
+            _ => new HttpResponseMessage(HttpStatusCode.OK);
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Requests.Add(request);
+            RequestBodies.Add(request.Content is null
+                ? string.Empty
+                : await request.Content.ReadAsStringAsync(cancellationToken));
+            return RespondWith(request);
+        }
+    }
+}

--- a/tests/Sorcha.Wallet.Pwa.Tests/Services/Presentation/PresentationEngineTests.cs
+++ b/tests/Sorcha.Wallet.Pwa.Tests/Services/Presentation/PresentationEngineTests.cs
@@ -279,6 +279,35 @@ public sealed class PresentationEngineTests
     }
 
     [Fact]
+    public async Task BuildVpTokenAsync_OkpHolderJwk_EmitsEdDsaHeaderAndOkpThumbprint()
+    {
+        // #1195 Phase 2 — a holder-cnf ROOT presented server-custody signs under the
+        // citizen's Ed25519 holder key. The KB-JWT header must say EdDSA (hardcoded
+        // ES256 was the mirror of the verifier-side "ES256-only rejected Ed25519-holder
+        // presentations" bug) and kid must be the RFC 7638 OKP thumbprint (crv, kty, x).
+        var (cred, _) = MakeRealCredential(Vct, ("givenName", "Stuart"));
+        var req = MakeRequest(["givenName"], []);
+        var match = _engine.Match(req, [cred]).Single();
+
+        var holderJwk = JsonSerializer.Deserialize<JsonElement>(
+            """{"kty":"OKP","crv":"Ed25519","x":"holderX"}""");
+
+        var vp = await _engine.BuildVpTokenAsync(
+            match, ["givenName"], req, holderJwk,
+            (_, _) => Task.FromResult(new byte[] { 1, 2, 3 }));
+
+        var (_, _, kbJwt) = PresentationEngine.SplitSdJwt(vp);
+        var header = JsonSerializer.Deserialize<JsonElement>(
+            Base64Url.DecodeFromChars(kbJwt!.Split('.')[0]));
+
+        header.GetProperty("alg").GetString().Should().Be("EdDSA");
+
+        var expectedThumbprint = Base64Url.EncodeToString(SHA256.HashData(
+            Encoding.UTF8.GetBytes("{\"crv\":\"Ed25519\",\"kty\":\"OKP\",\"x\":\"holderX\"}")));
+        header.GetProperty("kid").GetString().Should().Be(expectedThumbprint);
+    }
+
+    [Fact]
     public async Task BuildVpTokenAsync_ApprovedClaimsMissingRequired_Throws()
     {
         var (cred, _) = MakeRealCredential(Vct, ("givenName", "Stuart"));

--- a/tests/Sorcha.Wallet.Pwa.Tests/Services/Presentation/PresentationEngineTests.cs
+++ b/tests/Sorcha.Wallet.Pwa.Tests/Services/Presentation/PresentationEngineTests.cs
@@ -399,6 +399,103 @@ public sealed class PresentationEngineTests
     }
 
     [Fact]
+    public async Task BuildVpTokenEnvelopeAsync_MixedModes_RootServerCustodySigned_CopyDeviceSigned()
+    {
+        // #1195 Phase 2 (Task 7 fix round 2) — mixed signing modes within ONE envelope: each query's
+        // presentation is an independent SD-JWT with its own KB-JWT, verified per-query against its own
+        // credential's cnf. A ServerCustody entry must be signed by the HOLDER signer, a Device entry by
+        // the DEVICE signer — a device-signed root is the recorded silent-verification-failure trap.
+        const string AddressVct = "https://sorcha.dev/vc/address/v1";
+        var (rootCred, _) = MakeRealCredential(Vct, ("givenName", "Stuart"));
+        var (copyCred, _) = MakeRealCredential(AddressVct, ("postcode", "EH1 1AA"));
+
+        var req = MakeRequest(["givenName"], []);
+        using var deviceEcdsa = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        using var holderEcdsa = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        var deviceJwk = JsonSerializer.Deserialize<JsonElement>(JwkOf(deviceEcdsa));
+        var holderJwk = JsonSerializer.Deserialize<JsonElement>(JwkOf(holderEcdsa));
+
+        var deviceSigned = 0;
+        var holderSigned = 0;
+        Func<byte[], CancellationToken, Task<byte[]>> deviceSigner = (data, _) =>
+        {
+            deviceSigned++;
+            return Task.FromResult(deviceEcdsa.SignData(data, HashAlgorithmName.SHA256));
+        };
+        Func<byte[], CancellationToken, Task<byte[]>> holderSigner = (data, _) =>
+        {
+            holderSigned++;
+            return Task.FromResult(holderEcdsa.SignData(data, HashAlgorithmName.SHA256));
+        };
+
+        var rootMatch = new CredentialMatch { Credential = rootCred, SatisfiedRequired = ["givenName"], AvailableOptional = [] };
+        var copyMatch = new CredentialMatch { Credential = copyCred, SatisfiedRequired = ["postcode"], AvailableOptional = [] };
+        var consented = new List<ConsentedQuery>
+        {
+            new("identity", rootMatch, ["givenName"], ["givenName"], PresentationSigningMode.ServerCustody),
+            new("address", copyMatch, ["postcode"], ["postcode"], PresentationSigningMode.Device),
+        };
+
+        var json = await _engine.BuildVpTokenEnvelopeAsync(
+            consented, req, deviceJwk, deviceSigner, holderJwk, holderSigner);
+
+        deviceSigned.Should().Be(1);
+        holderSigned.Should().Be(1);
+
+        var envelope = DcqlVpToken.Parse(json);
+
+        // The ServerCustody presentation's KB-JWT verifies against the HOLDER key and carries its kid.
+        AssertKbJwtSignedBy(envelope.Presentations["identity"][0], holderEcdsa, holderJwk);
+        // The Device presentation's KB-JWT verifies against the DEVICE key and carries its kid.
+        AssertKbJwtSignedBy(envelope.Presentations["address"][0], deviceEcdsa, deviceJwk);
+    }
+
+    [Fact]
+    public async Task BuildVpTokenEnvelopeAsync_ServerCustodyEntryWithoutHolderSigner_ThrowsLoudly()
+    {
+        // Never a silent fallback to device-signing the root — that KB-JWT fails verification
+        // downstream with no local error.
+        var (rootCred, _) = MakeRealCredential(Vct, ("givenName", "Stuart"));
+        var req = MakeRequest(["givenName"], []);
+        using var deviceEcdsa = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        var deviceJwk = JsonSerializer.Deserialize<JsonElement>(JwkOf(deviceEcdsa));
+
+        var rootMatch = new CredentialMatch { Credential = rootCred, SatisfiedRequired = ["givenName"], AvailableOptional = [] };
+        var consented = new List<ConsentedQuery>
+        {
+            new("identity", rootMatch, ["givenName"], ["givenName"], PresentationSigningMode.ServerCustody),
+        };
+
+        var deviceSignerCalls = 0;
+        Func<byte[], CancellationToken, Task<byte[]>> deviceSigner = (data, _) =>
+        {
+            deviceSignerCalls++;
+            return Task.FromResult(deviceEcdsa.SignData(data, HashAlgorithmName.SHA256));
+        };
+
+        Func<Task> act = async () => await _engine.BuildVpTokenEnvelopeAsync(
+            consented, req, deviceJwk, deviceSigner);
+
+        (await act.Should().ThrowAsync<InvalidOperationException>())
+            .WithMessage("*server-custody*");
+        deviceSignerCalls.Should().Be(0, "the device signer must NEVER sign a server-custody entry");
+    }
+
+    /// <summary>Assert a presentation's KB-JWT verifies against <paramref name="key"/> and its kid is the JWK's thumbprint.</summary>
+    private static void AssertKbJwtSignedBy(string vp, ECDsa key, JsonElement jwk)
+    {
+        var (_, _, kbJwt) = PresentationEngine.SplitSdJwt(vp);
+        kbJwt.Should().NotBeNullOrEmpty();
+        var parts = kbJwt!.Split('.');
+        var signingInput = Encoding.ASCII.GetBytes($"{parts[0]}.{parts[1]}");
+        var signature = Base64Url.DecodeFromChars(parts[2]);
+        key.VerifyData(signingInput, signature, HashAlgorithmName.SHA256).Should().BeTrue();
+
+        var header = JsonSerializer.Deserialize<JsonElement>(Base64Url.DecodeFromChars(parts[0]));
+        header.GetProperty("kid").GetString().Should().Be(PresentationEngine.ComputeJwkThumbprint(jwk));
+    }
+
+    [Fact]
     public async Task BuildVpTokenEnvelopeAsync_Empty_Throws()
     {
         var req = MakeRequest(["givenName"], []);
@@ -650,6 +747,76 @@ public sealed class PresentationEngineTests
         s.Outcome.Should().Be(PresentationSelectionOutcome.Selected);
         s.Match!.Credential.Id.Should().Be(deviceCopy.Id);
         s.SigningMode.Should().Be(PresentationSigningMode.Device);
+    }
+
+    [Fact]
+    public void Select_TwoDistinctCredentials_ReturnsChoiceRequiredWithBoth()
+    {
+        // Fix round 2 — two GENUINELY distinct credentials (not a root/copy pair) matching the ask
+        // must offer the citizen a pick, exactly as before Task 7.
+        using var deviceKey = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        var deviceThumbprint = ThumbprintOf(JwkOf(deviceKey));
+
+        var (legacyA, _) = MakeRealCredential(Vct, ("givenName", "Stuart"));
+        var (legacyB, _) = MakeRealCredential(Vct, ("givenName", "Stiubhart"));
+        var req = MakeRequest(["givenName"], []);
+
+        var s = _engine.Select(
+            req, [legacyA, legacyB], deviceThumbprint, HolderThumbprint, PresentationSurface.Remote);
+
+        s.Outcome.Should().Be(PresentationSelectionOutcome.ChoiceRequired);
+        s.Match.Should().BeNull();
+        s.Candidates.Should().HaveCount(2);
+        s.Candidates!.Select(c => c.Match.Credential.Id)
+            .Should().BeEquivalentTo([legacyA.Id, legacyB.Id]);
+        s.Candidates.Should().OnlyContain(c => c.SigningMode == PresentationSigningMode.Device);
+    }
+
+    [Fact]
+    public void Select_RootPlusCopyPairOnly_AutoSelectsNoPicker()
+    {
+        // Fix round 2 — the root + this-device copy are ONE credential family (one identity, two
+        // bindings): they collapse to the per-surface representative and never offer a picker.
+        using var deviceKey = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        var deviceJwk = JwkOf(deviceKey);
+        var deviceThumbprint = ThumbprintOf(deviceJwk);
+
+        var root = MakeCnfCredential(Vct, OkpHolderJwk, "givenName");
+        var deviceCopy = MakeCnfCredential(Vct, deviceJwk, "givenName");
+        var req = MakeRequest(["givenName"], []);
+
+        foreach (var surface in new[]
+                 { PresentationSurface.Auto, PresentationSurface.Remote, PresentationSurface.InPerson })
+        {
+            var s = _engine.Select(req, [root, deviceCopy], deviceThumbprint, HolderThumbprint, surface);
+            s.Outcome.Should().Be(PresentationSelectionOutcome.Selected,
+                $"a root+copy pair is one identity and must auto-select on {surface}, no picker");
+        }
+    }
+
+    [Fact]
+    public void Select_BoundFamilyPlusDistinctLegacy_OffersPickerWithPerCandidateSigningModes()
+    {
+        // Fix round 2 — the bound family collapses to ONE representative, but a distinct legacy
+        // credential is a real alternative: the citizen picks, and each candidate carries ITS OWN
+        // signing mode (the picker must never re-derive the pairing).
+        using var deviceKey = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        var deviceThumbprint = ThumbprintOf(JwkOf(deviceKey));
+
+        var root = MakeCnfCredential(Vct, OkpHolderJwk, "givenName");
+        var (legacy, _) = MakeRealCredential(Vct, ("givenName", "Stuart"));
+        var req = MakeRequest(["givenName"], []);
+
+        var s = _engine.Select(
+            req, [root, legacy], deviceThumbprint, HolderThumbprint, PresentationSurface.Remote);
+
+        s.Outcome.Should().Be(PresentationSelectionOutcome.ChoiceRequired);
+        s.Candidates.Should().HaveCount(2);
+        var rootCandidate = s.Candidates!.Single(c => c.Match.Credential.Id == root.Id);
+        rootCandidate.SigningMode.Should().Be(PresentationSigningMode.ServerCustody,
+            "the root candidate must stay paired with server-custody signing even inside a picker");
+        s.Candidates!.Single(c => c.Match.Credential.Id == legacy.Id)
+            .SigningMode.Should().Be(PresentationSigningMode.Device);
     }
 
     [Fact]

--- a/tests/Sorcha.Wallet.Pwa.Tests/Services/Presentation/PresentationEngineTests.cs
+++ b/tests/Sorcha.Wallet.Pwa.Tests/Services/Presentation/PresentationEngineTests.cs
@@ -411,7 +411,209 @@ public sealed class PresentationEngineTests
         await act.Should().ThrowAsync<InvalidOperationException>();
     }
 
+    // ─────────────── Select — per-surface credential + signing choice (Task 7) ───────────────
+
+    [Fact]
+    public void Select_InPerson_RootAndThisDeviceCopyCached_ReturnsDeviceCopyDeviceSign()
+    {
+        using var deviceKey = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        var deviceJwk = JwkOf(deviceKey);
+        var deviceThumbprint = ThumbprintOf(deviceJwk);
+
+        var root = MakeCnfCredential(Vct, OkpHolderJwk, "givenName");
+        var deviceCopy = MakeCnfCredential(Vct, deviceJwk, "givenName");
+        var req = MakeRequest(["givenName"], []);
+
+        var selection = _engine.Select(req, [root, deviceCopy], deviceThumbprint, PresentationSurface.InPerson);
+
+        selection.Outcome.Should().Be(PresentationSelectionOutcome.Selected);
+        selection.Match!.Credential.Id.Should().Be(deviceCopy.Id);
+        selection.SigningMode.Should().Be(PresentationSigningMode.Device);
+    }
+
+    [Fact]
+    public void Select_Remote_RootAndThisDeviceCopyCached_ReturnsRootServerCustody()
+    {
+        using var deviceKey = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        var deviceJwk = JwkOf(deviceKey);
+        var deviceThumbprint = ThumbprintOf(deviceJwk);
+
+        var root = MakeCnfCredential(Vct, OkpHolderJwk, "givenName");
+        var deviceCopy = MakeCnfCredential(Vct, deviceJwk, "givenName");
+        var req = MakeRequest(["givenName"], []);
+
+        var selection = _engine.Select(req, [root, deviceCopy], deviceThumbprint, PresentationSurface.Remote);
+
+        selection.Outcome.Should().Be(PresentationSelectionOutcome.Selected);
+        selection.Match!.Credential.Id.Should().Be(root.Id);
+        // The root is NEVER device-signed — that KB-JWT fails verification with no local error.
+        selection.SigningMode.Should().Be(PresentationSigningMode.ServerCustody);
+    }
+
+    [Fact]
+    public void Select_InPerson_OnlyRootCached_ReturnsBindDeviceFirst()
+    {
+        using var deviceKey = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        var deviceThumbprint = ThumbprintOf(JwkOf(deviceKey));
+
+        var root = MakeCnfCredential(Vct, OkpHolderJwk, "givenName");
+        var req = MakeRequest(["givenName"], []);
+
+        var selection = _engine.Select(req, [root], deviceThumbprint, PresentationSurface.InPerson);
+
+        // NOT a doomed present, and NOT the root (device-signing the root cannot verify).
+        selection.Outcome.Should().Be(PresentationSelectionOutcome.BindDeviceFirst);
+        selection.Match.Should().BeNull();
+    }
+
+    [Fact]
+    public void Select_DifferentDeviceCopy_IsNeverSelectedForDeviceSigning()
+    {
+        // A copy bound to ANOTHER device (its cnf thumbprint ≠ this device's) can neither be
+        // device-signed here nor server-custody signed (its cnf is not the holder key). It must
+        // never be selected on any surface.
+        using var thisDevice = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        using var otherDevice = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        var thisThumbprint = ThumbprintOf(JwkOf(thisDevice));
+
+        var root = MakeCnfCredential(Vct, OkpHolderJwk, "givenName");
+        var otherDeviceCopy = MakeCnfCredential(Vct, JwkOf(otherDevice), "givenName");
+        var req = MakeRequest(["givenName"], []);
+
+        // In person: no copy for THIS device → bind first, and the other-device copy is not device-signed.
+        var inPerson = _engine.Select(req, [root, otherDeviceCopy], thisThumbprint, PresentationSurface.InPerson);
+        inPerson.Outcome.Should().Be(PresentationSelectionOutcome.BindDeviceFirst);
+        inPerson.Match.Should().BeNull();
+
+        // Auto / remote fall back to the ROOT (server custody), never the other-device copy.
+        foreach (var surface in new[] { PresentationSurface.Auto, PresentationSurface.Remote })
+        {
+            var s = _engine.Select(req, [root, otherDeviceCopy], thisThumbprint, surface);
+            s.Outcome.Should().Be(PresentationSelectionOutcome.Selected);
+            s.Match!.Credential.Id.Should().Be(root.Id);
+            s.Match.Credential.Id.Should().NotBe(otherDeviceCopy.Id);
+            s.SigningMode.Should().Be(PresentationSigningMode.ServerCustody);
+        }
+    }
+
+    [Fact]
+    public void Select_OnlyDifferentDeviceCopy_NoRoot_ReturnsNoMatch()
+    {
+        // Nothing usable on this device: an other-device copy alone can't be presented AND can't be
+        // bound (binding needs the root). Not a bind-first prompt — a plain no-match.
+        using var thisDevice = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        using var otherDevice = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        var thisThumbprint = ThumbprintOf(JwkOf(thisDevice));
+
+        var otherDeviceCopy = MakeCnfCredential(Vct, JwkOf(otherDevice), "givenName");
+        var req = MakeRequest(["givenName"], []);
+
+        _engine.Select(req, [otherDeviceCopy], thisThumbprint, PresentationSurface.InPerson)
+            .Outcome.Should().Be(PresentationSelectionOutcome.NoMatch);
+        _engine.Select(req, [otherDeviceCopy], thisThumbprint, PresentationSurface.Auto)
+            .Outcome.Should().Be(PresentationSelectionOutcome.NoMatch);
+    }
+
+    [Fact]
+    public void Select_Auto_PrefersThisDeviceCopyOverRoot()
+    {
+        using var deviceKey = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        var deviceJwk = JwkOf(deviceKey);
+        var deviceThumbprint = ThumbprintOf(deviceJwk);
+
+        var root = MakeCnfCredential(Vct, OkpHolderJwk, "givenName");
+        var deviceCopy = MakeCnfCredential(Vct, deviceJwk, "givenName");
+        var req = MakeRequest(["givenName"], []);
+
+        var selection = _engine.Select(req, [root, deviceCopy], deviceThumbprint, PresentationSurface.Auto);
+
+        selection.Outcome.Should().Be(PresentationSelectionOutcome.Selected);
+        selection.Match!.Credential.Id.Should().Be(deviceCopy.Id);
+        selection.SigningMode.Should().Be(PresentationSigningMode.Device);
+    }
+
+    [Fact]
+    public void Select_NullDeviceThumbprint_NoDeviceKey_SelectsRootServerCustody()
+    {
+        // A host with no usable device key (non-PWA / bridge absent) can never device-sign, so even a
+        // device copy in the cache is not signable here. Auto/Remote fall to the root; in person, with a
+        // copy present but unsignable and the root bindable, the answer is bind-first.
+        using var deviceKey = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        var deviceCopy = MakeCnfCredential(Vct, JwkOf(deviceKey), "givenName");
+        var root = MakeCnfCredential(Vct, OkpHolderJwk, "givenName");
+        var req = MakeRequest(["givenName"], []);
+
+        var remote = _engine.Select(req, [root, deviceCopy], deviceThumbprint: null, PresentationSurface.Remote);
+        remote.Outcome.Should().Be(PresentationSelectionOutcome.Selected);
+        remote.Match!.Credential.Id.Should().Be(root.Id);
+        remote.SigningMode.Should().Be(PresentationSigningMode.ServerCustody);
+
+        _engine.Select(req, [root, deviceCopy], deviceThumbprint: null, PresentationSurface.InPerson)
+            .Outcome.Should().Be(PresentationSelectionOutcome.BindDeviceFirst);
+    }
+
+    [Fact]
+    public void Select_RequestVctNotHeld_ReturnsNoMatch()
+    {
+        using var deviceKey = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        var deviceThumbprint = ThumbprintOf(JwkOf(deviceKey));
+
+        var root = MakeCnfCredential("https://sorcha.dev/vc/other/v1", OkpHolderJwk, "givenName");
+        var req = MakeRequest(["givenName"], []);   // asks for Vct, which is not held
+
+        _engine.Select(req, [root], deviceThumbprint, PresentationSurface.Remote)
+            .Outcome.Should().Be(PresentationSelectionOutcome.NoMatch);
+    }
+
     // ────────────────────────── helpers ──────────────────────────
+
+    /// <summary>A holder-cnf root's confirmation key is the citizen's Ed25519 (OKP) holder key.</summary>
+    private const string OkpHolderJwk = """{"kty":"OKP","crv":"Ed25519","x":"holderRootPublicKeyX"}""";
+
+    private static string ThumbprintOf(string jwkJson)
+        => PresentationEngine.ComputeJwkThumbprint(JsonSerializer.Deserialize<JsonElement>(jwkJson));
+
+    /// <summary>
+    /// Build a cached SD-JWT credential carrying a <c>cnf.jwk</c> in its payload (so the selection
+    /// layer can read its key binding) plus real disclosures for <paramref name="claimNames"/>.
+    /// </summary>
+    private static CachedCredential MakeCnfCredential(string vct, string cnfJwkJson, params string[] claimNames)
+    {
+        var headerSeg = Base64Url.EncodeToString(JsonSerializer.SerializeToUtf8Bytes(new
+        {
+            alg = "ES256",
+            typ = "dc+sd-jwt",
+        }));
+        var payloadSeg = Base64Url.EncodeToString(JsonSerializer.SerializeToUtf8Bytes(new Dictionary<string, object>
+        {
+            ["iss"] = "did:sorcha:org:test",
+            ["vct"] = vct,
+            ["iat"] = DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
+            ["cnf"] = new Dictionary<string, object>
+            {
+                ["jwk"] = JsonSerializer.Deserialize<JsonElement>(cnfJwkJson),
+            },
+        }));
+        var credentialJwt = $"{headerSeg}.{payloadSeg}.sig";
+
+        var disclosures = new List<string>();
+        Span<byte> salt = stackalloc byte[16];
+        foreach (var name in claimNames)
+        {
+            RandomNumberGenerator.Fill(salt);
+            disclosures.Add(Base64Url.EncodeToString(JsonSerializer.SerializeToUtf8Bytes(
+                new object[] { Base64Url.EncodeToString(salt), name, "value" })));
+        }
+
+        return new CachedCredential
+        {
+            Id = Guid.NewGuid(),
+            Vct = vct,
+            RawSdJwt = credentialJwt + string.Concat(disclosures.Select(d => "~" + d)),
+            AvailableClaimNames = claimNames,
+        };
+    }
+
 
     private static ParsedPresentationRequest MakeRequest(IReadOnlyList<string> required, IReadOnlyList<string> optional)
         => new()

--- a/tests/Sorcha.Wallet.Pwa.Tests/Services/Presentation/PresentationEngineTests.cs
+++ b/tests/Sorcha.Wallet.Pwa.Tests/Services/Presentation/PresentationEngineTests.cs
@@ -424,7 +424,8 @@ public sealed class PresentationEngineTests
         var deviceCopy = MakeCnfCredential(Vct, deviceJwk, "givenName");
         var req = MakeRequest(["givenName"], []);
 
-        var selection = _engine.Select(req, [root, deviceCopy], deviceThumbprint, PresentationSurface.InPerson);
+        var selection = _engine.Select(
+            req, [root, deviceCopy], deviceThumbprint, HolderThumbprint, PresentationSurface.InPerson);
 
         selection.Outcome.Should().Be(PresentationSelectionOutcome.Selected);
         selection.Match!.Credential.Id.Should().Be(deviceCopy.Id);
@@ -442,7 +443,8 @@ public sealed class PresentationEngineTests
         var deviceCopy = MakeCnfCredential(Vct, deviceJwk, "givenName");
         var req = MakeRequest(["givenName"], []);
 
-        var selection = _engine.Select(req, [root, deviceCopy], deviceThumbprint, PresentationSurface.Remote);
+        var selection = _engine.Select(
+            req, [root, deviceCopy], deviceThumbprint, HolderThumbprint, PresentationSurface.Remote);
 
         selection.Outcome.Should().Be(PresentationSelectionOutcome.Selected);
         selection.Match!.Credential.Id.Should().Be(root.Id);
@@ -459,19 +461,21 @@ public sealed class PresentationEngineTests
         var root = MakeCnfCredential(Vct, OkpHolderJwk, "givenName");
         var req = MakeRequest(["givenName"], []);
 
-        var selection = _engine.Select(req, [root], deviceThumbprint, PresentationSurface.InPerson);
+        var selection = _engine.Select(
+            req, [root], deviceThumbprint, HolderThumbprint, PresentationSurface.InPerson);
 
         // NOT a doomed present, and NOT the root (device-signing the root cannot verify).
         selection.Outcome.Should().Be(PresentationSelectionOutcome.BindDeviceFirst);
         selection.Match.Should().BeNull();
+        // The outcome carries the root so the UI can deep-link its credential card (the bind surface).
+        selection.RootToBind!.Credential.Id.Should().Be(root.Id);
     }
 
     [Fact]
     public void Select_DifferentDeviceCopy_IsNeverSelectedForDeviceSigning()
     {
-        // A copy bound to ANOTHER device (its cnf thumbprint ≠ this device's) can neither be
-        // device-signed here nor server-custody signed (its cnf is not the holder key). It must
-        // never be selected on any surface.
+        // A copy bound to ANOTHER device (its cnf thumbprint ≠ this device's AND ≠ the holder's) can
+        // neither be device-signed here nor server-custody signed. Never selected on any surface.
         using var thisDevice = ECDsa.Create(ECCurve.NamedCurves.nistP256);
         using var otherDevice = ECDsa.Create(ECCurve.NamedCurves.nistP256);
         var thisThumbprint = ThumbprintOf(JwkOf(thisDevice));
@@ -481,14 +485,15 @@ public sealed class PresentationEngineTests
         var req = MakeRequest(["givenName"], []);
 
         // In person: no copy for THIS device → bind first, and the other-device copy is not device-signed.
-        var inPerson = _engine.Select(req, [root, otherDeviceCopy], thisThumbprint, PresentationSurface.InPerson);
+        var inPerson = _engine.Select(
+            req, [root, otherDeviceCopy], thisThumbprint, HolderThumbprint, PresentationSurface.InPerson);
         inPerson.Outcome.Should().Be(PresentationSelectionOutcome.BindDeviceFirst);
         inPerson.Match.Should().BeNull();
 
         // Auto / remote fall back to the ROOT (server custody), never the other-device copy.
         foreach (var surface in new[] { PresentationSurface.Auto, PresentationSurface.Remote })
         {
-            var s = _engine.Select(req, [root, otherDeviceCopy], thisThumbprint, surface);
+            var s = _engine.Select(req, [root, otherDeviceCopy], thisThumbprint, HolderThumbprint, surface);
             s.Outcome.Should().Be(PresentationSelectionOutcome.Selected);
             s.Match!.Credential.Id.Should().Be(root.Id);
             s.Match.Credential.Id.Should().NotBe(otherDeviceCopy.Id);
@@ -508,9 +513,9 @@ public sealed class PresentationEngineTests
         var otherDeviceCopy = MakeCnfCredential(Vct, JwkOf(otherDevice), "givenName");
         var req = MakeRequest(["givenName"], []);
 
-        _engine.Select(req, [otherDeviceCopy], thisThumbprint, PresentationSurface.InPerson)
+        _engine.Select(req, [otherDeviceCopy], thisThumbprint, HolderThumbprint, PresentationSurface.InPerson)
             .Outcome.Should().Be(PresentationSelectionOutcome.NoMatch);
-        _engine.Select(req, [otherDeviceCopy], thisThumbprint, PresentationSurface.Auto)
+        _engine.Select(req, [otherDeviceCopy], thisThumbprint, HolderThumbprint, PresentationSurface.Auto)
             .Outcome.Should().Be(PresentationSelectionOutcome.NoMatch);
     }
 
@@ -525,7 +530,8 @@ public sealed class PresentationEngineTests
         var deviceCopy = MakeCnfCredential(Vct, deviceJwk, "givenName");
         var req = MakeRequest(["givenName"], []);
 
-        var selection = _engine.Select(req, [root, deviceCopy], deviceThumbprint, PresentationSurface.Auto);
+        var selection = _engine.Select(
+            req, [root, deviceCopy], deviceThumbprint, HolderThumbprint, PresentationSurface.Auto);
 
         selection.Outcome.Should().Be(PresentationSelectionOutcome.Selected);
         selection.Match!.Credential.Id.Should().Be(deviceCopy.Id);
@@ -543,12 +549,13 @@ public sealed class PresentationEngineTests
         var root = MakeCnfCredential(Vct, OkpHolderJwk, "givenName");
         var req = MakeRequest(["givenName"], []);
 
-        var remote = _engine.Select(req, [root, deviceCopy], deviceThumbprint: null, PresentationSurface.Remote);
+        var remote = _engine.Select(
+            req, [root, deviceCopy], deviceThumbprint: null, HolderThumbprint, PresentationSurface.Remote);
         remote.Outcome.Should().Be(PresentationSelectionOutcome.Selected);
         remote.Match!.Credential.Id.Should().Be(root.Id);
         remote.SigningMode.Should().Be(PresentationSigningMode.ServerCustody);
 
-        _engine.Select(req, [root, deviceCopy], deviceThumbprint: null, PresentationSurface.InPerson)
+        _engine.Select(req, [root, deviceCopy], deviceThumbprint: null, HolderThumbprint, PresentationSurface.InPerson)
             .Outcome.Should().Be(PresentationSelectionOutcome.BindDeviceFirst);
     }
 
@@ -561,14 +568,120 @@ public sealed class PresentationEngineTests
         var root = MakeCnfCredential("https://sorcha.dev/vc/other/v1", OkpHolderJwk, "givenName");
         var req = MakeRequest(["givenName"], []);   // asks for Vct, which is not held
 
-        _engine.Select(req, [root], deviceThumbprint, PresentationSurface.Remote)
+        _engine.Select(req, [root], deviceThumbprint, HolderThumbprint, PresentationSurface.Remote)
             .Outcome.Should().Be(PresentationSelectionOutcome.NoMatch);
+    }
+
+    [Fact]
+    public void Select_P256HolderWallet_RootAndCopyDiscriminatedByThumbprintNotKeyType()
+    {
+        // Fix round 1 — a P-256 wallet's holder key is EC, so its root's cnf is EC too: by KEY TYPE the
+        // root and a device copy are indistinguishable. Discrimination MUST be by RFC 7638 thumbprint
+        // against the holder key (the Task 5 server-side rule), or every P-256 wallet's root would be
+        // misclassified and selection would break for those users.
+        using var holderKey = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        using var deviceKey = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        var holderJwk = JwkOf(holderKey);
+        var deviceJwk = JwkOf(deviceKey);
+        var holderThumbprint = ThumbprintOf(holderJwk);
+        var deviceThumbprint = ThumbprintOf(deviceJwk);
+
+        var ecRoot = MakeCnfCredential(Vct, holderJwk, "givenName");
+        var deviceCopy = MakeCnfCredential(Vct, deviceJwk, "givenName");
+        var req = MakeRequest(["givenName"], []);
+
+        var remote = _engine.Select(
+            req, [ecRoot, deviceCopy], deviceThumbprint, holderThumbprint, PresentationSurface.Remote);
+        remote.Outcome.Should().Be(PresentationSelectionOutcome.Selected);
+        remote.Match!.Credential.Id.Should().Be(ecRoot.Id);
+        remote.SigningMode.Should().Be(PresentationSigningMode.ServerCustody);
+
+        var inPerson = _engine.Select(
+            req, [ecRoot, deviceCopy], deviceThumbprint, holderThumbprint, PresentationSurface.InPerson);
+        inPerson.Outcome.Should().Be(PresentationSelectionOutcome.Selected);
+        inPerson.Match!.Credential.Id.Should().Be(deviceCopy.Id);
+        inPerson.SigningMode.Should().Be(PresentationSigningMode.Device);
+
+        // And with only the EC root cached, in person still answers bind-first — not a doomed present.
+        var bindFirst = _engine.Select(
+            req, [ecRoot], deviceThumbprint, holderThumbprint, PresentationSurface.InPerson);
+        bindFirst.Outcome.Should().Be(PresentationSelectionOutcome.BindDeviceFirst);
+        bindFirst.RootToBind!.Credential.Id.Should().Be(ecRoot.Id);
+    }
+
+    [Fact]
+    public void Select_HolderThumbprintUnavailable_BoundCandidateOnly_FailsClosedWithNamedOutcome()
+    {
+        // Fix round 1 — without the holder thumbprint, a bound credential that is not THIS device's
+        // copy could be the root OR a foreign device's copy. Selection must fail CLOSED with the named
+        // outcome, never guess (a guessed server-custody sign over a foreign copy cannot verify).
+        using var deviceKey = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        var deviceThumbprint = ThumbprintOf(JwkOf(deviceKey));
+
+        var root = MakeCnfCredential(Vct, OkpHolderJwk, "givenName");
+        var req = MakeRequest(["givenName"], []);
+
+        foreach (var surface in new[]
+                 { PresentationSurface.Auto, PresentationSurface.Remote, PresentationSurface.InPerson })
+        {
+            var s = _engine.Select(req, [root], deviceThumbprint, holderThumbprint: null, surface);
+            s.Outcome.Should().Be(PresentationSelectionOutcome.HolderKeyUnavailable,
+                $"an unclassifiable bound credential must fail closed on {surface}");
+            s.Match.Should().BeNull();
+        }
+    }
+
+    [Fact]
+    public void Select_HolderThumbprintUnavailable_ThisDeviceCopyPresent_StillSelectsCopy()
+    {
+        // The this-device copy is DEFINITIVELY classifiable (its cnf thumbprint is ours) — no holder
+        // thumbprint needed. Selecting it is not a guess; only unclassifiable-only caches fail closed.
+        using var deviceKey = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        var deviceJwk = JwkOf(deviceKey);
+        var deviceThumbprint = ThumbprintOf(deviceJwk);
+
+        var root = MakeCnfCredential(Vct, OkpHolderJwk, "givenName");
+        var deviceCopy = MakeCnfCredential(Vct, deviceJwk, "givenName");
+        var req = MakeRequest(["givenName"], []);
+
+        var s = _engine.Select(
+            req, [root, deviceCopy], deviceThumbprint, holderThumbprint: null, PresentationSurface.Remote);
+
+        s.Outcome.Should().Be(PresentationSelectionOutcome.Selected);
+        s.Match!.Credential.Id.Should().Be(deviceCopy.Id);
+        s.SigningMode.Should().Be(PresentationSigningMode.Device);
+    }
+
+    [Fact]
+    public void Select_LegacyCredentialWithoutCnf_KeepsPhase1DeviceSignedBehaviour()
+    {
+        // A pre-Phase-2 credential carries no cnf — there is no binding for a verifier to check, so the
+        // Phase-1 device-signed present still verifies. Routing Present.razor through Select must NOT
+        // regress these: they stay selectable (device-signed) on every surface.
+        using var deviceKey = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        var deviceThumbprint = ThumbprintOf(JwkOf(deviceKey));
+
+        var (legacy, _) = MakeRealCredential(Vct, ("givenName", "Stuart"));
+        var req = MakeRequest(["givenName"], []);
+
+        foreach (var surface in new[]
+                 { PresentationSurface.Auto, PresentationSurface.Remote, PresentationSurface.InPerson })
+        {
+            var s = _engine.Select(req, [legacy], deviceThumbprint, HolderThumbprint, surface);
+            s.Outcome.Should().Be(PresentationSelectionOutcome.Selected,
+                $"a legacy no-cnf credential must stay presentable on {surface}");
+            s.Match!.Credential.Id.Should().Be(legacy.Id);
+            s.SigningMode.Should().Be(PresentationSigningMode.Device);
+        }
     }
 
     // ────────────────────────── helpers ──────────────────────────
 
     /// <summary>A holder-cnf root's confirmation key is the citizen's Ed25519 (OKP) holder key.</summary>
     private const string OkpHolderJwk = """{"kty":"OKP","crv":"Ed25519","x":"holderRootPublicKeyX"}""";
+
+    /// <summary>RFC 7638 thumbprint of <see cref="OkpHolderJwk"/> — the default holder thumbprint input.</summary>
+    private static readonly string HolderThumbprint = ThumbprintOf(OkpHolderJwk);
 
     private static string ThumbprintOf(string jwkJson)
         => PresentationEngine.ComputeJwkThumbprint(JsonSerializer.Deserialize<JsonElement>(jwkJson));

--- a/tests/Sorcha.Wallet.Service.Tests/Credentials/DeviceBoundCopyIssuanceCoordinatorTests.cs
+++ b/tests/Sorcha.Wallet.Service.Tests/Credentials/DeviceBoundCopyIssuanceCoordinatorTests.cs
@@ -159,18 +159,40 @@ public class DeviceBoundCopyIssuanceCoordinatorTests
     }
 
     [Fact]
-    public async Task PrepareAsync_ReconcileThrows_PropagatesAndAllocatesNoSlot()
+    public async Task PrepareAsync_ReconcileThrows_SurfacesTypedRefusalAndAllocatesNoSlot()
     {
+        // Fix round 2: a reconcile/revoke failure is a POLICY REFUSAL — surfaced as the typed
+        // exception (endpoint maps it to 409) with the cause preserved as InnerException.
         ArrangeCitizenWithDeviceCnf();
         _policy.Setup(p => p.ReconcileAsync(UserId, Vct, DeviceThumbprint, It.IsAny<CancellationToken>()))
             .ThrowsAsync(new InvalidOperationException("status list unavailable"));
 
         var act = async () => await CreateCoordinator().PrepareAsync(Recipient, Vct, DeviceJwk, OrgId, default);
 
-        await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("status list unavailable");
+        (await act.Should().ThrowAsync<DeviceBoundPolicyRefusalException>())
+            .WithInnerException<InvalidOperationException>().WithMessage("status list unavailable");
         // No partial state: a slot is never allocated when the policy aborts.
         _statusList.Verify(
             s => s.AllocateIndexAsync(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task PrepareAsync_HolderKeyResolutionFaults_PropagatesRawInfrastructureFault()
+    {
+        // Fix round 2: an infrastructure fault (holder-key resolution) is NOT a policy refusal —
+        // it propagates raw so the endpoint maps it to 503 (retryable).
+        _holderAddress.Setup(l => l.ResolvePlatformUserIdAsync(Recipient, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(UserId);
+        _holderKey.Setup(k => k.GetHolderJwkThumbprintAsync(Recipient, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("key derivation backend unavailable"));
+
+        var act = async () => await CreateCoordinator().PrepareAsync(Recipient, Vct, DeviceJwk, OrgId, default);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("key derivation backend unavailable");
+        _policy.Verify(
+            p => p.ReconcileAsync(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
             Times.Never);
     }
 

--- a/tests/Sorcha.Wallet.Service.Tests/Credentials/DeviceBoundCopyIssuanceCoordinatorTests.cs
+++ b/tests/Sorcha.Wallet.Service.Tests/Credentials/DeviceBoundCopyIssuanceCoordinatorTests.cs
@@ -1,0 +1,198 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Text.Json;
+
+using FluentAssertions;
+
+using Microsoft.Extensions.Logging.Abstractions;
+
+using Moq;
+
+using Sorcha.Cryptography;
+using Sorcha.Wallet.Service.Services.Implementation;
+using Sorcha.Wallet.Service.Services.Interfaces;
+
+using Xunit;
+
+namespace Sorcha.Wallet.Service.Tests.Credentials;
+
+/// <summary>
+/// Tests the <see cref="DeviceBoundCopyIssuanceCoordinator"/> mint-path wiring
+/// (Feature 1195, Phase 2, Task 5): the device-vs-root discriminator, the cap/eviction
+/// policy invocation, the F114 status-slot allocation, and the fail-closed abort.
+/// </summary>
+public class DeviceBoundCopyIssuanceCoordinatorTests
+{
+    private const string Recipient = "ws1qcitizen1";
+    private const string Vct = "https://credentials.sorcha.dev/assured-identity";
+    private static readonly Guid UserId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    private static readonly Guid OrgId = Guid.Parse("22222222-2222-2222-2222-222222222222");
+
+    // A device cnf JWK whose thumbprint is deterministic via the production helper.
+    private static readonly JsonElement DeviceJwk = JsonSerializer.Deserialize<JsonElement>(
+        """{"kty":"EC","crv":"P-256","x":"device-x-coordinate-value-000000000000000000","y":"device-y-coordinate-value-000000000000000000"}""");
+
+    private static string DeviceThumbprint => JsonWebKeyThumbprint.Compute(DeviceJwk);
+
+    private readonly Mock<IHolderAddressLookup> _holderAddress = new();
+    private readonly Mock<IHolderKeyService> _holderKey = new();
+    private readonly Mock<IDeviceBoundCredentialPolicy> _policy = new();
+    private readonly Mock<IDeviceBoundCredentialLookup> _lookup = new();
+    private readonly Mock<IDeviceBoundCredentialRevoker> _revoker = new();
+    private readonly Mock<ICitizenStatusListPublisher> _statusList = new();
+    private readonly Mock<IOrgStatusSigningWalletResolver> _orgResolver = new();
+
+    private DeviceBoundCopyIssuanceCoordinator CreateCoordinator() =>
+        new(_holderAddress.Object, _holderKey.Object, _policy.Object, _lookup.Object,
+            _revoker.Object, _statusList.Object, _orgResolver.Object,
+            NullLogger<DeviceBoundCopyIssuanceCoordinator>.Instance);
+
+    private void ArrangeCitizenWithDeviceCnf()
+    {
+        _holderAddress.Setup(l => l.ResolvePlatformUserIdAsync(Recipient, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(UserId);
+        // Holder key thumbprint differs from the device cnf → it's a device copy.
+        _holderKey.Setup(k => k.GetHolderJwkThumbprintAsync(Recipient, It.IsAny<CancellationToken>()))
+            .ReturnsAsync("holder-thumbprint-not-the-device");
+    }
+
+    private void ArrangeStatusAllocation(int listId, int index)
+    {
+        _orgResolver.Setup(r => r.ResolveAsync(OrgId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync("ws1qorgstatus");
+        _statusList.Setup(s => s.AllocateIndexAsync(OrgId, "ws1qorgstatus", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((listId, index));
+        _statusList.Setup(s => s.BuildStatusListUri(OrgId, listId))
+            .Returns($"https://n1.sorcha.dev/api/v1/wallet/status/{OrgId:N}/citizen-devices/{listId}.statuslist+jwt");
+    }
+
+    [Fact]
+    public async Task PrepareAsync_DeviceBoundCopy_InvokesReconcileWithUserTypeAndThumbprint()
+    {
+        ArrangeCitizenWithDeviceCnf();
+        _policy.Setup(p => p.ReconcileAsync(UserId, Vct, DeviceThumbprint, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new DeviceBindDisposition(DeviceBindKind.NewWithinCap, null));
+        ArrangeStatusAllocation(listId: 0, index: 5);
+
+        var plan = await CreateCoordinator().PrepareAsync(Recipient, Vct, DeviceJwk, OrgId, default);
+
+        plan.Should().NotBeNull();
+        plan!.StatusListIndex.Should().Be(5);
+        plan.StatusListUrl.Should().Contain("citizen-devices/0.statuslist+jwt");
+        _policy.Verify(p => p.ReconcileAsync(UserId, Vct, DeviceThumbprint, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task PrepareAsync_HolderBoundWebRoot_ReturnsNullAndDoesNotCallPolicy()
+    {
+        _holderAddress.Setup(l => l.ResolvePlatformUserIdAsync(Recipient, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(UserId);
+        // Holder key thumbprint EQUALS the incoming cnf → this is the web root.
+        _holderKey.Setup(k => k.GetHolderJwkThumbprintAsync(Recipient, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(DeviceThumbprint);
+
+        var plan = await CreateCoordinator().PrepareAsync(Recipient, Vct, DeviceJwk, OrgId, default);
+
+        plan.Should().BeNull();
+        _policy.Verify(
+            p => p.ReconcileAsync(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _statusList.Verify(
+            s => s.AllocateIndexAsync(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task PrepareAsync_NonCitizenRecipient_ReturnsNullAndDoesNotCallPolicy()
+    {
+        _holderAddress.Setup(l => l.ResolvePlatformUserIdAsync(Recipient, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Guid?)null);
+
+        var plan = await CreateCoordinator().PrepareAsync(Recipient, Vct, DeviceJwk, OrgId, default);
+
+        plan.Should().BeNull();
+        _policy.Verify(
+            p => p.ReconcileAsync(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task PrepareAsync_FourthDistinctDevice_EvictsOldestAndReturnsPlanForNewCopy()
+    {
+        ArrangeCitizenWithDeviceCnf();
+
+        // Use the REAL policy so eviction happens end-to-end: three distinct live copies,
+        // a fourth distinct device → the oldest is revoked and a plan is returned so the
+        // new copy is issued.
+        var now = DateTimeOffset.UtcNow;
+        var oldest = new DeviceBoundCredentialCopy("cred-oldest", "thumb-A", now.AddDays(-10), Guid.NewGuid(), "old");
+        _lookup.Setup(l => l.GetLiveCopiesAsync(UserId, Vct, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<DeviceBoundCredentialCopy>
+            {
+                new("cred-2", "thumb-B", now.AddDays(-1), Guid.NewGuid(), "b"),
+                oldest,
+                new("cred-3", "thumb-C", now.AddDays(-5), Guid.NewGuid(), "c"),
+            });
+        _revoker.Setup(r => r.RevokeAsync(UserId, It.Is<DeviceBoundCredentialCopy>(c => c.CredentialId == "cred-oldest"), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        var inbox = new Mock<ICitizenDeviceInboxWriter>();
+        inbox.Setup(i => i.WriteDeviceRevokedAsync(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var realPolicy = new DeviceBoundCredentialPolicy(
+            _lookup.Object, _revoker.Object, inbox.Object, NullLogger<DeviceBoundCredentialPolicy>.Instance);
+        ArrangeStatusAllocation(listId: 1, index: 9);
+
+        var coordinator = new DeviceBoundCopyIssuanceCoordinator(
+            _holderAddress.Object, _holderKey.Object, realPolicy, _lookup.Object,
+            _revoker.Object, _statusList.Object, _orgResolver.Object,
+            NullLogger<DeviceBoundCopyIssuanceCoordinator>.Instance);
+
+        var plan = await coordinator.PrepareAsync(Recipient, Vct, DeviceJwk, OrgId, default);
+
+        plan.Should().NotBeNull("the new (4th) copy must still be issued after eviction");
+        plan!.StatusListIndex.Should().Be(9);
+        _revoker.Verify(
+            r => r.RevokeAsync(UserId, It.Is<DeviceBoundCredentialCopy>(c => c.CredentialId == "cred-oldest"), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task PrepareAsync_ReconcileThrows_PropagatesAndAllocatesNoSlot()
+    {
+        ArrangeCitizenWithDeviceCnf();
+        _policy.Setup(p => p.ReconcileAsync(UserId, Vct, DeviceThumbprint, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("status list unavailable"));
+
+        var act = async () => await CreateCoordinator().PrepareAsync(Recipient, Vct, DeviceJwk, OrgId, default);
+
+        await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("status list unavailable");
+        // No partial state: a slot is never allocated when the policy aborts.
+        _statusList.Verify(
+            s => s.AllocateIndexAsync(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task PrepareAsync_ReplaceExisting_RevokesPriorSameThumbprintCopyThenPlans()
+    {
+        ArrangeCitizenWithDeviceCnf();
+        _policy.Setup(p => p.ReconcileAsync(UserId, Vct, DeviceThumbprint, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new DeviceBindDisposition(DeviceBindKind.ReplaceExisting, null));
+
+        var prior = new DeviceBoundCredentialCopy("cred-prior", DeviceThumbprint, DateTimeOffset.UtcNow.AddDays(-3), Guid.NewGuid(), "same-device");
+        _lookup.Setup(l => l.GetLiveCopiesAsync(UserId, Vct, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<DeviceBoundCredentialCopy> { prior });
+        _revoker.Setup(r => r.RevokeAsync(UserId, It.Is<DeviceBoundCredentialCopy>(c => c.CredentialId == "cred-prior"), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        ArrangeStatusAllocation(listId: 0, index: 2);
+
+        var plan = await CreateCoordinator().PrepareAsync(Recipient, Vct, DeviceJwk, OrgId, default);
+
+        plan.Should().NotBeNull();
+        _revoker.Verify(
+            r => r.RevokeAsync(UserId, It.Is<DeviceBoundCredentialCopy>(c => c.CredentialId == "cred-prior"), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+}

--- a/tests/Sorcha.Wallet.Service.Tests/Credentials/DeviceBoundCredentialPolicyTests.cs
+++ b/tests/Sorcha.Wallet.Service.Tests/Credentials/DeviceBoundCredentialPolicyTests.cs
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Sorcha.Wallet.Service.Services.Implementation;
+using Sorcha.Wallet.Service.Services.Interfaces;
+
+namespace Sorcha.Wallet.Service.Tests.Credentials;
+
+/// <summary>
+/// Unit tests for <see cref="DeviceBoundCredentialPolicy"/> — the issuer-side max-3
+/// device-bound-copy cap with LRU eviction (Feature 1195, Phase 2, Task 4).
+/// </summary>
+public class DeviceBoundCredentialPolicyTests
+{
+    private const string CredentialType = "AssuredIdentityCredential";
+    private static readonly Guid UserId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+
+    private readonly Mock<IDeviceBoundCredentialLookup> _lookup = new(MockBehavior.Strict);
+    private readonly Mock<IDeviceBoundCredentialRevoker> _revoker = new(MockBehavior.Strict);
+    private readonly Mock<ICitizenDeviceInboxWriter> _inbox = new(MockBehavior.Strict);
+
+    private DeviceBoundCredentialPolicy CreatePolicy() =>
+        new(_lookup.Object, _revoker.Object, _inbox.Object,
+            NullLogger<DeviceBoundCredentialPolicy>.Instance);
+
+    private static DeviceBoundCredentialCopy Copy(
+        string id, string thumbprint, DateTimeOffset issuedAt) =>
+        new(CredentialId: id,
+            DeviceKeyThumbprint: thumbprint,
+            IssuedAt: issuedAt,
+            DeviceId: Guid.NewGuid(),
+            DeviceLabel: $"device-{id}");
+
+    private void SetupLiveCopies(params DeviceBoundCredentialCopy[] copies) =>
+        _lookup
+            .Setup(l => l.GetLiveCopiesAsync(UserId, CredentialType, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(copies.ToList());
+
+    [Fact]
+    public async Task ReconcileAsync_TwoExistingDistinctPlusNew_ReturnsNewWithinCapNoEviction()
+    {
+        var now = DateTimeOffset.UtcNow;
+        SetupLiveCopies(
+            Copy("cred-1", "thumb-A", now.AddDays(-2)),
+            Copy("cred-2", "thumb-B", now.AddDays(-1)));
+
+        var result = await CreatePolicy().ReconcileAsync(UserId, CredentialType, "thumb-NEW", default);
+
+        result.Kind.Should().Be(DeviceBindKind.NewWithinCap);
+        result.EvictedCredentialId.Should().BeNull();
+        _revoker.Verify(
+            r => r.RevokeAsync(It.IsAny<Guid>(), It.IsAny<DeviceBoundCredentialCopy>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _inbox.Verify(
+            i => i.WriteDeviceRevokedAsync(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task ReconcileAsync_ZeroExistingPlusNew_ReturnsNewWithinCap()
+    {
+        SetupLiveCopies();
+
+        var result = await CreatePolicy().ReconcileAsync(UserId, CredentialType, "thumb-NEW", default);
+
+        result.Kind.Should().Be(DeviceBindKind.NewWithinCap);
+        result.EvictedCredentialId.Should().BeNull();
+        _revoker.Verify(
+            r => r.RevokeAsync(It.IsAny<Guid>(), It.IsAny<DeviceBoundCredentialCopy>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task ReconcileAsync_ThreeExistingSameThumbprint_ReturnsReplaceExistingNoEviction()
+    {
+        var now = DateTimeOffset.UtcNow;
+        SetupLiveCopies(
+            Copy("cred-1", "thumb-A", now.AddDays(-3)),
+            Copy("cred-2", "thumb-B", now.AddDays(-2)),
+            Copy("cred-3", "thumb-C", now.AddDays(-1)));
+
+        // Re-bind the SAME device (thumb-B) — idempotent replace, count unchanged.
+        var result = await CreatePolicy().ReconcileAsync(UserId, CredentialType, "thumb-B", default);
+
+        result.Kind.Should().Be(DeviceBindKind.ReplaceExisting);
+        result.EvictedCredentialId.Should().BeNull();
+        _revoker.Verify(
+            r => r.RevokeAsync(It.IsAny<Guid>(), It.IsAny<DeviceBoundCredentialCopy>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _inbox.Verify(
+            i => i.WriteDeviceRevokedAsync(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task ReconcileAsync_ThreeExistingDistinctPlusNew_EvictsOldestRevokesAndNotifies()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var oldest = Copy("cred-oldest", "thumb-A", now.AddDays(-10));
+        SetupLiveCopies(
+            Copy("cred-2", "thumb-B", now.AddDays(-1)),
+            oldest, // deliberately not first in the list — oldest is by IssuedAt, not order
+            Copy("cred-3", "thumb-C", now.AddDays(-5)));
+
+        _revoker
+            .Setup(r => r.RevokeAsync(UserId, It.Is<DeviceBoundCredentialCopy>(c => c.CredentialId == "cred-oldest"), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        _inbox
+            .Setup(i => i.WriteDeviceRevokedAsync(UserId, oldest.DeviceId, oldest.DeviceLabel, It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var result = await CreatePolicy().ReconcileAsync(UserId, CredentialType, "thumb-NEW", default);
+
+        result.Kind.Should().Be(DeviceBindKind.NewWithEviction);
+        result.EvictedCredentialId.Should().Be("cred-oldest");
+        _revoker.Verify(
+            r => r.RevokeAsync(UserId, It.Is<DeviceBoundCredentialCopy>(c => c.CredentialId == "cred-oldest"), It.IsAny<CancellationToken>()),
+            Times.Once);
+        _inbox.Verify(
+            i => i.WriteDeviceRevokedAsync(UserId, oldest.DeviceId, oldest.DeviceLabel, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task ReconcileAsync_RevokeThrows_PropagatesAndLeavesNoPartialState()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var oldest = Copy("cred-oldest", "thumb-A", now.AddDays(-10));
+        SetupLiveCopies(
+            oldest,
+            Copy("cred-2", "thumb-B", now.AddDays(-1)),
+            Copy("cred-3", "thumb-C", now.AddDays(-5)));
+
+        _revoker
+            .Setup(r => r.RevokeAsync(UserId, It.IsAny<DeviceBoundCredentialCopy>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("status list unavailable"));
+
+        var act = async () => await CreatePolicy().ReconcileAsync(UserId, CredentialType, "thumb-NEW", default);
+
+        await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("status list unavailable");
+
+        // No partial state: the inbox is never written when revoke fails.
+        _inbox.Verify(
+            i => i.WriteDeviceRevokedAsync(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+}

--- a/tests/Sorcha.Wallet.Service.Tests/Credentials/DeviceBoundCredentialSeamTests.cs
+++ b/tests/Sorcha.Wallet.Service.Tests/Credentials/DeviceBoundCredentialSeamTests.cs
@@ -2,6 +2,7 @@
 // Copyright (c) 2026 Sorcha Contributors
 
 using System.Buffers.Text;
+using System.Net.Http;
 using System.Text;
 using System.Text.Json;
 
@@ -13,6 +14,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 
 using Sorcha.Cryptography;
+using Sorcha.ServiceClients.PlatformUserDevice;
 using Sorcha.Wallet.Core.Domain.Entities;
 using Sorcha.Wallet.Service.Credentials;
 using Sorcha.Wallet.Service.Services.Implementation;
@@ -99,14 +101,218 @@ public sealed class DeviceBoundCredentialSeamTests : IDisposable
         holderKey.Setup(k => k.GetHolderJwkThumbprintAsync(Wallet, It.IsAny<CancellationToken>()))
             .ReturnsAsync(JsonWebKeyThumbprint.Compute(HolderJwk));
 
+        var deviceClient = new Mock<IPlatformUserDeviceClient>();
+        deviceClient.Setup(c => c.ListAsync(UserId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<PlatformUserDeviceLookupResult>());
+
         var lookup = new EfCoreDeviceBoundCredentialLookup(
-            _db, store.Object, holderKey.Object, NullLogger<EfCoreDeviceBoundCredentialLookup>.Instance);
+            _db, store.Object, holderKey.Object, deviceClient.Object,
+            NullLogger<EfCoreDeviceBoundCredentialLookup>.Instance);
 
         var copies = await lookup.GetLiveCopiesAsync(UserId, Vct, default);
 
         copies.Should().ContainSingle("only the live device copy counts (root excluded, revoked excluded)");
         copies[0].CredentialId.Should().Be("device");
         copies[0].DeviceKeyThumbprint.Should().Be(JsonWebKeyThumbprint.Compute(DeviceJwk));
+    }
+
+    private static PlatformUserDeviceLookupResult RegisteredDevice(Guid deviceId, string label, string thumbprint) =>
+        new(DeviceId: deviceId,
+            PlatformUserId: UserId,
+            Label: label,
+            DevicePublicJwkThumbprint: thumbprint,
+            DevicePublicJwkJson: "{}",
+            Platform: "iOS",
+            Status: "Active",
+            EnrolledAt: DateTimeOffset.UtcNow.AddDays(-30),
+            DelegationExpiresAt: DateTimeOffset.UtcNow.AddDays(30),
+            DelegationCredentialJti: "jti-1",
+            StatusListId: 0,
+            StatusListIndex: 0);
+
+    [Fact]
+    public async Task Lookup_ThumbprintMatchesRegisteredDevice_PopulatesDeviceIdAndLabel()
+    {
+        // Fix round 1 (eviction notify): the copy's cnf thumbprint IS the Tenant registry's
+        // DevicePublicJwkThumbprint, so the lookup resolves DeviceId/Label for the F118 notice.
+        var deviceThumbprint = JsonWebKeyThumbprint.Compute(DeviceJwk);
+        var registeredDeviceId = Guid.Parse("55555555-5555-5555-5555-555555555555");
+
+        var store = new Mock<ICredentialStore>();
+        store.Setup(s => s.GetByWalletAsync(Wallet, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<CredentialEntity>
+            {
+                Credential("device", RawTokenWithCnf(DeviceJwk), CredentialStatus.Active),
+            });
+        var holderKey = new Mock<IHolderKeyService>();
+        holderKey.Setup(k => k.GetHolderJwkThumbprintAsync(Wallet, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(JsonWebKeyThumbprint.Compute(HolderJwk));
+        var deviceClient = new Mock<IPlatformUserDeviceClient>();
+        deviceClient.Setup(c => c.ListAsync(UserId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<PlatformUserDeviceLookupResult>
+            {
+                RegisteredDevice(Guid.NewGuid(), "Other phone", "some-other-thumbprint"),
+                RegisteredDevice(registeredDeviceId, "Stuart's iPhone", deviceThumbprint),
+            });
+
+        var lookup = new EfCoreDeviceBoundCredentialLookup(
+            _db, store.Object, holderKey.Object, deviceClient.Object,
+            NullLogger<EfCoreDeviceBoundCredentialLookup>.Instance);
+
+        var copies = await lookup.GetLiveCopiesAsync(UserId, Vct, default);
+
+        var copy = copies.Should().ContainSingle().Subject;
+        copy.DeviceId.Should().Be(registeredDeviceId, "the registry device with the matching thumbprint is the bound device");
+        copy.DeviceLabel.Should().Be("Stuart's iPhone");
+    }
+
+    [Fact]
+    public async Task Lookup_RegistryUnavailable_DegradesToDeterministicDeviceIdWithNullLabel()
+    {
+        // Fix round 1: a Tenant outage must be non-fatal to the mint. The copy is still
+        // returned (the cap still counts it); the DeviceId degrades to a deterministic
+        // thumbprint-derived Guid so the F118 notice still fires (never Guid.Empty, which
+        // CitizenDeviceInboxWriter short-circuits into silence).
+        var store = new Mock<ICredentialStore>();
+        store.Setup(s => s.GetByWalletAsync(Wallet, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<CredentialEntity>
+            {
+                Credential("device", RawTokenWithCnf(DeviceJwk), CredentialStatus.Active),
+            });
+        var holderKey = new Mock<IHolderKeyService>();
+        holderKey.Setup(k => k.GetHolderJwkThumbprintAsync(Wallet, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(JsonWebKeyThumbprint.Compute(HolderJwk));
+        var deviceClient = new Mock<IPlatformUserDeviceClient>();
+        deviceClient.Setup(c => c.ListAsync(UserId, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException("tenant unreachable"));
+
+        var lookup = new EfCoreDeviceBoundCredentialLookup(
+            _db, store.Object, holderKey.Object, deviceClient.Object,
+            NullLogger<EfCoreDeviceBoundCredentialLookup>.Instance);
+
+        var copies = await lookup.GetLiveCopiesAsync(UserId, Vct, default);
+
+        var copy = copies.Should().ContainSingle("registry outage must not hide live copies from the cap").Subject;
+        copy.DeviceId.Should().NotBe(Guid.Empty, "the eviction notice must still fire (writer no-ops on Guid.Empty)");
+        copy.DeviceLabel.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Eviction_EndToEnd_NotifiesInboxWithRegistryResolvedDeviceIdAndLabel()
+    {
+        // Fix round 1, end-to-end: REAL lookup (thumbprints from stored tokens + faked Tenant
+        // registry) feeding the REAL policy — a 4th distinct device evicts the oldest copy and
+        // the F118 inbox notice carries the registry-resolved DeviceId + label.
+        var oldestJwk = JsonSerializer.Deserialize<JsonElement>(
+            """{"kty":"EC","crv":"P-256","x":"oldest-x-00000000000000000000000000000000000","y":"oldest-y-00000000000000000000000000000000000"}""");
+        var secondJwk = JsonSerializer.Deserialize<JsonElement>(
+            """{"kty":"EC","crv":"P-256","x":"second-x-00000000000000000000000000000000000","y":"second-y-00000000000000000000000000000000000"}""");
+        var thirdJwk = JsonSerializer.Deserialize<JsonElement>(
+            """{"kty":"EC","crv":"P-256","x":"third-x-000000000000000000000000000000000000","y":"third-y-000000000000000000000000000000000000"}""");
+
+        var now = DateTimeOffset.UtcNow;
+        var oldest = Credential("cred-oldest", RawTokenWithCnf(oldestJwk), CredentialStatus.Active);
+        oldest.IssuedAt = now.AddDays(-10);
+        var second = Credential("cred-2", RawTokenWithCnf(secondJwk), CredentialStatus.Active);
+        second.IssuedAt = now.AddDays(-5);
+        var third = Credential("cred-3", RawTokenWithCnf(thirdJwk), CredentialStatus.Active);
+        third.IssuedAt = now.AddDays(-1);
+
+        var store = new Mock<ICredentialStore>();
+        store.Setup(s => s.GetByWalletAsync(Wallet, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<CredentialEntity> { second, oldest, third });
+
+        var holderKey = new Mock<IHolderKeyService>();
+        holderKey.Setup(k => k.GetHolderJwkThumbprintAsync(Wallet, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(JsonWebKeyThumbprint.Compute(HolderJwk));
+
+        var oldestDeviceId = Guid.Parse("66666666-6666-6666-6666-666666666666");
+        var deviceClient = new Mock<IPlatformUserDeviceClient>();
+        deviceClient.Setup(c => c.ListAsync(UserId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<PlatformUserDeviceLookupResult>
+            {
+                RegisteredDevice(oldestDeviceId, "Old iPad", JsonWebKeyThumbprint.Compute(oldestJwk)),
+                RegisteredDevice(Guid.NewGuid(), "Pixel", JsonWebKeyThumbprint.Compute(secondJwk)),
+                RegisteredDevice(Guid.NewGuid(), "iPhone", JsonWebKeyThumbprint.Compute(thirdJwk)),
+            });
+
+        var lookup = new EfCoreDeviceBoundCredentialLookup(
+            _db, store.Object, holderKey.Object, deviceClient.Object,
+            NullLogger<EfCoreDeviceBoundCredentialLookup>.Instance);
+
+        var revoker = new Mock<IDeviceBoundCredentialRevoker>();
+        revoker.Setup(r => r.RevokeAsync(UserId, It.IsAny<DeviceBoundCredentialCopy>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        var inbox = new Mock<ICitizenDeviceInboxWriter>();
+        inbox.Setup(i => i.WriteDeviceRevokedAsync(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var policy = new DeviceBoundCredentialPolicy(
+            lookup, revoker.Object, inbox.Object, NullLogger<DeviceBoundCredentialPolicy>.Instance);
+
+        var result = await policy.ReconcileAsync(UserId, Vct, "thumbprint-of-a-4th-device", default);
+
+        result.Kind.Should().Be(DeviceBindKind.NewWithEviction);
+        result.EvictedCredentialId.Should().Be("cred-oldest");
+        inbox.Verify(
+            i => i.WriteDeviceRevokedAsync(UserId, oldestDeviceId, "Old iPad", It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Eviction_RegistryUnavailable_StillEvictsAndNotifiesWithDegradedDeviceId()
+    {
+        // Fix round 1: Tenant outage is non-fatal — eviction (revoke) still happens, the
+        // mint still proceeds (NewWithEviction returned), and the notice degrades to the
+        // deterministic thumbprint-derived DeviceId with no label rather than going silent.
+        var oldestJwk = JsonSerializer.Deserialize<JsonElement>(
+            """{"kty":"EC","crv":"P-256","x":"oldest-x-00000000000000000000000000000000000","y":"oldest-y-00000000000000000000000000000000000"}""");
+        var secondJwk = JsonSerializer.Deserialize<JsonElement>(
+            """{"kty":"EC","crv":"P-256","x":"second-x-00000000000000000000000000000000000","y":"second-y-00000000000000000000000000000000000"}""");
+        var thirdJwk = JsonSerializer.Deserialize<JsonElement>(
+            """{"kty":"EC","crv":"P-256","x":"third-x-000000000000000000000000000000000000","y":"third-y-000000000000000000000000000000000000"}""");
+
+        var now = DateTimeOffset.UtcNow;
+        var oldest = Credential("cred-oldest", RawTokenWithCnf(oldestJwk), CredentialStatus.Active);
+        oldest.IssuedAt = now.AddDays(-10);
+        var second = Credential("cred-2", RawTokenWithCnf(secondJwk), CredentialStatus.Active);
+        second.IssuedAt = now.AddDays(-5);
+        var third = Credential("cred-3", RawTokenWithCnf(thirdJwk), CredentialStatus.Active);
+        third.IssuedAt = now.AddDays(-1);
+
+        var store = new Mock<ICredentialStore>();
+        store.Setup(s => s.GetByWalletAsync(Wallet, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<CredentialEntity> { second, oldest, third });
+        var holderKey = new Mock<IHolderKeyService>();
+        holderKey.Setup(k => k.GetHolderJwkThumbprintAsync(Wallet, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(JsonWebKeyThumbprint.Compute(HolderJwk));
+        var deviceClient = new Mock<IPlatformUserDeviceClient>();
+        deviceClient.Setup(c => c.ListAsync(UserId, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException("tenant unreachable"));
+
+        var lookup = new EfCoreDeviceBoundCredentialLookup(
+            _db, store.Object, holderKey.Object, deviceClient.Object,
+            NullLogger<EfCoreDeviceBoundCredentialLookup>.Instance);
+
+        var revoker = new Mock<IDeviceBoundCredentialRevoker>();
+        revoker.Setup(r => r.RevokeAsync(UserId, It.IsAny<DeviceBoundCredentialCopy>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        var inbox = new Mock<ICitizenDeviceInboxWriter>();
+        inbox.Setup(i => i.WriteDeviceRevokedAsync(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var policy = new DeviceBoundCredentialPolicy(
+            lookup, revoker.Object, inbox.Object, NullLogger<DeviceBoundCredentialPolicy>.Instance);
+
+        var result = await policy.ReconcileAsync(UserId, Vct, "thumbprint-of-a-4th-device", default);
+
+        result.Kind.Should().Be(DeviceBindKind.NewWithEviction, "the mint proceeds despite the registry outage");
+        revoker.Verify(
+            r => r.RevokeAsync(UserId, It.Is<DeviceBoundCredentialCopy>(c => c.CredentialId == "cred-oldest"), It.IsAny<CancellationToken>()),
+            Times.Once);
+        inbox.Verify(
+            i => i.WriteDeviceRevokedAsync(UserId, It.Is<Guid>(g => g != Guid.Empty), null, It.IsAny<CancellationToken>()),
+            Times.Once);
     }
 
     [Fact]

--- a/tests/Sorcha.Wallet.Service.Tests/Credentials/DeviceBoundCredentialSeamTests.cs
+++ b/tests/Sorcha.Wallet.Service.Tests/Credentials/DeviceBoundCredentialSeamTests.cs
@@ -1,0 +1,212 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Buffers.Text;
+using System.Text;
+using System.Text.Json;
+
+using FluentAssertions;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+
+using Moq;
+
+using Sorcha.Cryptography;
+using Sorcha.Wallet.Core.Domain.Entities;
+using Sorcha.Wallet.Service.Credentials;
+using Sorcha.Wallet.Service.Services.Implementation;
+using Sorcha.Wallet.Service.Services.Interfaces;
+using Sorcha.Wallet.Service.Tests.Services;
+
+using Xunit;
+
+namespace Sorcha.Wallet.Service.Tests.Credentials;
+
+/// <summary>
+/// Tests the two concrete policy seams (Feature 1195, Phase 2, Task 5):
+/// <see cref="EfCoreDeviceBoundCredentialLookup"/> (excludes the holder-bound root by cnf
+/// thumbprint) and <see cref="DeviceBoundCredentialRevoker"/> (flips the F114 status bit
+/// and marks the copy Revoked).
+/// </summary>
+public sealed class DeviceBoundCredentialSeamTests : IDisposable
+{
+    private const string Wallet = "ws1qcitizen1";
+    private const string Vct = "https://credentials.sorcha.dev/assured-identity";
+    private static readonly Guid UserId = Guid.Parse("33333333-3333-3333-3333-333333333333");
+    private static readonly Guid OrgId = Guid.Parse("44444444-4444-4444-4444-444444444444");
+
+    private static readonly JsonElement HolderJwk = JsonSerializer.Deserialize<JsonElement>(
+        """{"kty":"OKP","crv":"Ed25519","x":"holder-key-x-value-00000000000000000000000"}""");
+    private static readonly JsonElement DeviceJwk = JsonSerializer.Deserialize<JsonElement>(
+        """{"kty":"EC","crv":"P-256","x":"device-key-x-0000000000000000000000000000000","y":"device-key-y-0000000000000000000000000000000"}""");
+
+    private readonly TestCitizenWalletDbContext _db;
+
+    public DeviceBoundCredentialSeamTests()
+    {
+        var options = new DbContextOptionsBuilder<TestCitizenWalletDbContext>()
+            .UseInMemoryDatabase($"seam-{Guid.NewGuid()}")
+            .Options;
+        _db = new TestCitizenWalletDbContext(options);
+        _db.CitizenHolderIndex.Add(new CitizenHolderIndex
+        {
+            WalletAddress = Wallet,
+            PlatformUserId = UserId,
+            CreatedAt = DateTimeOffset.UtcNow,
+        });
+        _db.SaveChanges();
+    }
+
+    public void Dispose() => _db.Dispose();
+
+    /// <summary>Builds a minimal SD-JWT VC whose issuer-signed body carries the given cnf JWK.</summary>
+    private static string RawTokenWithCnf(JsonElement cnfJwk)
+    {
+        var header = Base64Url.EncodeToString(Encoding.UTF8.GetBytes("""{"alg":"EdDSA","typ":"vc+sd-jwt"}"""));
+        var body = Base64Url.EncodeToString(Encoding.UTF8.GetBytes(
+            JsonSerializer.Serialize(new Dictionary<string, object> { ["vct"] = Vct, ["cnf"] = new { jwk = cnfJwk } })));
+        return $"{header}.{body}.signature~";
+    }
+
+    /// <summary>Builds an SD-JWT VC body carrying the IETF status.status_list claim (register-copy shape).</summary>
+    private static string RawTokenWithIetfStatus(string uri, int idx)
+    {
+        var header = Base64Url.EncodeToString(Encoding.UTF8.GetBytes("""{"alg":"EdDSA","typ":"vc+sd-jwt"}"""));
+        var body = Base64Url.EncodeToString(Encoding.UTF8.GetBytes(JsonSerializer.Serialize(
+            new Dictionary<string, object>
+            {
+                ["vct"] = Vct,
+                ["cnf"] = new { jwk = DeviceJwk },
+                ["status"] = new { status_list = new { uri, idx } },
+            })));
+        return $"{header}.{body}.signature~";
+    }
+
+    [Fact]
+    public async Task Lookup_ExcludesHolderBoundRoot_ReturnsOnlyDeviceCopies()
+    {
+        var store = new Mock<ICredentialStore>();
+        store.Setup(s => s.GetByWalletAsync(Wallet, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<CredentialEntity>
+            {
+                Credential("root", RawTokenWithCnf(HolderJwk), CredentialStatus.Active),
+                Credential("device", RawTokenWithCnf(DeviceJwk), CredentialStatus.Active),
+                Credential("revoked-device", RawTokenWithCnf(DeviceJwk), CredentialStatus.Revoked),
+            });
+
+        var holderKey = new Mock<IHolderKeyService>();
+        holderKey.Setup(k => k.GetHolderJwkThumbprintAsync(Wallet, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(JsonWebKeyThumbprint.Compute(HolderJwk));
+
+        var lookup = new EfCoreDeviceBoundCredentialLookup(
+            _db, store.Object, holderKey.Object, NullLogger<EfCoreDeviceBoundCredentialLookup>.Instance);
+
+        var copies = await lookup.GetLiveCopiesAsync(UserId, Vct, default);
+
+        copies.Should().ContainSingle("only the live device copy counts (root excluded, revoked excluded)");
+        copies[0].CredentialId.Should().Be("device");
+        copies[0].DeviceKeyThumbprint.Should().Be(JsonWebKeyThumbprint.Compute(DeviceJwk));
+    }
+
+    [Fact]
+    public async Task Revoker_FlipsF114StatusBitAndMarksCopyRevoked()
+    {
+        var statusUrl = $"https://n1.sorcha.dev/api/v1/wallet/status/{OrgId:N}/citizen-devices/2.statuslist+jwt";
+        var entity = Credential("device", RawTokenWithCnf(DeviceJwk), CredentialStatus.Active);
+        entity.StatusListUrl = statusUrl;
+        entity.StatusListIndex = 42;
+
+        var store = new Mock<ICredentialStore>();
+        store.Setup(s => s.GetByIdForWalletAsync("device", Wallet, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(entity);
+        store.Setup(s => s.UpdateStatusAsync("device", Wallet, CredentialStatus.Revoked, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var statusList = new Mock<ICitizenStatusListPublisher>();
+        statusList.Setup(s => s.FlipAsync(OrgId, 2, 42, "ws1qorgstatus", It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        var orgResolver = new Mock<IOrgStatusSigningWalletResolver>();
+        orgResolver.Setup(r => r.ResolveAsync(OrgId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync("ws1qorgstatus");
+
+        var revoker = new DeviceBoundCredentialRevoker(
+            _db, store.Object, statusList.Object, orgResolver.Object,
+            NullLogger<DeviceBoundCredentialRevoker>.Instance);
+
+        var copy = new DeviceBoundCredentialCopy("device", JsonWebKeyThumbprint.Compute(DeviceJwk),
+            DateTimeOffset.UtcNow, Guid.Empty, null);
+
+        await revoker.RevokeAsync(UserId, copy, default);
+
+        statusList.Verify(s => s.FlipAsync(OrgId, 2, 42, "ws1qorgstatus", It.IsAny<CancellationToken>()), Times.Once);
+        store.Verify(s => s.UpdateStatusAsync("device", Wallet, CredentialStatus.Revoked, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Revoker_RegisterDeliveredCopy_ReadsIetfStatusClaimFromToken()
+    {
+        // A citizen copy delivered via the register path has NO StatusListUrl/Index columns
+        // (InboundCredentialDetector does not set them) — the allocation must be read from the
+        // signed IETF status claim in the token.
+        var statusUrl = $"https://n1.sorcha.dev/api/v1/wallet/status/{OrgId:N}/citizen-devices/3.statuslist+jwt";
+        var entity = Credential("device", RawTokenWithIetfStatus(statusUrl, 17), CredentialStatus.Active);
+        // Deliberately leave StatusListUrl/StatusListIndex null.
+
+        var store = new Mock<ICredentialStore>();
+        store.Setup(s => s.GetByIdForWalletAsync("device", Wallet, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(entity);
+        store.Setup(s => s.UpdateStatusAsync("device", Wallet, CredentialStatus.Revoked, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var statusList = new Mock<ICitizenStatusListPublisher>();
+        statusList.Setup(s => s.FlipAsync(OrgId, 3, 17, "ws1qorgstatus", It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        var orgResolver = new Mock<IOrgStatusSigningWalletResolver>();
+        orgResolver.Setup(r => r.ResolveAsync(OrgId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync("ws1qorgstatus");
+
+        var revoker = new DeviceBoundCredentialRevoker(
+            _db, store.Object, statusList.Object, orgResolver.Object,
+            NullLogger<DeviceBoundCredentialRevoker>.Instance);
+
+        var copy = new DeviceBoundCredentialCopy("device", JsonWebKeyThumbprint.Compute(DeviceJwk),
+            DateTimeOffset.UtcNow, Guid.Empty, null);
+
+        await revoker.RevokeAsync(UserId, copy, default);
+
+        statusList.Verify(s => s.FlipAsync(OrgId, 3, 17, "ws1qorgstatus", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Revoker_NoStatusAllocation_Throws()
+    {
+        var entity = Credential("device", RawTokenWithCnf(DeviceJwk), CredentialStatus.Active); // no StatusListUrl/Index
+        var store = new Mock<ICredentialStore>();
+        store.Setup(s => s.GetByIdForWalletAsync("device", Wallet, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(entity);
+
+        var revoker = new DeviceBoundCredentialRevoker(
+            _db, store.Object, Mock.Of<ICitizenStatusListPublisher>(), Mock.Of<IOrgStatusSigningWalletResolver>(),
+            NullLogger<DeviceBoundCredentialRevoker>.Instance);
+
+        var copy = new DeviceBoundCredentialCopy("device", "thumb", DateTimeOffset.UtcNow, Guid.Empty, null);
+
+        var act = async () => await revoker.RevokeAsync(UserId, copy, default);
+        await act.Should().ThrowAsync<InvalidOperationException>();
+    }
+
+    private static CredentialEntity Credential(string id, string rawToken, CredentialStatus status) => new()
+    {
+        Id = id,
+        Type = Vct,
+        IssuerDid = "did:sorcha:org:issuer",
+        SubjectDid = Wallet,
+        ClaimsJson = "{}",
+        RawToken = rawToken,
+        Status = status,
+        WalletAddress = Wallet,
+        IssuedAt = DateTimeOffset.UtcNow,
+        CreatedAt = DateTimeOffset.UtcNow,
+    };
+}

--- a/tests/Sorcha.Wallet.Service.Tests/Endpoints/CitizenWalletSignKbEndpointTests.cs
+++ b/tests/Sorcha.Wallet.Service.Tests/Endpoints/CitizenWalletSignKbEndpointTests.cs
@@ -1,0 +1,202 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Buffers.Text;
+using System.Reflection;
+using System.Security.Claims;
+using System.Text;
+using System.Text.Json;
+using FluentAssertions;
+using FluentValidation;
+using FluentValidation.Results;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Sorcha.CitizenWallet.Abstractions.Models;
+using Sorcha.Wallet.Service.Endpoints;
+using Sorcha.Wallet.Service.Services.Interfaces;
+using Xunit;
+
+namespace Sorcha.Wallet.Service.Tests.Endpoints;
+
+/// <summary>
+/// Tests for the <see cref="CitizenWalletEndpoints"/> <c>SignKbJwt</c> handler
+/// (#1195 Phase 2, Task 6a — server-custody KB-JWT signing for holder-<c>cnf</c>
+/// presentations). Uses the established reflection-based static-handler pattern
+/// (<see cref="CitizenWalletEnrolEndpointTests"/>). Security invariants under test:
+/// the holder key is ALWAYS resolved from the authenticated caller (never the body),
+/// and the endpoint refuses to act as a general-purpose signing oracle (only a
+/// <c>typ: kb+jwt</c> header may be signed — the same holder key signs device
+/// delegation credentials, so an unrestricted oracle would let a caller mint them).
+/// </summary>
+public sealed class CitizenWalletSignKbEndpointTests
+{
+    private static readonly Guid PlatformUserId = Guid.NewGuid();
+    private const string CitizenWallet = "ws1qcitizen1";
+
+    private readonly Mock<IValidator<KbJwtSignRequest>> _validator = new();
+    private readonly Mock<IHolderKeyService> _holderKeys = new();
+    private readonly Mock<Sorcha.Wallet.Core.Repositories.Interfaces.IWalletRepository> _walletRepository = new();
+
+    public CitizenWalletSignKbEndpointTests()
+    {
+        _validator.Setup(v => v.ValidateAsync(It.IsAny<KbJwtSignRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ValidationResult());
+    }
+
+    /// <summary>Build a KB-JWT signing input (b64url(header).b64url(payload)) with the given header fields.</summary>
+    private static string BuildSigningInput(string typ = "kb+jwt", string alg = "ES256")
+    {
+        var header = Base64Url.EncodeToString(JsonSerializer.SerializeToUtf8Bytes(
+            new Dictionary<string, string> { ["alg"] = alg, ["typ"] = typ, ["kid"] = "thumb" }));
+        var payload = Base64Url.EncodeToString(JsonSerializer.SerializeToUtf8Bytes(
+            new Dictionary<string, object> { ["nonce"] = "n-1", ["aud"] = "did:sorcha:org:x", ["sd_hash"] = "h" }));
+        return $"{header}.{payload}";
+    }
+
+    private static HttpContext BuildHttpContext(
+        Guid? platformUserId,
+        string? walletAddress)
+    {
+        var ctx = new DefaultHttpContext();
+        var claims = new List<Claim>();
+        if (platformUserId is not null)
+            claims.Add(new Claim("platform_user_id", platformUserId.Value.ToString()));
+        if (walletAddress is not null)
+            claims.Add(new Claim("wallet_address", walletAddress));
+        ctx.User = new ClaimsPrincipal(new ClaimsIdentity(claims, "TestAuth"));
+        return ctx;
+    }
+
+    private async Task<IResult> InvokeAsync(KbJwtSignRequest body, HttpContext context)
+    {
+        var method = typeof(CitizenWalletEndpoints).GetMethod(
+            "SignKbJwt",
+            BindingFlags.NonPublic | BindingFlags.Static);
+        method.Should().NotBeNull("SignKbJwt handler should exist");
+
+        var result = method!.Invoke(null, [
+            body,
+            context,
+            _validator.Object,
+            _holderKeys.Object,
+            _walletRepository.Object,
+            NullLogger<Program>.Instance,
+            CancellationToken.None
+        ]);
+        return await (Task<IResult>)result!;
+    }
+
+    [Fact]
+    public async Task SignKbJwt_HappyPath_SignsWithCallersHolderKey_ReturnsJoseAlgorithmAndSignature()
+    {
+        var signingInput = BuildSigningInput(alg: "EdDSA");
+        var signatureBytes = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8 };
+
+        // The holder key service returns the WALLET-style algorithm name; the
+        // endpoint must normalise it to the JOSE identifier for the response.
+        _holderKeys.Setup(h => h.SignAsync(
+                CitizenWallet,
+                It.Is<byte[]>(b => b.SequenceEqual(Encoding.ASCII.GetBytes(signingInput))),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync((signatureBytes, "ED25519"));
+
+        var ctx = BuildHttpContext(PlatformUserId, CitizenWallet);
+        var result = await InvokeAsync(new KbJwtSignRequest { SigningInput = signingInput }, ctx);
+
+        result.GetType().Name.Should().Contain("Ok");
+        var response = result.GetType().GetProperty("Value")!.GetValue(result)
+            .Should().BeOfType<KbJwtSignResponse>().Subject;
+        response.Signature.Should().Be(Base64Url.EncodeToString(signatureBytes));
+        response.Algorithm.Should().Be("EdDSA");
+
+        // The wallet whose key signs is the AUTHENTICATED caller's — resolved from
+        // the JWT claims, never from anything in the body.
+        _holderKeys.Verify(h => h.SignAsync(
+            CitizenWallet, It.IsAny<byte[]>(), It.IsAny<CancellationToken>()), Times.Once);
+        _holderKeys.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task SignKbJwt_MissingIdentity_ReturnsUnauthorized_AndNeverSigns()
+    {
+        var ctx = BuildHttpContext(platformUserId: null, walletAddress: null);
+        var result = await InvokeAsync(new KbJwtSignRequest { SigningInput = BuildSigningInput() }, ctx);
+
+        result.GetType().Name.Should().Contain("Unauthorized");
+        _holderKeys.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task SignKbJwt_ValidationFailure_ReturnsValidationProblem()
+    {
+        _validator.Setup(v => v.ValidateAsync(It.IsAny<KbJwtSignRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ValidationResult([new ValidationFailure("SigningInput", "is required")]));
+
+        var ctx = BuildHttpContext(PlatformUserId, CitizenWallet);
+        var result = await InvokeAsync(new KbJwtSignRequest { SigningInput = "" }, ctx);
+
+        result.GetType().Name.Should().ContainAny("Problem", "ValidationProblem");
+        _holderKeys.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task SignKbJwt_HeaderNotKbJwt_ReturnsBadRequest_AndNeverSigns()
+    {
+        // Oracle guard: the holder key also signs device delegation credentials.
+        // A non-kb+jwt header (e.g. a delegation VC or an access token) must be refused.
+        var ctx = BuildHttpContext(PlatformUserId, CitizenWallet);
+        var result = await InvokeAsync(
+            new KbJwtSignRequest { SigningInput = BuildSigningInput(typ: "JWT") }, ctx);
+
+        result.GetType().Name.Should().Contain("Problem");
+        var problem = result.GetType().GetProperty("ProblemDetails")!.GetValue(result)
+            .Should().BeAssignableTo<Microsoft.AspNetCore.Mvc.ProblemDetails>().Subject;
+        problem.Status.Should().Be(StatusCodes.Status400BadRequest);
+        _holderKeys.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task SignKbJwt_HeaderAlgMismatchesHolderKey_ReturnsNamedBadRequest()
+    {
+        // Never-silent invariant: a KB-JWT whose header alg cannot match the holder
+        // key's real algorithm would fail verification downstream with no clue why.
+        // The endpoint names the mismatch instead of returning an unusable signature.
+        var signingInput = BuildSigningInput(alg: "ES256");
+        _holderKeys.Setup(h => h.SignAsync(CitizenWallet, It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((new byte[] { 9 }, "ED25519"));
+
+        var ctx = BuildHttpContext(PlatformUserId, CitizenWallet);
+        var result = await InvokeAsync(new KbJwtSignRequest { SigningInput = signingInput }, ctx);
+
+        result.GetType().Name.Should().Contain("Problem");
+        var detail = result.GetType().GetProperty("ProblemDetails")!.GetValue(result)
+            .Should().BeAssignableTo<Microsoft.AspNetCore.Mvc.ProblemDetails>().Subject;
+        detail.Status.Should().Be(StatusCodes.Status400BadRequest);
+        detail.Detail.Should().Contain("ES256").And.Contain("EdDSA",
+            "the error must name both the header alg and the holder key's actual alg");
+    }
+
+    [Fact]
+    public async Task SignKbJwt_WalletUnknown_ReturnsNotFound()
+    {
+        _holderKeys.Setup(h => h.SignAsync(CitizenWallet, It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new KeyNotFoundException("no wallet"));
+
+        var ctx = BuildHttpContext(PlatformUserId, CitizenWallet);
+        var result = await InvokeAsync(new KbJwtSignRequest { SigningInput = BuildSigningInput(alg: "EdDSA") }, ctx);
+
+        result.GetType().Name.Should().Contain("NotFound");
+    }
+
+    [Fact]
+    public async Task SignKbJwt_MalformedSigningInput_ReturnsBadRequest_AndNeverSigns()
+    {
+        var ctx = BuildHttpContext(PlatformUserId, CitizenWallet);
+        var result = await InvokeAsync(
+            new KbJwtSignRequest { SigningInput = "not-a-jws-signing-input" }, ctx);
+
+        result.GetType().Name.Should().Contain("Problem");
+        _holderKeys.VerifyNoOtherCalls();
+    }
+}

--- a/tests/Sorcha.Wallet.Service.Tests/Endpoints/IssueCredentialDeviceBoundTests.cs
+++ b/tests/Sorcha.Wallet.Service.Tests/Endpoints/IssueCredentialDeviceBoundTests.cs
@@ -1,0 +1,204 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Reflection;
+using System.Text.Json;
+
+using FluentAssertions;
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging.Abstractions;
+
+using Moq;
+
+using Sorcha.Cryptography.SdJwt;
+using Sorcha.Wallet.Core.Domain.Entities;
+using Sorcha.Wallet.Core.Domain.Enums;
+using Sorcha.Wallet.Core.Repositories.Interfaces;
+using Sorcha.Wallet.Service.Credentials;
+using Sorcha.Wallet.Service.Endpoints;
+using Sorcha.Wallet.Service.Services.Implementation;
+using Sorcha.Wallet.Service.Services.Interfaces;
+
+using Xunit;
+
+using WalletEntity = Sorcha.Wallet.Core.Domain.Entities.Wallet;
+
+namespace Sorcha.Wallet.Service.Tests.Endpoints;
+
+/// <summary>
+/// Mint-path wiring for the device-bound copy policy (Feature 1195, Phase 2, Task 5).
+/// Asserts that <c>IssueCredential</c> consults the
+/// <see cref="IDeviceBoundCopyIssuanceCoordinator"/> for a holder-bound (cnf) issuance,
+/// embeds the wallet-owned F114 status slot the coordinator returns, and aborts the mint
+/// (no credential stored) when the coordinator throws. Reflection-based static-handler
+/// invocation per <see cref="IssueCredentialVctDecouplingTests"/>.
+/// </summary>
+public sealed class IssueCredentialDeviceBoundTests
+{
+    private const string WalletAddress = "ws1qissuer1";
+    private const string Recipient = "ws1qcitizen1";
+    private const string VctUri = "https://credentials.sorcha.dev/assured-identity";
+
+    private static readonly JsonElement DeviceJwk = JsonSerializer.Deserialize<JsonElement>(
+        """{"kty":"EC","crv":"P-256","x":"device-x-value-0000000000000000000000000000","y":"device-y-value-0000000000000000000000000000"}""");
+
+    private readonly Mock<IWalletRepository> _walletRepository = new();
+    private readonly Mock<ISdJwtService> _sdJwt = new();
+    private readonly Mock<ICredentialStore> _store = new();
+    private readonly Mock<IIssuanceKeyService> _issuanceKey = new();
+    private readonly Mock<IWalletInboxWriter> _inboxWriter = new();
+    private readonly Mock<IDeviceBoundCopyIssuanceCoordinator> _coordinator = new();
+    private readonly List<CredentialEntity> _stored = new();
+    private Dictionary<string, object>? _signedClaims;
+
+    public IssueCredentialDeviceBoundTests()
+    {
+        _walletRepository.Setup(r => r.GetByAddressAsync(
+                WalletAddress, false, false, false, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new WalletEntity
+            {
+                Address = WalletAddress,
+                EncryptedPrivateKey = "test-key",
+                EncryptionKeyId = "test-kid",
+                Algorithm = "ED25519",
+                Owner = "test-owner",
+                Tenant = "test-tenant",
+                Name = "test-wallet",
+                Status = WalletStatus.Active
+            });
+        // Recipient wallet absent → only the issuer copy is stored (SkipRecipientStore also set).
+        _walletRepository.Setup(r => r.GetByAddressAsync(
+                Recipient, It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((WalletEntity?)null);
+
+        _issuanceKey.Setup(s => s.GetOrDeriveAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IssuanceKeyState?)null);
+        _issuanceKey.Setup(s => s.GetActiveSigningMaterialAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Guid orgId, CancellationToken _) => new IssuanceSigningMaterial(
+                OrganizationId: orgId,
+                IssuerDid: "did:sorcha:org:ws1qissuer1",
+                Kid: "did:sorcha:org:ws1qissuer1#vc-issuance-1",
+                PrivateKey: new byte[32],
+                Algorithm: "ED25519",
+                RotationIndex: 1));
+
+        // Capture the claims the wallet signs (holder-jwk overload — cnf binding present).
+        _sdJwt.Setup(s => s.CreateTokenAsync(
+                It.IsAny<Dictionary<string, object>>(),
+                It.IsAny<IEnumerable<string>?>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<byte[]>(),
+                It.IsAny<string>(),
+                It.IsAny<JsonElement>(),
+                It.IsAny<DateTimeOffset?>(),
+                It.IsAny<CancellationToken>(),
+                It.IsAny<IReadOnlyList<byte[]>?>(),
+                It.IsAny<string?>()))
+            .Callback((Dictionary<string, object> claims, IEnumerable<string>? _, string _, string _, byte[] _, string _,
+                    JsonElement _, DateTimeOffset? _, CancellationToken _, IReadOnlyList<byte[]>? _, string? _) =>
+                _signedClaims = claims)
+            .ReturnsAsync(new SdJwtToken { RawToken = "eyJhbGciOiJFZERTQSJ9.test.sig~" });
+
+        _store.Setup(s => s.StoreAsync(It.IsAny<CredentialEntity>(), It.IsAny<CancellationToken>()))
+            .Callback<CredentialEntity, CancellationToken>((e, _) => _stored.Add(e))
+            .Returns(Task.CompletedTask);
+
+        _inboxWriter.Setup(w => w.WriteCredentialReceivedAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+    }
+
+    private IssueCredentialRequest DeviceBoundRequest() => new()
+    {
+        CredentialType = "AssuredIdentityCredential",
+        Vct = VctUri,
+        Claims = new Dictionary<string, object> { ["foo"] = "bar" },
+        RecipientWallet = Recipient,
+        SkipRecipientStore = true,
+        TenantId = Guid.NewGuid().ToString(),
+        HolderJwk = DeviceJwk,
+    };
+
+    [Fact]
+    public async Task IssueCredential_DeviceBoundPlan_EmbedsIetfStatusAndStoresF114Slot()
+    {
+        var statusUrl = $"https://n1.sorcha.dev/api/v1/wallet/status/{Guid.NewGuid():N}/citizen-devices/0.statuslist+jwt";
+        _coordinator.Setup(c => c.PrepareAsync(
+                Recipient, VctUri, It.IsAny<JsonElement>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new DeviceBoundMintPlan(statusUrl, 7));
+
+        var result = await InvokeAsync(WalletAddress, DeviceBoundRequest());
+
+        result.GetType().Name.Should().Contain("Ok");
+        var issuer = _stored.Should().ContainSingle().Subject;
+        issuer.StatusListUrl.Should().Be(statusUrl, "the device copy embeds the wallet-owned F114 slot");
+        issuer.StatusListIndex.Should().Be(7);
+
+        _signedClaims.Should().NotBeNull();
+        _signedClaims!.Should().ContainKey("status", "device copies use the IETF Token Status List claim shape");
+        _coordinator.Verify(c => c.PrepareAsync(
+            Recipient, VctUri, It.IsAny<JsonElement>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task IssueCredential_CoordinatorReturnsNull_LeavesStatusUnchanged()
+    {
+        // Web root / non-device: coordinator returns null → no status slot embedded.
+        _coordinator.Setup(c => c.PrepareAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<JsonElement>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((DeviceBoundMintPlan?)null);
+
+        await InvokeAsync(WalletAddress, DeviceBoundRequest());
+
+        var issuer = _stored.Should().ContainSingle().Subject;
+        issuer.StatusListUrl.Should().BeNull("a null plan leaves the request's (absent) status allocation unchanged");
+        issuer.StatusListIndex.Should().BeNull();
+        _signedClaims.Should().NotBeNull();
+        _signedClaims!.Should().NotContainKey("status");
+    }
+
+    [Fact]
+    public async Task IssueCredential_CoordinatorThrows_AbortsMintAndStoresNothing()
+    {
+        _coordinator.Setup(c => c.PrepareAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<JsonElement>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("eviction revoke failed"));
+
+        var result = await InvokeAsync(WalletAddress, DeviceBoundRequest());
+
+        result.GetType().Name.Should().NotContain("Ok", "a policy abort must not mint a credential");
+        _stored.Should().BeEmpty("no credential is signed or stored when the policy aborts");
+        _sdJwt.Verify(s => s.CreateTokenAsync(
+                It.IsAny<Dictionary<string, object>>(), It.IsAny<IEnumerable<string>?>(), It.IsAny<string>(),
+                It.IsAny<string>(), It.IsAny<byte[]>(), It.IsAny<string>(), It.IsAny<JsonElement>(),
+                It.IsAny<DateTimeOffset?>(), It.IsAny<CancellationToken>(), It.IsAny<IReadOnlyList<byte[]>?>(), It.IsAny<string?>()),
+            Times.Never);
+    }
+
+    private async Task<IResult> InvokeAsync(string walletAddress, IssueCredentialRequest request)
+    {
+        var method = typeof(CredentialEndpoints).GetMethod(
+            "IssueCredential",
+            BindingFlags.NonPublic | BindingFlags.Static)!;
+        method.Should().NotBeNull("IssueCredential handler should exist");
+
+        var result = method.Invoke(null, [
+            walletAddress,
+            request,
+            _walletRepository.Object,
+            null!, // IKeyManagementService — not used on the issuance-key signing path
+            _sdJwt.Object,
+            _store.Object,
+            new NullLoggerFactory(),
+            _inboxWriter.Object,
+            _issuanceKey.Object,
+            null,  // IOrgCertChainProvider (optional)
+            _coordinator.Object,
+            CancellationToken.None
+        ]);
+        return await (Task<IResult>)result!;
+    }
+}

--- a/tests/Sorcha.Wallet.Service.Tests/Endpoints/IssueCredentialDeviceBoundTests.cs
+++ b/tests/Sorcha.Wallet.Service.Tests/Endpoints/IssueCredentialDeviceBoundTests.cs
@@ -161,16 +161,42 @@ public sealed class IssueCredentialDeviceBoundTests
     }
 
     [Fact]
-    public async Task IssueCredential_CoordinatorThrows_AbortsMintAndStoresNothing()
+    public async Task IssueCredential_PolicyRefusal_Returns409AndStoresNothing()
     {
+        // Fix round 2: a cap-policy REFUSAL (eviction/replacement revoke failed) is 409 —
+        // retrying as-is won't help until the conflicting copy state changes.
         _coordinator.Setup(c => c.PrepareAsync(
                 It.IsAny<string>(), It.IsAny<string>(), It.IsAny<JsonElement>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
-            .ThrowsAsync(new InvalidOperationException("eviction revoke failed"));
+            .ThrowsAsync(new DeviceBoundPolicyRefusalException(
+                "cap refused", new InvalidOperationException("eviction revoke failed")));
 
         var result = await InvokeAsync(WalletAddress, DeviceBoundRequest());
 
-        result.GetType().Name.Should().NotContain("Ok", "a policy abort must not mint a credential");
-        _stored.Should().BeEmpty("no credential is signed or stored when the policy aborts");
+        var problem = result.Should().BeOfType<Microsoft.AspNetCore.Http.HttpResults.ProblemHttpResult>().Subject;
+        problem.StatusCode.Should().Be(StatusCodes.Status409Conflict);
+        AssertNothingMinted();
+    }
+
+    [Fact]
+    public async Task IssueCredential_CoordinatorInfrastructureFault_Returns503AndStoresNothing()
+    {
+        // Fix round 2: a transient infrastructure fault (holder-key resolution, status-list
+        // allocation) is 503 so the PWA client can retry; the message leaks no internal detail.
+        _coordinator.Setup(c => c.PrepareAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<JsonElement>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("redis connection refused at 10.0.0.5"));
+
+        var result = await InvokeAsync(WalletAddress, DeviceBoundRequest());
+
+        var problem = result.Should().BeOfType<Microsoft.AspNetCore.Http.HttpResults.ProblemHttpResult>().Subject;
+        problem.StatusCode.Should().Be(StatusCodes.Status503ServiceUnavailable);
+        problem.ProblemDetails.Detail.Should().NotContain("10.0.0.5", "internal fault detail must not leak to the client");
+        AssertNothingMinted();
+    }
+
+    private void AssertNothingMinted()
+    {
+        _stored.Should().BeEmpty("no credential is signed or stored when the coordinator aborts");
         _sdJwt.Verify(s => s.CreateTokenAsync(
                 It.IsAny<Dictionary<string, object>>(), It.IsAny<IEnumerable<string>?>(), It.IsAny<string>(),
                 It.IsAny<string>(), It.IsAny<byte[]>(), It.IsAny<string>(), It.IsAny<JsonElement>(),

--- a/tests/Sorcha.Wallet.Service.Tests/Endpoints/IssueCredentialStatusListUrlGuardTests.cs
+++ b/tests/Sorcha.Wallet.Service.Tests/Endpoints/IssueCredentialStatusListUrlGuardTests.cs
@@ -107,6 +107,7 @@ public sealed class IssueCredentialStatusListUrlGuardTests
             null!, // IWalletInboxWriter — not reached by the URL guard
             null,  // IIssuanceKeyService (optional — F120)
             null,  // IOrgCertChainProvider (optional)
+            null,  // IDeviceBoundCopyIssuanceCoordinator (optional — F1195 Phase 2)
             CancellationToken.None
         ]);
         return await (Task<IResult>)result!;

--- a/tests/Sorcha.Wallet.Service.Tests/Endpoints/IssueCredentialVctDecouplingTests.cs
+++ b/tests/Sorcha.Wallet.Service.Tests/Endpoints/IssueCredentialVctDecouplingTests.cs
@@ -181,6 +181,7 @@ public sealed class IssueCredentialVctDecouplingTests
             _inboxWriter.Object,
             _issuanceKey.Object,
             null,  // IOrgCertChainProvider (optional)
+            null,  // IDeviceBoundCopyIssuanceCoordinator (optional — F1195 Phase 2)
             CancellationToken.None
         ]);
         return await (Task<IResult>)result!;


### PR DESCRIPTION
## Summary

Implements #1195 Phase 2 per `docs/superpowers/specs/2026-07-16-device-bound-reissuance-design.md` (executed task-by-task via `docs/superpowers/plans/2026-07-16-device-bound-reissuance.md` with per-task independent review + a final whole-branch review).

**One assurance, two bindings:** the web-issued AIAS root stays holder-`cnf` (server-custody presentable); a second AIAS **device-registration blueprint**, driven by a **"Bind to device"** button on the wallet ID card, presents the root (entitlement + verified claim source) and mints a **device-`cnf` copy** bound to the phone's non-extractable P-256 key. A `DeviceBoundCredentialPolicy` caps copies at **3 per user with LRU eviction** (status-list revoke + F118 inbox notice). The wallet **auto-selects root vs device copy per presentation surface**. Delegation stays OFF every presentation path.

## The 8 tasks (+ inserted sub-tasks found necessary during execution)

1. **Apply blueprint correction** — root back to `sorcha-holder-key` (holder-`cnf`).
2. **`aias-device-registration.template.json`** — presents the root (`presentationSource: SorchaWallet`, canonical vct URI), captures the device JWK, mints the copy. Same-register targeting mirrors the apply blueprint (pinned by test).
3. **Engine: `/presentedCredential/*`** — issuance claims sourced from the **verified** root presentation with strict precedence over client payload (fail-closed reserved key; sync + async paths; the gated action's payload reaches issuance via outcome-tx reconstruction).
4. **`DeviceBoundCredentialPolicy`** — max-3 per (user, credentialType) keyed on RFC 7638 thumbprint; idempotent re-bind; revoke-oldest-before-mint; revoke failure aborts.
5. **Mint-path wiring** — thumbprint-vs-slot-108 discriminator (P-256-wallet-safe); F114 status slot allocated at mint (device copies are now revocable); eviction notice resolves the real device via the Tenant registry; 409 policy refusal vs 503 retryable fault.
6. **PWA "Bind to device"** (+6a server-custody `sign-kb` endpoint; +6b completion of the SorchaWallet presentation rail: execute-path initiation, wallet-reachable callback, session wiring, full-disclosure-via-pass-through).
7. **Presentation selection per surface** — 5-way thumbprint classification; root never device-signed (single + multi-credential paths); explicit "bind this device first" outcome; picker preserved for distinct candidates.
8. **Verifier parity tests** — device-`cnf` copy verifies in person; holder-`cnf` root verifies server-custody; **wrong-key negatives fail loudly** ("Key binding mismatch", zero claims).

## Security fixes landed en route

- **RFC 9901 disclosure anchoring** in the shared `VerifiablePresentationValidator` (pre-existing hole: disclosure segments were accepted without `_sd` digest verification — forged-claim injection / required-claim override; RED-proven attack tests). Covers object-SD, array-element SD, nested fixpoint, distinct unsupported-`_sd_alg` rejection.
- **Payload-spoofing closure** on `/presentedCredential/*` (client payload could previously satisfy issuance claim mappings; three smuggle vectors closed and tested).
- **Server-custody verification branch** (final-review fix): delegation-free holder-signed KB-JWTs verify against the credential's own `cnf.jwk`; delegation-present behaviour byte-identical; real consumer+validator boundary tests (no mocks) incl. the wrong-key negative.

## Tests

| Project | Before | After |
|---|---|---|
| Blueprint.Service.Tests | 967 | 988 (+5 skip) |
| Wallet.Service.Tests | 927 | 958 |
| Wallet.Pwa.Tests | 383 | 429 |
| Verifier.Tests | 103 | 116 |
| Haip.Service.Tests | 97 | 101 |

All 0 failures. Every task TDD'd (RED evidence recorded per task); per-task independent review + final whole-branch review: **Ready to merge: Yes**.

## Follow-ups (tracked)

- #1199 — verifier hardening: HAIP verify path lacks disclosure anchoring (parity); Verifier.Engine doesn't check the primary credential's own status-list bit at the gate. Both pre-existing.
- #1198 — verifier vct not gated (pre-existing, noted in T8 tests).
- **n1 deploy checks before the phone E2E:** AIAS issuer-key resolution must be wired (requireIssuerSignature=true on the bind gate), then the live pass: web apply → Bind to device → present in person → verify. Ships as client images (`sorcha-wallet-pwa`, `sorcha-ui-web`) + `wallet-service` + `blueprint-service`.

## Documentation

- Wallet Service README + `docs/reference/API-DOCUMENTATION.md` (sign-kb endpoint, consumer-tier callback), endpoint `.WithSummary()`/`.WithDescription()` throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011svtWMsJSk3ngWz7gkovc9