### PR TITLE
fix: [#1195] passkey signup sends the email-verification email (was dead-ending passkey users at email_verified=false)

### DIFF
--- a/docs/guides/AUTHENTICATION-SETUP.md
+++ b/docs/guides/AUTHENTICATION-SETUP.md
@@ -622,6 +622,7 @@ All users must have a verified email address before accessing the platform.
 | OIDC (IDP returns `email_verified: true`) | Email is trusted and marked as verified immediately — no additional verification required |
 | OIDC (no `email_verified` claim, or `false`) | User is redirected to a "Complete your profile" page and must verify their email via a token-based flow |
 | Local email/password account | A verification email is sent on registration with a time-limited token (24 hours) |
+| Passkey (WebAuthn) signup with a real email | A verification email is sent on registration completion (`register/verify`), identical to the email/password path — a passkey does not establish email ownership. Skipped for passkey-only signups that use a synthetic `@placeholder.local` address, and for users who are already verified. |
 
 ### Token-Based Verification Flow
 

--- a/src/Services/Sorcha.Tenant.Service/Endpoints/PublicPasskeyEndpoints.cs
+++ b/src/Services/Sorcha.Tenant.Service/Endpoints/PublicPasskeyEndpoints.cs
@@ -162,6 +162,7 @@ public static class PublicPasskeyEndpoints
         IIdentityRepository identityRepository,
         IOrganizationRepository organizationRepository,
         ITokenService tokenService,
+        IEmailVerificationService emailVerificationService,
         TenantDbContext db,
         ILogger<Program> logger,
         CancellationToken ct)
@@ -247,6 +248,15 @@ public static class PublicPasskeyEndpoints
             var tokenResponse = await tokenService.GenerateUserTokenAsync(
                 userIdentity, publicOrg, platformUser.Id, registrationTier, cancellationToken: ct);
 
+            // Passkey signup does NOT establish email ownership — unlike email+password (which
+            // verifies via the emailed token) or social login (which trusts the IdP's verified
+            // claim). Without this, a passkey-first user is created with EmailVerified=false and
+            // never receives a verification email, permanently dead-ending them at any flow gated
+            // on email_verified (e.g. the AIAS Assured Identity journey). Send the same verification
+            // email as the password path — guarded so real, not-yet-verified emails only.
+            await SendPasskeySignupVerificationEmailAsync(
+                userIdentity, platformUser, emailVerificationService, logger, ct);
+
             logger.LogInformation(
                 "Public passkey registration completed for PlatformUser {PlatformUserId}",
                 platformUser.Id);
@@ -268,6 +278,49 @@ public static class PublicPasskeyEndpoints
             {
                 ["attestation_response"] = [ex.Message]
             });
+        }
+    }
+
+    /// <summary>
+    /// Sends the email-verification email for a passkey signup, mirroring the email+password path
+    /// (<c>RegistrationService</c>). Guarded so it only fires for a REAL, not-yet-verified email:
+    /// <list type="bullet">
+    /// <item>an already-verified user (e.g. adding a passkey to an existing account) is skipped;</item>
+    /// <item>the <c>@placeholder.local</c> synthetic address used when no email was supplied is skipped.</item>
+    /// </list>
+    /// The dispatch is wrapped in try/catch and is non-fatal — a transient email failure must NOT
+    /// fail the passkey registration; the user can re-request verification from the login page.
+    /// </summary>
+    internal static async Task SendPasskeySignupVerificationEmailAsync(
+        UserIdentity userIdentity,
+        PlatformUser platformUser,
+        IEmailVerificationService emailVerificationService,
+        ILogger logger,
+        CancellationToken ct)
+    {
+        // Guard 1: don't re-verify an already-verified user.
+        if (platformUser.EmailVerified)
+        {
+            return;
+        }
+
+        // Guard 2: only send to a real email — skip the placeholder used for passkey-only signups.
+        if (string.IsNullOrWhiteSpace(platformUser.Email)
+            || platformUser.Email.EndsWith("@placeholder.local", StringComparison.OrdinalIgnoreCase))
+        {
+            return;
+        }
+
+        try
+        {
+            await emailVerificationService.GenerateAndSendVerificationAsync(userIdentity, ct);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex,
+                "Failed to send passkey-signup verification email for user {Email} (UserId: {UserId}). "
+                + "User can re-request verification from the login page.",
+                userIdentity.Email, userIdentity.Id);
         }
     }
 

--- a/tests/Sorcha.Tenant.Service.Tests/Endpoints/PublicPasskeySignupVerificationEmailTests.cs
+++ b/tests/Sorcha.Tenant.Service.Tests/Endpoints/PublicPasskeySignupVerificationEmailTests.cs
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using FluentAssertions;
+
+using Microsoft.Extensions.Logging.Abstractions;
+
+using Moq;
+
+using Sorcha.Tenant.Service.Endpoints;
+using Sorcha.Tenant.Service.Models;
+using Sorcha.Tenant.Service.Services;
+
+using Xunit;
+
+namespace Sorcha.Tenant.Service.Tests.Endpoints;
+
+/// <summary>
+/// Unit tests for the passkey-signup verification-email dispatch helper
+/// (<see cref="PublicPasskeyEndpoints.SendPasskeySignupVerificationEmailAsync"/>).
+///
+/// Passkey-first signup does not establish email ownership (unlike email+password,
+/// which verifies via the emailed token, or social login, which trusts the IdP).
+/// The helper must therefore send the same verification email as the password path,
+/// but only for a REAL, not-yet-verified email — and it must never let an email
+/// failure bubble up and fail the registration.
+/// </summary>
+public class PublicPasskeySignupVerificationEmailTests
+{
+    private static (UserIdentity identity, PlatformUser user) MakePair(string email, bool emailVerified)
+    {
+        var platformUser = new PlatformUser
+        {
+            Id = Guid.NewGuid(),
+            Email = email,
+            DisplayName = "Passkey Person",
+            EmailVerified = emailVerified
+        };
+        var identity = new UserIdentity
+        {
+            PlatformUserId = platformUser.Id,
+            Email = email,
+            DisplayName = "Passkey Person"
+        };
+        return (identity, platformUser);
+    }
+
+    [Fact]
+    public async Task SendPasskeySignupVerificationEmailAsync_RealUnverifiedUser_SendsVerification()
+    {
+        var (identity, user) = MakePair("citizen@example.com", emailVerified: false);
+        var svc = new Mock<IEmailVerificationService>();
+        svc.Setup(s => s.GenerateAndSendVerificationAsync(It.IsAny<UserIdentity>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync("token");
+
+        await PublicPasskeyEndpoints.SendPasskeySignupVerificationEmailAsync(
+            identity, user, svc.Object, NullLogger.Instance, CancellationToken.None);
+
+        svc.Verify(s => s.GenerateAndSendVerificationAsync(identity, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task SendPasskeySignupVerificationEmailAsync_PlaceholderEmail_DoesNotSend()
+    {
+        var (identity, user) = MakePair($"passkey-{Guid.NewGuid():N}@placeholder.local", emailVerified: false);
+        var svc = new Mock<IEmailVerificationService>();
+
+        await PublicPasskeyEndpoints.SendPasskeySignupVerificationEmailAsync(
+            identity, user, svc.Object, NullLogger.Instance, CancellationToken.None);
+
+        svc.Verify(s => s.GenerateAndSendVerificationAsync(It.IsAny<UserIdentity>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task SendPasskeySignupVerificationEmailAsync_AlreadyVerifiedUser_DoesNotSend()
+    {
+        var (identity, user) = MakePair("verified@example.com", emailVerified: true);
+        var svc = new Mock<IEmailVerificationService>();
+
+        await PublicPasskeyEndpoints.SendPasskeySignupVerificationEmailAsync(
+            identity, user, svc.Object, NullLogger.Instance, CancellationToken.None);
+
+        svc.Verify(s => s.GenerateAndSendVerificationAsync(It.IsAny<UserIdentity>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task SendPasskeySignupVerificationEmailAsync_ServiceThrows_SwallowsAndDoesNotRethrow()
+    {
+        var (identity, user) = MakePair("citizen@example.com", emailVerified: false);
+        var svc = new Mock<IEmailVerificationService>();
+        svc.Setup(s => s.GenerateAndSendVerificationAsync(It.IsAny<UserIdentity>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("SMTP down"));
+
+        var act = async () => await PublicPasskeyEndpoints.SendPasskeySignupVerificationEmailAsync(
+            identity, user, svc.Object, NullLogger.Instance, CancellationToken.None);
+
+        await act.Should().NotThrowAsync();
+        svc.Verify(s => s.GenerateAndSendVerificationAsync(identity, It.IsAny<CancellationToken>()), Times.Once);
+    }
+}


### PR DESCRIPTION
Live-found P0 from on-device AIAS testing: **passkey signup left the account permanently email-unverifiable**, dead-ending every passkey user at any `email_verified`-gated flow (the AIAS agent rejects 'identity could not be assured because I haven't verified my email'). n1 logs confirmed: passkey registration created the user with `EmailVerified=false`, sent the 'Passkey added' security email (so SMTP works) but **never a verification email** — email+password sends one, social pre-verifies via the IdP, passkey did neither.

Fix: `RegisterVerify` now dispatches the same verification email as the email+password path (`IEmailVerificationService.GenerateAndSendVerificationAsync`), extracted into a guarded `internal static` helper — skips already-verified users and the `@placeholder.local` address, non-fatal on send failure. Additive; email+password/social/sign-in untouched.

Tests: Tenant.Service.Tests 1528→1532 (+4 behavioural helper tests), RED→GREEN. Independent review: no findings, ready to merge. Deploy: `tenant-service`. Live-verify: a real passkey signup on n1 should now receive a verification email.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011svtWMsJSk3ngWz7gkovc9