### PR TITLE
ci: prove the one-liner installer — nightly clean-VM + pre-merge guard

### DIFF
--- a/.github/workflows/ai-discoverability-check.yml
+++ b/.github/workflows/ai-discoverability-check.yml
@@ -130,7 +130,7 @@ jobs:
           echo "Body:    $body"
           echo "Status:  $status"
           [ "$status" = "200" ] || { echo "Expected HTTP 200, got $status"; exit 1; }
-          echo "$body" | python -c 'import sys, json; d = json.load(sys.stdin); assert d.get("status") == "Healthy", d' || {
+          echo "$body" | python -c 'import sys, json; d = json.load(sys.stdin); assert d.get("status","").lower() == "healthy", d' || {
             echo "Aggregated health response did not report Healthy"
             exit 1
           }

--- a/.github/workflows/ai-discoverability-check.yml
+++ b/.github/workflows/ai-discoverability-check.yml
@@ -28,6 +28,10 @@ on:
     # Docker Engine, asserting the verify-installation curl returns 200.
     # Runs at 04:00 UTC; reports success / failure to the workflow run history.
     - cron: '0 4 * * *'
+  workflow_dispatch:
+    # Manual trigger — lets a maintainer run the clean-VM one-liner check
+    # on demand (e.g. to validate a change to the installer before relying on
+    # the nightly schedule).
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -87,35 +91,39 @@ jobs:
               ].join('\n')
             });
 
-  # T090 — nightly clean-VM run of the quickstart. Boots the full stack on
-  # an ubuntu-latest runner (which ships with Docker Engine), runs the setup
-  # script, then asserts the verify-installation curl returns 200 with every
-  # service Healthy. Confirms the agent-runnable claim for SC-010.
+  # T090 — nightly clean-VM run of the PUBLISHED one-liner. Deliberately does NOT
+  # check out the repo: it starts from a bare ubuntu-latest runner (Docker Engine
+  # + git + curl preinstalled) and runs the exact command from the README's
+  # "Try it in one line", which fetches scripts/install.sh from master, clones,
+  # and hands off to sorcha-setup.sh. This proves the whole user path — raw URL,
+  # clone, installer, setup, boot — not just the setup script from a checkout.
+  # Runs nightly and on manual dispatch. (PRs that touch the installer scripts are
+  # validated separately by installer-check.yml.)
   quickstart-on-clean-vm:
     name: Nightly clean-VM quickstart
-    if: github.event_name == 'schedule'
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 20
 
     steps:
-      - name: Check out repository
-        uses: actions/checkout@v4
-
-      - name: Confirm Docker Engine is available
+      - name: Confirm tooling (Docker, git, curl) is available
         run: |
           docker --version
           docker compose version
+          git --version
+          curl --version | head -1
 
-      - name: Run sorcha-setup.sh in quiet mode
+      - name: Install Sorcha via the published one-liner
         run: |
-          chmod +x scripts/sorcha-setup.sh
-          ./scripts/sorcha-setup.sh --quiet
+          set -euo pipefail
+          # Exactly the command documented in README → "Try it in one line".
+          curl -fsSL https://raw.githubusercontent.com/Sorcha-Platform/Sorcha/master/scripts/install.sh | bash -s -- --quiet
 
       - name: Verify installation
         run: |
           set -euo pipefail
-          # Quickstart's documented verify-installation curl. Asserts HTTP 200
-          # AND that the body parses as JSON with status == Healthy.
+          # Documented verify-installation curl. Asserts HTTP 200 AND that the
+          # body parses as JSON with status == Healthy.
           response=$(curl -sf -w '\nHTTP_STATUS:%{http_code}' http://localhost/api/health)
           status=$(echo "$response" | grep '^HTTP_STATUS:' | cut -d: -f2)
           body=$(echo "$response" | sed '/^HTTP_STATUS:/d')
@@ -129,4 +137,5 @@ jobs:
 
       - name: Capture container logs on failure
         if: failure()
+        working-directory: sorcha
         run: docker compose logs --tail=200

--- a/.github/workflows/installer-check.yml
+++ b/.github/workflows/installer-check.yml
@@ -55,7 +55,7 @@ jobs:
           echo "Body:    $body"
           echo "Status:  $status"
           [ "$status" = "200" ] || { echo "Expected HTTP 200, got $status"; exit 1; }
-          echo "$body" | python -c 'import sys, json; d = json.load(sys.stdin); assert d.get("status") == "Healthy", d' || {
+          echo "$body" | python -c 'import sys, json; d = json.load(sys.stdin); assert d.get("status","").lower() == "healthy", d' || {
             echo "Aggregated health response did not report Healthy"
             exit 1
           }

--- a/.github/workflows/installer-check.yml
+++ b/.github/workflows/installer-check.yml
@@ -1,0 +1,65 @@
+name: Installer Check
+
+# Boots the full stack from the installer on any PR that touches the setup path,
+# so a broken installer — or a new compose env var without a default, or setup
+# config drift — is caught BEFORE merge. The nightly clean-VM one-liner check
+# (in ai-discoverability-check.yml) only runs post-merge against master, so this
+# is the pre-merge guard for the same "does it actually come up" question.
+#
+# It runs the checked-out scripts/install.sh, which detects the existing checkout
+# and hands off to scripts/sorcha-setup.sh (--quiet) — validating this PR's
+# installer + setup script + .env generation against this PR's compose files.
+
+on:
+  pull_request:
+    branches: [ master ]
+    paths:
+      - 'scripts/install.sh'
+      - 'scripts/install.ps1'
+      - 'scripts/sorcha-setup.sh'
+      - '.env.example'
+      - 'docker-compose.yml'
+      - '.github/workflows/installer-check.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  install-and-boot:
+    name: Install and boot the stack
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Confirm Docker Engine is available
+        run: |
+          docker --version
+          docker compose version
+
+      - name: Run the installer (detects checkout → runs sorcha-setup.sh --quiet)
+        run: |
+          set -euo pipefail
+          chmod +x scripts/install.sh scripts/sorcha-setup.sh
+          bash scripts/install.sh --quiet
+
+      - name: Verify installation
+        run: |
+          set -euo pipefail
+          response=$(curl -sf -w '\nHTTP_STATUS:%{http_code}' http://localhost/api/health)
+          status=$(echo "$response" | grep '^HTTP_STATUS:' | cut -d: -f2)
+          body=$(echo "$response" | sed '/^HTTP_STATUS:/d')
+          echo "Body:    $body"
+          echo "Status:  $status"
+          [ "$status" = "200" ] || { echo "Expected HTTP 200, got $status"; exit 1; }
+          echo "$body" | python -c 'import sys, json; d = json.load(sys.stdin); assert d.get("status") == "Healthy", d' || {
+            echo "Aggregated health response did not report Healthy"
+            exit 1
+          }
+
+      - name: Capture container logs on failure
+        if: failure()
+        run: docker compose logs --tail=200

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -57,9 +57,14 @@ echo ""
 
 # When this installer was piped from curl, our stdin is the pipe — not a
 # keyboard — so the setup's prompts must read from the controlling terminal.
-# If there is no terminal at all (e.g. CI), fall back to an all-defaults run.
-if [ -r /dev/tty ]; then
-  exec bash scripts/sorcha-setup.sh "$@" </dev/tty
+# If there is no usable terminal (e.g. CI), fall back to an all-defaults run.
+#
+# Test that /dev/tty can actually be OPENED, not merely that it exists: on a
+# runner without a controlling terminal the device node is present and readable
+# by permission bits, yet open() fails with ENXIO. `[ -r /dev/tty ]` checks the
+# permission bits only, so it wrongly reports success there — attempt the open.
+if { : < /dev/tty; } 2>/dev/null; then
+  exec bash scripts/sorcha-setup.sh "$@" < /dev/tty
 else
   say "No interactive terminal detected — running with defaults (--quiet)."
   exec bash scripts/sorcha-setup.sh --quiet "$@"

--- a/scripts/sorcha-setup.sh
+++ b/scripts/sorcha-setup.sh
@@ -508,6 +508,14 @@ EOF
         return 0
     fi
 
+    # openssl creates the .pfx 0600 (owner-only). The api-gateway / ui-web
+    # containers run hardened as a non-root uid and mount ./docker/certs read-only,
+    # so a 0600 file owned by the host user is unreadable inside the container —
+    # the gateway then dies at startup with "Access to '/https/aspnetapp.pfx' is
+    # denied". Make the dev cert world-readable (it is a throwaway self-signed
+    # dev key, never a production secret).
+    chmod 0644 "$pfx" 2>/dev/null || true
+
     success "Generated dev certificate at $pfx"
 }
 


### PR DESCRIPTION
Wires the one-line installer into CI so it's continuously proven — the clean-machine end-to-end run we flagged as the last missing proof.

## Two checks

**1. Nightly clean-VM one-liner** (`ai-discoverability-check.yml` → `quickstart-on-clean-vm`)
Rewired to run the **exact published command** on a bare `ubuntu-latest` runner with **no checkout**:
```bash
curl -fsSL https://raw.githubusercontent.com/Sorcha-Platform/Sorcha/master/scripts/install.sh | bash -s -- --quiet
```
This exercises the *whole* user path — raw URL → `git clone` → `install.sh` → `sorcha-setup.sh` → docker boot → health — not just `sorcha-setup.sh` from a checkout as before. Added `workflow_dispatch` so it can be run on demand.

**2. Pre-merge installer guard** (new `installer-check.yml`)
The nightly runs *post-merge* against master, so a broken installer would ship before it's caught. This job boots the stack from the checked-out `install.sh` on any PR touching `scripts/install.sh` / `install.ps1` / `sorcha-setup.sh`, `.env.example`, or `docker-compose.yml` — so installer regressions **and** compose env-var drift (a new required var without a default — exactly the class of bug I just fixed in #1235) fail the PR, not production.

Both assert the documented verify curl returns `200` with `status == Healthy` and dump container logs on failure.

## This PR self-tests
`installer-check.yml` lists itself in its `paths`, so **this PR runs the boot test** — a live end-to-end proof of the installer before merge. Watch the *Install and boot the stack* check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019gakk5iqR3xvq3MPupF6AE