### PR TITLE
verify: refresh /verify + VerdictTrailPanel to refined identity

### DIFF
--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Verify/VerdictTrailPanel.razor.css
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Verify/VerdictTrailPanel.razor.css
@@ -1,15 +1,29 @@
 /* SPDX-License-Identifier: MIT */
 /* Copyright (c) 2026 Sorcha Contributors */
 
+/* Sorcha refined identity — DARK is the default; light via @media (prefers-color-scheme: light).
+   Token map from the previous theme: --card→--surface, --ground→--surface-alt,
+   --brand→--primary (borders/accents) or --primary-btn (button fills w/ white text),
+   --brand-ink→--violet-ink. Functional --good/--warn/--bad are pass/warn/fail status only. */
 .verdict-trail-panel {
-    --brand: #4b3fd4; --brand-ink: #3a2fb0;
-    --card: #fff; --line: #e7e6f2; --ink: #1b1a2e; --ink-2: #54536b; --ink-3: #8a8aa1;
-    --good: #12894f; --good-bg: #e7f6ee; --good-line: #bfe6d0;
-    --warn: #a86a12; --warn-bg: #fbf1de; --warn-line: #eed9ad;
-    --bad: #c02c39; --bad-bg: #fbe9eb; --bad-line: #f0c4c9;
-    --ground: #f5f5fb;
+    --surface: #14152A; --surface-alt: #191A31; --surface-hi: #1E2140;
+    --primary: #6366F1; --primary-btn: #4F46E5; --primary-btn-hover: #5B52EC;
+    --violet: #818CF8; --violet-ink: #A5B4FC;
+    --ink: #F4F5FF; --ink-2: #A9A8C2; --ink-3: #726F90;
+    --line: #262A44; --line-2: #2B2940;
+    --good: #54D08A; --good-bg: #12261C; --good-line: #245C3C;
+    --warn: #E5B45C; --warn-bg: #2A2213; --warn-line: #5E4C22;
+    --bad: #F2848D; --bad-bg: #2A1418; --bad-line: #5E2B31;
     font-family: -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
     color: var(--ink); line-height: 1.45; max-width: 420px; margin: 0 auto;
+}
+
+/* focus ring on every interactive element — never removed */
+.verdict-trail-panel .st.act:focus-visible,
+.verdict-trail-panel .btn:focus-visible,
+.verdict-trail-panel .trail > summary:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 3px rgba(129, 140, 248, 0.55);
 }
 
 /* verdict banner (identity) */
@@ -49,8 +63,8 @@
 /* portrait */
 .portrait-wrap { display: flex; flex-direction: column; align-items: center; text-align: center; margin-bottom: 18px; }
 .portrait {
-    border-radius: 16px; overflow: hidden; border: 3px solid var(--card);
-    box-shadow: 0 0 0 1px var(--line), 0 12px 26px rgba(43, 37, 150, .16); background: #c9c7e4; aspect-ratio: 3 / 4;
+    border-radius: 16px; overflow: hidden; border: 3px solid var(--surface);
+    box-shadow: 0 0 0 1px var(--line), 0 12px 26px rgba(0, 0, 0, .38); background: var(--surface-hi); aspect-ratio: 3 / 4;
 }
 .portrait.lg { width: 172px; } .portrait.sm { width: 120px; }
 .portrait img { display: block; width: 100%; height: 100%; object-fit: cover; }
@@ -58,7 +72,7 @@
 .name { margin-top: 8px; font-size: 1.5rem; font-weight: 700; letter-spacing: -.02em; }
 
 /* shared-with-you */
-.disc { border: 1px solid var(--line); border-radius: 14px; padding: 14px 15px; margin-bottom: 14px; background: var(--card); }
+.disc { border: 1px solid var(--line); border-radius: 14px; padding: 14px 15px; margin-bottom: 14px; background: var(--surface); }
 .disc h3 { margin: 0 0 10px; font-size: .7rem; text-transform: uppercase; letter-spacing: .09em; color: var(--ink-3); font-weight: 700; }
 .row { display: flex; justify-content: space-between; gap: 14px; padding: 7px 0; border-top: 1px solid var(--line); font-size: .9rem; }
 .row:first-of-type { border-top: 0; }
@@ -69,22 +83,23 @@
 
 /* privacy */
 .privacy {
-    background: rgba(75, 63, 212, .08); border: 1px solid rgba(75, 63, 212, .22);
+    background: color-mix(in srgb, var(--primary) 12%, transparent);
+    border: 1px solid color-mix(in srgb, var(--primary) 28%, transparent);
     border-radius: 12px; padding: 11px 13px; margin-bottom: 14px; font-size: .8rem; color: var(--ink-2);
 }
-.privacy b { color: var(--brand-ink); }
+.privacy b { color: var(--violet-ink); }
 
 /* issuer */
 .issuer {
     display: flex; align-items: center; gap: 10px; font-size: .84rem; color: var(--ink-2);
-    padding: 11px 14px; border: 1px solid var(--line); border-radius: 12px; margin-bottom: 14px; background: var(--ground);
+    padding: 11px 14px; border: 1px solid var(--line); border-radius: 12px; margin-bottom: 14px; background: var(--surface-alt);
 }
-.issuer .seal { flex: 0 0 auto; width: 20px; height: 20px; border-radius: 50%; background: var(--brand); color: #fff; display: grid; place-items: center; font-size: .66rem; font-weight: 700; }
+.issuer .seal { flex: 0 0 auto; width: 20px; height: 20px; border-radius: 50%; background: var(--primary); color: #fff; display: grid; place-items: center; font-size: .66rem; font-weight: 700; }
 .issuer b { color: var(--ink); font-weight: 600; }
 
 /* trail */
 .trail { border: 1px solid var(--line); border-radius: 14px; overflow: hidden; }
-.trail > summary { list-style: none; cursor: pointer; display: flex; align-items: center; gap: 10px; padding: 13px 15px; font-size: .86rem; font-weight: 600; }
+.trail > summary { list-style: none; cursor: pointer; display: flex; align-items: center; gap: 10px; padding: 13px 15px; font-size: .86rem; font-weight: 600; border-radius: 14px; }
 .trail > summary::-webkit-details-marker { display: none; }
 .trail > summary .caret { margin-left: auto; color: var(--ink-3); transition: transform .2s; }
 .trail[open] > summary .caret { transform: rotate(90deg); }
@@ -94,27 +109,39 @@
 .layer .ic { flex: 0 0 auto; width: 26px; height: 26px; border-radius: 8px; display: grid; place-items: center; font-size: .8rem; font-weight: 700; }
 .ic.ok { background: var(--good-bg); color: var(--good); }
 .ic.bad { background: var(--bad-bg); color: var(--bad); }
-.ic.q { background: var(--ground); color: var(--ink-2); }
+.ic.q { background: var(--surface-alt); color: var(--ink-2); }
 .layer .lx { flex: 1; min-width: 0; }
 .layer .lt { font-size: .86rem; font-weight: 600; display: block; }
 .layer .ld { font-size: .76rem; color: var(--ink-2); }
 .layer .st { font-size: .68rem; font-weight: 700; text-transform: uppercase; letter-spacing: .06em; padding: 3px 8px; border-radius: 999px; border: 0; }
 .st.ok { background: var(--good-bg); color: var(--good); }
 .st.bad { background: var(--bad-bg); color: var(--bad); }
-.st.q, .st.na { background: var(--ground); color: var(--ink-2); }
-.st.act { background: var(--brand); color: #fff; cursor: pointer; }
+.st.q, .st.na { background: var(--surface-alt); color: var(--ink-2); }
+.st.act { background: var(--primary-btn); color: #fff; cursor: pointer; }
+.st.act:hover { background: var(--primary-btn-hover); }
 
 /* foot */
 .foot { display: flex; gap: 10px; margin-top: 18px; }
-.btn { flex: 1; text-align: center; padding: 12px; border-radius: 12px; font-weight: 600; font-size: .9rem; border: 1px solid var(--line); background: var(--card); color: var(--ink); cursor: pointer; }
-.btn.primary { background: var(--brand); border-color: var(--brand); color: #fff; }
+.btn { flex: 1; text-align: center; padding: 12px; border-radius: 12px; font-weight: 600; font-size: .9rem; border: 1px solid var(--line); background: var(--surface); color: var(--ink); cursor: pointer; }
+.btn.primary { background: var(--primary-btn); border-color: var(--primary-btn); color: #fff; }
+.btn.primary:hover { background: var(--primary-btn-hover); border-color: var(--primary-btn-hover); }
 
-@media (prefers-color-scheme: dark) {
+/* light theme override */
+@media (prefers-color-scheme: light) {
     .verdict-trail-panel {
-        --brand: #8b80f5; --brand-ink: #a79dff; --card: #191826; --line: #2b2940;
-        --ink: #ecebf7; --ink-2: #a9a8c2; --ink-3: #726f90; --ground: #0f0e1a;
-        --good: #54d08a; --good-bg: #13291f; --good-line: #245c3c;
-        --warn: #e5b45c; --warn-bg: #2c2413; --warn-line: #5e4c22;
-        --bad: #f2848d; --bad-bg: #2c1518; --bad-line: #5e2b31;
+        --surface: #FFFFFF; --surface-alt: #F7F7FC; --surface-hi: #FFFFFF;
+        --primary: #4F46E5; --primary-btn: #4F46E5; --primary-btn-hover: #4338CA;
+        --violet: #6366F1; --violet-ink: #4338CA;
+        --ink: #16172A; --ink-2: #54536B; --ink-3: #8A8AA1;
+        --line: #E7E6F2; --line-2: #E7E6F2;
+        --good: #12894F; --good-bg: #E7F6EE; --good-line: #BFE6D0;
+        --warn: #A86A12; --warn-bg: #FBF1DE; --warn-line: #EED9AD;
+        --bad: #C02C39; --bad-bg: #FBE9EB; --bad-line: #F0C4C9;
     }
+    .portrait { box-shadow: 0 0 0 1px var(--line), 0 12px 26px rgba(43, 37, 150, .16); }
+}
+
+/* honour reduced motion */
+@media (prefers-reduced-motion: reduce) {
+    .verdict-trail-panel * { animation: none !important; transition: none !important; }
 }

--- a/src/Apps/Sorcha.Verifier/Components/App.razor
+++ b/src/Apps/Sorcha.Verifier/Components/App.razor
@@ -9,9 +9,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <base href="/verify/" />
     <link rel="manifest" href="manifest.webmanifest" />
-    <meta name="theme-color" content="#1b2a4a" />
+    <meta name="theme-color" content="#090A14" />
     <link rel="apple-touch-icon" href="icons/icon.svg" />
     <link rel="stylesheet" href="@Assets["_content/MudBlazor/MudBlazor.min.css"]" />
+    <link rel="stylesheet" href="css/verify.css" />
     <HeadOutlet />
 </head>
 <body>

--- a/src/Apps/Sorcha.Verifier/Components/Layout/MainLayout.razor
+++ b/src/Apps/Sorcha.Verifier/Components/Layout/MainLayout.razor
@@ -4,22 +4,28 @@
 *@
 @inherits LayoutComponentBase
 
-<MudThemeProvider />
+@* The Verifier is a dark-first operator kiosk; custom chrome + panel still honour
+   light via @@media (prefers-color-scheme: light) in verify.css / the shared panel. *@
+<MudThemeProvider IsDarkMode="true" />
 <MudPopoverProvider />
 <MudDialogProvider />
 @* Snackbar Phase 6 (closer): MudSnackbarProvider unmounted across the
    platform. See Sorcha.UI.Web.Client MainLayout for rationale. *@
 
 <MudLayout>
-    <MudAppBar Elevation="1">
-        <MudText Typo="Typo.h6">Sorcha Verifier</MudText>
+    <MudAppBar Elevation="0" Class="verify-appbar">
+        <div class="verify-brand">
+            <img src="icons/sorcha-icon.svg" alt="Sorcha" class="verify-brand-icon" />
+            <span class="verify-wordmark">Sorcha <span class="verify-wordmark-alt">Verifier</span></span>
+        </div>
         <MudSpacer />
+        <span class="verify-env-chip"><span class="verify-env-dot"></span>n1.sorcha.dev</span>
         <button id="sorcha-install-btn" type="button" class="sorcha-install-btn"
                 style="display:none" onclick="window.sorchaPromptInstall && window.sorchaPromptInstall()">
             Install app
         </button>
     </MudAppBar>
-    <MudMainContent>
+    <MudMainContent Class="verify-main">
         @Body
     </MudMainContent>
 </MudLayout>

--- a/src/Apps/Sorcha.Verifier/Components/Pages/Index.razor
+++ b/src/Apps/Sorcha.Verifier/Components/Pages/Index.razor
@@ -17,9 +17,8 @@
 
 <PageTitle>Sorcha Verifier</PageTitle>
 
-<MudContainer MaxWidth="MaxWidth.Small" Class="mt-8">
-    <MudText Typo="Typo.h4" Class="mb-1">Sorcha Verifier</MudText>
-    <MudText Typo="Typo.body2" Color="Color.Secondary" Class="mb-6">
+<MudContainer MaxWidth="MaxWidth.Small" Class="mt-8 verify-shell">
+    <MudText Typo="Typo.body2" Class="mb-6 verify-intro">
         Ask a question, show the QR. The citizen approves in their wallet, and the verified
         result — with its full validation trail — appears here.
     </MudText>
@@ -30,10 +29,21 @@
     }
     else if (!_complete)
     {
-        <VerificationSessionQr Question="@_selectedQuestion"
-                               CancellationToken="@_pageCts.Token"
-                               OnOutcome="@HandleOutcomeAsync"
-                               OnCompleted="@HandleCompletedAsync" />
+        <div class="verify-pending">
+            <div class="verify-pending-title">@_selectedQuestion.Label</div>
+            @if (!string.IsNullOrWhiteSpace(_selectedQuestion.Purpose))
+            {
+                <div class="verify-pending-purpose">@_selectedQuestion.Purpose</div>
+            }
+            <VerificationSessionQr Question="@_selectedQuestion"
+                                   CancellationToken="@_pageCts.Token"
+                                   OnOutcome="@HandleOutcomeAsync"
+                                   OnCompleted="@HandleCompletedAsync" />
+            <div class="verify-waiting" data-testid="verify-waiting">
+                <span class="verify-waiting-pulse"></span>
+                Waiting for the citizen's wallet…
+            </div>
+        </div>
     }
     else
     {

--- a/src/Apps/Sorcha.Verifier/wwwroot/css/verify.css
+++ b/src/Apps/Sorcha.Verifier/wwwroot/css/verify.css
@@ -1,0 +1,195 @@
+/* SPDX-License-Identifier: MIT */
+/* Copyright (c) 2026 Sorcha Contributors */
+
+/* Sorcha Verifier desk — refined identity page shell.
+   DARK is the default (operator kiosk); light via @media (prefers-color-scheme: light).
+   Loaded AFTER MudBlazor.min.css so these rules win over the Mud dark palette surfaces. */
+
+:root {
+    --bg-0: #090A14; --bg-1: #0F1020;
+    --surface: #14152A; --surface-alt: #191A31; --surface-hi: #1E2140;
+    --primary: #6366F1; --primary-btn: #4F46E5; --primary-btn-hover: #5B52EC;
+    --violet: #818CF8; --violet-ink: #A5B4FC;
+    --ink: #F4F5FF; --ink-2: #A9A8C2; --ink-3: #726F90;
+    --line: #262A44; --line-2: #2B2940;
+    --good: #54D08A; --good-bg: #12261C; --good-line: #245C3C;
+    --warn: #E5B45C; --warn-bg: #2A2213; --warn-line: #5E4C22;
+    --bad: #F2848D; --bad-bg: #2A1418; --bad-line: #5E2B31;
+    --grid: rgba(99, 102, 241, 0.10);
+}
+
+@media (prefers-color-scheme: light) {
+    :root {
+        --bg-0: #EEEFF6; --bg-1: #F5F5FB;
+        --surface: #FFFFFF; --surface-alt: #F7F7FC; --surface-hi: #FFFFFF;
+        --primary: #4F46E5; --primary-btn: #4F46E5; --primary-btn-hover: #4338CA;
+        --violet: #6366F1; --violet-ink: #4338CA;
+        --ink: #16172A; --ink-2: #54536B; --ink-3: #8A8AA1;
+        --line: #E7E6F2; --line-2: #E7E6F2;
+        --good: #12894F; --good-bg: #E7F6EE; --good-line: #BFE6D0;
+        --warn: #A86A12; --warn-bg: #FBF1DE; --warn-line: #EED9AD;
+        --bad: #C02C39; --bad-bg: #FBE9EB; --bad-line: #F0C4C9;
+        --grid: rgba(99, 102, 241, 0.07);
+    }
+}
+
+/* ---- page background (static, no JS/canvas) ---- */
+html, body {
+    background: var(--bg-1);
+    color: var(--ink);
+}
+body {
+    background:
+        radial-gradient(120% 90% at 50% -10%, rgba(99, 102, 241, 0.13), transparent 60%),
+        linear-gradient(160deg, var(--bg-0), var(--bg-1));
+    background-attachment: fixed;
+    min-height: 100vh;
+}
+/* faint 56px grid, faded toward the bottom */
+body::before {
+    content: "";
+    position: fixed;
+    inset: 0;
+    z-index: 0;
+    pointer-events: none;
+    background-image:
+        linear-gradient(var(--grid) 1px, transparent 1px),
+        linear-gradient(90deg, var(--grid) 1px, transparent 1px);
+    background-size: 56px 56px;
+    -webkit-mask-image: radial-gradient(130% 100% at 50% 0%, #000 55%, transparent 100%);
+    mask-image: radial-gradient(130% 100% at 50% 0%, #000 55%, transparent 100%);
+}
+
+/* let the page background show through the Mud surfaces */
+.mud-layout { background: transparent !important; }
+.mud-main-content { background: transparent !important; position: relative; z-index: 1; }
+.verify-main { padding-top: 64px; }
+
+/* ---- top bar ---- */
+.verify-appbar.mud-appbar {
+    background: color-mix(in srgb, var(--bg-0) 62%, transparent) !important;
+    -webkit-backdrop-filter: blur(10px);
+    backdrop-filter: blur(10px);
+    border-bottom: 1px solid var(--line);
+    box-shadow: none !important;
+    color: var(--ink);
+}
+.verify-brand { display: flex; align-items: center; gap: 10px; min-width: 0; }
+.verify-brand-icon { width: 30px; height: 30px; border-radius: 8px; display: block; flex: 0 0 auto; }
+.verify-wordmark { font-weight: 700; font-size: 1.05rem; color: var(--ink); letter-spacing: -.01em; white-space: nowrap; }
+.verify-wordmark-alt { color: var(--ink-3); font-weight: 700; }
+
+.verify-env-chip {
+    display: inline-flex; align-items: center; gap: 7px;
+    font-size: .75rem; color: var(--ink-2);
+    border: 1px solid var(--line); border-radius: 999px;
+    padding: 5px 11px; margin-right: 12px; white-space: nowrap;
+    background: color-mix(in srgb, var(--surface) 55%, transparent);
+}
+.verify-env-dot {
+    width: 7px; height: 7px; border-radius: 50%; background: var(--good);
+    box-shadow: 0 0 0 3px color-mix(in srgb, var(--good) 25%, transparent);
+}
+
+/* install button (id/class/onclick/display:none preserved in markup) — ghost restyle */
+.sorcha-install-btn {
+    font: inherit; font-size: .82rem; font-weight: 600;
+    color: var(--violet-ink);
+    background: transparent;
+    border: 1px solid var(--line);
+    border-radius: 9px; padding: 7px 14px;
+    cursor: pointer; white-space: nowrap;
+    transition: border-color .15s, color .15s;
+}
+.sorcha-install-btn:hover { border-color: var(--primary); color: var(--violet-ink); }
+.sorcha-install-btn:focus-visible { outline: none; box-shadow: 0 0 0 3px rgba(129, 140, 248, 0.55); }
+
+/* ---- page content shell ---- */
+.verify-shell { position: relative; z-index: 1; }
+.verify-intro { color: var(--ink-2); }
+.verify-heading { color: var(--ink); font-weight: 700; }
+
+/* ---- Ask state (QuestionSelectionPanel — themed by CSS only) ---- */
+.question-selection-panel .mud-button-root.mud-button-outlined {
+    border-color: var(--line);
+    color: var(--ink);
+    background: var(--surface);
+    border-radius: 12px;
+    padding: 14px 16px;
+    text-transform: none;
+    font-weight: 600;
+    justify-content: flex-start;
+    transition: border-color .15s, background .15s;
+}
+.question-selection-panel .mud-button-root.mud-button-outlined:hover {
+    border-color: var(--primary);
+    background: var(--surface-hi);
+}
+.question-selection-panel .mud-button-root.mud-button-text {
+    color: var(--violet-ink);
+    text-transform: none;
+    font-weight: 600;
+}
+.question-selection-panel .mud-button-root:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 3px rgba(129, 140, 248, 0.55);
+}
+
+/* ---- Pending state (VerificationSessionQr — themed by CSS only) ---- */
+.verify-pending { display: flex; flex-direction: column; align-items: center; gap: 16px; }
+.verify-pending-title {
+    font-size: 1.05rem; font-weight: 700; color: var(--ink); text-align: center;
+}
+.verify-pending-purpose { font-size: .85rem; color: var(--ink-2); text-align: center; margin-top: -8px; }
+
+.verification-session-qr [data-testid="qr-active"] {
+    display: flex; flex-direction: column; align-items: center; gap: 14px;
+}
+.verification-session-qr [data-testid="qr-active"] img {
+    background: #fff;
+    padding: 16px;
+    border-radius: 18px;
+    border: 1px solid var(--line);
+    box-shadow: 0 12px 34px rgba(0, 0, 0, .40);
+}
+/* constrain the openid4vp:// request URI: monospace, bordered chip, truncated */
+.verification-session-qr [data-testid="deep-link"] {
+    display: block;
+    max-width: 288px;
+    margin: 0 auto;
+    font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+    font-size: .72rem;
+    color: var(--violet-ink);
+    text-decoration: none;
+    background: var(--surface-alt);
+    border: 1px solid var(--line);
+    border-radius: 9px;
+    padding: 8px 11px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+.verification-session-qr [data-testid="deep-link"]:hover { border-color: var(--primary); }
+.verification-session-qr [data-testid="deep-link"]:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 3px rgba(129, 140, 248, 0.55);
+}
+
+/* "Waiting for the citizen's wallet…" pulse */
+.verify-waiting {
+    display: inline-flex; align-items: center; gap: 9px;
+    font-size: .84rem; color: var(--ink-2);
+}
+.verify-waiting-pulse {
+    width: 9px; height: 9px; border-radius: 50%; background: var(--primary);
+    animation: verify-pulse 1.6s ease-in-out infinite;
+}
+@keyframes verify-pulse {
+    0%, 100% { opacity: .35; transform: scale(.85); box-shadow: 0 0 0 0 color-mix(in srgb, var(--primary) 45%, transparent); }
+    50% { opacity: 1; transform: scale(1); box-shadow: 0 0 0 6px color-mix(in srgb, var(--primary) 0%, transparent); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .verify-waiting-pulse { animation: none; opacity: 1; }
+    * { scroll-behavior: auto !important; }
+}

--- a/src/Apps/Sorcha.Verifier/wwwroot/icons/sorcha-icon.svg
+++ b/src/Apps/Sorcha.Verifier/wwwroot/icons/sorcha-icon.svg
@@ -1,0 +1,125 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512">
+  <defs>
+    <!-- Clip to iOS-style rounded square -->
+    <clipPath id="iconShape">
+      <rect x="0" y="0" width="512" height="512" rx="112" ry="112"/>
+    </clipPath>
+
+    <!-- Deep dark purple-black background gradient -->
+    <linearGradient id="bgGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%"   style="stop-color:#090A14"/>
+      <stop offset="100%" style="stop-color:#0F1020"/>
+    </linearGradient>
+
+    <!-- Subtle radial bloom behind the S (violet) -->
+    <radialGradient id="bloom" cx="50%" cy="50%" r="42%">
+      <stop offset="0%"   style="stop-color:#6366F1;stop-opacity:0.14"/>
+      <stop offset="100%" style="stop-color:#6366F1;stop-opacity:0"/>
+    </radialGradient>
+
+    <!-- Glow for drifting squares -->
+    <filter id="squareGlow" x="-80%" y="-80%" width="260%" height="260%">
+      <feGaussianBlur in="SourceGraphic" stdDeviation="3.5" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+
+    <!-- S glow: white text + violet bloom -->
+    <filter id="sGlow" x="-18%" y="-18%" width="136%" height="136%">
+      <feGaussianBlur in="SourceGraphic" stdDeviation="12" result="blur"/>
+      <feColorMatrix in="blur" type="matrix"
+        values="0.24 0    0    0 0
+                0    0.25 0    0 0
+                0    0    0.95 0 0
+                0    0    0    0.55 0" result="violetBloom"/>
+      <feMerge>
+        <feMergeNode in="violetBloom"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+  </defs>
+
+  <g clip-path="url(#iconShape)">
+
+    <!-- ── BACKGROUND ── -->
+    <rect x="0" y="0" width="512" height="512" fill="url(#bgGrad)"/>
+    <rect x="0" y="0" width="512" height="512" fill="url(#bloom)"/>
+
+    <!-- ── GRID (56px spacing, 9 divisions) ── -->
+    <!-- These are intentionally very faint — just like the site -->
+    <g stroke="#6366F1" stroke-width="0.7" opacity="0.10">
+      <!-- Horizontal -->
+      <line x1="0" y1="56"  x2="512" y2="56"/>
+      <line x1="0" y1="112" x2="512" y2="112"/>
+      <line x1="0" y1="168" x2="512" y2="168"/>
+      <line x1="0" y1="224" x2="512" y2="224"/>
+      <line x1="0" y1="280" x2="512" y2="280"/>
+      <line x1="0" y1="336" x2="512" y2="336"/>
+      <line x1="0" y1="392" x2="512" y2="392"/>
+      <line x1="0" y1="448" x2="512" y2="448"/>
+      <!-- Vertical -->
+      <line x1="56"  y1="0" x2="56"  y2="512"/>
+      <line x1="112" y1="0" x2="112" y2="512"/>
+      <line x1="168" y1="0" x2="168" y2="512"/>
+      <line x1="224" y1="0" x2="224" y2="512"/>
+      <line x1="280" y1="0" x2="280" y2="512"/>
+      <line x1="336" y1="0" x2="336" y2="512"/>
+      <line x1="392" y1="0" x2="392" y2="512"/>
+      <line x1="448" y1="0" x2="448" y2="512"/>
+    </g>
+
+    <!-- ── DRIFTING SQUARES (the animated particles from the site) ── -->
+    <!-- Varied sizes, opacities, and positions for an organic scatter feel -->
+    <!-- Each is a small square aligned loosely to the grid -->
+
+    <!-- Top area -->
+    <rect x="52"  y="49"  width="8" height="8" rx="1.5" fill="#6366F1" opacity="0.45" filter="url(#squareGlow)"/>
+    <rect x="358" y="94"  width="6" height="6" rx="1"   fill="#818CF8" opacity="0.35"/>
+    <rect x="446" y="47"  width="9" height="9" rx="1.5" fill="#6366F1" opacity="0.40" filter="url(#squareGlow)"/>
+    <rect x="108" y="108" width="7" height="7" rx="1.5" fill="#6366F1" opacity="0.30"/>
+
+    <!-- Right side -->
+    <rect x="450" y="168" width="8" height="8" rx="1.5" fill="#818CF8" opacity="0.38" filter="url(#squareGlow)"/>
+    <rect x="392" y="280" width="6" height="6" rx="1"   fill="#6366F1" opacity="0.28"/>
+    <rect x="460" y="335" width="9" height="9" rx="1.5" fill="#6366F1" opacity="0.42" filter="url(#squareGlow)"/>
+    <rect x="390" y="450" width="7" height="7" rx="1.5" fill="#818CF8" opacity="0.32"/>
+
+    <!-- Bottom area -->
+    <rect x="275" y="454" width="8" height="8" rx="1.5" fill="#6366F1" opacity="0.38" filter="url(#squareGlow)"/>
+    <rect x="108" y="446" width="6" height="6" rx="1"   fill="#6366F1" opacity="0.30"/>
+    <rect x="52"  y="396" width="9" height="9" rx="1.5" fill="#818CF8" opacity="0.40" filter="url(#squareGlow)"/>
+
+    <!-- Left side -->
+    <rect x="48"  y="168" width="7" height="7" rx="1.5" fill="#6366F1" opacity="0.35"/>
+    <rect x="56"  y="280" width="8" height="8" rx="1.5" fill="#818CF8" opacity="0.40" filter="url(#squareGlow)"/>
+    <rect x="110" y="335" width="6" height="6" rx="1"   fill="#6366F1" opacity="0.28"/>
+
+    <!-- A few mid-field, smaller/dimmer so they don't compete with S -->
+    <rect x="168" y="112" width="5" height="5" rx="1"   fill="#6366F1" opacity="0.22"/>
+    <rect x="340" y="168" width="5" height="5" rx="1"   fill="#6366F1" opacity="0.20"/>
+    <rect x="168" y="400" width="5" height="5" rx="1"   fill="#818CF8" opacity="0.22"/>
+    <rect x="340" y="390" width="6" height="6" rx="1"   fill="#6366F1" opacity="0.20"/>
+
+    <!-- ── S LETTER ── -->
+    <!-- Shadow/depth layer -->
+    <text x="258" y="338"
+          font-family="'Helvetica Neue', 'Arial Black', Arial, sans-serif"
+          font-size="282"
+          font-weight="900"
+          text-anchor="middle"
+          fill="#4F46E5"
+          opacity="0.35"
+          transform="translate(3,5)">S</text>
+    <!-- Main S with violet glow -->
+    <text x="256" y="336"
+          font-family="'Helvetica Neue', 'Arial Black', Arial, sans-serif"
+          font-size="282"
+          font-weight="900"
+          text-anchor="middle"
+          fill="#FFFFFF"
+          filter="url(#sGlow)">S</text>
+
+  </g>
+</svg>


### PR DESCRIPTION
## What

Restyles the operator-facing **Verifier desk** (`/verify`) and the shared **`VerdictTrailPanel`** to Sorcha's refined visual identity — **theme + layout only**, no behavioural change. All bUnit tests pass **unchanged**.

- **Dark is the default** (operator kiosk); light via `@media (prefers-color-scheme: light)`.
- Dark-indigo ground with a static violet **bloom + faint 56px grid** (masked to fade downward) — **no drifting-particle canvas / no JS**.
- Translucent blurred **top bar**: brand `sorcha-icon.svg` (30px) + "Sorcha **Verifier**" wordmark, an `n1.sorcha.dev` env chip, and the existing **Install app** button restyled as a ghost button (id/onclick/`display:none` preserved).
- `VerdictTrailPanel` restyled by the new tokens: `--primary-btn` (#4F46E5) for white-text fills, `--violet-ink` for accent text, functional `--good/--warn/--bad` for pass/warn/fail only.

## Files
- `Sorcha.UI.Components.User/Components/Verify/VerdictTrailPanel.razor.css` — rewritten (dark-default tokens + light `@media`, focus rings, reduced-motion).
- `Sorcha.Verifier/wwwroot/css/verify.css` — new page shell (bg + grid, top bar, Ask/Pending theming via the shared components' existing classes/testids).
- `Sorcha.Verifier/wwwroot/icons/sorcha-icon.svg` — canonical brand icon.
- `Sorcha.Verifier/Components/{App.razor, Layout/MainLayout.razor, Pages/Index.razor}` — link CSS + `theme-color #090A14`; dark theme + top bar; pending purpose/waiting-pulse markup.

## Guarantees
- **No behavioural change** — `VerdictViewModel`, `VerificationOutcome`, `ValidationLayer`, the preset catalogue, `HaipVerificationTransport`, `IRegisterAnchorClient` untouched; the shared `QuestionSelectionPanel`/`VerificationSessionQr` **markup + data-testids** unchanged (themed via CSS only, so the PWA is unaffected).
- **All `data-testid`s preserved**; **no test edits**.
- Accessibility: white button text only on `--primary-btn`, accent text on `--violet-ink`, a `:focus-visible` ring on every interactive element, `prefers-reduced-motion` honoured.
- `grep -riE "48bb78|667eea|764ba2|4b3fd4|8b80f5"` over the verifier + verify components → **no matches**.

## Tests
`Sorcha.Verifier.Tests` 117 pass · `Sorcha.UI.Core.Tests` 1483 pass (1 pre-existing unrelated flaky `MyCredentialsTests.DeclineOnlyPendingCredential`) — both unchanged from baseline. Verifier app + `Sorcha.UI.Components.User` build clean.

## Deferred (nice-to-have)
A real **copy button** on the request-URI chip needs editing the shared PWA component — achieved the framed/monospace/truncated look via CSS instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)