### PR TITLE
docs: fix stale/misleading service-library READMEs

### DIFF
--- a/src/Common/Sorcha.ServiceClients/README.md
+++ b/src/Common/Sorcha.ServiceClients/README.md
@@ -1,122 +1,86 @@
 # Sorcha.ServiceClients
 
-**Consolidated gRPC/HTTP clients for inter-service communication**
+**Consolidated gRPC + HTTP clients for inter-service communication**
 
 ## Purpose
 
-This library provides unified client implementations for all Sorcha microservices, eliminating duplication across service projects. All services should reference this library instead of creating their own client implementations.
+Unified client implementations for Sorcha's services so consumers don't hand-roll (and duplicate) their own. Reference this library and call `AddServiceClients(...)` to register everything.
 
-## Architecture
+## Two-project layout
 
-Each service has:
-- **Interface** (`I{Service}Client`) - Defines all methods needed by ANY consumer
-- **Implementation** (`{Service}Client`) - gRPC or HTTP client implementation
-- **Models** - Shared DTOs and response types
+- **`Sorcha.ServiceClients`** (this project) — the umbrella. Holds the **gRPC** clients (`IDocketSyncClient`, `IRegisterAddressClient`, `IWalletNotificationClient`), the **Peer** client (`IPeerServiceClient`), the DID resolver wiring, and the single `AddServiceClients(...)` DI entry point.
+- **`Sorcha.ServiceClients.Http`** — the **HTTP REST** typed clients. `AddServiceClients` delegates their registration here (`AddHttpServiceClients`). This is where the `I{Service}ServiceClient` interfaces live.
 
-## Supported Services
+## Supported clients
 
-| Service | Protocol | Status | Interface |
-|---------|----------|--------|-----------|
-| Wallet Service | gRPC (planned) / HTTP (current) | Stub | `IWalletServiceClient` |
-| Register Service | gRPC (planned) / HTTP (current) | Stub | `IRegisterServiceClient` |
-| Blueprint Service | gRPC (planned) / HTTP (current) | Stub | `IBlueprintServiceClient` |
-| Peer Service | gRPC | Partial | `IPeerServiceClient` |
-| Validator Service | gRPC | Complete | Via proto |
-| Tenant Service | HTTP | Planned | `ITenantServiceClient` |
+| Client | Protocol | Where | Interface |
+|--------|----------|-------|-----------|
+| Wallet | HTTP | `Sorcha.ServiceClients.Http` | `IWalletServiceClient` |
+| Register | HTTP | `Sorcha.ServiceClients.Http` | `IRegisterServiceClient` |
+| Blueprint | HTTP | `Sorcha.ServiceClients.Http` | `IBlueprintServiceClient` |
+| Tenant | HTTP | `Sorcha.ServiceClients.Http` | `ITenantServiceClient` |
+| Validator | HTTP | `Sorcha.ServiceClients.Http` | `IValidatorServiceClient` |
+| HAIP | HTTP | `Sorcha.ServiceClients.Http` | `IHaipServiceClient` |
+| Participant / Passkey / Register-Invitation | HTTP | `Sorcha.ServiceClients.Http` | `IParticipantServiceClient`, `IPasskeyServiceClient`, `IRegisterInvitationServiceClient` |
+| Peer | gRPC | `Sorcha.ServiceClients` | `IPeerServiceClient` |
+| Docket sync / Register address / Wallet notification | gRPC | `Sorcha.ServiceClients` | `IDocketSyncClient`, `IRegisterAddressClient`, `IWalletNotificationClient` |
+| Validator (submit) | gRPC | Validator Service protos | via proto |
+
+> The HTTP clients are current and in use across the platform — not stubs. Service-to-service HTTP calls attach a service-tier bearer via `ServiceAuthMessageHandler`.
 
 ## Usage
 
-### 1. Add Package Reference
+### 1. Reference the project
 
 ```xml
 <ProjectReference Include="..\..\Common\Sorcha.ServiceClients\Sorcha.ServiceClients.csproj" />
 ```
 
-### 2. Register Clients in DI
+### 2. Register clients in DI
 
 ```csharp
-// Program.cs
+// Program.cs — registers the HTTP clients (via Sorcha.ServiceClients.Http),
+// the gRPC clients, the Peer client, and the DID resolvers.
 builder.Services.AddServiceClients(builder.Configuration);
 ```
 
-### 3. Inject and Use
+### 3. Inject and use
 
 ```csharp
-public class MyService
+public class MyService(IWalletServiceClient walletClient)
 {
-    private readonly IWalletServiceClient _walletClient;
-
-    public MyService(IWalletServiceClient walletClient)
-    {
-        _walletClient = walletClient;
-    }
-
-    public async Task DoWork()
-    {
-        var wallet = await _walletClient.CreateWalletAsync(...);
-    }
+    public Task DoWork() => walletClient.GetWalletsByOwnerAsync(ownerId);
 }
 ```
 
 ## Configuration
 
-Configure service endpoints in `appsettings.json`:
+Client addresses resolve via .NET Aspire service discovery when running under the AppHost. Overrides bind from configuration, e.g.:
 
 ```json
 {
   "ServiceClients": {
-    "WalletService": {
-      "Address": "https://localhost:7001",
-      "UseGrpc": false
-    },
-    "RegisterService": {
-      "Address": "https://localhost:7002",
-      "UseGrpc": false
-    },
-    "BlueprintService": {
-      "Address": "https://localhost:7003",
-      "UseGrpc": false
-    },
-    "PeerService": {
-      "Address": "https://localhost:7004",
-      "UseGrpc": true
-    }
+    "WalletService":    { "Address": "http://wallet-service:8080" },
+    "RegisterService":  { "Address": "http://register-service:8080" },
+    "BlueprintService": { "Address": "http://blueprint-service:8080" },
+    "ValidatorService": { "Address": "http://validator-service:8080" },
+    "PeerService":      { "Address": "http://peer-service:5000" }
   }
 }
 ```
 
-## Design Principles
+(Container-internal ports are `8080` for HTTP services and `5000` for the Peer gRPC endpoint; host-published ports differ — see `docs/getting-started/PORT-CONFIGURATION.md`.)
 
-1. **Single Source of Truth** - One client implementation per service
-2. **Comprehensive Interfaces** - Include ALL methods needed by ANY consumer
-3. **Service Discovery** - Use .NET Aspire service discovery when available
-4. **Resilience** - Built-in retry policies and circuit breakers
-5. **Protocol Agnostic** - Support both gRPC and HTTP where needed
+## Design principles
 
-## Migration from Service-Specific Clients
-
-### Before (Duplicated)
-```
-src/Services/Sorcha.Validator.Service/Clients/WalletServiceClient.cs
-src/Services/Sorcha.Blueprint.Service/Clients/WalletServiceClient.cs
-```
-
-### After (Consolidated)
-```
-src/Common/Sorcha.ServiceClients/Wallet/WalletServiceClient.cs
-```
-
-All services now reference `Sorcha.ServiceClients` and inject `IWalletServiceClient`.
+1. **Single source of truth** — one client implementation per service; consumers don't re-roll them.
+2. **Comprehensive interfaces** — an interface carries all methods any consumer needs.
+3. **Service discovery** — Aspire discovery when available, config override otherwise.
+4. **Resilience** — retry/backoff on the HTTP handlers.
+5. **Protocol-appropriate** — HTTP for REST surfaces, gRPC for peer/replication/notification streams.
 
 ## Contributing
 
-When adding new methods:
-1. Add method to the interface (`I{Service}Client`)
-2. Implement in the client class (`{Service}Client`)
-3. Update this README with the new functionality
-4. Add integration tests in `tests/Sorcha.ServiceClients.Tests`
+When adding a method: add it to the interface, implement it in the client, update this README, and add a test under `tests/Sorcha.ServiceClients.Tests`.
 
-## Status
-
-**Current Phase:** Consolidation in progress
-**Target Completion:** Sprint 11 (US3 - Consensus implementation)
+> **Do not re-declare Wallet HTTP DTOs.** The canonical `WalletDto` / `CreateWallet*` / `SignTransaction*` / `WalletAddressDto` / `AddressListResponse` live only in `Sorcha.Wallet.Contracts` (CI-gated by `wallet-contracts-gate`).

--- a/src/Common/Sorcha.Storage.Abstractions/README.md
+++ b/src/Common/Sorcha.Storage.Abstractions/README.md
@@ -17,10 +17,11 @@ This library provides a unified abstraction layer for multi-tier storage in the 
 | Interface | Purpose | Tier |
 |-----------|---------|------|
 | `ICacheStore` | High-performance key-value cache | Hot |
-| `IRepository<TEntity, TId>` | CRUD operations for relational data | Warm |
 | `IDocumentStore<TDocument, TId>` | Flexible schema document storage | Warm |
 | `IWormStore<TDocument, TId>` | Append-only immutable storage | Cold |
 | `IVerifiedCache<TDocument, TId>` | Cache with WORM verification | Hot + Cold |
+
+> **There is no generic `IRepository<T>` here (or anywhere).** Relational/operational persistence is done through **service-specific** repository interfaces (`IWalletRepository`, `IRegisterRepository`, `IInstanceStore`, `IActionStore`, …), each with its own EF Core / MongoDB / Redis / in-memory implementation chosen at registration time (see CLAUDE.md Pattern #5 / #10). This package provides the cross-cutting tiered seams above, not a generic entity repository.
 
 ### Verified Cache
 
@@ -148,32 +149,15 @@ public class MyService
 }
 ```
 
-### Repository (Relational Data)
+### Relational / operational data — service-specific repositories
+
+Relational persistence is **not** provided by a generic interface in this package. Each service defines its own repository interface and depends on it directly; the backend (EF Core / MongoDB / Redis / in-memory) is chosen at registration time (CLAUDE.md Pattern #5 / #10):
 
 ```csharp
-public class WalletService
+public class WalletService(IWalletRepository repository)
 {
-    private readonly IRepository<Wallet, Guid> _repository;
-
-    public async Task<Wallet> CreateWalletAsync(CreateWalletRequest request)
-    {
-        var wallet = new Wallet
-        {
-            Id = Guid.NewGuid(),
-            Name = request.Name,
-            Algorithm = request.Algorithm
-        };
-
-        await _repository.AddAsync(wallet);
-        await _repository.SaveChangesAsync();
-
-        return wallet;
-    }
-
-    public async Task<PagedResult<Wallet>> GetWalletsAsync(int page, int pageSize)
-    {
-        return await _repository.GetPagedAsync(page, pageSize);
-    }
+    public Task<Wallet> CreateWalletAsync(CreateWalletRequest request) =>
+        repository.AddAsync(new Wallet { Id = Guid.NewGuid(), Name = request.Name, Algorithm = request.Algorithm });
 }
 ```
 
@@ -254,8 +238,8 @@ public class DocketQueryService
 ┌─────────────────────────▼───────────────────────────────────┐
 │              Storage Abstractions Layer                      │
 │  ┌──────────────┐ ┌──────────────┐ ┌──────────────────────┐ │
-│  │ ICacheStore  │ │ IRepository  │ │ IVerifiedCache       │ │
-│  │ IDocumentStore│ │ IWormStore  │ │ (Cache + WORM)       │ │
+│  │ ICacheStore  │ │ IDocumentStore│ │ IVerifiedCache       │ │
+│  │              │ │ IWormStore   │ │ (Cache + WORM)       │ │
 │  └──────────────┘ └──────────────┘ └──────────────────────┘ │
 └─────────────────────────┬───────────────────────────────────┘
                           │
@@ -337,9 +321,10 @@ public class MyServiceTests
 
 - `Sorcha.Storage.InMemory` - In-memory implementations for testing
 - `Sorcha.Storage.Redis` - Redis cache implementation
-- `Sorcha.Storage.EFCore` - Entity Framework Core repository
 - `Sorcha.Storage.MongoDB` - MongoDB document and WORM stores
 - `Sorcha.Register.Storage` - Register Service storage integration
+
+(There is no `Sorcha.Storage.EFCore` package — EF Core persistence lives in each service's own `EfCore*Store` against its service-specific repository interface.)
 
 ## License
 

--- a/src/Core/Sorcha.Register.Storage/README.md
+++ b/src/Core/Sorcha.Register.Storage/README.md
@@ -111,13 +111,12 @@ public class RegisterManager
         _repository = repository;
     }
 
-    public async Task<Register> CreateRegisterAsync(string name, string tenantId)
+    public async Task<Register> CreateRegisterAsync(string name)
     {
         var register = new Register
         {
             Id = Guid.NewGuid().ToString("N"),
             Name = name,
-            TenantId = tenantId,
             Status = RegisterStatus.Online
         };
 
@@ -296,8 +295,7 @@ public class RegisterManagerTests
         var register = await _repository.InsertRegisterAsync(new Register
         {
             Id = "test-register",
-            Name = "Test",
-            TenantId = "tenant-1"
+            Name = "Test"
         });
 
         var docket = new Docket

--- a/src/Services/Sorcha.Peer.Service/README.md
+++ b/src/Services/Sorcha.Peer.Service/README.md
@@ -277,6 +277,8 @@ grpcurl -plaintext -d '{
 
 ## Configuration
 
+> ⚠️ **Stale-config warning (2026-07-21).** The `CentralNode:*` / hub-node (`n0`/`n1`/`n2`) configuration model described in the sections below is **superseded and no longer bound by the service.** `Program.cs` binds a single `PeerService` section (`builder.Configuration.GetSection("PeerService")` → `PeerServiceConfiguration`), whose sub-objects are `SeedNodes`, `RegisterSync`, `PeerDiscovery`, `Communication`, etc. — there is no `GetSection("CentralNode")` anywhere. The hub/central-node topology was replaced by seed/anchor rendezvous (Feature 143, which also retired the standalone `Sorcha.PeerRouter` app). Treat the `CentralNode`/PeerRouter material below as historical until this section is rewritten against `Core/PeerServiceConfiguration.cs`.
+
 ### appsettings.json Structure
 
 ```json


### PR DESCRIPTION
Part of the documentation-accuracy sweep — service/library READMEs. Every claim verified against code, which **corrected two wrong audit findings** in the process.

## Fixed
- **`Sorcha.ServiceClients`** — the audit called its client API "fictional (exists nowhere)". **Wrong** — `IWalletServiceClient` etc. are real and current; they live in the sibling **`Sorcha.ServiceClients.Http`** project (`AddServiceClients` delegates to it). The README was stale differently: it marked live HTTP clients as "Stub/Planned" and described a long-since-landed "consolidation in progress". Rewrote to describe the real two-project split, list all 9 HTTP clients as current, fix the stale port config, drop the Sprint-11 status.
- **`Sorcha.Storage.Abstractions`** — removed the generic `IRepository<TEntity,TId>` (table, example, diagram) — genuinely doesn't exist. Verified the *other* seams (`IDocumentStore`/`IWormStore`/`IVerifiedCache`) **are** generic and kept their signatures (the audit had dropped them). Removed the non-existent `Sorcha.Storage.EFCore` package line.
- **`Sorcha.Peer.Service`** — added a stale-config banner: the `CentralNode:*` / hub-node (`n0/n1/n2`) model documented below (43 mentions) is superseded and **not bound** — `Program.cs` binds a single `PeerService` section. Feature 143 replaced it with seed/anchor rendezvous and retired the standalone PeerRouter. (Full section rewrite deferred; the banner stops the misdirection now.)
- **`Sorcha.Register.Storage`** — removed `Register.TenantId` from the examples (property removed from the model).

## Still to do (this PR is partial)
Blueprint/Wallet READMEs (phantom repository-layer sections, port/date inconsistencies), plus the big content rebuilds: `getting-started.md` rewrite, architecture consolidation, API-DOCUMENTATION HAIP/Peer sections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019gakk5iqR3xvq3MPupF6AE