### PR TITLE
feat: signup polish — passkey progress overlay + idempotent email verification

### DIFF
--- a/src/Services/Sorcha.Tenant.Service/Services/EmailVerificationService.cs
+++ b/src/Services/Sorcha.Tenant.Service/Services/EmailVerificationService.cs
@@ -86,17 +86,30 @@ public class EmailVerificationService : IEmailVerificationService
             return (false, "Invalid verification token.");
         }
 
+        // Idempotent success. Verification links are single-click by nature, but email
+        // security scanners (Outlook SafeLinks, Apple Mail, corporate gateways) routinely
+        // PRE-FETCH the URL before the human clicks it. If we consumed (nulled) the token on
+        // that first touch, the human's real click would then fail with "invalid token" even
+        // though their email IS verified. Instead we retain the token until it expires and
+        // treat a repeat hit on an already-verified account as success — the page shows
+        // "you're all set", not a scary failure.
+        if (platformUser.EmailVerified)
+        {
+            return (true, null);
+        }
+
         if (platformUser.VerificationTokenExpiresAt.HasValue
             && platformUser.VerificationTokenExpiresAt.Value < DateTimeOffset.UtcNow)
         {
             return (false, "Verification token has expired.");
         }
 
-        // Mark email as verified on PlatformUser
+        // Mark email as verified. The token is intentionally NOT cleared here so a subsequent
+        // pre-fetch / refresh of the same link still resolves to this user and returns the
+        // idempotent success above. It grants nothing beyond marking the email verified and
+        // expires naturally via VerificationTokenExpiresAt (a re-issue overwrites it).
         platformUser.EmailVerified = true;
         platformUser.EmailVerifiedAt = DateTimeOffset.UtcNow;
-        platformUser.VerificationToken = null;
-        platformUser.VerificationTokenExpiresAt = null;
 
         await _dbContext.SaveChangesAsync(cancellationToken);
 

--- a/src/Services/Sorcha.Tenant.Service/wwwroot/js/webauthn.js
+++ b/src/Services/Sorcha.Tenant.Service/wwwroot/js/webauthn.js
@@ -190,6 +190,76 @@ sorcha.webauthn = (function () {
     }
 
     // -------------------------------------------------------------------------
+    // Progress overlay
+    // -------------------------------------------------------------------------
+    // A self-contained, full-screen status shown during the passkey ceremony so
+    // the user never faces a blank / frozen screen — in particular the pause after
+    // the OS passkey sheet closes, while the account is created and tokens minted.
+    // Injected lazily into <body>; requires no page markup or external CSS.
+
+    var _overlayEl = null;
+    var _overlayTextEl = null;
+
+    function ensureOverlay() {
+        if (_overlayEl) { return; }
+
+        if (!document.getElementById('sorcha-webauthn-overlay-style')) {
+            var style = document.createElement('style');
+            style.id = 'sorcha-webauthn-overlay-style';
+            style.textContent =
+                '@keyframes sorcha-wa-spin{to{transform:rotate(360deg)}}' +
+                '#sorcha-webauthn-overlay{position:fixed;inset:0;z-index:2147483647;display:flex;' +
+                'flex-direction:column;align-items:center;justify-content:center;gap:18px;' +
+                'background:rgba(17,17,27,.72);backdrop-filter:blur(2px);' +
+                '-webkit-backdrop-filter:blur(2px);color:#fff;font-size:1.05rem;line-height:1.4;' +
+                'font-family:inherit;text-align:center;padding:24px;opacity:0;' +
+                'transition:opacity .15s ease}' +
+                '#sorcha-webauthn-overlay.is-visible{opacity:1}' +
+                '#sorcha-webauthn-overlay .sorcha-wa-spinner{width:46px;height:46px;border-radius:50%;' +
+                'border:4px solid rgba(255,255,255,.25);border-top-color:#fff;' +
+                'animation:sorcha-wa-spin .8s linear infinite}';
+            document.head.appendChild(style);
+        }
+
+        _overlayEl = document.createElement('div');
+        _overlayEl.id = 'sorcha-webauthn-overlay';
+        _overlayEl.setAttribute('role', 'status');
+        _overlayEl.setAttribute('aria-live', 'polite');
+
+        var spinner = document.createElement('div');
+        spinner.className = 'sorcha-wa-spinner';
+        spinner.setAttribute('aria-hidden', 'true');
+
+        _overlayTextEl = document.createElement('div');
+        _overlayTextEl.className = 'sorcha-wa-text';
+
+        _overlayEl.appendChild(spinner);
+        _overlayEl.appendChild(_overlayTextEl);
+        document.body.appendChild(_overlayEl);
+    }
+
+    /**
+     * Shows (or updates the text of) the full-screen progress overlay.
+     * @param {string} text - Status message to display.
+     */
+    function showProgress(text) {
+        ensureOverlay();
+        _overlayTextEl.textContent = text;
+        // Force a reflow so the opacity transition runs even on the first show.
+        void _overlayEl.offsetWidth;
+        _overlayEl.classList.add('is-visible');
+    }
+
+    /**
+     * Hides the progress overlay. Safe to call when it was never shown.
+     */
+    function hideProgress() {
+        if (_overlayEl) {
+            _overlayEl.classList.remove('is-visible');
+        }
+    }
+
+    // -------------------------------------------------------------------------
     // Public API
     // -------------------------------------------------------------------------
 
@@ -210,6 +280,8 @@ sorcha.webauthn = (function () {
      */
     async function signIn(optionsUrl, verifyUrl, returnUrl) {
         try {
+            showProgress('Signing you in…');
+
             // Step 1: Get assertion options from server
             var optionsResponse = await fetch(optionsUrl, {
                 method: 'POST',
@@ -218,6 +290,7 @@ sorcha.webauthn = (function () {
             });
 
             if (!optionsResponse.ok) {
+                hideProgress();
                 var errorData = await optionsResponse.json().catch(function () { return null; });
                 var errorMsg = (errorData && (errorData.detail || errorData.title || errorData.error))
                     || 'Failed to get passkey options. Please try again.';
@@ -230,14 +303,17 @@ sorcha.webauthn = (function () {
             var publicKeyOptions = prepareAssertionOptions(optionsData.options);
 
             // Step 2: Invoke browser WebAuthn API
+            showProgress('Waiting for your passkey…');
             var credential = await navigator.credentials.get({ publicKey: publicKeyOptions });
 
             if (!credential) {
+                hideProgress();
                 alert('Passkey sign-in was cancelled or no credential was selected.');
                 return;
             }
 
             // Step 3: Serialize and POST assertion response to server
+            showProgress('Finishing sign-in…');
             var assertionPayload = {
                 transaction_id: transactionId,
                 assertion_response: serializeAssertionResponse(credential)
@@ -250,6 +326,7 @@ sorcha.webauthn = (function () {
             });
 
             if (!verifyResponse.ok) {
+                hideProgress();
                 var verifyError = await verifyResponse.json().catch(function () { return null; });
                 var verifyMsg = (verifyError && (verifyError.detail || verifyError.title || verifyError.error))
                     || 'Passkey verification failed. Please try again.';
@@ -257,7 +334,8 @@ sorcha.webauthn = (function () {
                 return;
             }
 
-            // Step 4: Redirect to app with tokens in hash
+            // Step 4: Redirect to app with tokens in hash. Leave the overlay visible
+            // through navigation so the screen never flashes empty.
             var tokenData = await verifyResponse.json();
             window.location.href = buildAppRedirectUrl(
                 tokenData.access_token,
@@ -266,6 +344,7 @@ sorcha.webauthn = (function () {
             );
 
         } catch (err) {
+            hideProgress();
             if (err && err.name === 'NotAllowedError') {
                 alert('Passkey sign-in was cancelled or timed out. Please try again.');
             } else if (err && err.name === 'SecurityError') {
@@ -295,6 +374,8 @@ sorcha.webauthn = (function () {
      */
     async function register(optionsUrl, verifyUrl, displayName, email, returnUrl) {
         try {
+            showProgress('Starting secure sign-up…');
+
             // Step 1: Get registration options from server
             var optionsResponse = await fetch(optionsUrl, {
                 method: 'POST',
@@ -306,6 +387,7 @@ sorcha.webauthn = (function () {
             });
 
             if (!optionsResponse.ok) {
+                hideProgress();
                 var statusCode = optionsResponse.status;
                 var errorData = await optionsResponse.json().catch(function () { return null; });
 
@@ -325,14 +407,18 @@ sorcha.webauthn = (function () {
             var publicKeyOptions = prepareCreationOptions(optionsData.options);
 
             // Step 2: Invoke browser WebAuthn API
+            showProgress('Waiting for your passkey…');
             var credential = await navigator.credentials.create({ publicKey: publicKeyOptions });
 
             if (!credential) {
+                hideProgress();
                 alert('Passkey registration was cancelled. Please try again.');
                 return;
             }
 
-            // Step 3: Serialize and POST attestation response to server
+            // Step 3: Serialize and POST attestation response to server. This is where the
+            // account is created + tokens minted — the pause the overlay covers.
+            showProgress('Creating your account…');
             var attestationPayload = {
                 transaction_id: transactionId,
                 attestation_response: serializeAttestationResponse(credential)
@@ -345,6 +431,7 @@ sorcha.webauthn = (function () {
             });
 
             if (!verifyResponse.ok) {
+                hideProgress();
                 var verifyError = await verifyResponse.json().catch(function () { return null; });
                 var verifyMsg = (verifyError && (verifyError.detail || verifyError.title || verifyError.error))
                     || 'Passkey registration failed. Please try again.';
@@ -352,7 +439,8 @@ sorcha.webauthn = (function () {
                 return;
             }
 
-            // Step 4: Redirect to app with tokens in hash
+            // Step 4: Redirect to app with tokens in hash. Leave the overlay visible
+            // through navigation so the screen never flashes empty.
             var tokenData = await verifyResponse.json();
             window.location.href = buildAppRedirectUrl(
                 tokenData.access_token,
@@ -361,6 +449,7 @@ sorcha.webauthn = (function () {
             );
 
         } catch (err) {
+            hideProgress();
             if (err && err.name === 'NotAllowedError') {
                 alert('Passkey registration was cancelled or timed out. Please try again.');
             } else if (err && err.name === 'InvalidStateError') {

--- a/tests/Sorcha.Tenant.Service.Tests/Services/EmailVerificationServiceTests.cs
+++ b/tests/Sorcha.Tenant.Service.Tests/Services/EmailVerificationServiceTests.cs
@@ -144,6 +144,29 @@ public class EmailVerificationServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task VerifyTokenAsync_RepeatHitOnSameLink_ReturnsIdempotentSuccess()
+    {
+        // Models an email security scanner pre-fetching the link (first hit) followed by the
+        // human's real click (second hit): both must succeed, and welcome fires exactly once.
+        var (platformUser, user) = await SeedUserAsync();
+        var service = CreateService();
+        var token = await service.GenerateAndSendVerificationAsync(user, CancellationToken.None);
+
+        var first = await service.VerifyTokenAsync(token, CancellationToken.None);
+        var second = await service.VerifyTokenAsync(token, CancellationToken.None);
+
+        first.Success.Should().BeTrue();
+        second.Success.Should().BeTrue("a repeat click on an already-verified link must not read as failure");
+        second.Error.Should().BeNull();
+
+        var reloaded = await _dbContext.PlatformUsers.AsNoTracking().FirstAsync(u => u.Id == platformUser.Id);
+        reloaded.EmailVerified.Should().BeTrue();
+
+        _transactional.Verify(t => t.SendWelcomeAsync(
+            It.IsAny<WelcomeDispatchContext>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
     public async Task VerifyTokenAsync_InvalidToken_ReturnsErrorAndDoesNotDispatch()
     {
         var service = CreateService();


### PR DESCRIPTION
Two fixes surfaced during live AIAS onboarding testing on n1.

## 1. Passkey ceremony had no progress feedback

"Register with passkey" (and passkey sign-in) do a lot silently — options fetch → OS passkey sheet → account creation + token minting → redirect. After the OS sheet closes there was a **blank, frozen-looking screen** until the redirect fired, which reads as "it hung."

Added a **self-contained, lazily-injected full-screen progress overlay** inside the shared `webauthn.js`. Both `register` and `signIn` drive it through staged text:

- register: *Starting secure sign-up…* → *Waiting for your passkey…* → *Creating your account…* → (stays up through redirect)
- signIn: *Signing you in…* → *Waiting for your passkey…* → *Finishing sign-in…* → (stays up through redirect)

No page markup or external CSS required (styles + spinner injected once). The overlay is **hidden on every error/cancel path** before the existing `alert()`, and in `catch`. Both the signup and login pages benefit with zero page changes.

## 2. "Verification failed" on a link that actually worked

Email security scanners (Outlook SafeLinks, Apple Mail, corporate gateways) routinely **pre-fetch** the verification URL before the human clicks. Because the token was single-use and nulled on first touch, the human's real click then hit *"Invalid verification token"* — even though their email **was** verified. Confusing and alarming.

`EmailVerificationService.VerifyTokenAsync` is now **idempotent**:
- The token is **retained until it expires** (it grants nothing beyond marking the email verified; a re-issue overwrites it).
- A repeat hit on an **already-verified** account short-circuits to **success**, so the page shows "you're all set", not a failure.

Added `VerifyTokenAsync_RepeatHitOnSameLink_ReturnsIdempotentSuccess` modelling the scanner-prefetch-then-human-click sequence (both succeed; welcome fires exactly once).

## Verification

- `Sorcha.Tenant.Service.Tests` **1542 passed** / 0 failed (new idempotency test included; email snapshots unchanged).
- `webauthn.js` passes `node --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)