### PR TITLE
fix: [#1195] PWA bind 404 (instance-id Guid format) + replaced-credential empty vct

### DIFF
--- a/src/Apps/Sorcha.Wallet.Pwa/Services/Applications/IApplicationActionClient.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Services/Applications/IApplicationActionClient.cs
@@ -140,7 +140,7 @@ public sealed class HttpApplicationActionClient : IApplicationActionClient
     {
         try
         {
-            var instanceResponse = await _http.GetAsync($"api/instances/{instanceId:N}", ct);
+            var instanceResponse = await _http.GetAsync($"api/instances/{instanceId:D}", ct);
             if (!instanceResponse.IsSuccessStatusCode)
             {
                 return ClassifyFailure(instanceId, "instance", instanceResponse.StatusCode);
@@ -157,7 +157,7 @@ public sealed class HttpApplicationActionClient : IApplicationActionClient
             // Instance-scoped, consumer-readable read — NOT GET /api/blueprints/{id} (authoring-only,
             // Feature 147). See the class remarks for why.
             var actionResponse = await _http.GetAsync(
-                $"api/instances/{instanceId:N}/actions/{actionId}", ct);
+                $"api/instances/{instanceId:D}/actions/{actionId}", ct);
             if (!actionResponse.IsSuccessStatusCode)
             {
                 return ClassifyFailure(instanceId, "action", actionResponse.StatusCode);
@@ -243,7 +243,7 @@ public sealed class HttpApplicationActionClient : IApplicationActionClient
         var execBody = new ActionExecuteBody(
             BlueprintId: context.BlueprintId,
             ActionId: context.ActionId.ToString(),
-            InstanceId: context.InstanceId.ToString("N"),
+            InstanceId: context.InstanceId.ToString("D"),
             SenderWallet: context.SenderWallet,
             RegisterAddress: context.RegisterId,
             PayloadData: payloadData);
@@ -251,7 +251,7 @@ public sealed class HttpApplicationActionClient : IApplicationActionClient
         try
         {
             var response = await _http.PostAsJsonAsync(
-                $"api/instances/{context.InstanceId:N}/actions/{context.ActionId}/execute",
+                $"api/instances/{context.InstanceId:D}/actions/{context.ActionId}/execute",
                 execBody, JsonOptions, ct);
 
             if (response.IsSuccessStatusCode)

--- a/src/Apps/Sorcha.Wallet.Pwa/Services/ISyncService.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Services/ISyncService.cs
@@ -250,12 +250,18 @@ public sealed class SyncService : ISyncService
         }
         foreach (var replaced in delta.Credentials.Replaced)
         {
+            // Populate Vct + claim names from the new credential's SD-JWT — leaving them empty
+            // (the pre-fix behaviour) made a replaced credential unmatchable: PresentationEngine
+            // matches on Vct, so an empty match identifier reports "None of your credentials match"
+            // for the exact type the citizen holds. Mirrors the Added path (ToCachedCredential).
             await _cache.UpsertAsync(new CachedCredential
             {
                 Id = StringToCacheGuid(replaced.NewId),
-                Vct = string.Empty,
+                Vct = SdJwtReader.ReadVct(replaced.Jwt),
                 RawSdJwt = replaced.Jwt,
-                AvailableClaimNames = [],
+                AvailableClaimNames = SdJwtReader.ReadDisclosedClaims(replaced.Jwt)
+                    .Select(c => c.Name)
+                    .ToList(),
             }, ct);
         }
         // Revoked entries are surfaced via the cache's existence; v1 leaves the

--- a/src/Apps/Sorcha.Wallet.Pwa/Services/SdJwtReader.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Services/SdJwtReader.cs
@@ -110,6 +110,29 @@ public static class SdJwtReader
         return null;
     }
 
+    /// <summary>Reads the credential's <c>vct</c> claim (the JWT body before the first '~'); empty when absent.</summary>
+    public static string ReadVct(string? rawSdJwt)
+    {
+        if (string.IsNullOrWhiteSpace(rawSdJwt)) return string.Empty;
+
+        var jwt = rawSdJwt.Split('~')[0];
+        var parts = jwt.Split('.');
+        if (parts.Length < 2) return string.Empty;
+
+        try
+        {
+            var bytes = Base64Url.DecodeFromChars(parts[1]);
+            using var doc = JsonDocument.Parse(bytes);
+            if (doc.RootElement.TryGetProperty("vct", out var vct) && vct.ValueKind == JsonValueKind.String)
+                return vct.GetString() ?? string.Empty;
+        }
+        catch
+        {
+            // Not a decodable JWT body — treat as "no vct known".
+        }
+        return string.Empty;
+    }
+
     // --- Disclosure reconstruction (ports the server's NestedDisclosure.Reconstruct /
     // SdJwtClaimProjection algorithm into pure BCL — System.Text.Json[.Nodes] only, no
     // Sorcha.Cryptography, since this runs in Blazor WebAssembly.) ---

--- a/tests/Sorcha.Wallet.Pwa.Tests/Services/Applications/HttpApplicationActionClientTests.cs
+++ b/tests/Sorcha.Wallet.Pwa.Tests/Services/Applications/HttpApplicationActionClientTests.cs
@@ -44,7 +44,7 @@ public sealed class HttpApplicationActionClientTests
         // "forbidden", never asked to guess that it means "you must be offline".
         var client = Create(req =>
         {
-            if (req.RequestUri!.AbsolutePath.EndsWith($"/api/instances/{InstanceId:N}", StringComparison.Ordinal))
+            if (req.RequestUri!.AbsolutePath.EndsWith($"/api/instances/{InstanceId:D}", StringComparison.Ordinal))
             {
                 return Ok(InstanceJson);
             }
@@ -62,7 +62,7 @@ public sealed class HttpApplicationActionClientTests
     {
         var client = Create(req =>
         {
-            if (req.RequestUri!.AbsolutePath.EndsWith($"/api/instances/{InstanceId:N}", StringComparison.Ordinal))
+            if (req.RequestUri!.AbsolutePath.EndsWith($"/api/instances/{InstanceId:D}", StringComparison.Ordinal))
             {
                 return Ok(InstanceJson);
             }
@@ -79,7 +79,7 @@ public sealed class HttpApplicationActionClientTests
     {
         var client = Create(req =>
         {
-            if (req.RequestUri!.AbsolutePath.EndsWith($"/api/instances/{InstanceId:N}", StringComparison.Ordinal))
+            if (req.RequestUri!.AbsolutePath.EndsWith($"/api/instances/{InstanceId:D}", StringComparison.Ordinal))
             {
                 return Ok(InstanceJson);
             }
@@ -96,7 +96,7 @@ public sealed class HttpApplicationActionClientTests
     {
         var client = Create(req =>
         {
-            if (req.RequestUri!.AbsolutePath.EndsWith($"/api/instances/{InstanceId:N}", StringComparison.Ordinal))
+            if (req.RequestUri!.AbsolutePath.EndsWith($"/api/instances/{InstanceId:D}", StringComparison.Ordinal))
             {
                 return Ok(InstanceJson);
             }
@@ -119,11 +119,11 @@ public sealed class HttpApplicationActionClientTests
                 hitBlueprintEndpoint = true;
                 return new HttpResponseMessage(HttpStatusCode.Forbidden);
             }
-            if (req.RequestUri!.AbsolutePath.EndsWith($"/api/instances/{InstanceId:N}", StringComparison.Ordinal))
+            if (req.RequestUri!.AbsolutePath.EndsWith($"/api/instances/{InstanceId:D}", StringComparison.Ordinal))
             {
                 return Ok(InstanceJson);
             }
-            if (req.RequestUri!.AbsolutePath.EndsWith($"/api/instances/{InstanceId:N}/actions/1", StringComparison.Ordinal))
+            if (req.RequestUri!.AbsolutePath.EndsWith($"/api/instances/{InstanceId:D}/actions/1", StringComparison.Ordinal))
             {
                 return Ok(ActionSchemaJson);
             }
@@ -148,6 +148,39 @@ public sealed class HttpApplicationActionClientTests
         var result = await client.LoadFormAsync(InstanceId);
 
         result.Status.Should().Be(ApplicationFormLoadStatus.Forbidden);
+    }
+
+    // Regression for the #1195 Phase 2 live bind failure (2026-07-17): the server generates, stores
+    // (text column), and matches instance ids in the canonical hyphenated ("D") Guid form
+    // (Guid.NewGuid().ToString()); this client formatted the URL Guid as ":N" (no hyphens), so every
+    // GET /api/instances/{id} 404'd — surfacing as "The device-binding workflow could not be prepared
+    // (NotFound)". The handler here serves ONLY the hyphenated path, reproducing the server, so it fails
+    // against the ":N" implementation and passes against ":D".
+    [Fact]
+    public async Task LoadFormAsync_UsesCanonicalHyphenatedInstanceId_MatchesServerStoredForm()
+    {
+        string? requestedInstancePath = null;
+        var client = Create(req =>
+        {
+            var path = req.RequestUri!.AbsolutePath;
+            if (path.EndsWith($"/api/instances/{InstanceId:D}", StringComparison.Ordinal))
+            {
+                requestedInstancePath = path;
+                return Ok(InstanceJson);
+            }
+            if (path.EndsWith($"/api/instances/{InstanceId:D}/actions/1", StringComparison.Ordinal))
+            {
+                return Ok(ActionSchemaJson);
+            }
+            // The server has no route for the no-hyphen ("N") form — it 404s exactly as n1 did.
+            return new HttpResponseMessage(HttpStatusCode.NotFound);
+        }, keys: Keys());
+
+        var result = await client.LoadFormAsync(InstanceId);
+
+        result.Status.Should().Be(ApplicationFormLoadStatus.Loaded);
+        requestedInstancePath.Should().NotBeNull("the client must request the hyphenated instance id the server stores");
+        requestedInstancePath.Should().Contain("-", "the instance id in the URL must be the canonical hyphenated Guid form");
     }
 
     private static HolderKeysView Keys() => new() { WalletAddress = "ws1qcitizen" };

--- a/tests/Sorcha.Wallet.Pwa.Tests/Services/SdJwtReaderTests.cs
+++ b/tests/Sorcha.Wallet.Pwa.Tests/Services/SdJwtReaderTests.cs
@@ -66,6 +66,21 @@ public sealed class SdJwtReaderTests
     }
 
     [Fact]
+    public void ReadVct_ReadsCanonicalUriVct()
+    {
+        var sd = JwtBody(new { vct = "https://sorcha.dev/vc/assured-identity/v1" }) + "~";
+        SdJwtReader.ReadVct(sd).Should().Be("https://sorcha.dev/vc/assured-identity/v1");
+    }
+
+    [Fact]
+    public void ReadVct_NoVctOrNull_ReturnsEmpty()
+    {
+        SdJwtReader.ReadVct(JwtBody(new { exp = 1L }) + "~").Should().BeEmpty();
+        SdJwtReader.ReadVct(null).Should().BeEmpty();
+        SdJwtReader.ReadVct("just.a.jwt").Should().BeEmpty();
+    }
+
+    [Fact]
     public void ReadDisclosedClaims_ObjectValue_RendersFieldNamesNotRawJson()
     {
         // A disclosure whose VALUE is an object must not print as {"town":"Edinburgh"}.

--- a/tests/Sorcha.Wallet.Pwa.Tests/Services/SyncServiceTests.cs
+++ b/tests/Sorcha.Wallet.Pwa.Tests/Services/SyncServiceTests.cs
@@ -300,6 +300,37 @@ public sealed class SyncServiceTests
             "the DCQL matcher checks required claims against AvailableClaimNames");
     }
 
+    [Fact]
+    public async Task SyncAsync_ReplacedCredential_CachesWithVctAndClaims_SoItStaysMatchable()
+    {
+        // Regression (#1195 live 2026-07-17): the Replaced delta branch cached Vct = string.Empty and
+        // AvailableClaimNames = [], so a replaced credential could never satisfy a presentation request
+        // for its own type — "None of your credentials match https://sorcha.dev/vc/assured-identity/v1".
+        var fullName = SdJwtDisclosure("salt1", "fullName", "Ada Lovelace");
+        var jwt = SdJwtBody(new
+            {
+                vct = "https://sorcha.dev/vc/assured-identity/v1",
+                _sd = new[] { SdJwtDigest(fullName) },
+            })
+            + "~" + fullName + "~";
+
+        _client.Setup(c => c.SyncAsync(null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SyncResponse
+            {
+                SyncToken = "cursor-r",
+                Credentials = new SyncCredentialChanges
+                {
+                    Replaced = new[] { new ReplacedCredentialEntry { OldId = "urn:old", NewId = "urn:new", Jwt = jwt } },
+                },
+            });
+
+        await _sut.SyncAsync();
+
+        var cached = (await _cache.ListAsync()).Should().ContainSingle().Subject;
+        cached.Vct.Should().Be("https://sorcha.dev/vc/assured-identity/v1");
+        cached.AvailableClaimNames.Should().Contain("fullName");
+    }
+
     private static string SdJwtBody(object payload) =>
         "eyJhbGciOiJFUzI1NiJ9." +
         System.Buffers.Text.Base64Url.EncodeToString(


### PR DESCRIPTION
On-device #1195 Phase 2 test surfaced two PWA client bugs (both root-caused, TDD-fixed):

**1. Bind fails with 'device-binding workflow could not be prepared (NotFound)'** — `HttpApplicationActionClient` formatted the instance Guid as `:N` (no hyphens) in `/api/instances/{id}` URLs and the execute body, but the server stores/matches the canonical hyphenated (`:D`) form → every GET/execute 404'd. n1 logs show `POST /api/instances/` 201 (creates `8492074c-b437-...`) immediately followed by `GET /api/instances/8492074cb4374e...` 404. Latent because the AIAS apply runs on the web; the bind flow is the first real PWA caller. RED-proven.

**2. Present fails with 'None of your credentials match'** for a held type — the Replaced sync branch cached `Vct = string.Empty` + no claim names, making replaced credentials unmatchable. Now parses vct + claims from the SD-JWT (new `SdJwtReader.ReadVct`), mirroring the Added path. (May be a contributor to the reported present error; a stale pre-deploy phone cache is the other candidate — a clean re-sync distinguishes them.)

PWA-only; deploy `sorcha-wallet-pwa`. Tests 430→433, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011svtWMsJSk3ngWz7gkovc9