### PR TITLE
fix: Cluster C — org-key revoke stops advertising a phantom DID-revocation capability

### DIFF
--- a/src/Services/Sorcha.Wallet.Service/Endpoints/OrgKeyEndpoints.cs
+++ b/src/Services/Sorcha.Wallet.Service/Endpoints/OrgKeyEndpoints.cs
@@ -71,8 +71,10 @@ public static class OrgKeyEndpoints
             .WithName("RevokeOrgKey")
             .WithSummary("Revoke a derived organisation key")
             .WithDescription(
-                "Permanently revokes a derived key and locks the associated wallet. " +
-                "If the key was used for Identity purposes, a DID revocation event is triggered.")
+                "Permanently revokes a derived key (marks it Revoked) and locks the associated wallet. "
+                + "This changes org-key state only; it does NOT update any published DID document. A "
+                + "VCIssuance key stays resolvable in the org's did.json until it is revoked via "
+                + "POST /api/v1/orgs/{orgId}/issuance-key/revoke, which republishes the document.")
             .RequireAuthorization("RequireAdministrator", "RequirePlatformAudience")
             .Produces(StatusCodes.Status200OK)
             .Produces(StatusCodes.Status400BadRequest)
@@ -220,13 +222,18 @@ public static class OrgKeyEndpoints
         try
         {
             await orgKeyService.RevokeKeyAsync(orgId, derivedKeyId, ct);
+            // Report only what actually happened. The previous response carried
+            // didRevocationPublished:false — a field describing a capability this path does not have
+            // (it never publishes a DID document), which read as "we tried and it didn't publish"
+            // rather than "this endpoint does not touch DID documents at all". Dropped rather than
+            // hard-coded, so the response stops advertising a phantom capability. DID-document
+            // revocation for VCIssuance keys is a separate pipeline — see the endpoint description.
             return Results.Ok(new
             {
                 derivedKeyId,
                 status = "Revoked",
                 revokedAt = DateTime.UtcNow,
-                walletLocked = true,
-                didRevocationPublished = false // TODO: Will be true when DID revocation service is available
+                walletLocked = true
             });
         }
         catch (KeyNotFoundException)

--- a/src/Services/Sorcha.Wallet.Service/Services/Implementation/OrgKeyDerivationService.cs
+++ b/src/Services/Sorcha.Wallet.Service/Services/Implementation/OrgKeyDerivationService.cs
@@ -479,14 +479,32 @@ public class OrgKeyDerivationService : IOrgKeyDerivationService
             wallet.Status = WalletStatus.Locked;
         }
 
-        // If this is an Identity key, log that a DID revocation event should be published
-        if (record.KeyUsage == KeyUsage.Identity)
+        // A note on the DID side, per KeyUsage — because "revoke" here only changes the F083
+        // DerivedKeyRecord/wallet state, never a published DID document:
+        //
+        //  * Identity keys are NOT published into any did:sorcha:org document and nothing in the
+        //    codebase resolves or verifies against a KeyUsage.Identity key — so there is no DID
+        //    revocation to publish and the DB revocation above is the whole of it. (The earlier
+        //    "DID revocation service not yet implemented" TODO implied a missing publish step for a
+        //    key that is never published in the first place.)
+        //
+        //  * VCIssuance keys ARE resolvable — but through a DIFFERENT subsystem (Feature 120/149:
+        //    IssuanceKeyService + the Tenant OrgDidDocumentService). That org DID document is built
+        //    from IssuanceKeyState (Active slots only), NOT from DerivedKeyRecord.Status. Revoking a
+        //    VCIssuance key via THIS path marks the DerivedKeyRecord Revoked but leaves IssuanceKeyState
+        //    Active, so the key stays in the published did.json and is still honoured by verifiers.
+        //    That is a real "revoked-but-resolvable" inconsistency; the correct surface for a VCIssuance
+        //    key is POST /api/v1/orgs/{orgId}/issuance-key/revoke, which republishes the DID document.
+        //    Whether this endpoint should refuse VCIssuance keys or delegate to that pipeline is a
+        //    design decision tracked separately — until then, warn loudly rather than fail silently.
+        if (record.KeyUsage == KeyUsage.VCIssuance)
         {
-            // TODO: Publish DID revocation event when DID revocation service is available
             _logger.LogWarning(
-                "Identity key {DerivedKeyRecordId} revoked for wallet {WalletAddress}. " +
-                "DID revocation event should be published (DID revocation service not yet implemented).",
-                derivedKeyRecordId, record.WalletAddress);
+                "VCIssuance key {DerivedKeyRecordId} for wallet {WalletAddress} was revoked via the F083 org-key "
+                + "endpoint. This does NOT update the published org DID document — the key remains resolvable and "
+                + "honoured by verifiers until it is revoked via the issuance-key endpoint "
+                + "(POST /api/v1/orgs/{OrganizationId}/issuance-key/revoke). Revoke it there to drop it from did.json.",
+                derivedKeyRecordId, record.WalletAddress, record.OrganizationId);
         }
 
         await _db.SaveChangesAsync(ct);

--- a/tests/Sorcha.Wallet.Service.Tests/Services/OrgKeyDerivationServiceTests.cs
+++ b/tests/Sorcha.Wallet.Service.Tests/Services/OrgKeyDerivationServiceTests.cs
@@ -195,15 +195,19 @@ public class OrgKeyDerivationServiceTests : IDisposable
     }
 
     [Fact]
-    public async Task RevokeKeyAsync_IdentityKey_LogsDIDRevocation()
+    public async Task RevokeKeyAsync_IdentityKey_RevokesCleanly_WithoutClaimingADidRevocation()
     {
-        // Arrange
+        // Identity keys are never published into a DID document and nothing resolves them, so the DB
+        // revocation is the whole of it — there is no DID revocation to publish. This used to log
+        // "DID revocation event should be published (… not yet implemented)", implying a missing
+        // publish step for a key that is never published; that misleading warning is gone.
         var (_, derivedKey) = await SeedActiveKey(KeyUsage.Identity);
 
-        // Act
         await _sut.RevokeKeyAsync(OrgId, derivedKey.Id);
 
-        // Assert - verify logger was called with DID revocation message
+        var record = await _dbContext.DerivedKeyRecords.FindAsync(derivedKey.Id);
+        record!.Status.Should().Be(DerivedKeyStatus.Revoked);
+
         _loggerMock.Verify(
             x => x.Log(
                 LogLevel.Warning,
@@ -211,7 +215,36 @@ public class OrgKeyDerivationServiceTests : IDisposable
                 It.Is<It.IsAnyType>((o, t) => o.ToString()!.Contains("DID revocation event should be published")),
                 It.IsAny<Exception?>(),
                 It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
-            Times.Once);
+            Times.Never,
+            "Identity keys are not published to a DID document, so no phantom DID-revocation warning should be logged");
+    }
+
+    /// <summary>
+    /// The real "revoked-but-resolvable" inconsistency: the org DID document is built from
+    /// IssuanceKeyState (Active slots), not DerivedKeyRecord.Status. Revoking a VCIssuance key via this
+    /// F083 path leaves the key in the published did.json, still honoured by verifiers. Behaviour is
+    /// unchanged (the DB revoke still happens), but it must warn loudly rather than fail silently.
+    /// The unify-or-refuse decision is tracked separately.
+    /// </summary>
+    [Fact]
+    public async Task RevokeKeyAsync_VCIssuanceKey_WarnsThatTheDidDocumentIsNotUpdated()
+    {
+        var (_, derivedKey) = await SeedActiveKey(KeyUsage.VCIssuance);
+
+        await _sut.RevokeKeyAsync(OrgId, derivedKey.Id);
+
+        var record = await _dbContext.DerivedKeyRecords.FindAsync(derivedKey.Id);
+        record!.Status.Should().Be(DerivedKeyStatus.Revoked, "the DB revoke still happens");
+
+        _loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((o, t) => o.ToString()!.Contains("does NOT update the published org DID document")),
+                It.IsAny<Exception?>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once,
+            "revoking a resolvable VCIssuance key via this path must warn that it stays in did.json");
     }
 
     #endregion


### PR DESCRIPTION
The TODO said "wire up DID revocation publishing" for org-key revoke. Investigating against the code (not the TODO text) found that premise is a **phantom**, and the real defect is dishonesty — same theme as Cluster A.

## What the investigation found
- The `KeyUsage.Identity` branch carrying the TODO is **inert but harmless**: Identity keys are never published into any `did:sorcha:org` document and nothing in the codebase resolves or verifies against one (`KeyUsage.Identity` appears exactly once in `src/` — the warning itself). There is no DID revocation to publish.
- The only *resolvable* org keys — **VCIssuance** — already have complete, working revocation via a **different** subsystem (F120/149 `IssuanceKeyService` + Tenant `OrgDidDocumentService`), whose endpoint is `POST .../issuance-key/revoke`.

So "a revoked key stays resolvable" was a phantom for Identity keys and already-solved for VCIssuance keys. **No security hole.** The actual defect: the DELETE endpoint returned `didRevocationPublished: false` inside a `200 OK` "Revoked" body while its description claimed "a DID revocation event is triggered."

## This PR (honesty, no behaviour change)
- Drops the phantom `didRevocationPublished` field — reports only what happened.
- Corrects the endpoint description.
- Replaces the misleading Identity-branch "DID revocation not yet implemented" warning with an accurate account.

## Plus: surfaces a genuine latent inconsistency, loudly
The org DID document is built from `IssuanceKeyState` (Active slots), **not** `DerivedKeyRecord.Status`. So revoking a **VCIssuance** key via *this* F083 path leaves it in the published `did.json`, still honoured by verifiers — "revoked but resolvable." Behaviour is unchanged (the DB revoke still happens), but it now **warns loudly** and points at the issuance-key endpoint. Whether F083 should refuse VCIssuance keys or delegate to `IssuanceKeyService.RevokeAsync` is a design decision touching two subsystems and possibly live callers — filed as **#1221** rather than taken here.

## Verification
Wallet suite green: 959 pass. The existing VCIssuance-revoke success test still passes (behaviour unchanged); the Identity-log test is rewritten to assert the honest behaviour; a new test pins the VCIssuance staleness warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019gakk5iqR3xvq3MPupF6AE