### PR TITLE
feat: one-line installer (curl|bash / irm|iex) + rewrite getting-started

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,32 @@ A decentralised register platform for secure, multi-participant data flow orches
 
 Sorcha lets organizations define structured workflows — called **blueprints** — where multiple parties exchange, validate, and record data with cryptographic guarantees. Every transaction is signed, every change is immutable, and every participant sees only what they're authorized to access.
 
+## Try it in one line
+
+With **Docker** and **git** installed, this downloads Sorcha, asks a few setup questions, generates your config, and brings the whole stack up:
+
+**macOS / Linux / WSL / Git Bash**
+```bash
+curl -fsSL https://raw.githubusercontent.com/Sorcha-Platform/Sorcha/master/scripts/install.sh | bash
+```
+
+**Windows PowerShell**
+```powershell
+irm https://raw.githubusercontent.com/Sorcha-Platform/Sorcha/master/scripts/install.ps1 | iex
+```
+
+When it finishes, open **http://localhost/app** and sign in with the credentials it prints. Add `--quiet` for a non-interactive, all-defaults install.
+
+<details><summary>Prefer to read the script before running it? (recommended for any <code>curl | bash</code>)</summary>
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/Sorcha-Platform/Sorcha/master/scripts/install.sh -o sorcha-install.sh
+less sorcha-install.sh   # review it
+bash sorcha-install.sh
+```
+It clones this repo into `./sorcha` and hands off to [`scripts/sorcha-setup.sh`](scripts/sorcha-setup.sh) — the same interactive setup you can run yourself after a manual `git clone` (see [Quick Start](#quick-start)).
+</details>
+
 ## What Sorcha Does
 
 | Capability | Description |
@@ -32,7 +58,7 @@ Sorcha implements **DAD** (Disclosure, Alteration, Destruction):
 
 ## Quick Start
 
-For the full quickstart (every prerequisite with version constraint, every common failure mode with documented fix, the verify-installation curl), see **[`docs/quickstart.md`](docs/quickstart.md)**. That document is agent-runnable end-to-end and is the canonical setup reference.
+Fastest path is the [one-line installer above](#try-it-in-one-line). This section covers the manual equivalent and what the installer does under the hood. For the full quickstart (every prerequisite with version constraint, every common failure mode with documented fix, the verify-installation curl), see **[`docs/quickstart.md`](docs/quickstart.md)** — the canonical, agent-runnable setup reference.
 
 The short version:
 

--- a/docs/getting-started/getting-started.md
+++ b/docs/getting-started/getting-started.md
@@ -1,262 +1,122 @@
 # Getting Started with Sorcha
 
-This guide will help you get Sorcha up and running on your local development machine.
+This guide takes you from nothing to a running Sorcha instance and your first workflow. Sorcha runs as a set of containers orchestrated by Docker Compose; the fastest way in is the one-line installer.
 
 ## Prerequisites
 
-Before you begin, ensure you have the following installed:
+- **Docker** — Docker Desktop (macOS/Windows) or Docker Engine + Compose v2 (Linux). This is the only hard requirement to *run* Sorcha.
+- **git** — used by the installer to fetch the repository.
+- Ports **80**, **443**, and **8080** free on the host.
+- (Only if you want to *build/develop* the code, not just run it: the **.NET 10 SDK**.)
 
-- [.NET 10 SDK](https://dotnet.microsoft.com/download/dotnet/10.0) (version 10.0.100 or later)
-- [Git](https://git-scm.com/)
-- A code editor:
-  - [Visual Studio 2025](https://visualstudio.microsoft.com/) (recommended for Windows)
-  - [Visual Studio Code](https://code.visualstudio.com/) with C# extension
-  - [JetBrains Rider](https://www.jetbrains.com/rider/)
+## Install
 
-Optional:
-- [Docker Desktop](https://www.docker.com/products/docker-desktop) for containerization
+### Option A — one line (recommended)
 
-## Installation
+Downloads Sorcha, asks a few setup questions, generates your `.env` (including a JWT signing key), pulls the images, starts every service, and bootstraps the platform:
 
-### 1. Clone the Repository
+**macOS / Linux / WSL / Git Bash**
+```bash
+curl -fsSL https://raw.githubusercontent.com/Sorcha-Platform/Sorcha/master/scripts/install.sh | bash
+```
+
+**Windows PowerShell** (needs Git for Windows or WSL for the bash step)
+```powershell
+irm https://raw.githubusercontent.com/Sorcha-Platform/Sorcha/master/scripts/install.ps1 | iex
+```
+
+Add `--quiet` to accept all defaults without prompts (handy for CI). To review the script before running it, see the “Prefer to read it first?” note in the [project README](../../README.md#try-it-in-one-line).
+
+### Option B — manual
 
 ```bash
 git clone https://github.com/Sorcha-Platform/Sorcha.git
-cd sorcha
+cd Sorcha
+
+# Interactive setup — checks prerequisites, generates .env, pulls images, starts services
+./scripts/sorcha-setup.sh
+
+# …or bare-bones, using the shipped defaults:
+cp .env.example .env
+docker compose up -d
 ```
 
-### 2. Restore Dependencies
+Either way, on success the gateway comes up. Verify:
 
 ```bash
-dotnet restore
+curl -s http://localhost/api/health   # every service should report Healthy
 ```
 
-### 3. Build the Solution
+## First login
+
+| What | Where |
+|------|-------|
+| **Main UI** | http://localhost/app |
+| **Blueprint Designer** | http://localhost/app/designer/blueprint |
+| **API Gateway** | http://localhost/ |
+| **API docs (Scalar)** | http://localhost/scalar/ |
+| **Health** | http://localhost/api/health |
+| **Aspire dashboard** (traces/logs/metrics) | http://localhost:18888 |
+
+Default administrator (created on first run — **change it for anything but local dev**):
+
+| Field | Value |
+|-------|-------|
+| Email | `admin@sorcha.local` |
+| Password | `Dev_Pass_2025!` |
+
+See [`guides/AUTHENTICATION-SETUP.md`](../guides/AUTHENTICATION-SETUP.md) for production auth configuration.
+
+## Your first blueprint
+
+A **blueprint** is a multi-party workflow: participants, actions, per-action schemas, and routing between them.
+
+1. Open the **Designer** at http://localhost/app/designer/blueprint. It's a rail-driven **Describe → Understand → Rehearse → Go live** flow — describe the workflow in plain language, refine the actions/schemas, rehearse it, then publish. Go-live is gated by a server-side rehearsal pass.
+2. Prefer to hand-author? Blueprints are JSON/YAML — see [`guides/blueprints/blueprint-format.md`](../guides/blueprints/blueprint-format.md) and the ready-made templates in [`blueprints/`](../../blueprints/). The `blueprint-builder` skill generates them too.
+3. Publish the blueprint to a **register** (a distributed ledger), then participants complete actions in sequence — each signed by their wallet, validated, routed, and recorded immutably.
+
+For a full worked end-to-end run, pick a scenario in [`walkthroughs/`](../../walkthroughs/README.md).
+
+## Developing the code (optional)
+
+To debug with breakpoints, run the platform through **.NET Aspire** instead of Compose:
 
 ```bash
-dotnet build
+dotnet run --project src/Apps/Sorcha.AppHost
 ```
 
-This will build all projects in the solution.
-
-## Running Sorcha
-
-### Using .NET Aspire (Recommended)
-
-The easiest way to run Sorcha is using the .NET Aspire orchestration:
+This starts every service (on their HTTPS Aspire ports, e.g. Blueprint `7000`, Wallet `7001`, Register `7290`, Tenant `7110`) plus the Aspire dashboard at http://localhost:18888. The full port map is in [`PORT-CONFIGURATION.md`](PORT-CONFIGURATION.md).
 
 ```bash
-dotnet run --project src/Sorcha.AppHost
+dotnet restore && dotnet build      # build the solution
+dotnet test                         # run the test suite
+dotnet format                       # format code
 ```
 
-This will:
-- Start the Blueprint Engine API
-- Start the Blueprint Designer web UI
-- Launch the Aspire dashboard
-- Configure service discovery automatically
-
-The Aspire dashboard will open in your browser at `http://localhost:15888` (or similar).
-
-From the dashboard, you can:
-- View all running services
-- See logs and traces
-- Monitor health status
-- Access service endpoints
-
-### Running Services Individually
-
-If you prefer to run services separately:
-
-**Blueprint Engine (API):**
-```bash
-cd src/Sorcha.Blueprint.Engine
-dotnet run
-```
-The API will be available at `https://localhost:7001` and `http://localhost:5001`.
-
-**Blueprint Designer (Web UI):**
-```bash
-cd src/Sorcha.Blueprint.Designer
-dotnet run
-```
-The designer will be available at `https://localhost:7002` and `http://localhost:5002`.
-
-## Accessing the Application
-
-Once running, you can access:
-
-- **Aspire Dashboard**: `http://localhost:15888`
-- **Blueprint Designer**: `https://localhost:7002` (or the URL shown in console)
-- **Blueprint Engine API**: `https://localhost:7001` (or the URL shown in console)
-- **API Documentation**: `https://localhost:7001/scalar/v1` (interactive Scalar UI)
-- **OpenAPI Spec**: `https://localhost:7001/openapi/v1.json`
-
-## Your First Blueprint
-
-### 1. Open the Designer
-
-Navigate to the Blueprint Designer in your browser.
-
-### 2. Create a Blueprint
-
-(UI walkthrough will be added here)
-
-### 3. Execute the Blueprint
-
-Use the Designer UI or make a direct API call:
+## Common operations
 
 ```bash
-curl -X POST https://localhost:7001/blueprints/execute \
-  -H "Content-Type: application/json" \
-  -d '{
-    "name": "My First Blueprint",
-    "actions": [
-      {
-        "type": "log",
-        "message": "Hello from Sorcha!"
-      }
-    ]
-  }'
-```
-
-## Development Workflow
-
-### 1. Make Changes
-
-Edit the source code in your preferred editor.
-
-### 2. Hot Reload
-
-If running with `dotnet run`, many changes will be automatically reloaded without restarting.
-
-### 3. Run Tests
-
-```bash
-dotnet test
-```
-
-### 4. Format Code
-
-```bash
-dotnet format
-```
-
-## Project Structure
-
-```
-Sorcha/
-├── src/
-│   ├── Sorcha.AppHost/              # Aspire orchestration host
-│   ├── Sorcha.ServiceDefaults/      # Shared configurations
-│   ├── Sorcha.Blueprint.Engine/     # Execution engine (API)
-│   └── Sorcha.Blueprint.Designer/   # Visual designer (Web)
-├── tests/                           # Test projects
-├── docs/                            # Documentation
-├── .github/                         # GitHub workflows
-├── Sorcha.sln                       # Solution file
-└── README.md                        # Main readme
-```
-
-## Configuration
-
-Configuration files are located in each project:
-
-- `appsettings.json` - Default settings
-- `appsettings.Development.json` - Development overrides
-- `appsettings.Production.json` - Production settings
-
-### Common Settings
-
-**Blueprint Engine (appsettings.json):**
-```json
-{
-  "Logging": {
-    "LogLevel": {
-      "Default": "Information"
-    }
-  },
-  "AllowedHosts": "*"
-}
-```
-
-**Environment Variables:**
-```bash
-# Set log level
-export ASPNETCORE_ENVIRONMENT=Development
-
-# Set custom ports
-export ASPNETCORE_URLS="https://localhost:8000;http://localhost:8001"
+docker compose ps                   # service status
+docker compose logs -f <service>    # follow a service's logs (e.g. blueprint-service)
+docker compose down                 # stop (keep data in volumes)
+docker compose down -v              # stop and delete all data
 ```
 
 ## Troubleshooting
 
-### Port Already in Use
+- **Port 80/443/8080 already in use** — free the port, or remap the gateway in `docker-compose.yml` (`ports:`) and re-run.
+- **HTTPS listener won't bind** — only affects port 443; HTTP on 80 still works. Generate a dev cert to enable HTTPS (see [`DOCKER-QUICK-START.md`](DOCKER-QUICK-START.md)).
+- **A service is unhealthy** — `docker compose logs <service>`; PostgreSQL/MongoDB may need a few seconds to initialise on first start.
+- More: [`../guides/TROUBLESHOOTING.md`](../guides/TROUBLESHOOTING.md).
 
-If you see port conflicts, you can change the ports in `Properties/launchSettings.json` for each project.
+## Next steps
 
-### SSL Certificate Issues
+- [`docs/architecture.md`](../architecture.md) — how the platform fits together, by service and data flow.
+- [`docs/reference/API-DOCUMENTATION.md`](../reference/API-DOCUMENTATION.md) — full REST/gRPC reference.
+- [`walkthroughs/README.md`](../../walkthroughs/README.md) — interactive end-to-end demos.
+- The **CLI**: `dotnet run --project src/Apps/Sorcha.Cli -- --help` (see [`src/Apps/Sorcha.Cli/README.md`](../../src/Apps/Sorcha.Cli/README.md)).
 
-Trust the development certificate:
-```bash
-dotnet dev-certs https --trust
-```
+## Getting help
 
-### Build Errors
-
-Clean and rebuild:
-```bash
-dotnet clean
-dotnet build
-```
-
-### .NET 10 Not Found
-
-Ensure you have .NET 10 SDK installed:
-```bash
-dotnet --version
-```
-
-Should show `10.0.100` or later.
-
-## Next Steps
-
-Now that you have Sorcha running, explore:
-
-- [Architecture Overview](../architecture.md) - Understand the system design
-- [Blueprint Format](../guides/blueprints/blueprint-format.md) - Learn the blueprint format
-- [API Reference](../reference/API-DOCUMENTATION.md) - Explore the REST API
-- [Contributing](../../CONTRIBUTING.md) - Help improve Sorcha
-
-## Getting Help
-
-- Check the [Troubleshooting Guide](../guides/TROUBLESHOOTING.md)
-- Browse [Documentation](../README.md)
-- Search [GitHub Issues](https://github.com/Sorcha-Platform/Sorcha/issues)
-- Ask in [GitHub Discussions](https://github.com/Sorcha-Platform/Sorcha/discussions)
-
-## Common Commands
-
-```bash
-# Restore packages
-dotnet restore
-
-# Build solution
-dotnet build
-
-# Run tests
-dotnet test
-
-# Run with Aspire
-dotnet run --project src/Sorcha.AppHost
-
-# Clean build artifacts
-dotnet clean
-
-# Format code
-dotnet format
-
-# Check for security vulnerabilities
-dotnet list package --vulnerable
-```
-
-Welcome to Sorcha! We're excited to have you here.
+- Search the [docs](../README.md) and existing [GitHub issues](https://github.com/Sorcha-Platform/Sorcha/issues).
+- Open a new issue with clear reproduction steps and environment details.

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Sorcha Contributors
+# =============================================================================
+# Sorcha one-line installer (Windows / PowerShell).
+#
+# Downloads Sorcha and runs the interactive setup. Requires git, Docker Desktop,
+# and a bash shell — Git for Windows bundles one (Git Bash), or use WSL.
+#
+#   irm https://raw.githubusercontent.com/Sorcha-Platform/Sorcha/master/scripts/install.ps1 | iex
+#
+# Prefer to read it first (recommended for any pipe-to-shell):
+#   irm https://raw.githubusercontent.com/Sorcha-Platform/Sorcha/master/scripts/install.ps1 -OutFile sorcha-install.ps1
+#   notepad sorcha-install.ps1 ; ./sorcha-install.ps1
+#
+# Environment overrides: $env:SORCHA_DIR (default: sorcha), $env:SORCHA_REF (default: master).
+# =============================================================================
+$ErrorActionPreference = 'Stop'
+
+function Say($m) { Write-Host "[sorcha-install] $m" -ForegroundColor Cyan }
+function Die($m) { Write-Host "[sorcha-install] ERROR: $m" -ForegroundColor Red; exit 1 }
+
+if (-not (Get-Command git    -ErrorAction SilentlyContinue)) { Die "git is required: https://git-scm.com/downloads" }
+if (-not (Get-Command docker -ErrorAction SilentlyContinue)) { Die "Docker Desktop is required: https://docs.docker.com/get-docker/" }
+if (-not (Get-Command bash   -ErrorAction SilentlyContinue)) { Die "A bash shell is required (install Git for Windows or enable WSL), then re-run." }
+
+$dir = if ($env:SORCHA_DIR) { $env:SORCHA_DIR } else { 'sorcha' }
+$ref = if ($env:SORCHA_REF) { $env:SORCHA_REF } else { 'master' }
+
+if (Test-Path 'scripts/sorcha-setup.sh') {
+    Say 'Existing Sorcha checkout detected here — running setup in place.'
+    $target = (Get-Location).Path
+}
+elseif (Test-Path "$dir/scripts/sorcha-setup.sh") {
+    Say "Using existing clone at ./$dir."
+    $target = (Resolve-Path $dir).Path
+}
+else {
+    if (Test-Path $dir) { Die "Target ./$dir already exists but is not a Sorcha clone. Set `$env:SORCHA_DIR to another path." }
+    Say "Cloning Sorcha ($ref) into ./$dir ..."
+    git clone --depth 1 --branch $ref https://github.com/Sorcha-Platform/Sorcha.git $dir
+    if ($LASTEXITCODE -ne 0) { Die 'git clone failed. Check your network and that the ref is valid.' }
+    $target = (Resolve-Path $dir).Path
+}
+
+Set-Location $target
+Say 'Handing off to the interactive setup (scripts/sorcha-setup.sh) via bash.'
+Write-Host ''
+& bash scripts/sorcha-setup.sh @args
+exit $LASTEXITCODE

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Sorcha Contributors
+# =============================================================================
+# Sorcha one-line installer.
+#
+# Downloads Sorcha and runs the interactive setup (prerequisite checks, config
+# questions, .env + JWT key generation, image pull, service start, bootstrap).
+#
+#   curl -fsSL https://raw.githubusercontent.com/Sorcha-Platform/Sorcha/master/scripts/install.sh | bash
+#
+# Prefer to read it before running (recommended for any curl|bash):
+#   curl -fsSL https://raw.githubusercontent.com/Sorcha-Platform/Sorcha/master/scripts/install.sh -o sorcha-install.sh
+#   less sorcha-install.sh && bash sorcha-install.sh
+#
+# Environment overrides:
+#   SORCHA_DIR   target directory to clone into      (default: ./sorcha)
+#   SORCHA_REF   branch or tag to install            (default: master)
+#
+# Any extra arguments are passed straight through to scripts/sorcha-setup.sh
+# (e.g. `--quiet` for a non-interactive, all-defaults install).
+# =============================================================================
+set -euo pipefail
+
+REPO_URL="https://github.com/Sorcha-Platform/Sorcha.git"
+REF="${SORCHA_REF:-master}"
+DIR="${SORCHA_DIR:-sorcha}"
+
+say()  { printf '\033[0;36m[sorcha-install]\033[0m %s\n' "$1"; }
+die()  { printf '\033[0;31m[sorcha-install] ERROR:\033[0m %s\n' "$1" >&2; exit 1; }
+
+# --- Prerequisites the installer itself needs (setup checks the rest) --------
+command -v git >/dev/null 2>&1 \
+  || die "git is required. Install it and re-run: https://git-scm.com/downloads"
+command -v docker >/dev/null 2>&1 \
+  || die "Docker is required. Install Docker Desktop / Engine and re-run: https://docs.docker.com/get-docker/"
+
+# --- Locate or fetch a Sorcha checkout ---------------------------------------
+if [ -f "scripts/sorcha-setup.sh" ]; then
+  say "Existing Sorcha checkout detected here — running setup in place."
+  TARGET="$(pwd)"
+elif [ -d "$DIR/.git" ] && [ -f "$DIR/scripts/sorcha-setup.sh" ]; then
+  say "Using existing clone at ./$DIR (fetching latest $REF)."
+  git -C "$DIR" pull --ff-only >/dev/null 2>&1 || say "(could not fast-forward — keeping your local checkout as-is)"
+  TARGET="$(cd "$DIR" && pwd)"
+else
+  [ -e "$DIR" ] && die "Target ./$DIR already exists but is not a Sorcha clone. Set SORCHA_DIR to another path."
+  say "Cloning Sorcha ($REF) into ./$DIR ..."
+  git clone --depth 1 --branch "$REF" "$REPO_URL" "$DIR" \
+    || die "git clone failed. Check your network and that '$REF' is a valid branch/tag."
+  TARGET="$(cd "$DIR" && pwd)"
+fi
+
+cd "$TARGET"
+say "Handing off to the interactive setup (scripts/sorcha-setup.sh)."
+echo ""
+
+# When this installer was piped from curl, our stdin is the pipe — not a
+# keyboard — so the setup's prompts must read from the controlling terminal.
+# If there is no terminal at all (e.g. CI), fall back to an all-defaults run.
+if [ -r /dev/tty ]; then
+  exec bash scripts/sorcha-setup.sh "$@" </dev/tty
+else
+  say "No interactive terminal detected — running with defaults (--quiet)."
+  exec bash scripts/sorcha-setup.sh --quiet "$@"
+fi


### PR DESCRIPTION
A single cut-and-paste front door that takes a new user from nothing to a running stack — near the top of the README so GitHub visitors see it immediately.

## The one-liner
```bash
curl -fsSL https://raw.githubusercontent.com/Sorcha-Platform/Sorcha/master/scripts/install.sh | bash
```
```powershell
irm https://raw.githubusercontent.com/Sorcha-Platform/Sorcha/master/scripts/install.ps1 | iex
```

## What's in it
- **`scripts/install.sh`** — checks git + docker, shallow-clones into `./sorcha` (or `$SORCHA_DIR`), and hands off to the **existing, well-tested `scripts/sorcha-setup.sh`** (prereq checks, config questions, `.env` + JWT key, image pull, service start, bootstrap). It does *not* reinvent setup — it just adds the download step that was missing. Handles the classic `curl | bash` interactivity trap by reading prompts from `/dev/tty`, falling back to `--quiet` when there's no terminal (CI). Reuses an existing checkout instead of re-cloning.
- **`scripts/install.ps1`** — Windows equivalent; clones and runs `sorcha-setup.sh` via bash (Git for Windows / WSL).
- **`README.md`** — new **"Try it in one line"** section right after the intro (before the feature table), with both one-liners, a one-line "what it does", first-login pointer, and a collapsible **"read it first"** alternative (good practice for pipe-to-shell). Quick Start now points at it as the fastest path.
- **`docs/getting-started/getting-started.md`** — full rewrite. The old version was almost entirely fiction (retired `Blueprint.Engine` API + `Blueprint.Designer` web UI, wrong paths, Aspire `15888`, ports `7001/7002`). Rewritten around the real Compose flow + first blueprint via `/app/designer/blueprint`; all 12 internal links verified.

## Safety notes
- `curl | bash` is the standard install pattern (rustup, homebrew, deno, …); the README leads with a **review-before-run** alternative and the script is short and auditable.
- Wraps the canonical `sorcha-setup.sh` only — the older `setup.sh` / `bootstrap-sorcha.sh` script-sprawl cleanup is a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019gakk5iqR3xvq3MPupF6AE