### PR TITLE
fix: backlog batch — version coherence, HAIP token hardening, admin unlock, #1192/#1188/#1183

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -144,7 +144,11 @@ jobs:
           # Pass the run identifiers into the build so the published assembly's
           # version matches the :2.<run>.<attempt> image tag below (the root
           # Directory.Build.props derives the version from these env vars).
-          # Dockerfiles that don't declare the matching ARG simply ignore these.
+          # NOTE: docker build-args are OPT-IN. A Dockerfile that does not declare the
+          # matching ARG silently discards these, and its assembly ships stamped with the
+          # local -dev version while the image is tagged 2.<run>.<attempt> — the tag and
+          # the payload then disagree. Every Dockerfile here MUST carry the ARG/ENV block
+          # (guarded by scripts/check-dockerfile-version-args.ps1).
           build-args: |
             GITHUB_RUN_NUMBER=${{ github.run_number }}
             GITHUB_RUN_ATTEMPT=${{ github.run_attempt }}

--- a/.github/workflows/version-args-gate.yml
+++ b/.github/workflows/version-args-gate.yml
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Sorcha Contributors
+#
+# Unified-versioning CI gate. Fails when any Dockerfile omits the
+# ARG/ENV GITHUB_RUN_NUMBER + GITHUB_RUN_ATTEMPT block.
+#
+# Docker build-args are opt-in: an undeclared ARG is silently discarded, so the
+# image ships an assembly stamped <Major>.0.0-dev while being tagged
+# 2.<run>.<attempt>. Nothing else in CI catches that disagreement.
+#
+# See scripts/check-dockerfile-version-args.ps1 and CLAUDE.md ("Unified
+# versioning") for the wider scheme.
+
+name: version-args-gate
+
+on:
+  pull_request:
+    paths:
+      - "**/Dockerfile*"
+      - "Directory.Build.props"
+      - "scripts/check-dockerfile-version-args.ps1"
+      - ".github/workflows/version-args-gate.yml"
+  workflow_dispatch:
+
+jobs:
+  dockerfile-version-args:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run unified-versioning gate
+        shell: pwsh
+        run: ./scripts/check-dockerfile-version-args.ps1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -349,6 +349,18 @@ Full reference: the **`jwt` skill** ("Tiered audiences + issuer hardening"). Met
 ```
 
 - **NEVER hard-code `<Version>` / `<AssemblyVersion>` / `<FileVersion>` in a `.csproj`.** New projects inherit automatically.
+- **Every `Dockerfile` MUST declare the build-args** — docker build-args are *opt-in*, so a Dockerfile
+  without `ARG GITHUB_RUN_NUMBER` / `ARG GITHUB_RUN_ATTEMPT` (plus the matching `ENV`) silently
+  discards what `docker-publish.yml` passes it. The assembly then ships stamped `2.0.0-dev` while the
+  image is tagged `2.<run>.<attempt>` — tag and payload disagree and **nothing fails**. Put the block
+  after the `COPY src/ …` line (post-restore, so the cacheable restore layer isn't invalidated).
+  Enforced by `scripts/check-dockerfile-version-args.ps1` (CI: `version-args-gate`).
+- **Never hand-bump the local `-dev` version** in the root props. It is always `<Major>.0.0-dev`. A
+  deployed artefact reporting `-dev` means the Dockerfile is missing the ARG block — fix that, not
+  the version string.
+- **Display the version via `SorchaVersion.Current`** (`Sorcha.UI.Core.Utilities`, in
+  `Sorcha.UI.Components.User`) — never re-resolve the assembly attribute per surface and never
+  hardcode a version in a `.razor` page.
 - Publish workflows **derive** the version (`dotnet pack`/`build` reads the env in CI) — do **not** reintroduce "bump `<Version>` + commit" steps. Docker images are tagged `:2.<run>.<attempt>`.
 - A **Major** bump is a deliberate edit to `<SorchaMajor>` in the root `Directory.Build.props`.
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -30,7 +30,15 @@
 
     <!-- Package / NuGet version (allows the -dev prerelease suffix locally). -->
     <Version>$(SorchaMajor).$(SorchaMinor).$(SorchaPatch)</Version>
-    <Version Condition="'$(GITHUB_RUN_NUMBER)' == ''">$(SorchaMajor).0.7-dev</Version>
+    <!--
+      Local builds are ALWAYS <Major>.0.0-dev. Do NOT hand-bump this to .1-dev, .2-dev, …:
+      a committed version bump is exactly what this scheme exists to eliminate, and a
+      moving local number cannot distinguish "new build" from "CI version didn't reach the
+      artefact". If a deployed artefact reports a -dev version, that is the bug — the
+      container's Dockerfile is missing the ARG/ENV block that surfaces GITHUB_RUN_NUMBER
+      to MSBuild (docker build-args are opt-in and silently dropped otherwise).
+    -->
+    <Version Condition="'$(GITHUB_RUN_NUMBER)' == ''">$(SorchaMajor).0.0-dev</Version>
 
     <!-- Assembly identity must be purely numeric (x.x.x.x). -->
     <AssemblyVersion>$(SorchaMajor).$(SorchaMinor).$(SorchaPatch).0</AssemblyVersion>

--- a/samples/strathcarron-portal/Dockerfile
+++ b/samples/strathcarron-portal/Dockerfile
@@ -22,6 +22,16 @@ COPY ["samples/Directory.Build.props", "samples/"]
 # entirety before restore. Slightly worse layer caching; far more
 # robust against transitive-reference changes.
 COPY src/ src/
+
+# Unified versioning: the root Directory.Build.props derives the version from
+# GITHUB_RUN_NUMBER / GITHUB_RUN_ATTEMPT (else <Major>.0.0-dev). MSBuild reads env
+# vars as properties, so surfacing the build-args as ENV here makes the published
+# assembly carry 2.<run>.<attempt> — matching the image tag. Declared AFTER
+# restore so the (cacheable) restore layer isn't invalidated every run.
+ARG GITHUB_RUN_NUMBER
+ARG GITHUB_RUN_ATTEMPT
+ENV GITHUB_RUN_NUMBER=${GITHUB_RUN_NUMBER}
+ENV GITHUB_RUN_ATTEMPT=${GITHUB_RUN_ATTEMPT}
 COPY samples/strathcarron-portal/ samples/strathcarron-portal/
 
 RUN dotnet restore "samples/strathcarron-portal/Sorcha.Sample.StrathcarronPortal.csproj"

--- a/scripts/check-dockerfile-version-args.ps1
+++ b/scripts/check-dockerfile-version-args.ps1
@@ -1,0 +1,98 @@
+#!/usr/bin/env pwsh
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Sorcha Contributors
+#
+# Unified-versioning CI gate: every Dockerfile must opt in to the build-args.
+#
+# The root Directory.Build.props derives ONE version for every component from
+# GITHUB_RUN_NUMBER / GITHUB_RUN_ATTEMPT, falling back to <Major>.0.0-dev when
+# they are unset. docker-publish.yml passes both as --build-arg to every image.
+#
+# Docker build-args are OPT-IN. A Dockerfile that does not declare a matching
+# `ARG` silently DISCARDS the value — the build then sees no env var, MSBuild
+# takes the local -dev branch, and the image ships an assembly stamped
+# "2.0.0-dev" while the image itself is tagged "2.<run>.<attempt>". The tag and
+# the payload disagree, and nothing fails: not the build, not the tests.
+#
+# That is exactly what happened — 12 of 14 Dockerfiles were missing the block,
+# so /app reported v2.0.7-dev, and every service's OpenAPI info.version and the
+# MCP manifest reported a -dev version in production. This gate exists so the
+# next Dockerfile added to the repo cannot reintroduce it.
+#
+# Usage:
+#   pwsh scripts/check-dockerfile-version-args.ps1
+#
+# Exit codes:
+#   0 — every Dockerfile declares both ARGs and both ENVs
+#   1 — at least one Dockerfile is missing the block
+
+[CmdletBinding()]
+param(
+    [string]$RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+)
+
+$ErrorActionPreference = 'Stop'
+
+$required = @(
+    'ARG GITHUB_RUN_NUMBER'
+    'ARG GITHUB_RUN_ATTEMPT'
+    'ENV GITHUB_RUN_NUMBER='
+    'ENV GITHUB_RUN_ATTEMPT='
+)
+
+Push-Location $RepoRoot
+try {
+    $dockerfiles = git ls-files '*Dockerfile*' | Where-Object { $_ }
+}
+finally {
+    Pop-Location
+}
+
+if (-not $dockerfiles) {
+    Write-Error 'No Dockerfiles found — is this being run outside the repository?'
+    exit 1
+}
+
+$violations = @()
+
+foreach ($relative in $dockerfiles) {
+    $full = Join-Path $RepoRoot $relative
+    if (-not (Test-Path $full)) { continue }
+
+    $content = Get-Content -Raw -LiteralPath $full
+    $missing = $required | Where-Object { $content -notlike "*$_*" }
+
+    if ($missing) {
+        $violations += [pscustomobject]@{
+            File    = $relative
+            Missing = ($missing -join ', ')
+        }
+    }
+}
+
+if ($violations.Count -gt 0) {
+    Write-Host ''
+    Write-Host 'Unified-versioning gate FAILED.' -ForegroundColor Red
+    Write-Host ''
+    Write-Host 'These Dockerfiles do not surface the CI build-args to MSBuild, so the' -ForegroundColor Red
+    Write-Host 'assemblies they publish will be stamped <Major>.0.0-dev while the image' -ForegroundColor Red
+    Write-Host 'is tagged 2.<run>.<attempt>:' -ForegroundColor Red
+    Write-Host ''
+    foreach ($v in $violations) {
+        Write-Host ("  {0}" -f $v.File) -ForegroundColor Yellow
+        Write-Host ("      missing: {0}" -f $v.Missing) -ForegroundColor DarkYellow
+    }
+    Write-Host ''
+    Write-Host 'Add this block AFTER the `COPY src/ ...` line (after restore, so the' -ForegroundColor Cyan
+    Write-Host 'cacheable restore layer is not invalidated on every run):' -ForegroundColor Cyan
+    Write-Host ''
+    Write-Host '  ARG GITHUB_RUN_NUMBER'
+    Write-Host '  ARG GITHUB_RUN_ATTEMPT'
+    Write-Host '  ENV GITHUB_RUN_NUMBER=${GITHUB_RUN_NUMBER}'
+    Write-Host '  ENV GITHUB_RUN_ATTEMPT=${GITHUB_RUN_ATTEMPT}'
+    Write-Host ''
+    exit 1
+}
+
+Write-Host ("Unified-versioning gate passed — {0} Dockerfile(s) declare the build-args." -f @($dockerfiles).Count) -ForegroundColor Green
+exit 0

--- a/src/Apps/Sorcha.Agent/Decision/Checks/PostcodeExistsCheck.cs
+++ b/src/Apps/Sorcha.Agent/Decision/Checks/PostcodeExistsCheck.cs
@@ -82,7 +82,7 @@ public sealed class PostcodeExistsCheck : IExternalCheck
 
         try
         {
-            var exists = await ValidateOnlineAsync(postcode, ct);
+            var exists = await ValidateOnlineAsync(normalized, ct);
             return new ExternalCheckResult(Name, exists, postcode);
         }
         catch (Exception ex) when (ex is not OperationCanceledException || !ct.IsCancellationRequested)

--- a/src/Apps/Sorcha.McpServer/Dockerfile
+++ b/src/Apps/Sorcha.McpServer/Dockerfile
@@ -22,6 +22,16 @@ RUN dotnet restore "Apps/Sorcha.McpServer/Sorcha.McpServer.csproj"
 # Copy source code
 COPY src/ .
 
+# Unified versioning: the root Directory.Build.props derives the version from
+# GITHUB_RUN_NUMBER / GITHUB_RUN_ATTEMPT (else <Major>.0.0-dev). MSBuild reads env
+# vars as properties, so surfacing the build-args as ENV here makes the published
+# assembly carry 2.<run>.<attempt> — matching the image tag. Declared AFTER
+# restore so the (cacheable) restore layer isn't invalidated every run.
+ARG GITHUB_RUN_NUMBER
+ARG GITHUB_RUN_ATTEMPT
+ENV GITHUB_RUN_NUMBER=${GITHUB_RUN_NUMBER}
+ENV GITHUB_RUN_ATTEMPT=${GITHUB_RUN_ATTEMPT}
+
 # Build and publish the application
 WORKDIR "/src/Apps/Sorcha.McpServer"
 RUN dotnet publish "Sorcha.McpServer.csproj" -c Release -o /app/publish /p:UseAppHost=false

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/Credentials/CredentialApiService.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/Credentials/CredentialApiService.cs
@@ -427,17 +427,35 @@ public class CredentialApiService : ICredentialApiService
     };
 
     /// <summary>
-    /// A nested object renders as its field names, not its JSON. Protocol keys are
-    /// dropped so a stray digest array degrades to an empty string, never a blob.
+    /// Summarises a nested object claim for a credential card as its VALUES, comma-joined —
+    /// an <c>address</c> renders "10 High St, Falkirk, FK1 1AA". It used to render the field
+    /// NAMES ("line1, town, postcode, country"), which read as placeholder text to the citizen
+    /// (#1188). Values only, without the "Line1: " labels the detail view uses, because on a
+    /// compact card an address reads naturally as a plain address.
+    ///
+    /// The blob-proofing this method was built for is preserved and in fact tightened: only
+    /// SCALAR properties contribute. Anything array-valued is skipped rather than named, so an
+    /// unresolved SD-JWT digest array cannot reach a card even under a key that escaped the
+    /// <c>_</c>-prefix drop — which is how one reached a citizen's card on n1. Nested objects
+    /// recurse through this same scalar-only path, so depth can never turn into raw JSON.
+    /// An object with nothing scalar to say renders as an empty string, as before.
     /// </summary>
     private static string SummariseObject(JsonElement el)
     {
-        var fields = el.EnumerateObject()
+        var values = el.EnumerateObject()
             .Where(p => !p.Name.StartsWith('_'))
-            .Select(p => p.Name)
+            .Select(p => p.Value.ValueKind switch
+            {
+                JsonValueKind.String => p.Value.GetString() ?? string.Empty,
+                JsonValueKind.Number => p.Value.ToString(),
+                JsonValueKind.True or JsonValueKind.False => p.Value.GetBoolean().ToString(),
+                JsonValueKind.Object => SummariseObject(p.Value),
+                _ => string.Empty
+            })
+            .Where(v => !string.IsNullOrWhiteSpace(v))
             .ToList();
 
-        return fields.Count == 0 ? string.Empty : string.Join(", ", fields);
+        return values.Count == 0 ? string.Empty : string.Join(", ", values);
     }
 
     private static CredentialDetailViewModel MapToDetailViewModel(CredentialDetailResponse entity)

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Utilities/Shared/SorchaVersion.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Utilities/Shared/SorchaVersion.cs
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Reflection;
+
+namespace Sorcha.UI.Core.Utilities;
+
+/// <summary>
+/// The single source of the version string shown anywhere in a Sorcha UI.
+///
+/// Every component of the platform is stamped with ONE build-time-derived version by the root
+/// <c>Directory.Build.props</c> — <c>2.&lt;GITHUB_RUN_NUMBER&gt;.&lt;GITHUB_RUN_ATTEMPT&gt;</c> on CI,
+/// <c>2.0.0-dev</c> locally. Surfaces used to each resolve (or hardcode) that independently, so
+/// <c>/app</c> could show three different answers on one page load: the footer read the assembly
+/// attribute, Help hardcoded <c>2.0.0-preview</c>, Settings hardcoded <c>1.0.0-preview</c> next to a
+/// "build number" that was really <c>DateTime.Now</c> and therefore changed on every render. Reading
+/// the version through this one helper is what keeps them agreeing.
+///
+/// Resolved from this assembly rather than the caller's on purpose: this is the *platform* version,
+/// not a per-assembly one, and every assembly inherits the same value anyway — so a shared read gives
+/// the same answer from the web client, a shared component library, or the PWA.
+///
+/// A <c>-dev</c> value on a deployed artefact is a BUG, not a local build: it means the image's
+/// Dockerfile is missing the <c>ARG</c>/<c>ENV GITHUB_RUN_NUMBER</c> block, so CI's build-args were
+/// silently dropped (docker build-args are opt-in) and the tag no longer matches the payload.
+/// </summary>
+public static class SorchaVersion
+{
+    /// <summary>
+    /// The display version, e.g. <c>2.838.1</c> or <c>2.0.0-dev</c>. Any <c>+&lt;commit&gt;</c> source-revision
+    /// suffix is trimmed. Falls back to the numeric assembly version, then <c>"unknown"</c>.
+    /// </summary>
+    public static string Current { get; } = Resolve();
+
+    private static string Resolve()
+    {
+        var assembly = typeof(SorchaVersion).Assembly;
+
+        var informational = assembly
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+            ?.InformationalVersion
+            ?.Split('+')[0];
+
+        if (!string.IsNullOrWhiteSpace(informational))
+        {
+            return informational;
+        }
+
+        return assembly.GetName().Version?.ToString() ?? "unknown";
+    }
+}

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Components/Layout/StatusFooter.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Components/Layout/StatusFooter.razor
@@ -30,17 +30,13 @@
 </MudAppBar>
 
 @code {
-    private string _version = "0.0.0";
+    private string _version = Sorcha.UI.Core.Utilities.SorchaVersion.Current;
     private bool _isConnected = true;
     private int _pendingActionCount = 0;
     private Timer? _healthTimer;
 
     protected override void OnInitialized()
     {
-        _version = Assembly.GetExecutingAssembly()
-            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
-            ?.InformationalVersion?.Split('+')[0] ?? "0.0.0";
-
         _healthTimer = new Timer(async _ => await CheckHealthAsync(), null,
             TimeSpan.Zero, TimeSpan.FromSeconds(30));
     }

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Help.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Help.razor
@@ -218,7 +218,7 @@
                     About Sorcha Platform
                 </MudText>
                 <MudText Typo="Typo.body2" Class="mb-2">
-                    <strong>Version:</strong> 2.0.0-preview
+                    <strong>Version:</strong> @Sorcha.UI.Core.Utilities.SorchaVersion.Current
                 </MudText>
                 <MudText Typo="Typo.body2" Class="mb-2">
                     <strong>Framework:</strong> .NET 10.0 / Blazor WebAssembly / .NET Aspire

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Settings.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Settings.razor
@@ -370,10 +370,7 @@
                                 @Loc.T("settings.about.versionInfo")
                             </MudText>
                             <MudText Typo="Typo.body2" Class="mb-1">
-                                <strong>@Loc.T("settings.about.version")</strong> 1.0.0-preview
-                            </MudText>
-                            <MudText Typo="Typo.body2" Class="mb-1">
-                                <strong>@Loc.T("settings.about.build")</strong> @_buildNumber
+                                <strong>@Loc.T("settings.about.version")</strong> @Sorcha.UI.Core.Utilities.SorchaVersion.Current
                             </MudText>
                             <MudText Typo="Typo.body2" Class="mb-1">
                                 <strong>@Loc.T("settings.about.framework")</strong> .NET 10.0
@@ -455,7 +452,6 @@
     private List<Profile> _profiles = new();
     private Profile? _activeProfile;
     private bool _loading = true;
-    private string _buildNumber = $"{DateTime.Now:yyyyMMdd}.{DateTime.Now:HHmm}";
 
     // Feature 150 — after retiring the Accounts + Security tabs the order is
     // Appearance=0, Language=1, Notifications=2, so the /settings/notifications

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web/Dockerfile
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web/Dockerfile
@@ -26,6 +26,16 @@ RUN dotnet restore "Apps/Sorcha.UI/Sorcha.UI.Web/Sorcha.UI.Web.csproj"
 # Copy source code
 COPY src/ .
 
+# Unified versioning: the root Directory.Build.props derives the version from
+# GITHUB_RUN_NUMBER / GITHUB_RUN_ATTEMPT (else <Major>.0.0-dev). MSBuild reads env
+# vars as properties, so surfacing the build-args as ENV here makes the published
+# assembly carry 2.<run>.<attempt> — matching the image tag. Declared AFTER
+# restore so the (cacheable) restore layer isn't invalidated every run.
+ARG GITHUB_RUN_NUMBER
+ARG GITHUB_RUN_ATTEMPT
+ENV GITHUB_RUN_NUMBER=${GITHUB_RUN_NUMBER}
+ENV GITHUB_RUN_ATTEMPT=${GITHUB_RUN_ATTEMPT}
+
 # Build and publish the application
 WORKDIR "/src/Apps/Sorcha.UI/Sorcha.UI.Web"
 RUN dotnet publish "Sorcha.UI.Web.csproj" -c Release -o /app/publish /p:UseAppHost=false

--- a/src/Apps/Sorcha.Verifier/Dockerfile
+++ b/src/Apps/Sorcha.Verifier/Dockerfile
@@ -18,6 +18,16 @@ RUN dotnet restore "src/Apps/Sorcha.Verifier/Sorcha.Verifier.csproj"
 
 COPY src/ ./src/
 
+# Unified versioning: the root Directory.Build.props derives the version from
+# GITHUB_RUN_NUMBER / GITHUB_RUN_ATTEMPT (else <Major>.0.0-dev). MSBuild reads env
+# vars as properties, so surfacing the build-args as ENV here makes the published
+# assembly carry 2.<run>.<attempt> — matching the image tag. Declared AFTER
+# restore so the (cacheable) restore layer isn't invalidated every run.
+ARG GITHUB_RUN_NUMBER
+ARG GITHUB_RUN_ATTEMPT
+ENV GITHUB_RUN_NUMBER=${GITHUB_RUN_NUMBER}
+ENV GITHUB_RUN_ATTEMPT=${GITHUB_RUN_ATTEMPT}
+
 WORKDIR "/src/src/Apps/Sorcha.Verifier"
 RUN dotnet publish "Sorcha.Verifier.csproj" -c Release -o /app/publish /p:UseAppHost=false
 

--- a/src/Apps/Sorcha.Wallet.Pwa/MainLayout.razor
+++ b/src/Apps/Sorcha.Wallet.Pwa/MainLayout.razor
@@ -193,20 +193,9 @@
     /// </summary>
     public event Action? OutstandingWorkChanged;
 
-    // Build version for the bottom-right badge. Stamped at build time by the unified
-    // versioning standard (root Directory.Build.props): 2.<run>.<attempt> on CI images,
-    // 2.0.0-dev locally. InformationalVersion may carry a "+<commit>" suffix — trim it.
-    private static readonly string AppVersion = ResolveAppVersion();
-
-    private static string ResolveAppVersion()
-    {
-        var asm = typeof(MainLayout).Assembly;
-        var info = asm.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
-        var trimmed = info?.Split('+')[0];
-        return string.IsNullOrWhiteSpace(trimmed)
-            ? (asm.GetName().Version?.ToString() ?? "dev")
-            : trimmed;
-    }
+    // Build version for the bottom-right badge — resolved through the shared helper so the PWA
+    // badge, the web footer, and the web About panels can never disagree. See SorchaVersion.
+    private static readonly string AppVersion = Sorcha.UI.Core.Utilities.SorchaVersion.Current;
 
     // ── Shell surface for the Home hero (Feature 141) ──────────────────────
     // The Home page cascades to this layout instance so its gradient hero can

--- a/src/Services/Sorcha.ApiGateway/Dockerfile
+++ b/src/Services/Sorcha.ApiGateway/Dockerfile
@@ -21,6 +21,16 @@ RUN dotnet restore "src/Services/Sorcha.ApiGateway/Sorcha.ApiGateway.csproj"
 # Copy source code
 COPY src/ ./src/
 
+# Unified versioning: the root Directory.Build.props derives the version from
+# GITHUB_RUN_NUMBER / GITHUB_RUN_ATTEMPT (else <Major>.0.0-dev). MSBuild reads env
+# vars as properties, so surfacing the build-args as ENV here makes the published
+# assembly carry 2.<run>.<attempt> — matching the image tag. Declared AFTER
+# restore so the (cacheable) restore layer isn't invalidated every run.
+ARG GITHUB_RUN_NUMBER
+ARG GITHUB_RUN_ATTEMPT
+ENV GITHUB_RUN_NUMBER=${GITHUB_RUN_NUMBER}
+ENV GITHUB_RUN_ATTEMPT=${GITHUB_RUN_ATTEMPT}
+
 # AI-discoverability (spec 117): the gateway embeds the canonical root llms.txt + docs/llms-full.txt
 # (see Sorcha.ApiGateway.csproj <EmbeddedResource>) to serve them at /llms.txt and /llms-full.txt.
 # They live outside src/, so copy them into the build context before the build resolves the embed.

--- a/src/Services/Sorcha.Blueprint.Service/Dockerfile
+++ b/src/Services/Sorcha.Blueprint.Service/Dockerfile
@@ -22,6 +22,16 @@ RUN dotnet restore "src/Services/Sorcha.Blueprint.Service/Sorcha.Blueprint.Servi
 # Copy source code
 COPY src/ ./src/
 
+# Unified versioning: the root Directory.Build.props derives the version from
+# GITHUB_RUN_NUMBER / GITHUB_RUN_ATTEMPT (else <Major>.0.0-dev). MSBuild reads env
+# vars as properties, so surfacing the build-args as ENV here makes the published
+# assembly carry 2.<run>.<attempt> — matching the image tag. Declared AFTER
+# restore so the (cacheable) restore layer isn't invalidated every run.
+ARG GITHUB_RUN_NUMBER
+ARG GITHUB_RUN_ATTEMPT
+ENV GITHUB_RUN_NUMBER=${GITHUB_RUN_NUMBER}
+ENV GITHUB_RUN_ATTEMPT=${GITHUB_RUN_ATTEMPT}
+
 # Build the application
 WORKDIR "/src/src/Services/Sorcha.Blueprint.Service"
 RUN dotnet build "Sorcha.Blueprint.Service.csproj" -c Release -o /app/build

--- a/src/Services/Sorcha.Blueprint.Service/Endpoints/InstanceActionEndpoints.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Endpoints/InstanceActionEndpoints.cs
@@ -46,7 +46,10 @@ public static class InstanceActionEndpoints
                 + "resolved from the wallet_address claim when present, else via a Wallet-Service lookup "
                 + "by owner (consumer-tier tokens carry no wallet_address per Feature 136) — 403 if none "
                 + "of the caller's wallets is a participant on the instance; 404 if the instance, "
-                + "blueprint, or action is not found.")
+                + "blueprint, or action is not found. A STARTING action whose sender is an open "
+                + "participant (no wallet bound in the published blueprint, Feature 103) is readable "
+                + "by any authenticated caller, because the citizen it exists for is not late-bound "
+                + "into the instance until they submit and its schema is a blank form.")
             .Produces<InstanceActionSchemaResponse>(StatusCodes.Status200OK)
             .Produces(StatusCodes.Status403Forbidden)
             .Produces(StatusCodes.Status404NotFound);
@@ -92,14 +95,23 @@ public static class InstanceActionEndpoints
         var isParticipant = callerWallets.Count > 0
             && instance.ParticipantWallets.Values.Any(participantWallet =>
                 callerWallets.Any(w => string.Equals(w, participantWallet, StringComparison.OrdinalIgnoreCase)));
-        if (!isParticipant)
+
+        // Resolved BEFORE the gate decides, because an open-participant starting action has to be
+        // readable by someone who is not yet a participant — see IsOpenStartingAction. Ordering is
+        // deliberate: a caller who fails the gate gets 403 whether or not the blueprint/action
+        // exists, so a non-participant still cannot probe for which actions are present (#1183).
+        var blueprint = await actionResolver.GetBlueprintAsync(instance.BlueprintId, cancellationToken);
+        var action = blueprint is null
+            ? null
+            : actionResolver.GetActionDefinition(blueprint, actionId.ToString());
+
+        if (!isParticipant && !IsOpenStartingAction(blueprint, action))
         {
             return Results.Problem(
                 "You are not a participant on this instance.",
                 statusCode: StatusCodes.Status403Forbidden);
         }
 
-        var blueprint = await actionResolver.GetBlueprintAsync(instance.BlueprintId, cancellationToken);
         if (blueprint is null)
         {
             return Results.NotFound(new
@@ -109,7 +121,6 @@ public static class InstanceActionEndpoints
             });
         }
 
-        var action = actionResolver.GetActionDefinition(blueprint, actionId.ToString());
         if (action is null)
         {
             return Results.NotFound(new { error = $"Action {actionId} not found in blueprint {instance.BlueprintId}." });
@@ -127,6 +138,41 @@ public static class InstanceActionEndpoints
         };
 
         return Results.Ok(response);
+    }
+
+    /// <summary>
+    /// Whether this action is a STARTING action whose sender is an OPEN participant — i.e. one the
+    /// published blueprint deliberately left unbound (<c>WalletAddress == null</c>), to be late-bound
+    /// to whoever submits first (Feature 103; publish-time guardrail <c>VAL_BP_010</c> rejects a
+    /// pre-bound open participant).
+    ///
+    /// Such a caller is NOT in <c>instance.ParticipantWallets</c> until they submit, so the plain
+    /// participant gate would refuse the very person the action exists for — a citizen opening a
+    /// "start an application on your phone" form would 403 before typing anything (#1183). This was
+    /// latent rather than live: an open starting action has no wallet on its sender, so it never
+    /// appears in a pending-actions list, and no PWA route reached a starting action's schema.
+    ///
+    /// Nothing participant-specific is disclosed by allowing the read — a starting action's schema
+    /// is a blank form. Authentication is still required (the group carries
+    /// <c>CanExecuteBlueprints</c>), and WHO may actually submit remains the submit path's decision:
+    /// <c>ActionExecutionService</c> applies its strict wallet-equality check only when
+    /// <c>WalletAddress</c> is non-null, and late-binds otherwise. This read gate is deliberately
+    /// consistent with that rule rather than stricter than it.
+    /// </summary>
+    private static bool IsOpenStartingAction(
+        Sorcha.Blueprint.Models.Blueprint? blueprint,
+        Sorcha.Blueprint.Models.Action? action)
+    {
+        if (blueprint is null || action is null || !action.IsStartingAction)
+        {
+            return false;
+        }
+
+        var sender = blueprint.Participants
+            .FirstOrDefault(p => string.Equals(p.Id, action.Sender, StringComparison.OrdinalIgnoreCase));
+
+        // No resolvable sender participant is treated as NOT open — fail closed.
+        return sender is not null && string.IsNullOrEmpty(sender.WalletAddress);
     }
 
     /// <summary>

--- a/src/Services/Sorcha.Haip.Service/Dockerfile
+++ b/src/Services/Sorcha.Haip.Service/Dockerfile
@@ -25,6 +25,16 @@ RUN dotnet restore "src/Services/Sorcha.Haip.Service/Sorcha.Haip.Service.csproj"
 # Copy source code
 COPY src/ ./src/
 
+# Unified versioning: the root Directory.Build.props derives the version from
+# GITHUB_RUN_NUMBER / GITHUB_RUN_ATTEMPT (else <Major>.0.0-dev). MSBuild reads env
+# vars as properties, so surfacing the build-args as ENV here makes the published
+# assembly carry 2.<run>.<attempt> — matching the image tag. Declared AFTER
+# restore so the (cacheable) restore layer isn't invalidated every run.
+ARG GITHUB_RUN_NUMBER
+ARG GITHUB_RUN_ATTEMPT
+ENV GITHUB_RUN_NUMBER=${GITHUB_RUN_NUMBER}
+ENV GITHUB_RUN_ATTEMPT=${GITHUB_RUN_ATTEMPT}
+
 # Build the application
 WORKDIR "/src/src/Services/Sorcha.Haip.Service"
 RUN dotnet build "Sorcha.Haip.Service.csproj" -c Release -o /app/build

--- a/src/Services/Sorcha.Haip.Service/Endpoints/TokenEndpoints.cs
+++ b/src/Services/Sorcha.Haip.Service/Endpoints/TokenEndpoints.cs
@@ -39,6 +39,13 @@ public static class TokenEndpoints
         IConfiguration configuration,
         CancellationToken ct)
     {
+        // RFC 6749 §5.1: a response carrying a token MUST NOT be cached. Set here, before any
+        // branch, so every exit path carries it — the success path is the one that matters, but
+        // an error response is equally not worth caching, and setting it once removes the chance
+        // that a future early-return quietly ships a cacheable token.
+        httpContext.Response.Headers.CacheControl = "no-store";
+        httpContext.Response.Headers.Pragma = "no-cache";
+
         // Read form-encoded body (OAuth 2.0 §4.1.3)
         var form = await httpContext.Request.ReadFormAsync(ct);
         var grantType = form["grant_type"].FirstOrDefault() ?? string.Empty;
@@ -76,8 +83,6 @@ public static class TokenEndpoints
         // Store the access token → offer mapping for later correlation
         await tokenStore.StoreAsync(accessToken, offerId.Value, ct);
 
-        // TODO: RFC 6749 §5.1 requires Cache-Control: no-store on token responses.
-        // Add a CachedResult wrapper (similar to Blueprint Service) to set the header.
         return Results.Ok(new TokenResponse
         {
             AccessToken = accessToken,

--- a/src/Services/Sorcha.Haip.Service/Services/AccessTokenStore.cs
+++ b/src/Services/Sorcha.Haip.Service/Services/AccessTokenStore.cs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Sorcha Contributors
 
+using System.Security.Cryptography;
+using System.Text;
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Caching.Memory;
 
@@ -12,11 +14,17 @@ namespace Sorcha.Haip.Service.Services;
 /// to prevent unbounded growth.
 /// </summary>
 /// <remarks>
-/// TODO: Hash the access token (SHA-256) before using it as the Redis key
-/// to prevent token exposure via key enumeration (SCAN).
-/// TODO: Implement IDisposable to dispose the MemoryCache fallback (CA2213).
+/// The token is SHA-256 hashed before it is used as a cache key. The key space is the
+/// only place the raw bearer token would otherwise come to rest: anyone able to read the
+/// Redis keyspace — a <c>SCAN</c>, a memory dump, a managed-Redis console, a support
+/// engineer with read access — could previously lift live bearer tokens verbatim and
+/// replay them until expiry. Hashing means the keyspace holds only a one-way digest, and
+/// lookup still works because the caller presents the token and we hash it the same way.
+///
+/// This is deliberately a hash and not encryption: nothing ever needs to recover the
+/// token from the key, so there is no key to manage and no way to reverse the store.
 /// </remarks>
-public class AccessTokenStore
+public sealed class AccessTokenStore : IDisposable
 {
     private readonly IDistributedCache? _cache;
     private readonly ILogger<AccessTokenStore> _logger;
@@ -40,7 +48,7 @@ public class AccessTokenStore
     /// </summary>
     public async Task StoreAsync(string accessToken, Guid offerId, CancellationToken ct = default)
     {
-        var key = $"haip:token:{accessToken}";
+        var key = KeyFor(accessToken);
         var value = offerId.ToString();
 
         if (_cache != null)
@@ -63,7 +71,7 @@ public class AccessTokenStore
     /// </summary>
     public async Task<Guid?> LookupAsync(string accessToken, CancellationToken ct = default)
     {
-        var key = $"haip:token:{accessToken}";
+        var key = KeyFor(accessToken);
 
         string? value;
         if (_cache != null)
@@ -79,5 +87,22 @@ public class AccessTokenStore
             return null;
 
         return offerId;
+    }
+
+    /// <summary>
+    /// The cache key for a token: <c>haip:token:{sha256-hex}</c>. Never let the raw token
+    /// reach the keyspace — see the remarks on <see cref="AccessTokenStore"/>. Hex rather
+    /// than base64 so the key is safe in every Redis tool and log without escaping.
+    /// </summary>
+    private static string KeyFor(string accessToken)
+    {
+        var digest = SHA256.HashData(Encoding.UTF8.GetBytes(accessToken));
+        return $"haip:token:{Convert.ToHexStringLower(digest)}";
+    }
+
+    /// <summary>Disposes the in-memory fallback cache (CA2213).</summary>
+    public void Dispose()
+    {
+        _memoryStore.Dispose();
     }
 }

--- a/src/Services/Sorcha.Peer.Service/Dockerfile
+++ b/src/Services/Sorcha.Peer.Service/Dockerfile
@@ -27,6 +27,16 @@ RUN dotnet restore "src/Services/Sorcha.Peer.Service/Sorcha.Peer.Service.csproj"
 # Copy source code (including proto files)
 COPY src/ ./src/
 
+# Unified versioning: the root Directory.Build.props derives the version from
+# GITHUB_RUN_NUMBER / GITHUB_RUN_ATTEMPT (else <Major>.0.0-dev). MSBuild reads env
+# vars as properties, so surfacing the build-args as ENV here makes the published
+# assembly carry 2.<run>.<attempt> — matching the image tag. Declared AFTER
+# restore so the (cacheable) restore layer isn't invalidated every run.
+ARG GITHUB_RUN_NUMBER
+ARG GITHUB_RUN_ATTEMPT
+ENV GITHUB_RUN_NUMBER=${GITHUB_RUN_NUMBER}
+ENV GITHUB_RUN_ATTEMPT=${GITHUB_RUN_ATTEMPT}
+
 # Build the application
 WORKDIR "/src/src/Services/Sorcha.Peer.Service"
 RUN dotnet build "Sorcha.Peer.Service.csproj" -c Release -o /app/build

--- a/src/Services/Sorcha.Register.Service/Dockerfile
+++ b/src/Services/Sorcha.Register.Service/Dockerfile
@@ -27,6 +27,16 @@ RUN dotnet restore "src/Services/Sorcha.Register.Service/Sorcha.Register.Service
 # Copy source code
 COPY src/ ./src/
 
+# Unified versioning: the root Directory.Build.props derives the version from
+# GITHUB_RUN_NUMBER / GITHUB_RUN_ATTEMPT (else <Major>.0.0-dev). MSBuild reads env
+# vars as properties, so surfacing the build-args as ENV here makes the published
+# assembly carry 2.<run>.<attempt> — matching the image tag. Declared AFTER
+# restore so the (cacheable) restore layer isn't invalidated every run.
+ARG GITHUB_RUN_NUMBER
+ARG GITHUB_RUN_ATTEMPT
+ENV GITHUB_RUN_NUMBER=${GITHUB_RUN_NUMBER}
+ENV GITHUB_RUN_ATTEMPT=${GITHUB_RUN_ATTEMPT}
+
 # Build the application
 WORKDIR "/src/src/Services/Sorcha.Register.Service"
 RUN dotnet build "Sorcha.Register.Service.csproj" -c Release -o /app/build

--- a/src/Services/Sorcha.Tenant.Service/Dockerfile
+++ b/src/Services/Sorcha.Tenant.Service/Dockerfile
@@ -21,6 +21,16 @@ RUN dotnet restore "src/Services/Sorcha.Tenant.Service/Sorcha.Tenant.Service.csp
 # Copy source code
 COPY src/ ./src/
 
+# Unified versioning: the root Directory.Build.props derives the version from
+# GITHUB_RUN_NUMBER / GITHUB_RUN_ATTEMPT (else <Major>.0.0-dev). MSBuild reads env
+# vars as properties, so surfacing the build-args as ENV here makes the published
+# assembly carry 2.<run>.<attempt> — matching the image tag. Declared AFTER
+# restore so the (cacheable) restore layer isn't invalidated every run.
+ARG GITHUB_RUN_NUMBER
+ARG GITHUB_RUN_ATTEMPT
+ENV GITHUB_RUN_NUMBER=${GITHUB_RUN_NUMBER}
+ENV GITHUB_RUN_ATTEMPT=${GITHUB_RUN_ATTEMPT}
+
 # Build the application
 WORKDIR "/src/src/Services/Sorcha.Tenant.Service"
 RUN dotnet build "Sorcha.Tenant.Service.csproj" -c Release -o /app/build

--- a/src/Services/Sorcha.Tenant.Service/Endpoints/OrganizationEndpoints.cs
+++ b/src/Services/Sorcha.Tenant.Service/Endpoints/OrganizationEndpoints.cs
@@ -329,6 +329,7 @@ public static class OrganizationEndpoints
         Guid organizationId,
         Guid userId,
         IIdentityRepository identityRepository,
+        IPlatformUserService platformUserService,
         TenantDbContext dbContext,
         ClaimsPrincipal user,
         CancellationToken cancellationToken)
@@ -339,14 +340,31 @@ public static class OrganizationEndpoints
             return TypedResults.NotFound();
         }
 
-        // TODO: FailedLoginCount, LockedUntil, LockedPermanently removed from UserIdentity.
-        // Account lockout will be handled by PlatformUser in a future task.
-        // For now, just reactivate the user status if suspended.
         if (targetUser.Status == IdentityStatus.Suspended)
         {
             targetUser.Status = IdentityStatus.Active;
         }
         await identityRepository.UpdateUserAsync(targetUser, cancellationToken);
+
+        // Clear the brute-force lockout state, which lives on PlatformUser (the cross-org identity
+        // anchor) rather than on the org-scoped UserIdentity. This endpoint used to reactivate a
+        // Suspended status and nothing else, on the grounds that lockout "will be handled by
+        // PlatformUser in a future task" — but that task has since landed
+        // (PlatformUserService.ValidatePasswordAsync enforces tiered thresholds and sets
+        // FailedLoginCount / LockedUntil / LockedPermanently). So an admin unlocking a
+        // brute-force-locked account cleared nothing, while the audit entry below recorded
+        // AccountUnlockedByAdmin as a success — the log asserted an unlock that had not happened.
+        //
+        // Not found is tolerated rather than fatal: a UserIdentity whose PlatformUser is missing is
+        // already an inconsistency, and the status reactivation above is still worth keeping.
+        var platformUser = await platformUserService.GetByIdAsync(targetUser.PlatformUserId, cancellationToken);
+        if (platformUser is not null)
+        {
+            platformUser.FailedLoginCount = 0;
+            platformUser.LockedUntil = null;
+            platformUser.LockedPermanently = false;
+            await platformUserService.UpdateAsync(platformUser, cancellationToken);
+        }
 
         dbContext.AuditLogEntries.Add(new AuditLogEntry
         {

--- a/src/Services/Sorcha.Validator.Service/Dockerfile
+++ b/src/Services/Sorcha.Validator.Service/Dockerfile
@@ -31,6 +31,16 @@ RUN dotnet restore "src/Services/Sorcha.Validator.Service/Sorcha.Validator.Servi
 # Copy source code
 COPY src/ ./src/
 
+# Unified versioning: the root Directory.Build.props derives the version from
+# GITHUB_RUN_NUMBER / GITHUB_RUN_ATTEMPT (else <Major>.0.0-dev). MSBuild reads env
+# vars as properties, so surfacing the build-args as ENV here makes the published
+# assembly carry 2.<run>.<attempt> — matching the image tag. Declared AFTER
+# restore so the (cacheable) restore layer isn't invalidated every run.
+ARG GITHUB_RUN_NUMBER
+ARG GITHUB_RUN_ATTEMPT
+ENV GITHUB_RUN_NUMBER=${GITHUB_RUN_NUMBER}
+ENV GITHUB_RUN_ATTEMPT=${GITHUB_RUN_ATTEMPT}
+
 # Build the application
 WORKDIR "/src/src/Services/Sorcha.Validator.Service"
 RUN dotnet build "Sorcha.Validator.Service.csproj" -c Release -o /app/build

--- a/src/Services/Sorcha.Wallet.Service/Dockerfile
+++ b/src/Services/Sorcha.Wallet.Service/Dockerfile
@@ -24,6 +24,16 @@ RUN dotnet restore "src/Services/Sorcha.Wallet.Service/Sorcha.Wallet.Service.csp
 # Copy source code
 COPY src/ ./src/
 
+# Unified versioning: the root Directory.Build.props derives the version from
+# GITHUB_RUN_NUMBER / GITHUB_RUN_ATTEMPT (else <Major>.0.0-dev). MSBuild reads env
+# vars as properties, so surfacing the build-args as ENV here makes the published
+# assembly carry 2.<run>.<attempt> — matching the image tag. Declared AFTER
+# restore so the (cacheable) restore layer isn't invalidated every run.
+ARG GITHUB_RUN_NUMBER
+ARG GITHUB_RUN_ATTEMPT
+ENV GITHUB_RUN_NUMBER=${GITHUB_RUN_NUMBER}
+ENV GITHUB_RUN_ATTEMPT=${GITHUB_RUN_ATTEMPT}
+
 # Build the application
 WORKDIR "/src/src/Services/Sorcha.Wallet.Service"
 RUN dotnet build "Sorcha.Wallet.Service.csproj" -c Release -o /app/build

--- a/tests/Sorcha.Agent.Tests/Decision/Checks/CheckTestSupport.cs
+++ b/tests/Sorcha.Agent.Tests/Decision/Checks/CheckTestSupport.cs
@@ -48,6 +48,12 @@ internal sealed class StubHttpMessageHandler : HttpMessageHandler
 
     public int Calls { get; private set; }
 
+    /// <summary>
+    /// The absolute URI of the most recent request. Lets a test assert what was actually put on the
+    /// wire — the postcode check normalises before the lookup, and only the URI proves it.
+    /// </summary>
+    public Uri? LastRequestUri { get; private set; }
+
     private StubHttpMessageHandler(Func<HttpRequestMessage, HttpResponseMessage> responder) => _responder = responder;
 
     /// <summary>Returns 200 with the given JSON body for every request.</summary>
@@ -65,6 +71,7 @@ internal sealed class StubHttpMessageHandler : HttpMessageHandler
     protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
     {
         Calls++;
+        LastRequestUri = request.RequestUri;
         return Task.FromResult(_responder(request));
     }
 

--- a/tests/Sorcha.Agent.Tests/Decision/Checks/PostcodeExistsCheckTests.cs
+++ b/tests/Sorcha.Agent.Tests/Decision/Checks/PostcodeExistsCheckTests.cs
@@ -24,6 +24,30 @@ public class PostcodeExistsCheckTests
         handler.Calls.Should().Be(1);
     }
 
+    /// <summary>
+    /// Regression for #1192. The online path used to receive the RAW postcode while only the offline
+    /// paths used the normalised one, so a real postcode with stray internal whitespace — e.g.
+    /// "EH9 1 JA", produced by the address-lookup autofill — was sent verbatim to postcodes.io.
+    /// Its /validate route is not space-tolerant: it answered result:false for a genuine Edinburgh
+    /// address, the AIAS agent rejected the application "postcode-not-found", and no credential was
+    /// issued. Asserting on the URI rather than the result, because a stub returning result:true
+    /// would pass regardless of what was actually requested.
+    /// </summary>
+    [Fact]
+    public async Task EvaluateAsync_PostcodeWithStrayWhitespace_QueriesNormalisedPostcode()
+    {
+        var handler = StubHttpMessageHandler.Json("""{ "status": 200, "result": true }""");
+        var check = new PostcodeExistsCheck("postcodeExists", "/address", handler.Client(), Fixture);
+
+        var result = await check.EvaluateAsync(AddressPayload("eh9 1 JA"), default);
+
+        handler.LastRequestUri!.AbsoluteUri.Should().Contain("/postcodes/EH91JA/validate");
+        result.Value.Should().BeTrue();
+
+        // Detail keeps the raw value — the rejection reason should echo what the citizen typed.
+        result.Detail.Should().Be("eh9 1 JA");
+    }
+
     [Fact]
     public async Task EvaluateAsync_LiveLookupInvalid_ReturnsFalse()
     {

--- a/tests/Sorcha.Blueprint.Service.Tests/Endpoints/InstanceActionEndpointsTests.cs
+++ b/tests/Sorcha.Blueprint.Service.Tests/Endpoints/InstanceActionEndpointsTests.cs
@@ -235,10 +235,24 @@ public sealed class InstanceActionEndpointsTests
         // Fast-path claim resolves to CitizenWallet, but the instance's recorded participant is a
         // different wallet — no Wallet Service call needed (claim fast path short-circuits).
         var instance = MakeInstance(OtherWallet);
+        var action = MakeAction();   // IsStartingAction defaults false — a mid-workflow action.
+        var blueprint = new BlueprintModel
+        {
+            Id = "bp-1", Title = "AIAS", Description = "desc-desc", Actions = [action],
+            Participants = [new Participant { Id = "citizen", Name = "Citizen", WalletAddress = OtherWallet }],
+        };
+
         var instanceStore = new Mock<IInstanceStore>();
         instanceStore.Setup(s => s.GetAsync("inst-1", It.IsAny<CancellationToken>())).ReturnsAsync(instance);
 
-        var resolver = new Mock<IActionResolverService>(MockBehavior.Strict);
+        // #1183 changed the ordering: the blueprint is now resolved BEFORE the gate decides, because
+        // an open-participant starting action must be readable by a not-yet-bound citizen. So a
+        // non-participant costs one extra (cached) blueprint lookup where it previously cost none —
+        // the resolver is no longer strict-with-no-calls here. The gate's verdict is unchanged.
+        var resolver = new Mock<IActionResolverService>();
+        resolver.Setup(r => r.GetBlueprintAsync("bp-1", It.IsAny<CancellationToken>())).ReturnsAsync(blueprint);
+        resolver.Setup(r => r.GetActionDefinition(blueprint, "1")).Returns(action);
+
         var walletClient = new Mock<IWalletServiceClient>(MockBehavior.Strict);
 
         var result = await InvokeAsync(
@@ -247,8 +261,103 @@ public sealed class InstanceActionEndpointsTests
         result.GetType().Name.Should().Contain("ProblemHttpResult");
         var problem = (ProblemHttpResult)result;
         problem.StatusCode.Should().Be(StatusCodes.Status403Forbidden);
-        resolver.VerifyNoOtherCalls();
         walletClient.VerifyNoOtherCalls();
+    }
+
+    /// <summary>
+    /// #1183 — an open-participant STARTING action (sender left unbound in the published blueprint
+    /// per Feature 103) must be readable by a citizen who is not yet a participant, because
+    /// late-binding only happens at submit. Previously this 403'd: the citizen could not open the
+    /// blank form they were meant to fill in.
+    /// </summary>
+    [Fact]
+    public async Task GetInstanceActionSchema_OpenParticipantStartingAction_ReadableByNonParticipant()
+    {
+        var instance = MakeInstance(OtherWallet);
+        var action = MakeAction();
+        action.IsStartingAction = true;
+        var blueprint = new BlueprintModel
+        {
+            Id = "bp-1", Title = "AIAS", Description = "desc-desc", Actions = [action],
+            // Open participant: WalletAddress deliberately null (VAL_BP_010 enforces this at publish).
+            Participants = [new Participant { Id = "citizen", Name = "Citizen", WalletAddress = null }],
+        };
+
+        var instanceStore = new Mock<IInstanceStore>();
+        instanceStore.Setup(s => s.GetAsync("inst-1", It.IsAny<CancellationToken>())).ReturnsAsync(instance);
+
+        var resolver = new Mock<IActionResolverService>();
+        resolver.Setup(r => r.GetBlueprintAsync("bp-1", It.IsAny<CancellationToken>())).ReturnsAsync(blueprint);
+        resolver.Setup(r => r.GetActionDefinition(blueprint, "1")).Returns(action);
+
+        var result = await InvokeAsync(
+            ContextWithWallet(CitizenWallet), "inst-1", 1,
+            instanceStore.Object, resolver.Object, WalletClientReturningNothing().Object);
+
+        var ok = result.Should().BeOfType<Ok<InstanceActionSchemaResponse>>().Subject;
+        ok.Value!.ActionId.Should().Be(1);
+    }
+
+    /// <summary>
+    /// The open-participant allowance is scoped to STARTING actions only. A pre-bound sender on a
+    /// starting action is a closed participant (and is itself a publish-time error, VAL_BP_010), so
+    /// it must not open the door.
+    /// </summary>
+    [Fact]
+    public async Task GetInstanceActionSchema_StartingActionWithBoundSender_StillForbiddenToNonParticipant()
+    {
+        var instance = MakeInstance(OtherWallet);
+        var action = MakeAction();
+        action.IsStartingAction = true;
+        var blueprint = new BlueprintModel
+        {
+            Id = "bp-1", Title = "AIAS", Description = "desc-desc", Actions = [action],
+            Participants = [new Participant { Id = "citizen", Name = "Citizen", WalletAddress = OtherWallet }],
+        };
+
+        var instanceStore = new Mock<IInstanceStore>();
+        instanceStore.Setup(s => s.GetAsync("inst-1", It.IsAny<CancellationToken>())).ReturnsAsync(instance);
+
+        var resolver = new Mock<IActionResolverService>();
+        resolver.Setup(r => r.GetBlueprintAsync("bp-1", It.IsAny<CancellationToken>())).ReturnsAsync(blueprint);
+        resolver.Setup(r => r.GetActionDefinition(blueprint, "1")).Returns(action);
+
+        var result = await InvokeAsync(
+            ContextWithWallet(CitizenWallet), "inst-1", 1,
+            instanceStore.Object, resolver.Object, WalletClientReturningNothing().Object);
+
+        ((ProblemHttpResult)result).StatusCode.Should().Be(StatusCodes.Status403Forbidden);
+    }
+
+    /// <summary>
+    /// The reordering must not turn the gate into a probe. A non-participant asking for an action
+    /// that does NOT exist must get the same 403 as one asking for an action that does — otherwise
+    /// 404-vs-403 leaks which actions a blueprint contains.
+    /// </summary>
+    [Fact]
+    public async Task GetInstanceActionSchema_NonParticipant_CannotDistinguishMissingActionFromForbidden()
+    {
+        var instance = MakeInstance(OtherWallet);
+        var blueprint = new BlueprintModel
+        {
+            Id = "bp-1", Title = "AIAS", Description = "desc-desc", Actions = [],
+            Participants = [new Participant { Id = "citizen", Name = "Citizen", WalletAddress = OtherWallet }],
+        };
+
+        var instanceStore = new Mock<IInstanceStore>();
+        instanceStore.Setup(s => s.GetAsync("inst-1", It.IsAny<CancellationToken>())).ReturnsAsync(instance);
+
+        var resolver = new Mock<IActionResolverService>();
+        resolver.Setup(r => r.GetBlueprintAsync("bp-1", It.IsAny<CancellationToken>())).ReturnsAsync(blueprint);
+        resolver.Setup(r => r.GetActionDefinition(blueprint, "99")).Returns((Sorcha.Blueprint.Models.Action?)null);
+
+        var result = await InvokeAsync(
+            ContextWithWallet(CitizenWallet), "inst-1", 99,
+            instanceStore.Object, resolver.Object, WalletClientReturningNothing().Object);
+
+        ((ProblemHttpResult)result).StatusCode.Should().Be(
+            StatusCodes.Status403Forbidden,
+            "a non-participant must not learn whether the action exists");
     }
 
     [Fact]
@@ -259,10 +368,22 @@ public sealed class InstanceActionEndpointsTests
         // wallet", so 403 is correct fail-closed behaviour, not the old "gate reads a claim citizens
         // never carry" bug.
         var instance = MakeInstance(CitizenWallet);
+        var action = MakeAction();   // Not a starting action — the open-participant door stays shut.
+        var blueprint = new BlueprintModel
+        {
+            Id = "bp-1", Title = "AIAS", Description = "desc-desc", Actions = [action],
+            Participants = [new Participant { Id = "citizen", Name = "Citizen", WalletAddress = CitizenWallet }],
+        };
+
         var instanceStore = new Mock<IInstanceStore>();
         instanceStore.Setup(s => s.GetAsync("inst-1", It.IsAny<CancellationToken>())).ReturnsAsync(instance);
 
-        var resolver = new Mock<IActionResolverService>(MockBehavior.Strict);
+        // Non-strict since #1183: the blueprint is now resolved before the gate decides (see the
+        // comment on GetInstanceActionSchema_WalletNotAParticipant_ReturnsForbidden).
+        var resolver = new Mock<IActionResolverService>();
+        resolver.Setup(r => r.GetBlueprintAsync("bp-1", It.IsAny<CancellationToken>())).ReturnsAsync(blueprint);
+        resolver.Setup(r => r.GetActionDefinition(blueprint, "1")).Returns(action);
+
         var walletClient = WalletClientReturningNothing();
 
         var result = await InvokeAsync(

--- a/tests/Sorcha.Haip.Service.Tests/Endpoints/TokenEndpointTests.cs
+++ b/tests/Sorcha.Haip.Service.Tests/Endpoints/TokenEndpointTests.cs
@@ -2,13 +2,18 @@
 // Copyright (c) 2026 Sorcha Contributors
 
 using System.Diagnostics.Metrics;
+using System.Reflection;
 using System.Text.Json;
 using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.Extensions.Primitives;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Sorcha.AtomicCache;
+using Sorcha.Haip.Service.Endpoints;
 using Sorcha.Haip.Service.Models;
 using Sorcha.Haip.Service.Services;
 using Xunit;
@@ -78,6 +83,82 @@ public class TokenEndpointTests
 
         first.Should().NotBeNull();
         second.Should().BeNull("pre-auth codes are one-time-use");
+    }
+
+    /// <summary>
+    /// RFC 6749 §5.1 — a response carrying an access token MUST NOT be cached. Without this an
+    /// intermediary (proxy, CDN, browser cache) may retain a live bearer token and serve it on.
+    /// </summary>
+    [Fact]
+    public async Task SuccessfulExchange_SetsNoStoreCacheHeaders()
+    {
+        var (offer, _) = await _offerService.CreateOfferAsync(
+            "ws1qissuer1", "tenant-1", "LicenseCredential",
+            new Dictionary<string, object> { ["name"] = "Alice" });
+
+        var httpContext = ContextWithForm(new Dictionary<string, StringValues>
+        {
+            ["grant_type"] = "urn:ietf:params:oauth:grant-type:pre-authorized_code",
+            ["pre-authorized_code"] = offer.PreAuthorizedCode,
+        });
+
+        var result = await InvokeExchangeAsync(httpContext);
+
+        result.Should().BeOfType<Ok<TokenResponse>>();
+        httpContext.Response.Headers.CacheControl.ToString().Should().Be("no-store");
+        httpContext.Response.Headers.Pragma.ToString().Should().Be("no-cache");
+    }
+
+    /// <summary>
+    /// The headers are set before any branch, so an early return cannot ship a cacheable response.
+    /// Pinned because the obvious implementation — setting them next to the success result — leaves
+    /// every error path uncovered and silently regresses the moment someone adds a new early return.
+    /// </summary>
+    [Fact]
+    public async Task RejectedExchange_AlsoSetsNoStoreCacheHeaders()
+    {
+        var httpContext = ContextWithForm(new Dictionary<string, StringValues>
+        {
+            ["grant_type"] = "authorization_code",   // unsupported → early 400
+        });
+
+        var result = await InvokeExchangeAsync(httpContext);
+
+        // BadRequest<T> is generic over an anonymous type here, so assert the status, not the shape.
+        result.Should().BeAssignableTo<IStatusCodeHttpResult>()
+            .Which.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
+        httpContext.Response.Headers.CacheControl.ToString().Should().Be("no-store");
+    }
+
+    private static DefaultHttpContext ContextWithForm(Dictionary<string, StringValues> fields)
+    {
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.ContentType = "application/x-www-form-urlencoded";
+        httpContext.Request.Form = new FormCollection(fields);
+        return httpContext;
+    }
+
+    private Task<IResult> InvokeExchangeAsync(HttpContext httpContext)
+    {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Haip:TokenLifetimeSeconds"] = "300",
+                ["Haip:IssuerUrl"] = "https://test.example/haip",
+            })
+            .Build();
+
+        using var tokenStore = new AccessTokenStore(
+            Mock.Of<ILogger<AccessTokenStore>>(), config, cache: null);
+
+        var method = typeof(TokenEndpoints).GetMethod(
+            "ExchangeToken", BindingFlags.NonPublic | BindingFlags.Static);
+        method.Should().NotBeNull("ExchangeToken should be reachable for reflection-based endpoint testing");
+
+        var result = method!.Invoke(null, [
+            httpContext, _codeStore, _nonceStore, tokenStore, _offerService, config, CancellationToken.None,
+        ]);
+        return (Task<IResult>)result!;
     }
 
     [Fact]

--- a/tests/Sorcha.Haip.Service.Tests/Services/AccessTokenStoreTests.cs
+++ b/tests/Sorcha.Haip.Service.Tests/Services/AccessTokenStoreTests.cs
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Security.Cryptography;
+using System.Text;
+using FluentAssertions;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Sorcha.Haip.Service.Services;
+using Xunit;
+
+namespace Sorcha.Haip.Service.Tests.Services;
+
+/// <summary>
+/// Tests for <see cref="AccessTokenStore"/>, with the emphasis on what the cache KEYSPACE holds.
+/// The store previously keyed on the raw bearer token, so anyone who could read the Redis keyspace
+/// — a <c>SCAN</c>, a managed-Redis console, a memory dump — could lift live tokens verbatim and
+/// replay them until expiry. Asserting the round-trip alone would not have caught that: the
+/// round-trip worked fine. These tests assert on the keys themselves.
+/// </summary>
+public class AccessTokenStoreTests
+{
+    private const string Token = "s3cret-bearer-token-value-do-not-leak";
+
+    private static IConfiguration Config() =>
+        new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?> { ["Haip:TokenLifetimeSeconds"] = "300" })
+            .Build();
+
+    private static AccessTokenStore StoreWith(IDistributedCache cache) =>
+        new(NullLogger<AccessTokenStore>.Instance, Config(), cache);
+
+    [Fact]
+    public async Task StoreAsync_NeverPutsTheRawTokenInTheCacheKey()
+    {
+        var cache = new RecordingDistributedCache();
+        using var store = StoreWith(cache);
+
+        await store.StoreAsync(Token, Guid.NewGuid());
+
+        cache.Keys.Should().ContainSingle();
+        cache.Keys[0].Should().NotContain(Token, "the keyspace must not hold a replayable bearer token");
+    }
+
+    [Fact]
+    public async Task StoreAsync_KeysOnTheSha256HexOfTheToken()
+    {
+        var cache = new RecordingDistributedCache();
+        using var store = StoreWith(cache);
+
+        await store.StoreAsync(Token, Guid.NewGuid());
+
+        var expected = Convert.ToHexStringLower(SHA256.HashData(Encoding.UTF8.GetBytes(Token)));
+        cache.Keys[0].Should().Be($"haip:token:{expected}");
+    }
+
+    [Fact]
+    public async Task LookupAsync_RoundTripsTheOfferId()
+    {
+        // Hashing is only useful if the caller can still resolve their own token.
+        var cache = new RecordingDistributedCache();
+        using var store = StoreWith(cache);
+        var offerId = Guid.NewGuid();
+
+        await store.StoreAsync(Token, offerId);
+        var resolved = await store.LookupAsync(Token);
+
+        resolved.Should().Be(offerId);
+    }
+
+    [Fact]
+    public async Task LookupAsync_UnknownToken_ReturnsNull()
+    {
+        var cache = new RecordingDistributedCache();
+        using var store = StoreWith(cache);
+        await store.StoreAsync(Token, Guid.NewGuid());
+
+        var resolved = await store.LookupAsync("some-other-token");
+
+        resolved.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task LookupAsync_HashesOnTheReadPathToo()
+    {
+        // A hash applied only on write would break every lookup; a hash applied only on read would
+        // leave the write path leaking. Pin that both sides agree.
+        var cache = new RecordingDistributedCache();
+        using var store = StoreWith(cache);
+
+        await store.LookupAsync(Token);
+
+        cache.Keys.Should().ContainSingle();
+        cache.Keys[0].Should().NotContain(Token);
+    }
+
+    [Fact]
+    public async Task InMemoryFallback_StillRoundTripsWhenNoDistributedCache()
+    {
+        // cache: null is the no-Redis path — it must behave identically.
+        using var store = new AccessTokenStore(NullLogger<AccessTokenStore>.Instance, Config(), cache: null);
+        var offerId = Guid.NewGuid();
+
+        await store.StoreAsync(Token, offerId);
+
+        (await store.LookupAsync(Token)).Should().Be(offerId);
+    }
+
+    /// <summary>
+    /// Records every key the store touches. The point of the whole exercise is what lands here.
+    /// </summary>
+    private sealed class RecordingDistributedCache : IDistributedCache
+    {
+        private readonly Dictionary<string, byte[]> _entries = new(StringComparer.Ordinal);
+
+        public List<string> Keys { get; } = [];
+
+        public byte[]? Get(string key)
+        {
+            Keys.Add(key);
+            return _entries.TryGetValue(key, out var value) ? value : null;
+        }
+
+        public Task<byte[]?> GetAsync(string key, CancellationToken token = default) =>
+            Task.FromResult(Get(key));
+
+        public void Set(string key, byte[] value, DistributedCacheEntryOptions options)
+        {
+            Keys.Add(key);
+            _entries[key] = value;
+        }
+
+        public Task SetAsync(string key, byte[] value, DistributedCacheEntryOptions options, CancellationToken token = default)
+        {
+            Set(key, value, options);
+            return Task.CompletedTask;
+        }
+
+        public void Refresh(string key) => Keys.Add(key);
+
+        public Task RefreshAsync(string key, CancellationToken token = default)
+        {
+            Refresh(key);
+            return Task.CompletedTask;
+        }
+
+        public void Remove(string key)
+        {
+            Keys.Add(key);
+            _entries.Remove(key);
+        }
+
+        public Task RemoveAsync(string key, CancellationToken token = default)
+        {
+            Remove(key);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/tests/Sorcha.Tenant.Service.Tests/Endpoints/UnlockUserEndpointTests.cs
+++ b/tests/Sorcha.Tenant.Service.Tests/Endpoints/UnlockUserEndpointTests.cs
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Reflection;
+using System.Security.Claims;
+using FluentAssertions;
+using Moq;
+using Sorcha.Tenant.Service.Data;
+using Sorcha.Tenant.Service.Data.Repositories;
+using Sorcha.Tenant.Service.Endpoints;
+using Sorcha.Tenant.Service.Models;
+using Sorcha.Tenant.Service.Services;
+using Sorcha.Tenant.Service.Tests.Helpers;
+using Xunit;
+
+namespace Sorcha.Tenant.Service.Tests.Endpoints;
+
+/// <summary>
+/// The admin "unlock account" endpoint. Brute-force lockout state lives on
+/// <see cref="PlatformUser"/> (the cross-org identity anchor), not on the org-scoped
+/// <see cref="UserIdentity"/> — <c>PlatformUserService.ValidatePasswordAsync</c> enforces tiered
+/// thresholds and sets <c>FailedLoginCount</c> / <c>LockedUntil</c> / <c>LockedPermanently</c>.
+///
+/// The endpoint used to reactivate a Suspended status and nothing else, carrying a TODO saying
+/// lockout "will be handled by PlatformUser in a future task". That task landed; the TODO did not
+/// get revisited. So an admin unlocking a locked-out account cleared nothing, while the audit entry
+/// recorded <c>AccountUnlockedByAdmin</c> as a success — the log asserted an unlock that had not
+/// happened, which is worse than the endpoint plainly not existing.
+/// </summary>
+public class UnlockUserEndpointTests : IDisposable
+{
+    private readonly TenantDbContext _dbContext;
+    private readonly Guid _orgId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+
+    public UnlockUserEndpointTests()
+    {
+        _dbContext = InMemoryDbContextFactory.Create();
+    }
+
+    public void Dispose() => _dbContext.Dispose();
+
+    [Fact]
+    public async Task UnlockUser_ClearsBruteForceLockoutStateOnPlatformUser()
+    {
+        var platformUser = LockedOutPlatformUser();
+        var identity = IdentityFor(platformUser.Id);
+        var platformUserService = ServiceReturning(platformUser);
+
+        var result = await InvokeAsync(identity, platformUserService.Object);
+
+        result.Should().NotBeNull();
+        platformUser.FailedLoginCount.Should().Be(0);
+        platformUser.LockedUntil.Should().BeNull();
+        platformUser.LockedPermanently.Should().BeFalse();
+        platformUserService.Verify(
+            s => s.UpdateAsync(platformUser, It.IsAny<CancellationToken>()),
+            Times.Once,
+            "clearing the fields in memory is not an unlock unless it is persisted");
+    }
+
+    [Fact]
+    public async Task UnlockUser_ClearsPermanentLockToo()
+    {
+        var platformUser = LockedOutPlatformUser();
+        platformUser.LockedPermanently = true;
+        platformUser.LockedUntil = null;
+        var platformUserService = ServiceReturning(platformUser);
+
+        await InvokeAsync(IdentityFor(platformUser.Id), platformUserService.Object);
+
+        platformUser.LockedPermanently.Should().BeFalse(
+            "a permanent lock is precisely the state an admin unlock exists to clear");
+    }
+
+    [Fact]
+    public async Task UnlockUser_AlsoReactivatesASuspendedIdentity()
+    {
+        // The pre-existing behaviour must survive: unlock still un-suspends.
+        var platformUser = LockedOutPlatformUser();
+        var identity = IdentityFor(platformUser.Id);
+        identity.Status = IdentityStatus.Suspended;
+
+        await InvokeAsync(identity, ServiceReturning(platformUser).Object);
+
+        identity.Status.Should().Be(IdentityStatus.Active);
+    }
+
+    [Fact]
+    public async Task UnlockUser_MissingPlatformUser_StillSucceedsAndReactivates()
+    {
+        // A UserIdentity whose PlatformUser is absent is already an inconsistency; the status
+        // reactivation is still worth doing, so this tolerates rather than faults.
+        var identity = IdentityFor(Guid.NewGuid());
+        identity.Status = IdentityStatus.Suspended;
+        var platformUserService = new Mock<IPlatformUserService>();
+        platformUserService
+            .Setup(s => s.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((PlatformUser?)null);
+
+        var result = await InvokeAsync(identity, platformUserService.Object);
+
+        result.Should().NotBeNull();
+        identity.Status.Should().Be(IdentityStatus.Active);
+        platformUserService.Verify(
+            s => s.UpdateAsync(It.IsAny<PlatformUser>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task UnlockUser_WritesTheAuditEntry()
+    {
+        var platformUser = LockedOutPlatformUser();
+
+        await InvokeAsync(IdentityFor(platformUser.Id), ServiceReturning(platformUser).Object);
+
+        _dbContext.AuditLogEntries.Should().ContainSingle(e =>
+            e.EventType == AuditEventType.AccountUnlockedByAdmin && e.Success);
+    }
+
+    private static PlatformUser LockedOutPlatformUser() => new()
+    {
+        Id = Guid.NewGuid(),
+        Email = "locked@example.com",
+        DisplayName = "Locked User",
+        FailedLoginCount = 12,
+        LockedUntil = DateTimeOffset.UtcNow.AddHours(4),
+        LockedPermanently = false,
+    };
+
+    private UserIdentity IdentityFor(Guid platformUserId) => new()
+    {
+        Id = Guid.NewGuid(),
+        OrganizationId = _orgId,
+        PlatformUserId = platformUserId,
+        Email = "locked@example.com",
+        DisplayName = "Locked User",
+        Status = IdentityStatus.Active,
+        Roles = [UserRole.Consumer],
+        CreatedAt = DateTimeOffset.UtcNow,
+    };
+
+    private static Mock<IPlatformUserService> ServiceReturning(PlatformUser platformUser)
+    {
+        var mock = new Mock<IPlatformUserService>();
+        mock.Setup(s => s.GetByIdAsync(platformUser.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(platformUser);
+        mock.Setup(s => s.UpdateAsync(It.IsAny<PlatformUser>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        return mock;
+    }
+
+    private async Task<object?> InvokeAsync(UserIdentity identity, IPlatformUserService platformUserService)
+    {
+        var identityRepository = new Mock<IIdentityRepository>();
+        identityRepository
+            .Setup(r => r.GetUserByIdAsync(identity.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(identity);
+        identityRepository
+            .Setup(r => r.UpdateUserAsync(It.IsAny<UserIdentity>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((UserIdentity u, CancellationToken _) => u);
+
+        var principal = new ClaimsPrincipal(new ClaimsIdentity(
+            [new Claim("sub", Guid.NewGuid().ToString())], "test"));
+
+        var method = typeof(OrganizationEndpoints).GetMethod(
+            "UnlockUser", BindingFlags.NonPublic | BindingFlags.Static);
+        method.Should().NotBeNull("UnlockUser should be reachable for reflection-based endpoint testing");
+
+        var task = (Task)method!.Invoke(null, [
+            _orgId, identity.Id, identityRepository.Object, platformUserService,
+            _dbContext, principal, CancellationToken.None,
+        ])!;
+
+        await task;
+        return task.GetType().GetProperty("Result")?.GetValue(task);
+    }
+}

--- a/tests/Sorcha.UI.Core.Tests/Credentials/CredentialApiServiceTests.cs
+++ b/tests/Sorcha.UI.Core.Tests/Credentials/CredentialApiServiceTests.cs
@@ -337,6 +337,59 @@ public class CredentialApiServiceTests
         }
     }
 
+    /// <summary>
+    /// #1188 — an object claim on a card rendered its FIELD NAMES ("line1, town, postcode,
+    /// country"), which reads as placeholder text to the citizen. It must render the values.
+    /// Values only, no "Line1: " labels — on a compact card an address reads as an address.
+    /// </summary>
+    [Fact]
+    public async Task GetCredentialsAsync_ObjectClaim_RendersValuesNotFieldNames()
+    {
+        var json = """
+        [{
+          "id": "urn:credential:1", "type": "AssuredIdentityCredential",
+          "issuerDid": "did:sorcha:org:ws11q", "subjectDid": "did:sorcha:w:ws11q",
+          "status": "Active", "issuedAt": "2026-07-01T00:00:00Z",
+          "claimsJson": "{\"address\":{\"line1\":\"10 High St\",\"town\":\"Falkirk\",\"postcode\":\"FK1 1AA\"}}",
+          "disclosableClaims": []
+        }]
+        """;
+        var service = CreateServiceReturning(json);
+
+        var result = await service.GetCredentialsAsync("ws11q");
+
+        var address = result[0].HighlightClaims.Single(c => c.ClaimName == "address").Value;
+        address.Should().Be("10 High St, Falkirk, FK1 1AA");
+        address.Should().NotContain("line1", "field names read as placeholder text to the citizen");
+        address.Should().NotContain("postcode");
+    }
+
+    /// <summary>
+    /// The blob-proofing that predates #1188 must survive rendering values. An array-valued
+    /// property is skipped rather than named, so an unresolved SD-JWT digest array cannot reach
+    /// a card even under a key that escaped the <c>_</c>-prefix drop — the n1 defect's shape.
+    /// </summary>
+    [Fact]
+    public async Task GetCredentialsAsync_ObjectClaim_SkipsArrayValuedPropertiesEntirely()
+    {
+        var json = """
+        [{
+          "id": "urn:credential:1", "type": "AssuredIdentityCredential",
+          "issuerDid": "did:sorcha:org:ws11q", "subjectDid": "did:sorcha:w:ws11q",
+          "status": "Active", "issuedAt": "2026-07-01T00:00:00Z",
+          "claimsJson": "{\"address\":{\"town\":\"Falkirk\",\"sd\":[\"zSH_kfTeW2Mlc\"]}}",
+          "disclosableClaims": []
+        }]
+        """;
+        var service = CreateServiceReturning(json);
+
+        var result = await service.GetCredentialsAsync("ws11q");
+
+        var address = result[0].HighlightClaims.Single(c => c.ClaimName == "address").Value;
+        address.Should().Be("Falkirk");
+        address.Should().NotContain("zSH_kfTeW2Mlc");
+    }
+
     [Fact]
     public async Task GetCredentialsAsync_BuildsClaimSummaryOfNamesNotValues()
     {


### PR DESCRIPTION
A batch of backlogged small fixes. Six commits, each independently reviewable.

## 1. Version coherence — the reported symptom was a misdiagnosis

`/app` showed `v2.0.7-dev` while the image was tagged `2.838.x`. The footer was **not** hardcoded — it read the assembly attribute correctly all along.

The real bug: **docker build-args are opt-in.** CI passed `GITHUB_RUN_NUMBER`/`GITHUB_RUN_ATTEMPT` to every image, but **12 of 14 Dockerfiles never declared the matching `ARG`**, so the values were silently discarded and the assembly shipped `-dev` inside an image tagged `2.<run>.<attempt>`. Nothing failed — not the build, not the tests.

Wider than the UI: every **service's OpenAPI `info.version`** and the **MCP manifest** were also reporting `-dev` in production.

Also: `Directory.Build.props` had been **hand-bumped** `.4`→`.7` across three commits — the committed version bump this scheme exists to eliminate, and a symptom of the Docker gap rather than a fix. Reverted to `2.0.0-dev` with a note.

New `version-args-gate` CI workflow, **verified to fail when the block is removed**, not merely to pass today.

Version *display* single-sourced through `SorchaVersion.Current` — `/app` could previously show three different answers in one page load (footer, Help `2.0.0-preview`, Settings `1.0.0-preview` beside a "build number" that was `DateTime.Now`).

## 2. HAIP token hardening (3 TODOs, same request path)

- **`AccessTokenStore` keyed Redis on the raw bearer token.** The keyspace was the one place a live token came to rest in the clear — a `SCAN`, a managed-Redis console or a memory dump would yield replayable tokens. Now SHA-256 hashed. Tests assert on the **keys**, not the round-trip: the round-trip always worked, which is why this survived.
- **RFC 6749 §5.1 `Cache-Control: no-store`** on token responses. Set before any branch, so no early return can ship a cacheable token — pinned by a test on the 400 path.
- `AccessTokenStore` now disposes its `MemoryCache` (CA2213).

## 3. Admin unlock actually unlocks

The endpoint reactivated a Suspended identity and nothing else, behind a TODO saying lockout would move to `PlatformUser` "in a future task". **That task landed; the TODO didn't get revisited.** So an admin unlocking a brute-force-locked account cleared nothing — while still writing an `AccountUnlockedByAdmin` audit entry with `Success: true`. The log asserted an unlock that never happened, which is worse than the endpoint not existing.

## 4. #1192 — postcode normalisation
Raw postcode went to postcodes.io, whose `/validate` is not space-tolerant. `"EH9 1 JA"` (autofill artefact) → a genuine Edinburgh application rejected `postcode-not-found`, no credential issued.

## 5. #1188 — object claims render values, not field names
An address showed `line1, town, postcode, country`. Blob-proofing preserved and **tightened**: array-valued properties are now skipped rather than named, so a stray SD-JWT digest array can't reach a card even under a key that escapes the `_`-prefix drop.

## 6. #1183 — open-participant starting actions readable before submit
An open participant isn't in `ParticipantWallets` until they submit, so the gate refused the very person the action exists for. Latent today, a landmine for the next citizen-facing starting action in the PWA. Response ordering preserved so the gate can't become a probe for which actions exist.

## Verification
- Version derivation proven both ways: `2.838.2` with CI env, `2.0.0` without
- Every gate and security fix **negative-tested** — confirmed failing against the unfixed code, not just passing after
- Full suites green: Agent 171, Blueprint 1006, HAIP 109, Tenant 1537

## Known unrelated red
`build-and-test` may fail on `MyCredentialsTests.DeclineOnlyPendingCredential_NeverRendersBlankPage` — **pre-existing on clean master**, reproduced with this branch stashed. Filed as #1211. `claude-review` fails on an empty `ANTHROPIC_API_KEY` (infra).

Docs: CLAUDE.md "Unified versioning".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019gakk5iqR3xvq3MPupF6AE