### PR TITLE
fix: Cluster A — surfaces that returned a confident but false answer

### DIFF
--- a/src/Common/Sorcha.ServiceClients.Http/Validator/IValidatorServiceClient.cs
+++ b/src/Common/Sorcha.ServiceClients.Http/Validator/IValidatorServiceClient.cs
@@ -55,6 +55,51 @@ public interface IValidatorServiceClient
         string registerId,
         bool persistMemPool,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets the validators currently operational (online) for a register — the live heartbeat set
+    /// held in the Validator Service's registry. Calls <c>GET /api/validators/{registerId}</c>.
+    /// </summary>
+    /// <remarks>
+    /// Transport / non-success faults are <b>propagated</b>, deliberately not swallowed to an empty
+    /// list: "the Validator Service could not be reached" and "no validators are online" are
+    /// different answers, and returning the former as the latter is exactly the confident-but-false
+    /// result the operational endpoint exists to avoid. The caller decides how to surface the fault
+    /// (the Register Service maps it to 503).
+    /// </remarks>
+    /// <param name="registerId">The register whose operational validators to list.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The operational validators; an empty list only if the register genuinely has none online.</returns>
+    Task<IReadOnlyList<OperationalValidatorSummary>> GetOperationalValidatorsAsync(
+        string registerId,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// A validator currently reporting operational on a register, as surfaced by the Validator Service's
+/// <c>GET /api/validators/{registerId}</c>. Only fields that endpoint actually returns are modelled —
+/// there is deliberately no last-heartbeat timestamp or leader flag here, because the source
+/// projection does not expose them and inventing them would be another false answer.
+/// </summary>
+public record OperationalValidatorSummary
+{
+    /// <summary>Validator's unique identifier (wallet address).</summary>
+    public required string ValidatorId { get; init; }
+
+    /// <summary>Validator's public key.</summary>
+    public string? PublicKey { get; init; }
+
+    /// <summary>gRPC endpoint for peer communication.</summary>
+    public string? GrpcEndpoint { get; init; }
+
+    /// <summary>Current status (lower-cased, as returned by the Validator Service).</summary>
+    public string? Status { get; init; }
+
+    /// <summary>When the validator registered.</summary>
+    public DateTimeOffset? RegisteredAt { get; init; }
+
+    /// <summary>Order index used for rotating leader election, when present.</summary>
+    public int? OrderIndex { get; init; }
 }
 
 /// <summary>

--- a/src/Common/Sorcha.ServiceClients.Http/Validator/ValidatorServiceClient.cs
+++ b/src/Common/Sorcha.ServiceClients.Http/Validator/ValidatorServiceClient.cs
@@ -256,6 +256,47 @@ public class ValidatorServiceClient : IValidatorServiceClient
         return false;
     }
 
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<OperationalValidatorSummary>> GetOperationalValidatorsAsync(
+        string registerId,
+        CancellationToken cancellationToken = default)
+    {
+        await SetAuthHeaderAsync(cancellationToken);
+
+        var response = await _httpClient.GetAsync(
+            $"/api/validators/{Uri.EscapeDataString(registerId)}",
+            cancellationToken);
+
+        // Do NOT swallow a failure to an empty list — see IValidatorServiceClient remarks. An
+        // unreachable Validator Service must surface as a fault so the caller can say "unknown",
+        // not silently report "no validators online".
+        response.EnsureSuccessStatusCode();
+
+        var payload = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions, cancellationToken);
+
+        var result = new List<OperationalValidatorSummary>();
+        if (payload.TryGetProperty("validators", out var validators)
+            && validators.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var v in validators.EnumerateArray())
+            {
+                result.Add(new OperationalValidatorSummary
+                {
+                    ValidatorId = v.TryGetProperty("validatorId", out var id) ? id.GetString() ?? string.Empty : string.Empty,
+                    PublicKey = v.TryGetProperty("publicKey", out var pk) ? pk.GetString() : null,
+                    GrpcEndpoint = v.TryGetProperty("grpcEndpoint", out var ep) ? ep.GetString() : null,
+                    Status = v.TryGetProperty("status", out var st) ? st.GetString() : null,
+                    RegisteredAt = v.TryGetProperty("registeredAt", out var ra) && ra.ValueKind != JsonValueKind.Null
+                        ? ra.GetDateTimeOffset() : null,
+                    OrderIndex = v.TryGetProperty("orderIndex", out var oi) && oi.ValueKind == JsonValueKind.Number
+                        ? oi.GetInt32() : null,
+                });
+            }
+        }
+
+        return result;
+    }
+
     private Task SetAuthHeaderAsync(CancellationToken cancellationToken) =>
         ServiceClientAuthHelper.SetAuthHeaderAsync(
             _httpClient, _serviceAuth, _logger, "Validator Service", cancellationToken);

--- a/src/Common/Sorcha.TransactionHandler/Core/Transaction.cs
+++ b/src/Common/Sorcha.TransactionHandler/Core/Transaction.cs
@@ -130,16 +130,24 @@ public class Transaction : ITransaction
 
     /// <inheritdoc/>
     /// <remarks>
-    /// Review M1 (DEFERRED — see the security-hardening backlog): this verify is a placeholder —
-    /// it computes the signing hash but never compares it against the signature (public-key
-    /// extraction is a "return success as placeholder" TODO), so it returns
-    /// <see cref="TransactionStatus.Success"/> for any signed transaction with valid payloads.
-    /// It is NOT on any live path (the V1 <c>TransactionFactory</c> is not DI-registered; the real
-    /// validator verifies via <c>ICryptoModule.VerifyAsync</c>) and has no non-test callers, so the
-    /// risk is purely latent. Making it fail loud is the right fix, but V1 is the module's only
-    /// implemented transaction version and an entire signing/verification test suite asserts this
-    /// behaviour — resolving it needs a decision (implement real V1 verification vs excise the V1
-    /// verify path + its no-op tests), which is out of scope for the mechanical Bucket-B pass.
+    /// <para>
+    /// This V1 in-model verify does NOT cryptographically verify the signature. The whole V1
+    /// sign/verify path is placeholder scaffolding: <see cref="SignAsync"/> never derives a
+    /// public key, hardcodes <c>SenderWallet = "ws1temp"</c>, and does not decode the WIF — so
+    /// there is no public key stored on or recoverable from the transaction to verify against.
+    /// Real verification is therefore impossible here without building the entire key-derivation
+    /// chain; the live validator path verifies via <c>ICryptoModule.VerifyAsync</c> with a
+    /// resolved key, and this type has no non-test callers (the V1 <c>TransactionFactory</c> is
+    /// not DI-registered).
+    /// </para>
+    /// <para>
+    /// It previously returned <see cref="TransactionStatus.Success"/> for any signed transaction
+    /// with valid payloads — affirming a signature it never checked. It now fails closed with
+    /// <see cref="TransactionStatus.VerificationNotImplemented"/> so nothing can build on a false
+    /// "verified". The payload check still runs first: an invalid payload is a real, detectable
+    /// failure worth surfacing, and a genuinely unsigned transaction still returns
+    /// <see cref="TransactionStatus.NotSigned"/>.
+    /// </para>
     /// </remarks>
     public async Task<TransactionStatus> VerifyAsync(
         CancellationToken cancellationToken = default)
@@ -149,20 +157,14 @@ public class Transaction : ITransaction
 
         try
         {
-            // Compute signing hash
-            var signingData = SerializeForSigning();
-            var hash1 = _hashProvider.ComputeHash(signingData, HashType.SHA256);
-            var hash2 = _hashProvider.ComputeHash(hash1, HashType.SHA256);
-
-            // TODO: Extract public key from wallet address
-            // For now, return success as placeholder
-
-            // Verify payloads
+            // Payloads are still genuinely checkable, so a bad payload is reported honestly.
             var payloadsValid = await PayloadManager.VerifyAllAsync();
             if (!payloadsValid)
                 return TransactionStatus.InvalidPayload;
 
-            return TransactionStatus.Success;
+            // Fail closed: the signature itself cannot be verified for V1 (no recoverable public
+            // key — see the remarks). Never return Success for an unchecked signature.
+            return TransactionStatus.VerificationNotImplemented;
         }
         catch
         {

--- a/src/Common/Sorcha.TransactionHandler/Enums/TransactionStatus.cs
+++ b/src/Common/Sorcha.TransactionHandler/Enums/TransactionStatus.cs
@@ -50,5 +50,14 @@ public enum TransactionStatus
     /// <summary>
     /// Access denied to payload
     /// </summary>
-    AccessDenied = 8
+    AccessDenied = 8,
+
+    /// <summary>
+    /// The transaction is signed, but this transaction version cannot cryptographically
+    /// verify the signature — verification is not implemented for it. This is a fail-closed
+    /// result, never <see cref="Success"/>: a caller must treat it as "not verified", not
+    /// "verified". The live validator path verifies via <c>ICryptoModule.VerifyAsync</c>;
+    /// the V1 in-model verify is placeholder scaffolding with no production caller.
+    /// </summary>
+    VerificationNotImplemented = 9
 }

--- a/src/Services/Sorcha.Register.Service/Endpoints/RegisterPolicyEndpoints.cs
+++ b/src/Services/Sorcha.Register.Service/Endpoints/RegisterPolicyEndpoints.cs
@@ -4,6 +4,7 @@
 using System.ComponentModel.DataAnnotations;
 using Sorcha.Register.Core.Services;
 using Sorcha.Register.Models;
+using Sorcha.ServiceClients.Validator;
 
 namespace Sorcha.Register.Service.Endpoints;
 
@@ -216,27 +217,60 @@ public static class RegisterPolicyEndpoints
         .Produces<ApprovedValidatorsResponse>(StatusCodes.Status200OK)
         .Produces(StatusCodes.Status401Unauthorized);
 
-        validatorGroup.MapGet("/operational", (
+        validatorGroup.MapGet("/operational", async (
+            IValidatorServiceClient validatorClient,
+            ILogger<Program> logger,
             string registerId,
             CancellationToken cancellationToken) =>
         {
-            // TODO: Operational validator state lives in Redis within the Validator Service.
-            // This endpoint needs cross-service resolution — either a service client call
-            // to the Validator Service or a shared Redis read. Returning empty for now.
-            return Results.Ok(new OperationalValidatorsResponse
+            // Operational (online) validator state lives in the Validator Service's registry, keyed
+            // by heartbeat TTL. Proxy to it rather than guess. Critically, a failure to reach it is
+            // surfaced as 503 (Unavailable) — NOT an empty list — because "we cannot tell who is
+            // online" and "no one is online" are different answers, and returning the former as the
+            // latter is the confident-but-false result this endpoint used to give unconditionally.
+            try
             {
-                RegisterId = registerId,
-                Validators = [],
-                Count = 0
-            });
+                var operational = await validatorClient.GetOperationalValidatorsAsync(registerId, cancellationToken);
+
+                var validators = operational
+                    .Select(v => new OperationalValidatorInfo
+                    {
+                        ValidatorId = v.ValidatorId,
+                        PublicKey = v.PublicKey,
+                        GrpcEndpoint = v.GrpcEndpoint,
+                        Status = v.Status,
+                        RegisteredAt = v.RegisteredAt,
+                        OrderIndex = v.OrderIndex,
+                    })
+                    .ToList();
+
+                return Results.Ok(new OperationalValidatorsResponse
+                {
+                    RegisterId = registerId,
+                    Validators = validators,
+                    Count = validators.Count
+                });
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex,
+                    "Could not resolve operational validators for register {RegisterId} from the Validator Service",
+                    registerId);
+                return Results.Problem(
+                    title: "Operational validator state is unavailable",
+                    detail: "The Validator Service could not be reached to determine which validators are online. "
+                        + "This is not the same as there being none online.",
+                    statusCode: StatusCodes.Status503ServiceUnavailable);
+            }
         })
         .WithName("GetOperationalValidators")
         .WithSummary("Get validators currently online for a register")
-        .WithDescription("Returns validators currently reporting operational heartbeats via the ValidatorRegistry. " +
-            "NOTE: This endpoint is a placeholder — operational state is managed by the Validator Service " +
-            "and requires cross-service integration to resolve.")
+        .WithDescription("Returns validators currently reporting operational heartbeats, resolved live from the "
+            + "Validator Service's registry. Returns 503 if the Validator Service cannot be reached — an empty "
+            + "list means there are genuinely none online, never that the state is unknown.")
         .Produces<OperationalValidatorsResponse>(StatusCodes.Status200OK)
-        .Produces(StatusCodes.Status401Unauthorized);
+        .Produces(StatusCodes.Status401Unauthorized)
+        .Produces(StatusCodes.Status503ServiceUnavailable);
     }
 }
 
@@ -396,22 +430,45 @@ public class PolicyVersionEntry
 }
 
 /// <summary>
-/// Information about a validator that is currently operational
+/// Information about a validator that is currently operational.
 /// </summary>
+/// <remarks>
+/// Modelled on what the Validator Service's live registry actually exposes. It deliberately does
+/// NOT carry a last-heartbeat timestamp or an <c>IsLeader</c> flag: the registry's projection
+/// surfaces neither (heartbeats drive the TTL that keeps an entry in the operational set, but the
+/// timestamp is not returned, and leadership is rotating rather than a static per-validator fact).
+/// Presence in this list already means "reporting operational heartbeats"; inventing a heartbeat
+/// time or a leader flag would just be another confident-but-false field.
+/// </remarks>
 public class OperationalValidatorInfo
 {
     /// <summary>
-    /// Decentralized identifier (DID) of the validator
+    /// Validator's unique identifier (wallet address).
     /// </summary>
-    public string Did { get; set; } = string.Empty;
+    public string ValidatorId { get; set; } = string.Empty;
 
     /// <summary>
-    /// UTC timestamp of the last heartbeat received from this validator
+    /// Validator's public key.
     /// </summary>
-    public DateTimeOffset LastHeartbeat { get; set; }
+    public string? PublicKey { get; set; }
 
     /// <summary>
-    /// Whether this validator is the current leader
+    /// gRPC endpoint for peer communication.
     /// </summary>
-    public bool IsLeader { get; set; }
+    public string? GrpcEndpoint { get; set; }
+
+    /// <summary>
+    /// Current status as reported by the Validator Service.
+    /// </summary>
+    public string? Status { get; set; }
+
+    /// <summary>
+    /// When the validator registered.
+    /// </summary>
+    public DateTimeOffset? RegisteredAt { get; set; }
+
+    /// <summary>
+    /// Order index used for rotating leader election, when present.
+    /// </summary>
+    public int? OrderIndex { get; set; }
 }

--- a/src/Services/Sorcha.Validator.Service/Services/ControlBlueprintVersionResolver.cs
+++ b/src/Services/Sorcha.Validator.Service/Services/ControlBlueprintVersionResolver.cs
@@ -334,34 +334,38 @@ public class ControlBlueprintVersionResolver : IControlBlueprintVersionResolver
         ControlBlueprintVersionInfo versionInfo,
         CancellationToken ct)
     {
-        // Get the configuration that was active at this version
-        // For now, we use the current genesis config and apply changes up to this version
-        // A more complete implementation would reconstruct the config at each version
-
+        // The only configuration this resolver can retrieve is the CURRENT one
+        // (GetFullConfigAsync). That is the genuine configuration of the ACTIVE version — but for a
+        // superseded historical version it is the wrong answer, and this method used to return it
+        // anyway, stamped with the historical version's number. A point-in-time query for "the
+        // control config as of version N" (or as-of a past timestamp) therefore silently received
+        // today's config wearing an old version's label.
+        //
+        // Reconstructing a historical config means replaying the control transactions onto the
+        // genesis configuration (the deltas are retained on-chain; see FindControlTransactionsAsync
+        // / DetermineChangeType), which is not implemented and no per-version snapshot is stored to
+        // shortcut it. Until that exists, this fails closed for superseded versions rather than
+        // returning a confident-but-wrong configuration: a caller that audits or validates against
+        // "the config as of that version" must not be handed the current one and told it is historic.
         var config = await _genesisConfigService.GetFullConfigAsync(registerId, ct);
 
-        // If this is the genesis version, use the config as-is
-        if (versionInfo.VersionNumber == 1)
+        if (!versionInfo.IsActive)
         {
-            return new ResolvedControlBlueprintVersion
-            {
-                RegisterId = registerId,
-                VersionNumber = 1,
-                TransactionId = versionInfo.TransactionId,
-                ActiveFrom = versionInfo.ActiveFrom,
-                Configuration = config,
-                IsActive = versionInfo.IsActive,
-                PreviousVersionTransactionId = null,
-                ChangeDescription = versionInfo.ChangeDescription
-            };
+            throw new NotSupportedException(
+                $"Cannot resolve the control-blueprint configuration as of version {versionInfo.VersionNumber} "
+                + $"on register '{registerId}': historical configuration reconstruction is not implemented, and "
+                + "only the active version's configuration is retrievable. Returning the current configuration "
+                + "labelled as this historical version would be incorrect. Version metadata (number, transaction, "
+                + "activation time) is available via GetVersionHistoryAsync without reconstructing the config.");
         }
 
-        // For later versions, we would need to reconstruct the config state
-        // For now, we return the current config with version metadata
-        // TODO: Implement proper config reconstruction by replaying control transactions
-
-        var history = await GetVersionHistoryAsync(registerId, ct);
-        var previousVersion = history.FirstOrDefault(v => v.VersionNumber == versionInfo.VersionNumber - 1);
+        // The active version's configuration genuinely IS the current configuration. For a
+        // genesis-only register this is version 1; after updates it is the latest version. Either
+        // way the label matches the payload, so this branch is honest.
+        var previousVersionTransactionId = versionInfo.VersionNumber == 1
+            ? null
+            : (await GetVersionHistoryAsync(registerId, ct))
+                .FirstOrDefault(v => v.VersionNumber == versionInfo.VersionNumber - 1)?.TransactionId;
 
         return new ResolvedControlBlueprintVersion
         {
@@ -369,9 +373,9 @@ public class ControlBlueprintVersionResolver : IControlBlueprintVersionResolver
             VersionNumber = versionInfo.VersionNumber,
             TransactionId = versionInfo.TransactionId,
             ActiveFrom = versionInfo.ActiveFrom,
-            Configuration = config, // Current config - TODO: reconstruct historical state
+            Configuration = config,
             IsActive = versionInfo.IsActive,
-            PreviousVersionTransactionId = previousVersion?.TransactionId,
+            PreviousVersionTransactionId = previousVersionTransactionId,
             ChangeDescription = versionInfo.ChangeDescription
         };
     }

--- a/tests/Sorcha.ServiceClients.Tests/Validator/ValidatorServiceClientTests.cs
+++ b/tests/Sorcha.ServiceClients.Tests/Validator/ValidatorServiceClientTests.cs
@@ -184,6 +184,58 @@ public class ValidatorServiceClientTests
         result.ErrorMessage.Should().Contain("InternalServerError");
     }
 
+    [Fact]
+    public async Task GetOperationalValidatorsAsync_MapsTheValidatorArray()
+    {
+        var responseJson = """
+        {
+          "registerId": "reg-1",
+          "count": 2,
+          "validators": [
+            { "validatorId": "ws1qval1", "publicKey": "pk1", "grpcEndpoint": "http://v1:5001", "status": "active", "registeredAt": "2026-07-01T00:00:00+00:00", "orderIndex": 0 },
+            { "validatorId": "ws1qval2", "publicKey": "pk2", "grpcEndpoint": "http://v2:5001", "status": "active", "registeredAt": "2026-07-02T00:00:00+00:00", "orderIndex": 1 }
+          ]
+        }
+        """;
+        var client = CreateClient(new HttpClient(new FakeHttpHandler(HttpStatusCode.OK, responseJson)));
+
+        var result = await client.GetOperationalValidatorsAsync("reg-1");
+
+        result.Should().HaveCount(2);
+        result[0].ValidatorId.Should().Be("ws1qval1");
+        result[0].Status.Should().Be("active");
+        result[0].OrderIndex.Should().Be(0);
+        result[1].ValidatorId.Should().Be("ws1qval2");
+    }
+
+    [Fact]
+    public async Task GetOperationalValidatorsAsync_GenuinelyNoneOnline_ReturnsEmpty()
+    {
+        var client = CreateClient(new HttpClient(new FakeHttpHandler(
+            HttpStatusCode.OK, """{ "registerId": "reg-1", "count": 0, "validators": [] }""")));
+
+        var result = await client.GetOperationalValidatorsAsync("reg-1");
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetOperationalValidatorsAsync_ServiceUnreachable_Throws_NotEmptyList()
+    {
+        // The whole point: a transport fault must NOT masquerade as "no validators online".
+        var client = CreateClient(new HttpClient(new FakeHttpHandler(new HttpRequestException("connection refused"))));
+
+        await Assert.ThrowsAsync<HttpRequestException>(() => client.GetOperationalValidatorsAsync("reg-1"));
+    }
+
+    [Fact]
+    public async Task GetOperationalValidatorsAsync_NonSuccessStatus_Throws_NotEmptyList()
+    {
+        var client = CreateClient(new HttpClient(new FakeHttpHandler(HttpStatusCode.InternalServerError, "{}")));
+
+        await Assert.ThrowsAsync<HttpRequestException>(() => client.GetOperationalValidatorsAsync("reg-1"));
+    }
+
     /// <summary>
     /// Fake HTTP message handler for testing
     /// </summary>

--- a/tests/Sorcha.TransactionHandler.Tests/Integration/EndToEndTransactionTests.cs
+++ b/tests/Sorcha.TransactionHandler.Tests/Integration/EndToEndTransactionTests.cs
@@ -58,9 +58,10 @@ public class EndToEndTransactionTests
         Assert.NotNull(transaction.SenderWallet);
         Assert.Equal(TransactionVersion.V1, transaction.Version);
 
-        // Verify the transaction signature
+        // V1 in-model verify fails closed — it cannot check the signature (no recoverable public
+        // key; see Transaction.VerifyAsync). The signing assertions above are the real subject here.
         var verifyStatus = await transaction.VerifyAsync();
-        Assert.Equal(TransactionStatus.Success, verifyStatus);
+        Assert.Equal(TransactionStatus.VerificationNotImplemented, verifyStatus);
     }
 
     [Fact]

--- a/tests/Sorcha.TransactionHandler.Tests/Integration/SigningVerificationTests.cs
+++ b/tests/Sorcha.TransactionHandler.Tests/Integration/SigningVerificationTests.cs
@@ -27,7 +27,7 @@ public class SigningVerificationTests
     }
 
     [Fact]
-    public async Task SignAndVerify_CompleteWorkflow_ShouldSucceed()
+    public async Task SignAndVerify_CompleteWorkflow_SigningSucceeds_VerifyFailsClosed()
     {
         // Arrange
         var builder = new TransactionBuilder(_cryptoModule, _hashProvider, _symmetricCrypto);
@@ -47,7 +47,7 @@ public class SigningVerificationTests
         var verifyStatus = await transaction.VerifyAsync();
 
         // Assert
-        Assert.Equal(TransactionStatus.Success, verifyStatus);
+        Assert.Equal(TransactionStatus.VerificationNotImplemented, verifyStatus);
         Assert.NotNull(transaction.Signature);
         Assert.NotNull(transaction.TxId);
     }
@@ -97,8 +97,9 @@ public class SigningVerificationTests
         Assert.True(ed25519Transaction.IsSuccess);
         Assert.NotNull(ed25519Transaction.Value!.Signature);
 
+        // Signing is the subject; V1 verify fails closed (see Transaction.VerifyAsync).
         var ed25519VerifyStatus = await ed25519Transaction.Value!.VerifyAsync();
-        Assert.Equal(TransactionStatus.Success, ed25519VerifyStatus);
+        Assert.Equal(TransactionStatus.VerificationNotImplemented, ed25519VerifyStatus);
     }
 
     [Fact]
@@ -118,7 +119,7 @@ public class SigningVerificationTests
     }
 
     [Fact]
-    public async Task SignedTransaction_IsImmutable_ShouldVerify()
+    public async Task SignedTransaction_IsImmutable_VerifyFailsClosed()
     {
         // Arrange
         var builder = new TransactionBuilder(_cryptoModule, _hashProvider, _symmetricCrypto);
@@ -137,14 +138,14 @@ public class SigningVerificationTests
         var verifyStatus = await transaction.VerifyAsync();
 
         // Assert - Transaction should be properly signed and immutable
-        Assert.Equal(TransactionStatus.Success, verifyStatus);
+        Assert.Equal(TransactionStatus.VerificationNotImplemented, verifyStatus);
         Assert.NotNull(transaction.Signature);
         Assert.NotNull(transaction.TxId);
         Assert.NotNull(transaction.Metadata);
     }
 
     [Fact]
-    public async Task MultipleTransactions_DifferentSigners_ShouldAllVerify()
+    public async Task MultipleTransactions_DifferentSigners_ProduceUniqueSignatures()
     {
         // Arrange - Create three different wallets and transactions
         var wallet1 = await TestHelpers.GenerateTestWalletAsync(WalletNetworks.ED25519);
@@ -175,9 +176,9 @@ public class SigningVerificationTests
             .Build().Value!;
 
         // Assert - All should verify
-        Assert.Equal(TransactionStatus.Success, await tx1.VerifyAsync());
-        Assert.Equal(TransactionStatus.Success, await tx2.VerifyAsync());
-        Assert.Equal(TransactionStatus.Success, await tx3.VerifyAsync());
+        Assert.Equal(TransactionStatus.VerificationNotImplemented, await tx1.VerifyAsync());
+        Assert.Equal(TransactionStatus.VerificationNotImplemented, await tx2.VerifyAsync());
+        Assert.Equal(TransactionStatus.VerificationNotImplemented, await tx3.VerifyAsync());
 
         // All should have unique signatures
         Assert.NotEqual(Convert.ToBase64String(tx1.Signature!), Convert.ToBase64String(tx2.Signature!));
@@ -218,7 +219,7 @@ public class SigningVerificationTests
     }
 
     [Fact]
-    public async Task TransactionWithPayloads_SignatureCoversAllData_ShouldVerify()
+    public async Task TransactionWithPayloads_SignatureCoversAllData_VerifyFailsClosed()
     {
         // Arrange
         var builder = new TransactionBuilder(_cryptoModule, _hashProvider, _symmetricCrypto);
@@ -243,7 +244,7 @@ public class SigningVerificationTests
         var verifyStatus = await transaction.VerifyAsync();
 
         // Assert
-        Assert.Equal(TransactionStatus.Success, verifyStatus);
+        Assert.Equal(TransactionStatus.VerificationNotImplemented, verifyStatus);
     }
 
     [Fact]
@@ -300,11 +301,11 @@ public class SigningVerificationTests
         Assert.True(transaction.Signature.Length > 0);
 
         var verifyStatus = await transaction.VerifyAsync();
-        Assert.Equal(TransactionStatus.Success, verifyStatus);
+        Assert.Equal(TransactionStatus.VerificationNotImplemented, verifyStatus);
     }
 
     [Fact]
-    public async Task TransactionChain_AllSignaturesVerify_ShouldSucceed()
+    public async Task TransactionChain_ProducesLinkedSignatures()
     {
         // Arrange - Create a chain of transactions
         var wallet = await TestHelpers.GenerateTestWalletAsync(WalletNetworks.ED25519);
@@ -336,9 +337,9 @@ public class SigningVerificationTests
             .Build().Value!;
 
         // Act & Assert - All signatures should verify
-        Assert.Equal(TransactionStatus.Success, await tx1.VerifyAsync());
-        Assert.Equal(TransactionStatus.Success, await tx2.VerifyAsync());
-        Assert.Equal(TransactionStatus.Success, await tx3.VerifyAsync());
+        Assert.Equal(TransactionStatus.VerificationNotImplemented, await tx1.VerifyAsync());
+        Assert.Equal(TransactionStatus.VerificationNotImplemented, await tx2.VerifyAsync());
+        Assert.Equal(TransactionStatus.VerificationNotImplemented, await tx3.VerifyAsync());
 
         // Verify chain integrity
         Assert.Equal(tx1.TxId, tx2.PreviousTxHash);

--- a/tests/Sorcha.TransactionHandler.Tests/Unit/TransactionTests.cs
+++ b/tests/Sorcha.TransactionHandler.Tests/Unit/TransactionTests.cs
@@ -119,23 +119,27 @@ public class TransactionTests
     }
 
     [Fact]
-    public async Task VerifyAsync_ShouldSucceedForValidSignature()
+    public async Task VerifyAsync_SignedTransaction_FailsClosedAsNotImplemented()
     {
-        // Arrange
+        // V1 in-model verify does not cryptographically check the signature — there is no
+        // recoverable public key on the transaction (see Transaction.VerifyAsync remarks). It must
+        // fail closed rather than return Success for a signature it never checked. This used to
+        // assert Success, which was the no-op affirming itself.
         var payloadManager = new PayloadManager(_symmetricCrypto, _cryptoModule, _hashProvider);
         var transaction = new Transaction(_cryptoModule, _hashProvider, payloadManager);
         var wallet = await TestHelpers.GenerateTestWalletAsync(WalletNetworks.ED25519);
 
         transaction.Recipients = new[] { wallet.Address };
 
-        // Sign the transaction
+        // Sign the transaction (the signing scaffolding does produce a signature).
         await transaction.SignAsync(wallet.PrivateKeyWif);
 
         // Act
         var status = await transaction.VerifyAsync();
 
         // Assert
-        Assert.Equal(TransactionStatus.Success, status);
+        Assert.Equal(TransactionStatus.VerificationNotImplemented, status);
+        Assert.NotEqual(TransactionStatus.Success, status);
     }
 
     [Fact]

--- a/tests/Sorcha.Validator.Service.Tests/Services/ControlBlueprintVersionResolverTests.cs
+++ b/tests/Sorcha.Validator.Service.Tests/Services/ControlBlueprintVersionResolverTests.cs
@@ -319,6 +319,81 @@ public class ControlBlueprintVersionResolverTests
 
     #endregion
 
+    #region Historical config fail-loud (#4)
+
+    // BuildResolvedVersionAsync is private, and control-transaction detection is currently a no-op
+    // (TransactionMetaData.ActionId is a uint, so its ToString never matches the "control.*" action
+    // ids — filed separately), so no multi-version history can be built through the public API. These
+    // tests reach the method directly to pin the fail-loud contract regardless of that.
+
+    private System.Threading.Tasks.Task<ResolvedControlBlueprintVersion?> InvokeBuildResolvedVersion(
+        string registerId, ControlBlueprintVersionInfo versionInfo)
+    {
+        var method = typeof(ControlBlueprintVersionResolver).GetMethod(
+            "BuildResolvedVersionAsync",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        method.Should().NotBeNull();
+        return (System.Threading.Tasks.Task<ResolvedControlBlueprintVersion?>)method!.Invoke(
+            _resolver, [registerId, versionInfo, CancellationToken.None])!;
+    }
+
+    [Fact]
+    public async Task BuildResolvedVersion_SupersededHistoricalVersion_FailsClosed_NotAlie()
+    {
+        // The whole point of #4: only the CURRENT config is retrievable, so a superseded historical
+        // version cannot be resolved without reconstruction. It used to return today's config stamped
+        // with the old version's number — a confident false answer. It must now fail loud instead.
+        var registerId = "test-register";
+        _genesisConfigServiceMock.Setup(g => g.GetFullConfigAsync(registerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateTestGenesisConfig(registerId));
+
+        var supersededV2 = new ControlBlueprintVersionInfo
+        {
+            RegisterId = registerId,
+            VersionNumber = 2,
+            TransactionId = "tx-2",
+            ActiveFrom = DateTimeOffset.UtcNow.AddHours(-2),
+            ChangeType = "ConfigUpdate",
+            IsActive = false,   // superseded — this is the case that used to lie
+        };
+
+        var act = () => InvokeBuildResolvedVersion(registerId, supersededV2);
+
+        (await act.Should().ThrowAsync<NotSupportedException>())
+            .WithMessage("*version 2*")
+            .WithMessage("*not implemented*");
+    }
+
+    [Fact]
+    public async Task BuildResolvedVersion_ActiveVersion_ReturnsCurrentConfig_Truthfully()
+    {
+        // The active version's config genuinely IS the current config, so this stays honest and must
+        // NOT throw — this is what GetActiveVersionAsync relies on.
+        var registerId = "test-register";
+        var config = CreateTestGenesisConfig(registerId);
+        _genesisConfigServiceMock.Setup(g => g.GetFullConfigAsync(registerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(config);
+
+        var activeV2 = new ControlBlueprintVersionInfo
+        {
+            RegisterId = registerId,
+            VersionNumber = 2,
+            TransactionId = "tx-2",
+            ActiveFrom = DateTimeOffset.UtcNow.AddHours(-1),
+            ChangeType = "ConfigUpdate",
+            IsActive = true,
+        };
+
+        var result = await InvokeBuildResolvedVersion(registerId, activeV2);
+
+        result.Should().NotBeNull();
+        result!.VersionNumber.Should().Be(2);
+        result.Configuration.Should().Be(config);
+        result.IsActive.Should().BeTrue();
+    }
+
+    #endregion
+
     #region InvalidateCache Tests
 
     [Fact]


### PR DESCRIPTION
Four surfaces that returned a plausible-but-false answer, where a caller could not tell the answer apart from the truth. Per the agreed approach: **fail loud, then implement the cheap ones.** Three commits; two more items filed rather than fixed (real work, and one is already a documented placeholder).

## 1. `/validators/operational` — IMPLEMENTED
Returned a hardcoded empty list with `Count = 0`, so the endpoint reported "no validators online" even when validators were healthy.

Operational state already lives in the Validator Service's heartbeat registry and is exposed at `GET /api/validators/{registerId}` (`RequireAuthenticated`, which a service token satisfies); the Register Service already had `IValidatorServiceClient` in DI. Added a client method + proxied it.

**The honesty-critical decision:** a failure to reach the Validator Service returns **503, not an empty list**. "We cannot tell who is online" and "no one is online" are different answers, and collapsing the first into the second *is* the bug. The DTO (no consumers) was reshaped to the fields the registry truthfully exposes — the old `LastHeartbeat`/`IsLeader` were dropped rather than filled with proxies, which would just be a new false answer.

## 2. V1 `Transaction.VerifyAsync` — FAILS CLOSED
Computed the signing hash then never compared it — returned `Success` for **any** signed transaction. Real verification is impossible as written (the sign path is scaffolding: no public key is derived or stored, `SenderWallet = "ws1temp"`, WIF never decoded). No production caller (V1 `TransactionFactory` isn't DI-registered). Now returns a truthfully-named `VerificationNotImplemented` — total, benchmark-safe, every test stays a live assertion.

## 3. `ControlBlueprintVersionResolver` historical config — FAILS CLOSED
Could only fetch the *current* config, then returned it stamped with a *historical* version's label — a silent wrong-config for point-in-time queries. The honest discriminator is `IsActive`: the active version's config genuinely is the current one (kept working), only *superseded* versions were the lie (now throw). No production point-in-time consumer today, so this is defensive.

**Found alongside:** control-transaction detection is broken (`uint` ActionId compared against `"control.*"` strings), so version history is silently stuck at v1 and the historical path is unreachable. Filed as #1215.

## Filed, not fixed
- **#1216** — `urgentCount` hardcoded 0. The urgency engine exists but isn't wired; needs a new urgency-aware query, and it's already a *documented* placeholder (not a silent lie).
- **#1217** — `RegisterSchemaProvider` empty catalog. Unregistered and unconsumed, so nothing lies today; blocked on a Register endpoint that doesn't exist.

## Verification
Every fail-loud path **negative-tested** (confirmed the old behaviour would fail the new tests). Suites green: ServiceClients 318, TransactionHandler 250, Validator 1000, Register builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019gakk5iqR3xvq3MPupF6AE