### PR TITLE
fix: verify desk — link scoped CSS bundle + filter machine claims from verdict

### DIFF
--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Models/Verification/VerdictViewModel.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Models/Verification/VerdictViewModel.cs
@@ -64,6 +64,18 @@ public sealed class VerdictViewModel
     private const string AnchorClaim = "registerAnchor";
 
     /// <summary>
+    /// SD-JWT / VC machine fields that must never appear in the operator-facing "Shared with you"
+    /// list — they are credential plumbing (type, status, key binding, timestamps, anchor key), not
+    /// disclosed identity attributes. Filtered from the display pairs; the raw disclosed set is still
+    /// used for the portrait / age / anchor lookups.
+    /// </summary>
+    private static readonly HashSet<string> NonDisplayClaims = new(StringComparer.Ordinal)
+    {
+        "vct", "credentialStatus", "status", "cnf", "iss", "iat", "exp", "nbf",
+        "sub", "jti", "id", "_sd", "_sd_alg", AnchorClaim,
+    };
+
+    /// <summary>
     /// Build the view model from a completed <paramref name="outcome"/> and the chosen
     /// <paramref name="question"/> preset. Known credential claims and required VCT come from the
     /// preset so the verdict can be computed client-side without a server session store (R-001).
@@ -82,6 +94,11 @@ public sealed class VerdictViewModel
         var withheld = known.Where(c => !disclosed.ContainsKey(c)).ToList();
 
         var disclosedPairs = disclosed
+            .Where(kvp => !NonDisplayClaims.Contains(kvp.Key))
+            // Skip structured (object/array) values — e.g. an undisclosed `address` surfaced as its
+            // raw {"_sd":[…]} digest — which would dump machine JSON into the operator's view. The
+            // portrait is exempt (it renders separately as a marker row).
+            .Where(kvp => kvp.Key == PortraitClaim || !LooksLikeStructuredJson(kvp.Value))
             .Select(kvp => new KeyValuePair<string, string>(
                 kvp.Key,
                 kvp.Key == PortraitClaim ? "<portrait>" : kvp.Value?.ToString() ?? ""))
@@ -149,4 +166,15 @@ public sealed class VerdictViewModel
         string s when bool.TryParse(s, out var b) => b,
         _ => null,
     };
+
+    /// <summary>
+    /// True when the value stringifies to a JSON object/array (starts with <c>{</c> or <c>[</c>) —
+    /// the shape an undisclosed nested claim (e.g. a partially-disclosed address carrying its raw
+    /// <c>_sd</c> digests) takes. Such values are machine plumbing, not a human-readable disclosure.
+    /// </summary>
+    private static bool LooksLikeStructuredJson(object? value)
+    {
+        var s = value?.ToString()?.TrimStart();
+        return !string.IsNullOrEmpty(s) && (s[0] == '{' || s[0] == '[');
+    }
 }

--- a/src/Apps/Sorcha.Verifier/Components/App.razor
+++ b/src/Apps/Sorcha.Verifier/Components/App.razor
@@ -12,6 +12,9 @@
     <meta name="theme-color" content="#090A14" />
     <link rel="apple-touch-icon" href="icons/icon.svg" />
     <link rel="stylesheet" href="@Assets["_content/MudBlazor/MudBlazor.min.css"]" />
+    @* Blazor CSS-isolation bundle — carries VerdictTrailPanel's scoped styles (and any other
+       component-scoped CSS). Without this link the verdict panel renders unstyled. *@
+    <link rel="stylesheet" href="@Assets["Sorcha.Verifier.styles.css"]" />
     <link rel="stylesheet" href="css/verify.css" />
     <HeadOutlet />
 </head>


### PR DESCRIPTION
## What
Two defects on the desk `/verify` verdict, surfaced by the first real browser test:

1. **Panel rendered unstyled.** `Sorcha.Verifier/Components/App.razor` never linked the Blazor CSS-isolation bundle (`Sorcha.Verifier.styles.css`), so `VerdictTrailPanel`'s scoped styles never loaded — the panel showed as plain text with no cards/banner/pills (the page shell + global `verify.css` were fine). Now linked.
2. **Raw JSON in "Shared with you".** `VerdictViewModel.From` stringified *every* disclosed claim, so SD-JWT/VC machine fields (`vct`, `credentialStatus`, `cnf`, `iss`, and an undisclosed nested `address` surfaced as its raw `{"_sd":[…]}` digest) leaked into the operator view. Now filtered: a denylist of machine keys + skipping structured (object/array) values. The raw disclosed set is still used for the portrait / age / register-anchor lookups.

## Not changed
Theme, layout, behaviour, `data-testid`s, and DI seams unchanged. The two rejection/warn/fail/age treatments are unaffected.

## Tests
`Sorcha.UI.Core.Tests` 1483 pass (1 pre-existing unrelated flaky `MyCredentialsTests`) · `Sorcha.Verifier.Tests` 117 pass — both unchanged from baseline. Verifier app builds clean.

## Note on console messages (all benign, not this app)
The `contentscript.js MaxListenersExceededWarning` / `ObjectMultiplex orphaned … app-init/background-liveness` come from a browser **wallet extension**, not `/verify`. `beforeinstallprompt … Banner not shown` is expected — `pwa-install.js` suppresses Chrome's default banner to show our own Install button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)