### PR TITLE
fix: Cluster B — security trio (#1213 wallet authz, #1214 SMS, #1212 OIDC)

### DIFF
--- a/src/Services/Sorcha.Blueprint.Service/Program.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Program.cs
@@ -1252,10 +1252,27 @@ var actionsGroup = app.MapGroup("/api/actions")
 // Get available blueprints for a wallet/register combination
 // </summary>
 actionsGroup.MapGet("/{wallet}/{register}/blueprints", async (
-    string wallet, // TODO: Filter by wallet access permissions
+    string wallet,
     string register,
-    IPublishedBlueprintStore publishedStore) =>
+    HttpContext httpContext,
+    IPublishedBlueprintStore publishedStore,
+    Sorcha.ServiceClients.Wallet.IWalletServiceClient walletClient,
+    CancellationToken ct) =>
 {
+    // Authorize: the caller must own the {wallet} they are querying as. CanExecuteBlueprints is only
+    // "any authenticated user", so without this any authenticated caller could pass any wallet in the
+    // path. Resolve the caller's wallets the same way the rest of the service does — the wallet_address
+    // claim, else a Wallet-Service owner lookup, since consumer-tier tokens omit the claim (Feature 136);
+    // a gate reading the claim alone would 403 every real citizen. Fail closed on an empty resolved set.
+    var callerWallets = await Sorcha.Blueprint.Service.Services.Infrastructure.ParticipantWalletResolver
+        .ResolveUserWalletAddressesAsync(httpContext, walletClient, logger, ct);
+    if (!callerWallets.Any(w => string.Equals(w, wallet, StringComparison.OrdinalIgnoreCase)))
+    {
+        return Results.Problem(
+            "You do not own the wallet in this request.",
+            statusCode: StatusCodes.Status403Forbidden);
+    }
+
     // Get only blueprints published to this specific register
     var publishedForRegister = await publishedStore.GetByRegisterAsync(register);
     var availableBlueprints = publishedForRegister.Select(pub =>
@@ -1294,8 +1311,12 @@ actionsGroup.MapGet("/{wallet}/{register}/blueprints", async (
 })
 .WithName("GetAvailableBlueprints")
 .WithSummary("Get available blueprints")
-.WithDescription("Retrieve blueprints and actions available to a specific wallet/register combination")
-.CacheOutput(policy => policy.Expire(TimeSpan.FromMinutes(5)).Tag("blueprints"));
+.WithDescription("Retrieve blueprints and actions available to a specific wallet/register combination. "
+    + "The caller must own the wallet in the path (403 otherwise).")
+.Produces(StatusCodes.Status403Forbidden);
+// No .CacheOutput here: the endpoint is now caller-specific, and the previous route-only cache policy
+// (keyed on {wallet}/{register} with no VaryBy on caller identity) could serve one caller's authorized
+// result to another. It was also inert under an auth-required group, so nothing is lost by dropping it.
 
 // Get a single published blueprint (with full action schemas) for a wallet /
 // register / blueprintId. Returns the latest version published to this
@@ -1304,11 +1325,24 @@ actionsGroup.MapGet("/{wallet}/{register}/blueprints", async (
 // the 404 bug where non-authoring nodes could not start submissions.
 // (.WithSummary / .WithDescription on the endpoint provide the OpenAPI doc.)
 actionsGroup.MapGet("/{wallet}/{register}/blueprints/{blueprintId}", async (
-    string wallet, // TODO: Filter by wallet access permissions
+    string wallet,
     string register,
     string blueprintId,
-    IPublishedBlueprintStore publishedStore) =>
+    HttpContext httpContext,
+    IPublishedBlueprintStore publishedStore,
+    Sorcha.ServiceClients.Wallet.IWalletServiceClient walletClient,
+    CancellationToken ct) =>
 {
+    // Same ownership gate as the list endpoint above — the caller must own {wallet}.
+    var callerWallets = await Sorcha.Blueprint.Service.Services.Infrastructure.ParticipantWalletResolver
+        .ResolveUserWalletAddressesAsync(httpContext, walletClient, logger, ct);
+    if (!callerWallets.Any(w => string.Equals(w, wallet, StringComparison.OrdinalIgnoreCase)))
+    {
+        return Results.Problem(
+            "You do not own the wallet in this request.",
+            statusCode: StatusCodes.Status403Forbidden);
+    }
+
     var publishedForRegister = await publishedStore.GetByRegisterAsync(register);
     var match = publishedForRegister
         .Where(pub => string.Equals(pub.BlueprintId, blueprintId, StringComparison.OrdinalIgnoreCase))
@@ -1324,8 +1358,9 @@ actionsGroup.MapGet("/{wallet}/{register}/blueprints/{blueprintId}", async (
 })
 .WithName("GetPublishedBlueprintDetail")
 .WithSummary("Get published blueprint detail")
-.WithDescription("Retrieve a single published blueprint including full action schemas. Sourced from the published blueprint store — works on any node, not just the authoring node.")
-.CacheOutput(policy => policy.Expire(TimeSpan.FromMinutes(5)).Tag("blueprints"));
+.WithDescription("Retrieve a single published blueprint including full action schemas. Sourced from the published blueprint store — works on any node, not just the authoring node. The caller must own the wallet in the path (403 otherwise).")
+.Produces(StatusCodes.Status403Forbidden);
+// No .CacheOutput — see the note on the sibling list endpoint above.
 
 // <summary>
 // Get actions for a wallet/register (paginated)

--- a/src/Services/Sorcha.Tenant.Service/Endpoints/OidcEndpoints.cs
+++ b/src/Services/Sorcha.Tenant.Service/Endpoints/OidcEndpoints.cs
@@ -216,9 +216,23 @@ public static class OidcEndpoints
             }
         }
 
-        // Provision or match the user using the extracted claims
-        var (user, isFirstLogin) = await provisioningService.ProvisionOrMatchUserAsync(
-            org.Id, exchangeResult.Claims!, cancellationToken);
+        // Provision or match the user using the extracted claims. Refused (403) when the IdP did not
+        // verify the email — email is the only identity key on this path, so an unverified one is unsafe.
+        UserIdentity user;
+        bool isFirstLogin;
+        try
+        {
+            (user, isFirstLogin) = await provisioningService.ProvisionOrMatchUserAsync(
+                org.Id, exchangeResult.Claims!, cancellationToken);
+        }
+        catch (OidcEmailNotVerifiedException ex)
+        {
+            return TypedResults.Json(new OidcCallbackResult
+            {
+                Success = false,
+                Error = ex.Message
+            }, statusCode: StatusCodes.Status403Forbidden);
+        }
 
         // Check if 2FA is required
         var totpStatus = await totpService.GetStatusAsync(user.Id, cancellationToken);

--- a/src/Services/Sorcha.Tenant.Service/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Services/Sorcha.Tenant.Service/Extensions/ServiceCollectionExtensions.cs
@@ -353,6 +353,8 @@ public static class ServiceCollectionExtensions
         // service. Unconfigured ⇒ the SMS channel never resolves and SmsAvailable stays false.
         if (!string.IsNullOrEmpty(configuration["Sms:AcsConnectionString"]))
         {
+            // Bind SmsSettings so AcsSmsSender can read AllowNoOpSender / FromNumber via IOptions.
+            services.Configure<Services.Sms.SmsSettings>(configuration.GetSection("Sms"));
             services.AddSingleton<Services.Sms.ISmsSender, Services.Sms.AcsSmsSender>();
             services.AddScoped<IVerificationChannel, SmsOtpChannel>();
             services.AddScoped<ISmsPhoneVerificationService, SmsPhoneVerificationService>();

--- a/src/Services/Sorcha.Tenant.Service/Pages/Auth/OidcCallback.cshtml.cs
+++ b/src/Services/Sorcha.Tenant.Service/Pages/Auth/OidcCallback.cshtml.cs
@@ -173,9 +173,21 @@ public class OidcCallbackModel : PageModel
                 }
             }
 
-            // Provision or match the user account
-            var (user, isFirstLogin) = await _oidcProvisioningService.ProvisionOrMatchUserAsync(
-                exchangeResult.OrgId, exchangeResult.Claims!, ct);
+            // Provision or match the user account. Refused when the IdP did not verify the email —
+            // email is the only identity key on this path, so an unverified one is unsafe (#1212).
+            UserIdentity user;
+            bool isFirstLogin;
+            try
+            {
+                (user, isFirstLogin) = await _oidcProvisioningService.ProvisionOrMatchUserAsync(
+                    exchangeResult.OrgId, exchangeResult.Claims!, ct);
+            }
+            catch (OidcEmailNotVerifiedException ex)
+            {
+                _logger.LogWarning("OIDC callback refused: {Reason}", ex.Message);
+                ErrorMessage = ex.Message;
+                return Page();
+            }
 
             // Check if profile completion is required (missing email or display name)
             var needsProfile = await _oidcProvisioningService.DetermineProfileCompletionAsync(user);

--- a/src/Services/Sorcha.Tenant.Service/Services/OidcProvisioningService.cs
+++ b/src/Services/Sorcha.Tenant.Service/Services/OidcProvisioningService.cs
@@ -9,6 +9,23 @@ using Sorcha.Tenant.Service.Models.Dtos;
 namespace Sorcha.Tenant.Service.Services;
 
 /// <summary>
+/// Thrown when an OIDC login is refused because the IdP did not assert <c>email_verified</c>. The OIDC
+/// provisioning path matches and creates users by email, so an unverified email cannot be trusted as an
+/// identity key (see <see cref="OidcProvisioningService.ProvisionOrMatchUserAsync"/> / #1212). Callers
+/// render this as a clean auth failure, not a 500.
+/// </summary>
+public sealed class OidcEmailNotVerifiedException : Exception
+{
+    /// <summary>The user-facing refusal message.</summary>
+    public const string UserFacingMessage =
+        "Your identity provider has not verified your email address, so sign-in cannot continue. "
+        + "Verify your email with your provider and try again.";
+
+    /// <summary>Creates the exception with the standard user-facing message.</summary>
+    public OidcEmailNotVerifiedException() : base(UserFacingMessage) { }
+}
+
+/// <summary>
 /// Provisions new users or matches returning users after OIDC authentication.
 /// Matches by ExternalIdpSubject (NOT email) to handle email changes at the IDP.
 /// New users are auto-provisioned with Member role and ProvisionedVia=Oidc.
@@ -33,6 +50,22 @@ public class OidcProvisioningService : IOidcProvisioningService
     public async Task<(UserIdentity User, bool IsFirstLogin)> ProvisionOrMatchUserAsync(
         Guid orgId, OidcUserClaims claims, CancellationToken cancellationToken)
     {
+        // Security gate (#1212): this method matches and provisions users purely by EMAIL — the IdP
+        // subject is not persisted (UserIdentity.ExternalIdpSubject was removed; subject-based matching
+        // is a follow-on that routes through PlatformSocialLogin). Email is not a safe key when the IdP
+        // does not assert it verified: controlling an unverified mailbox value would otherwise be enough
+        // to be matched onto an existing account (takeover), or to seed an account a later verified login
+        // collides with. So refuse unless email_verified is true — the same rule the social-login path
+        // (ResolveOrCreateSocialUserAsync) already enforces. This gates BOTH the match and the create
+        // below, and lives in the service so no caller can forget it.
+        if (!claims.EmailVerified)
+        {
+            _logger.LogWarning(
+                "OIDC login refused for org {OrgId}: the IdP did not assert email_verified for subject {Subject}",
+                orgId, claims.Subject);
+            throw new OidcEmailNotVerifiedException();
+        }
+
         // TODO: ExternalIdpSubject removed from UserIdentity — matching by external subject
         // will be handled by PlatformSocialLogin in a future task. For now, match by email as fallback.
         var existingUser = await _dbContext.UserIdentities

--- a/src/Services/Sorcha.Tenant.Service/Services/Sms/ISmsSender.cs
+++ b/src/Services/Sorcha.Tenant.Service/Services/Sms/ISmsSender.cs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Sorcha Contributors
 
+using Microsoft.Extensions.Options;
+
 namespace Sorcha.Tenant.Service.Services.Sms;
 
 /// <summary>
@@ -23,27 +25,61 @@ public class SmsSettings
 
     /// <summary>The sender phone number / short code (E.164) the provider sends from.</summary>
     public string? FromNumber { get; set; }
+
+    /// <summary>
+    /// Development escape hatch: when <c>true</c>, <see cref="AcsSmsSender"/> logs the dispatch and
+    /// returns without sending, so the SMS flows are exercisable locally without a live provider.
+    /// Default <c>false</c> — a configured-but-unimplemented provider then fails loud rather than
+    /// silently dropping one-time codes. MUST NOT be set in Production.
+    /// </summary>
+    public bool AllowNoOpSender { get; set; }
 }
 
 /// <summary>
 /// Config-gated SMS sender. The concrete provider HTTP call (Azure Communication Services SMS, Twilio,
-/// etc.) is operator-specific and intentionally left as a clearly-marked integration point — this
-/// implementation logs the dispatch so the flow is exercisable in non-production environments without a
-/// live provider. Registered only when <see cref="SmsSettings.AcsConnectionString"/> is present.
+/// etc.) is operator-specific and <b>not yet implemented</b>. Registered only when
+/// <see cref="SmsSettings.AcsConnectionString"/> is present — which is exactly the setting an operator
+/// sets when they intend to turn SMS ON.
 /// </summary>
+/// <remarks>
+/// This previously logged "SMS dispatched" and returned without sending — so setting the connection
+/// string switched the SMS 2FA / phone-verification surfaces ON while every code silently vanished,
+/// and the log claimed success. A user who made SMS their only second factor was then locked out with
+/// nothing in the logs to explain it. Configured no longer means implemented: absent the explicit
+/// <see cref="SmsSettings.AllowNoOpSender"/> dev flag, a send now throws so the misconfiguration
+/// surfaces immediately instead of as undeliverable codes. See issue #1214 for the real-provider work.
+/// </remarks>
 public sealed class AcsSmsSender : ISmsSender
 {
     private readonly ILogger<AcsSmsSender> _logger;
+    private readonly SmsSettings _settings;
 
     /// <summary>Creates a new <see cref="AcsSmsSender"/>.</summary>
-    public AcsSmsSender(ILogger<AcsSmsSender> logger) => _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    public AcsSmsSender(ILogger<AcsSmsSender> logger, IOptions<SmsSettings> settings)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _settings = settings?.Value ?? throw new ArgumentNullException(nameof(settings));
+    }
 
     /// <inheritdoc />
     public Task SendAsync(string toE164, string message, CancellationToken cancellationToken = default)
     {
-        // TODO(operator): wire the configured provider's SMS REST/SDK call here. The message contains a
-        // one-time code, so do NOT log the body in Production — log metadata only.
-        _logger.LogInformation("SMS dispatched to {ToMasked} ({Length} chars)", Mask(toE164), message.Length);
+        if (!_settings.AllowNoOpSender)
+        {
+            // Fail loud: do NOT report success for a message that was never sent. The caller
+            // (2FA send / phone capture) surfaces this as a failure the user actually sees.
+            throw new NotSupportedException(
+                "SMS sending is not implemented: AcsSmsSender has no provider call wired in, but "
+                + "Sms:AcsConnectionString is set so the SMS surfaces are enabled. Implement the provider "
+                + "call (issue #1214), or set Sms:AllowNoOpSender=true to use a logging no-op in "
+                + "development. Refusing to silently drop a one-time code.");
+        }
+
+        // Dev no-op path (AllowNoOpSender=true). The message contains a one-time code, so log
+        // metadata only, and make it unmistakable that nothing was actually delivered.
+        _logger.LogWarning(
+            "SMS NOT SENT (Sms:AllowNoOpSender dev no-op) to {ToMasked} ({Length} chars) — no provider is wired",
+            Mask(toE164), message.Length);
         return Task.CompletedTask;
     }
 

--- a/tests/Sorcha.Blueprint.Service.Tests/Endpoints/CatalogueWalletOwnershipTests.cs
+++ b/tests/Sorcha.Blueprint.Service.Tests/Endpoints/CatalogueWalletOwnershipTests.cs
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Net;
+using FluentAssertions;
+using Sorcha.Blueprint.Service.Tests.Integration;
+using Xunit;
+
+namespace Sorcha.Blueprint.Service.Tests.Endpoints;
+
+/// <summary>
+/// #1213 — the blueprint catalogue endpoints (<c>GET /api/actions/{wallet}/{register}/blueprints</c>
+/// and its <c>/{blueprintId}</c> sibling) took the wallet from the route and never checked the caller
+/// owned it. The group's only gate is <c>CanExecuteBlueprints</c> = "any authenticated user", so any
+/// authenticated caller could query as any wallet. The caller must now own the wallet in the path.
+///
+/// The ownership gate runs before the store lookup, so these tests need no published blueprint: an
+/// owned wallet passes the gate (200, possibly empty), an unowned wallet is refused (403) before any
+/// data is touched — which also means a non-owner cannot use the 200-vs-404 distinction to probe.
+/// </summary>
+public class CatalogueWalletOwnershipTests : IClassFixture<BlueprintServiceWebApplicationFactory>
+{
+    private readonly HttpClient _client;
+
+    public CatalogueWalletOwnershipTests(BlueprintServiceWebApplicationFactory factory)
+    {
+        _client = factory.CreateClient();
+    }
+
+    private const string Owned = BlueprintServiceWebApplicationFactory.TestOwnedWalletAddress;
+    private const string NotOwned = "ws1qsomeoneelse0000000000000000000000000000";
+
+    [Fact]
+    public async Task ListBlueprints_WalletNotOwnedByCaller_Returns403()
+    {
+        var response = await _client.GetAsync($"/api/actions/{NotOwned}/registers-x/blueprints");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task ListBlueprints_WalletOwnedByCaller_IsNotForbidden()
+    {
+        var response = await _client.GetAsync($"/api/actions/{Owned}/registers-x/blueprints");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task BlueprintDetail_WalletNotOwnedByCaller_Returns403()
+    {
+        var response = await _client.GetAsync($"/api/actions/{NotOwned}/registers-x/blueprints/some-bp");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task BlueprintDetail_WalletOwnedByCaller_PassesGate_ThenNotFound()
+    {
+        // Owned → past the gate; the unknown blueprint then legitimately 404s. The point is that a
+        // 404 (not a 403) proves the gate let an owner through — and that a non-owner never reaches it.
+        var response = await _client.GetAsync($"/api/actions/{Owned}/registers-x/blueprints/unknown-bp");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+}

--- a/tests/Sorcha.Blueprint.Service.Tests/Integration/ActionApiIntegrationTests.cs
+++ b/tests/Sorcha.Blueprint.Service.Tests/Integration/ActionApiIntegrationTests.cs
@@ -31,8 +31,9 @@ public class ActionApiIntegrationTests : IClassFixture<BlueprintServiceWebApplic
     [Fact]
     public async Task GetAvailableBlueprints_WithPublishedBlueprints_ReturnsBlueprints()
     {
-        // Arrange
-        var wallet = "test-wallet-001";
+        // Arrange — the caller must own the wallet in the path (#1213). The test principal owns
+        // TestOwnedWalletAddress via the factory's owner-keyed wallet mock.
+        var wallet = BlueprintServiceWebApplicationFactory.TestOwnedWalletAddress;
         var register = "test-register-001";
 
         // Create and publish a blueprint via the API
@@ -63,8 +64,8 @@ public class ActionApiIntegrationTests : IClassFixture<BlueprintServiceWebApplic
     [Fact]
     public async Task GetAvailableBlueprints_WithDifferentWalletRegister_ReturnsValidResponse()
     {
-        // Arrange - different wallet/register than other tests
-        var wallet = "test-wallet-002";
+        // Arrange - different register; caller must still own the wallet in the path (#1213).
+        var wallet = BlueprintServiceWebApplicationFactory.TestOwnedWalletAddress;
         var register = "test-register-002";
 
         // Act

--- a/tests/Sorcha.Blueprint.Service.Tests/Integration/BlueprintServiceWebApplicationFactory.cs
+++ b/tests/Sorcha.Blueprint.Service.Tests/Integration/BlueprintServiceWebApplicationFactory.cs
@@ -35,6 +35,12 @@ public class BlueprintServiceWebApplicationFactory : WebApplicationFactory<Progr
     public Mock<HttpMessageHandler> MockWalletHttpHandler { get; } = new();
     public Mock<HttpMessageHandler> MockRegisterHttpHandler { get; } = new();
 
+    /// <summary>The owner id (NameIdentifier) the <see cref="TestAuthenticationHandler"/> principal carries.</summary>
+    public const string TestPrincipalOwnerId = "00000000-0000-0000-0000-000000000123";
+
+    /// <summary>The single wallet the test principal owns, per the owner-keyed lookup mock.</summary>
+    public const string TestOwnedWalletAddress = "ws1qtestowned00000000000000000000000000000";
+
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
         // Add test configuration for Redis connection string
@@ -155,6 +161,25 @@ public class BlueprintServiceWebApplicationFactory : WebApplicationFactory<Progr
                 CreatedAt = DateTime.UtcNow.AddDays(-1),
                 UpdatedAt = DateTime.UtcNow
             });
+
+        // Owner-keyed wallet lookup — used by ParticipantWalletResolver's fallback (the test principal
+        // carries no wallet_address claim). The TestAuthenticationHandler's NameIdentifier is the owner
+        // key, so a wallet resolves for that owner and for no one else. Lets the #1213 catalogue
+        // ownership gate be exercised: the caller "owns" TestOwnedWalletAddress and nothing else.
+        mockWalletClient
+            .Setup(x => x.GetWalletsByOwnerAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string owner, CancellationToken _) =>
+                owner == TestPrincipalOwnerId
+                    ? new List<WalletInfo>
+                    {
+                        new WalletInfo
+                        {
+                            Address = TestOwnedWalletAddress,
+                            Name = "Owned Wallet", PublicKey = "pk", Algorithm = "ED25519",
+                            Status = "Active", Owner = owner, Tenant = "test-tenant",
+                        }
+                    }
+                    : new List<WalletInfo>());
 
         // Mock VerifySignatureAsync - required for action submission signature verification
         mockWalletClient

--- a/tests/Sorcha.Tenant.Service.Tests/Services/AcsSmsSenderTests.cs
+++ b/tests/Sorcha.Tenant.Service.Tests/Services/AcsSmsSenderTests.cs
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Sorcha.Tenant.Service.Services.Sms;
+using Xunit;
+
+namespace Sorcha.Tenant.Service.Tests.Services;
+
+/// <summary>
+/// #1214 — AcsSmsSender has no real provider call. It used to log "SMS dispatched" and return, so a
+/// configured deploy switched SMS 2FA / phone-verification ON while every one-time code silently
+/// vanished and the log claimed success. It must fail loud unless an operator explicitly opts into the
+/// dev no-op.
+/// </summary>
+public class AcsSmsSenderTests
+{
+    private static AcsSmsSender Create(bool allowNoOp) =>
+        new(NullLogger<AcsSmsSender>.Instance,
+            Options.Create(new SmsSettings { AcsConnectionString = "endpoint=...", AllowNoOpSender = allowNoOp }));
+
+    [Fact]
+    public async Task SendAsync_NoDevFlag_Throws_RatherThanSilentlyDropTheCode()
+    {
+        var sender = Create(allowNoOp: false);
+
+        var act = () => sender.SendAsync("+447700900123", "Your code is 123456");
+
+        (await act.Should().ThrowAsync<NotSupportedException>())
+            .WithMessage("*not implemented*")
+            .WithMessage("*AllowNoOpSender*");
+    }
+
+    [Fact]
+    public async Task SendAsync_DevFlagSet_ReturnsWithoutThrowing()
+    {
+        var sender = Create(allowNoOp: true);
+
+        // No throw — the dev no-op path. (It logs a NOT-SENT warning; behaviour under test is that it
+        // does not pretend to have sent, i.e. it does not throw and does not report success as delivery.)
+        await sender.SendAsync("+447700900123", "Your code is 123456");
+    }
+}

--- a/tests/Sorcha.Tenant.Service.Tests/Services/OidcProvisioningServiceTests.cs
+++ b/tests/Sorcha.Tenant.Service.Tests/Services/OidcProvisioningServiceTests.cs
@@ -68,6 +68,52 @@ public class OidcProvisioningServiceTests : IDisposable
         user.Status.Should().Be(IdentityStatus.Active);
     }
 
+    /// <summary>
+    /// #1212 — the OIDC path matches and provisions purely by email (the IdP subject is not persisted),
+    /// so an unverified email cannot be trusted as an identity key. A login whose IdP did not assert
+    /// email_verified must be refused, not silently matched or provisioned.
+    /// </summary>
+    [Fact]
+    public async Task ProvisionOrMatchUserAsync_UnverifiedEmail_IsRefused()
+    {
+        var service = CreateService();
+        var claims = CreateClaims(sub: "oidc|unverified", email: "attacker@example.com", name: "Mallory",
+            emailVerified: false);
+
+        var act = () => service.ProvisionOrMatchUserAsync(_testOrgId, claims, CancellationToken.None);
+
+        await act.Should().ThrowAsync<OidcEmailNotVerifiedException>();
+    }
+
+    [Fact]
+    public async Task ProvisionOrMatchUserAsync_UnverifiedEmail_DoesNotMatchAnExistingUser()
+    {
+        // The takeover vector: an existing account must NOT be handed to a login carrying that email
+        // unverified. Refuse before matching, and leave the existing user's LastLoginAt untouched.
+        var service = CreateService();
+        var existing = new UserIdentity
+        {
+            OrganizationId = _testOrgId,
+            PlatformUserId = Guid.NewGuid(),
+            Email = "victim@example.com",
+            DisplayName = "Victim",
+            Roles = [UserRole.Consumer],
+            ProvisionedVia = ProvisioningMethod.Oidc,
+            LastLoginAt = DateTimeOffset.UtcNow.AddDays(-30),
+        };
+        _dbContext.UserIdentities.Add(existing);
+        await _dbContext.SaveChangesAsync();
+        var originalLogin = existing.LastLoginAt;
+
+        var claims = CreateClaims(sub: "oidc|attacker", email: "victim@example.com", name: "Not The Victim",
+            emailVerified: false);
+
+        var act = () => service.ProvisionOrMatchUserAsync(_testOrgId, claims, CancellationToken.None);
+
+        await act.Should().ThrowAsync<OidcEmailNotVerifiedException>();
+        existing.LastLoginAt.Should().Be(originalLogin, "an unverified login must not touch the existing account");
+    }
+
     [Fact]
     public async Task ProvisionOrMatchUserAsync_ReturningUser_ReturnsExistingAndUpdatesLastLoginAt()
     {
@@ -265,7 +311,7 @@ public class OidcProvisioningServiceTests : IDisposable
         string? upn = null,
         string? givenName = null,
         string? familyName = null,
-        bool emailVerified = false)
+        bool emailVerified = true)   // #1212: provisioning now requires a verified email; default the happy path to true
     {
         return new OidcUserClaims
         {


### PR DESCRIPTION
Three security fixes surfaced by the TODO sweep. Each ships the minimal correct fix; two carry a larger follow-on filed rather than half-done. One PR per cluster.

## 1. #1213 — blueprint catalogue endpoints didn't check wallet ownership
`GET /api/actions/{wallet}/{register}/blueprints` and its `/{blueprintId}` sibling took the wallet from the route, echoed it, and never checked the caller owned it. The group's only gate is `CanExecuteBlueprints` = "any authenticated user", so any authenticated caller could query as any wallet.

Both handlers now resolve the caller's wallets via `ParticipantWalletResolver` (claim, else Wallet-Service owner lookup — consumer-tier tokens omit the claim under Feature 136) and 403 unless the route wallet is theirs. Dropped the `.CacheOutput` (route-keyed, no VaryBy on caller — would serve one caller's authorized result to another once the endpoint is caller-specific; also inert under an auth-required group).

**Found while fixing:** two pre-existing integration tests queried with arbitrary wallets and correctly began to 403 — updated to the owned wallet. Four new tests pin owned→through / unowned→403 on both endpoints, and the gate runs before the store lookup so a non-owner can't use 404-vs-403 to probe.

*Residual (noted, not silently left):* results are still register-wide — the wallet param doesn't yet *filter* the set. That result-scoping has no wallet-access model to build on; separate follow-up.

## 2. #1214 — SMS sender silently dropped one-time codes
`AcsSmsSender` had no provider call — it logged "SMS dispatched" and returned. But it's registered exactly when an operator sets `Sms:AcsConnectionString`, i.e. when they mean to turn SMS on. So configuring ACS switched SMS 2FA / phone-verification on while every code vanished and the log claimed success — a user with SMS as their only second factor was locked out with nothing in the logs.

`SendAsync` now throws unless an explicit `Sms:AllowNoOpSender` dev flag is set, so a misconfigured deploy fails loud at first send instead of dropping codes. With the flag, it logs an unmistakable "SMS NOT SENT (dev no-op)". Real provider call remains the #1214 follow-up.

## 3. #1212 — OIDC matched on unverified email
`OidcProvisioningService` matched and provisioned users purely by email (the IdP subject isn't persisted) and never checked `email_verified`. Controlling an unverified mailbox value was enough to be matched onto an existing account (takeover) or seed a colliding one.

Now refuses (`OidcEmailNotVerifiedException`) unless `email_verified` — gating both match and create, same rule the social-login path already enforces. The guard is in the service (unbypassable); both callers render a clean auth failure, not a 500. Tests cover unverified→refused and specifically that an unverified login doesn't touch an existing account.

*This is "email fallback only if verified".* True **subject**-first matching needs the `PlatformSocialLogin` migration (changes the return type, ripples into both callers) — filed as **#1219**.

## Verification
Full suites green: Blueprint 1010, Tenant 1541 — new tests included. Each guard's tests assert the throw/403 that only the new code produces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019gakk5iqR3xvq3MPupF6AE