### PR TITLE
feat: default new wallets to a 24-word recovery phrase

### DIFF
--- a/src/Apps/Sorcha.Cli/Commands/WalletCommands.cs
+++ b/src/Apps/Sorcha.Cli/Commands/WalletCommands.cs
@@ -588,7 +588,7 @@ public class WalletCreateCommand : Command
         _wordCountOption = new Option<int>("--word-count", "-w")
         {
             Description = "Number of words in mnemonic (12, 15, 18, 21, or 24)",
-            DefaultValueFactory = _ => 12
+            DefaultValueFactory = _ => 24
         };
 
         _passphraseOption = new Option<string?>("--passphrase", "-p")
@@ -1332,7 +1332,7 @@ public class WalletCreateBatchCommand : Command
                         {
                             Name = walletName,
                             Algorithm = algorithm,
-                            WordCount = 12
+                            WordCount = 24
                         };
 
                         var response = await client.CreateWalletAsync(request, $"Bearer {token}");

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Wallets/CreateWallet.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Wallets/CreateWallet.razor
@@ -61,11 +61,11 @@
 
                         <MudItem xs="12" sm="6">
                             <MudSelect T="int" Label="Word Count" @bind-Value="request.WordCount" Required="true" Variant="Variant.Outlined" HelperText="Mnemonic phrase length">
-                                <MudSelectItem Value="12">12 words (Standard)</MudSelectItem>
-                                <MudSelectItem Value="15">15 words</MudSelectItem>
-                                <MudSelectItem Value="18">18 words</MudSelectItem>
+                                <MudSelectItem Value="24">24 words (Recommended)</MudSelectItem>
                                 <MudSelectItem Value="21">21 words</MudSelectItem>
-                                <MudSelectItem Value="24">24 words (Maximum security)</MudSelectItem>
+                                <MudSelectItem Value="18">18 words</MudSelectItem>
+                                <MudSelectItem Value="15">15 words</MudSelectItem>
+                                <MudSelectItem Value="12">12 words</MudSelectItem>
                             </MudSelect>
                         </MudItem>
 
@@ -206,7 +206,7 @@
     {
         Name = "",
         Algorithm = "ED25519",
-        WordCount = 12
+        WordCount = 24
     };
 
     private CreateWalletResponse? response;

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Wallets/RecoverWallet.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Wallets/RecoverWallet.razor
@@ -128,7 +128,7 @@
         MnemonicWords = Array.Empty<string>()
     };
 
-    private int wordCount = 12;
+    private int wordCount = 24;
     private List<string> words = new();
     private string mnemonicText = "";
     private bool useTextArea = false;

--- a/src/Common/Sorcha.Cryptography/Core/KeyManager.cs
+++ b/src/Common/Sorcha.Cryptography/Core/KeyManager.cs
@@ -39,13 +39,13 @@ public class KeyManager : IKeyManager
     {
         try
         {
-            // Generate a 12-word mnemonic (only for ED25519 and NIST P-256)
+            // Generate a 24-word mnemonic (only for ED25519 and NIST P-256)
             string? mnemonic = null;
             byte[]? seed = null;
 
             if (network == WalletNetworks.ED25519 || network == WalletNetworks.NISTP256)
             {
-                var mnemonicResult = GenerateMnemonic(12);
+                var mnemonicResult = GenerateMnemonic(24);
                 if (!mnemonicResult.IsSuccess || mnemonicResult.Value == null)
                     return CryptoResult<KeyRing>.Failure(mnemonicResult.Status, mnemonicResult.ErrorMessage);
 
@@ -132,7 +132,7 @@ public class KeyManager : IKeyManager
     /// <summary>
     /// Generates a random mnemonic phrase.
     /// </summary>
-    public CryptoResult<string> GenerateMnemonic(int wordCount = 12)
+    public CryptoResult<string> GenerateMnemonic(int wordCount = 24)
     {
         try
         {

--- a/src/Common/Sorcha.Cryptography/Interfaces/IKeyManager.cs
+++ b/src/Common/Sorcha.Cryptography/Interfaces/IKeyManager.cs
@@ -27,7 +27,7 @@ public interface IKeyManager
     /// <summary>
     /// Recovers a key ring from a mnemonic recovery phrase.
     /// </summary>
-    /// <param name="mnemonic">The 12-word mnemonic phrase.</param>
+    /// <param name="mnemonic">The mnemonic recovery phrase (12, 15, 18, 21, or 24 words).</param>
     /// <param name="password">Optional password if one was used during creation.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>A result containing the recovered key ring or error status.</returns>
@@ -39,9 +39,9 @@ public interface IKeyManager
     /// <summary>
     /// Generates a random mnemonic phrase.
     /// </summary>
-    /// <param name="wordCount">The number of words (12, 15, 18, 21, or 24).</param>
+    /// <param name="wordCount">The number of words (12, 15, 18, 21, or 24). Defaults to 24.</param>
     /// <returns>A result containing the mnemonic phrase or error status.</returns>
-    CryptoResult<string> GenerateMnemonic(int wordCount = 12);
+    CryptoResult<string> GenerateMnemonic(int wordCount = 24);
 
     /// <summary>
     /// Validates a mnemonic phrase.

--- a/src/Common/Sorcha.Cryptography/Models/KeyRing.cs
+++ b/src/Common/Sorcha.Cryptography/Models/KeyRing.cs
@@ -18,7 +18,7 @@ public class KeyRing : IDisposable
     public required WalletNetworks Network { get; init; }
 
     /// <summary>
-    /// Gets or sets the mnemonic recovery phrase (12 words).
+    /// Gets or sets the mnemonic recovery phrase (12, 15, 18, 21, or 24 words; new wallets default to 24).
     /// </summary>
     public string? Mnemonic { get; init; }
 

--- a/src/Common/Sorcha.Wallet.Contracts/Models/CreateWalletRequest.cs
+++ b/src/Common/Sorcha.Wallet.Contracts/Models/CreateWalletRequest.cs
@@ -29,9 +29,9 @@ public sealed record CreateWalletRequest
     [Required]
     public string Algorithm { get; set; } = string.Empty;
 
-    /// <summary>Number of words in mnemonic (12, 15, 18, 21, or 24).</summary>
+    /// <summary>Number of words in mnemonic (12, 15, 18, 21, or 24). Defaults to 24.</summary>
     [Bip39WordCount]
-    public int WordCount { get; set; } = 12;
+    public int WordCount { get; set; } = 24;
 
     /// <summary>Optional passphrase for additional security.</summary>
     public string? Passphrase { get; set; }

--- a/src/Core/Sorcha.Wallet.Core/Services/Implementation/WalletManager.cs
+++ b/src/Core/Sorcha.Wallet.Core/Services/Implementation/WalletManager.cs
@@ -73,7 +73,7 @@ public class WalletManager : IWalletService
         string algorithm,
         string owner,
         string tenant,
-        int wordCount = 12,
+        int wordCount = 24,
         string? passphrase = null,
         SigningMode? signingModeOverride = null,
         CancellationToken cancellationToken = default)

--- a/src/Core/Sorcha.Wallet.Portable/Domain/ValueObjects/Mnemonic.cs
+++ b/src/Core/Sorcha.Wallet.Portable/Domain/ValueObjects/Mnemonic.cs
@@ -42,9 +42,9 @@ public record Mnemonic
     /// <summary>
     /// Generates a new random mnemonic
     /// </summary>
-    /// <param name="wordCount">Number of words (12 or 24)</param>
+    /// <param name="wordCount">Number of words (12 or 24). Defaults to 24.</param>
     /// <returns>A new mnemonic</returns>
-    public static Mnemonic Generate(int wordCount = 12)
+    public static Mnemonic Generate(int wordCount = 24)
     {
         var entropy = wordCount == 24 ? NBitcoin.WordCount.TwentyFour : NBitcoin.WordCount.Twelve;
         return new Mnemonic(new NBitcoin.Mnemonic(Wordlist.English, entropy));
@@ -116,6 +116,6 @@ public record Mnemonic
     /// Returns a string representation of the mnemonic showing the word count for security.
     /// The actual mnemonic phrase is never exposed in ToString() to prevent accidental logging.
     /// </summary>
-    /// <returns>A string indicating the number of words (e.g., "Mnemonic(12 words)").</returns>
+    /// <returns>A string indicating the number of words (e.g., "Mnemonic(24 words)").</returns>
     public override string ToString() => $"Mnemonic({WordCount} words)";
 }

--- a/src/Core/Sorcha.Wallet.Portable/Services/Interfaces/IWalletService.cs
+++ b/src/Core/Sorcha.Wallet.Portable/Services/Interfaces/IWalletService.cs
@@ -29,7 +29,7 @@ public interface IWalletService
         string algorithm,
         string owner,
         string tenant,
-        int wordCount = 12,
+        int wordCount = 24,
         string? passphrase = null,
         SigningMode? signingModeOverride = null,
         CancellationToken cancellationToken = default);

--- a/src/Services/Sorcha.Tenant.Service/Emails/Templates/welcome-public.html
+++ b/src/Services/Sorcha.Tenant.Service/Emails/Templates/welcome-public.html
@@ -8,7 +8,7 @@
   </a>
 </p>
 <h3 style="margin:24px 0 8px;font-size:17px;">One thing worth knowing now</h3>
-<p>When you create your first wallet, {{ branding.sender_name | html.escape }} will show you a <strong>12-word recovery phrase</strong>. Write it down the moment you see it — a password manager or a piece of paper in a drawer both work. That phrase is the only way back into your wallet if you lose access. We can't see it and can't get it back for you — that's the whole point.</p>
+<p>When you create your first wallet, {{ branding.sender_name | html.escape }} will show you a <strong>24-word recovery phrase</strong>. Write it down the moment you see it — a password manager or a piece of paper in a drawer both work. That phrase is the only way back into your wallet if you lose access. We can't see it and can't get it back for you — that's the whole point.</p>
 <p>No rush, but when you're ready to create a wallet, that's the moment to have a pen handy.</p>
 <h3 style="margin:24px 0 8px;font-size:17px;">What's next</h3>
 <ul style="margin:0 0 16px;padding-left:20px;">

--- a/src/Services/Sorcha.Tenant.Service/Emails/Templates/welcome-public.txt
+++ b/src/Services/Sorcha.Tenant.Service/Emails/Templates/welcome-public.txt
@@ -8,7 +8,7 @@ Your account is ready. Jump in whenever you're set.
 ONE THING WORTH KNOWING NOW
 
 When you create your first wallet, {{ branding.sender_name }} will show you a
-12-word recovery phrase. Write it down the moment you see it — a password
+24-word recovery phrase. Write it down the moment you see it — a password
 manager or a piece of paper in a drawer both work. That phrase is the only way
 back into your wallet if you lose access. We can't see it and can't get it
 back for you — that's the whole point.

--- a/tests/Sorcha.Tenant.Service.Tests/Fixtures/Emails/welcome-public.html
+++ b/tests/Sorcha.Tenant.Service.Tests/Fixtures/Emails/welcome-public.html
@@ -20,7 +20,7 @@
             </a>
           </p>
           <h3 style="margin:24px 0 8px;font-size:17px;">One thing worth knowing now</h3>
-          <p>When you create your first wallet, Sorcha will show you a <strong>12-word recovery phrase</strong>. Write it down the moment you see it — a password manager or a piece of paper in a drawer both work. That phrase is the only way back into your wallet if you lose access. We can't see it and can't get it back for you — that's the whole point.</p>
+          <p>When you create your first wallet, Sorcha will show you a <strong>24-word recovery phrase</strong>. Write it down the moment you see it — a password manager or a piece of paper in a drawer both work. That phrase is the only way back into your wallet if you lose access. We can't see it and can't get it back for you — that's the whole point.</p>
           <p>No rush, but when you're ready to create a wallet, that's the moment to have a pen handy.</p>
           <h3 style="margin:24px 0 8px;font-size:17px;">What's next</h3>
           <ul style="margin:0 0 16px;padding-left:20px;">

--- a/tests/Sorcha.Tenant.Service.Tests/Fixtures/Emails/welcome-public.txt
+++ b/tests/Sorcha.Tenant.Service.Tests/Fixtures/Emails/welcome-public.txt
@@ -7,7 +7,7 @@ Your account is ready. Jump in whenever you're set.
 ONE THING WORTH KNOWING NOW
 
 When you create your first wallet, Sorcha will show you a
-12-word recovery phrase. Write it down the moment you see it — a password
+24-word recovery phrase. Write it down the moment you see it — a password
 manager or a piece of paper in a drawer both work. That phrase is the only way
 back into your wallet if you lose access. We can't see it and can't get it
 back for you — that's the whole point.

--- a/tests/Sorcha.UI.E2E.Tests/Tests/Wallets/CreateWalletTests.cs
+++ b/tests/Sorcha.UI.E2E.Tests/Tests/Wallets/CreateWalletTests.cs
@@ -87,12 +87,12 @@ public class CreateWalletTests : AuthenticatedDockerTestBase
     }
 
     /// <summary>
-    /// Standalone path: navigating directly to wallets/create (no query string) uses 12-word default
-    /// and empty name — confirming standalone behavior is unchanged (FR-009, SC-005).
+    /// Standalone path: navigating directly to wallets/create (no query string) uses the 24-word
+    /// default and empty name — confirming standalone behavior (FR-009, SC-005).
     /// </summary>
     [Test]
     [Ignore("Pending manual verification; standalone flow should be unchanged from pre-157")]
-    public async Task StandaloneWalletCreation_NoQueryString_DefaultsTo12WordsAndEmptyName()
+    public async Task StandaloneWalletCreation_NoQueryString_DefaultsTo24WordsAndEmptyName()
     {
         await NavigateAuthenticatedAsync("/wallets/create");
         await Page.WaitForLoadStateAsync();
@@ -100,7 +100,7 @@ public class CreateWalletTests : AuthenticatedDockerTestBase
         var wordCountInput = Page.Locator("[data-testid='word-count-selector'], [name='wordCount']");
         var value = await wordCountInput.InputValueAsync();
 
-        Assert.That(value, Is.EqualTo("12"), "Standalone wallet creation should default to 12 words");
+        Assert.That(value, Is.EqualTo("24"), "Standalone wallet creation should default to 24 words");
 
         var nameInput = Page.Locator("[data-testid='wallet-name-input'], [name='walletName']");
         var nameValue = await nameInput.InputValueAsync();

--- a/tests/Sorcha.Wallet.Core.Tests/Domain/ValueObjects/MnemonicTests.cs
+++ b/tests/Sorcha.Wallet.Core.Tests/Domain/ValueObjects/MnemonicTests.cs
@@ -9,12 +9,12 @@ namespace Sorcha.Wallet.Core.Tests.Domain.ValueObjects;
 public class MnemonicTests
 {
     [Fact]
-    public void Generate_Default_Produces12WordMnemonic()
+    public void Generate_Default_Produces24WordMnemonic()
     {
         var mnemonic = Mnemonic.Generate();
 
-        mnemonic.WordCount.Should().Be(12);
-        mnemonic.Phrase.Split(' ').Should().HaveCount(12);
+        mnemonic.WordCount.Should().Be(24);
+        mnemonic.Phrase.Split(' ').Should().HaveCount(24);
     }
 
     [Fact]
@@ -118,7 +118,7 @@ public class MnemonicTests
 
         var result = mnemonic.ToString();
 
-        result.Should().Be("Mnemonic(12 words)");
+        result.Should().Be("Mnemonic(24 words)");
         result.Should().NotContain(mnemonic.Phrase.Split(' ')[0]);
     }
 

--- a/tests/Sorcha.Wallet.Core.Tests/Services/WalletManagerTests.cs
+++ b/tests/Sorcha.Wallet.Core.Tests/Services/WalletManagerTests.cs
@@ -106,7 +106,7 @@ public class WalletManagerTests
         wallet.Name.Should().Be("My Wallet");
         wallet.Status.Should().Be(WalletStatus.Active);
         mnemonic.Should().NotBeNull();
-        mnemonic.WordCount.Should().Be(12);
+        mnemonic.WordCount.Should().Be(24);
     }
 
     [Fact]

--- a/tests/Sorcha.Wallet.Service.Tests/Integration/HybridSigningIntegrationTests.cs
+++ b/tests/Sorcha.Wallet.Service.Tests/Integration/HybridSigningIntegrationTests.cs
@@ -75,7 +75,7 @@ public class HybridSigningIntegrationTests
         wallet.Should().NotBeNull();
         wallet.Algorithm.Should().Be("ML-DSA-65");
         wallet.PublicKey.Should().NotBeNullOrEmpty();
-        mnemonic.WordCount.Should().Be(12);
+        mnemonic.WordCount.Should().Be(24);
     }
 
     [Fact]

--- a/tests/Sorcha.Wallet.Service.Tests/Services/WalletManagerTests.cs
+++ b/tests/Sorcha.Wallet.Service.Tests/Services/WalletManagerTests.cs
@@ -130,7 +130,7 @@ public class WalletManagerTests : IDisposable
         wallet.EncryptedPrivateKey.Should().NotBeNullOrEmpty();
 
         mnemonic.Should().NotBeNull();
-        mnemonic.WordCount.Should().Be(12);
+        mnemonic.WordCount.Should().Be(24);
 
         // Verify wallet was saved
         var savedWallet = await _repository.GetByAddressAsync(wallet.Address);


### PR DESCRIPTION
## What

Make **24 words** the default recovery-phrase length for new wallets, everywhere.

The create-wallet wizard already presented "24 words (Maximum security)" as its selected value, but every underlying default was still **12**, and the welcome email told new users to expect a **"12-word recovery phrase."** So the UI, the code, and the onboarding email disagreed. This aligns them on 24.

## Why

Surfaced during live AIAS onboarding testing on n1 — the welcome email said 12-word while the wizard defaulted to 24. 24 words (256-bit entropy) is the stronger, industry-standard default; we now say it consistently.

## Changes

- **Crypto/wallet defaults 12 → 24**: `KeyManager.GenerateMnemonic` + internal KeyRing generation, `IKeyManager`, `CreateWalletRequest.WordCount`, `WalletManager`, portable `Mnemonic.Generate` + `IWalletService`, CLI `--word-count` default + batch create.
- **UI**: `CreateWallet.razor` defaults to 24 and lists it first as *"24 words (Recommended)"*; `RecoverWallet` word-count picker defaults to 24.
- **Welcome email** (`welcome-public` html + txt): now says *"24-word recovery phrase"*; snapshot fixtures regenerated (only that line changed).
- **Doc comments** on `IKeyManager` / `KeyRing` / `Mnemonic` no longer hard-code "12 words".
- **Tests**: those that pinned the 12-word default updated to 24 (`MnemonicTests`, `WalletManagerTests`, the ignored E2E standalone-default test). Tests that pass an explicit 12 (`KeyManagerTests`, the override-survival E2E) left unchanged — 12 remains a valid selectable option.

## Verification

- `Sorcha.Wallet.Core.Tests` 122/122 ✅, `Sorcha.Cryptography.Tests` 386/386 ✅, `Sorcha.Wallet.Contracts.Tests` 24/24 ✅, `Sorcha.Tenant.Service.Tests` 1541 ✅ (email snapshots regenerated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)