### PR TITLE
fix: sorcha-setup.sh captures the latest config surface (email, social login, peer)

### DIFF
--- a/scripts/sorcha-setup.sh
+++ b/scripts/sorcha-setup.sh
@@ -340,6 +340,25 @@ ask_configuration() {
     echo "Sorcha can use Claude AI for interactive blueprint design."
     ask "Anthropic API key (leave empty to skip)" "" ANTHROPIC_API_KEY
 
+    # Transactional email (Feature 112) — verification / invite / welcome emails.
+    echo ""
+    echo -e "${BOLD}Transactional Email (Optional)${NC}"
+    echo "The Tenant Service sends verification / invite / welcome emails."
+    echo "Leave the connection string empty for local dev (emails are skipped, not sent)."
+    ask "Azure Communication Services email connection string (leave empty to skip)" "" ACS_EMAIL_CONNECTION_STRING
+    if [ -n "$ACS_EMAIL_CONNECTION_STRING" ]; then
+        ask "From address for outbound email" "noreply@sorcha.dev" EMAIL_FROM_ADDRESS
+    else
+        EMAIL_FROM_ADDRESS="noreply@sorcha.dev"
+    fi
+    EMAIL_FROM_NAME="Sorcha Platform"
+    # Base URL used to build links in email bodies — derive from the installation name.
+    if [ "$INSTALLATION_NAME" = "localhost" ]; then
+        EMAIL_BASE_URL="http://localhost"
+    else
+        EMAIL_BASE_URL="https://${INSTALLATION_NAME}"
+    fi
+
     # Peer network
     echo ""
     echo -e "${BOLD}Peer Network (Optional)${NC}"
@@ -397,11 +416,26 @@ ASPNETCORE_ENVIRONMENT=${ASPNETCORE_ENVIRONMENT}
 # AI Integration
 ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
 
+# Transactional Email (Feature 112 — leave the ACS connection string empty for no email in dev)
+ACS_EMAIL_CONNECTION_STRING=${ACS_EMAIL_CONNECTION_STRING:-}
+EMAIL_BASE_URL=${EMAIL_BASE_URL:-http://localhost}
+EMAIL_FROM_ADDRESS=${EMAIL_FROM_ADDRESS:-noreply@sorcha.dev}
+EMAIL_FROM_NAME=${EMAIL_FROM_NAME:-Sorcha Platform}
+
+# Social Login OAuth (optional — fill in to enable Google / GitHub sign-in;
+# see docs/guides/SOCIAL-LOGIN-SETUP.md)
+GOOGLE_OAUTH_CLIENT_ID=${GOOGLE_OAUTH_CLIENT_ID:-}
+GOOGLE_OAUTH_CLIENT_SECRET=${GOOGLE_OAUTH_CLIENT_SECRET:-}
+GITHUB_OAUTH_CLIENT_ID=${GITHUB_OAUTH_CLIENT_ID:-}
+GITHUB_OAUTH_CLIENT_SECRET=${GITHUB_OAUTH_CLIENT_SECRET:-}
+
 # Peer Network
 PEER_NODE_ID=${PEER_NODE_ID}
+PEER_PUBLIC_ADDRESS=${PEER_PUBLIC_ADDRESS:-}
 SEED_PEER_NODE_ID=${SEED_PEER_NODE_ID}
 SEED_PEER_HOST=${SEED_PEER_HOST}
 SEED_PEER_PORT=${SEED_PEER_PORT}
+SEED_PEER_ENABLE_TLS=${SEED_PEER_ENABLE_TLS:-false}
 ENVFILE
 
     success ".env file written"


### PR DESCRIPTION
Follow-up to the one-line installer (#1233). You asked whether the setup actually captures the latest platform changes — I audited it, and it didn't.

## The gap
`sorcha-setup.sh` wrote only **13** of the **33** env vars the current `docker-compose.yml` consumes. The ports are all optional (compose `${VAR:-default}`), but the setup had drifted behind two real features:
- **Feature 112 transactional email** (`ACS_EMAIL_CONNECTION_STRING`, `EMAIL_BASE_URL`, `EMAIL_FROM_ADDRESS`, `EMAIL_FROM_NAME`) — never asked, never written.
- **Social-login OAuth** (Google/GitHub client id+secret) — documented in `.env.example`, absent from the generated `.env`.

Everything still *booted* (defaults cover it), but a user who wanted verification/welcome emails or social sign-in got a silent no-op and had to hand-edit `.env`.

## The fix
- New **"Transactional Email (Optional)"** step: prompts for the ACS connection string (empty = skip, the local default), derives `EMAIL_BASE_URL` from the installation name, sets from-address/name.
- `write_env_file` now emits the email block, the four social-login keys (empty + a pointer to `SOCIAL-LOGIN-SETUP.md`), and the newer peer vars `PEER_PUBLIC_ADDRESS` + `SEED_PEER_ENABLE_TLS` — matching `.env.example`.

## Verified
Generated a sample `.env` end-to-end — it now covers **every** non-port var compose reads. Email keys use `:-` defaults so `write_env_file` stays safe under `set -u`. Syntax + lib-load smoke pass; the bats suite asserts no `.env` contents so it's unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019gakk5iqR3xvq3MPupF6AE