### PR TITLE
fix: AIAS rehearsal recognises post-VCT-decoupling credential + cold-node timeout

### DIFF
--- a/demos/AIAS/rehearse.ps1
+++ b/demos/AIAS/rehearse.ps1
@@ -24,7 +24,9 @@ param(
     [ValidateSet('docker', 'n1')][string]$Target = 'docker',
     [string]$StateFile = (Join-Path $PSScriptRoot "state.json"),
     [int]$DecisionTimeoutSeconds = 60,
-    [int]$DeliveryTimeoutSeconds = 60
+    # The first credential delivery on a freshly-genesis'd node (cold register seal + wallet sync)
+    # can take longer than a warm node — 120s keeps the happy path reliable right after a re-genesis.
+    [int]$DeliveryTimeoutSeconds = 120
 )
 
 Set-StrictMode -Version Latest
@@ -186,7 +188,15 @@ function Test-CredentialDelivered {
         try {
             $snap = Invoke-SorchaApi -Method GET -Uri "$api/v1/wallet/credentials" -Headers $Applicant.Session.Headers
             if ($snap.credentials -and $snap.credentials.Count -gt 0) {
-                $hit = $snap.credentials | Where-Object { $_.vct -match "AssuredIdentity" -or $_.displayLabel -match "Assured" } | Select-Object -First 1
+                # Match the AssuredIdentity credential across both the pre- and post-VCT-decoupling
+                # (#1187) shapes: the vct is now the URI ".../assured-identity/v1" (hyphenated), not
+                # the bare "AssuredIdentityCredential" the old matcher looked for, and displayLabel is
+                # empty in the summary projection. Match the vct URI slug OR the credentialType OR a
+                # label, so the harness recognises the credential the engine actually mints.
+                $hit = $snap.credentials | Where-Object {
+                    $_.vct -match "assured-identity" -or $_.vct -match "AssuredIdentity" -or
+                    $_.credentialType -match "AssuredIdentity" -or $_.displayLabel -match "Assured"
+                } | Select-Object -First 1
                 if ($hit) { return $hit }
             }
         } catch { }


### PR DESCRIPTION
## What

The AIAS rehearsal harness (`demos/AIAS/rehearse.ps1`) reported a **false APPROVAL failure** on a freshly re-genesis'd n1. The agent approved, and the engine **did** mint + deliver the `AssuredIdentityCredential` (confirmed in blueprint-service logs and by querying the applicant's wallet) — but `Test-CredentialDelivered` never recognised it.

## Why it broke

Two stale spots, both from the **VCT decoupling (#1187)** which landed after this script was written:

1. **Matcher**: looked for `vct -match "AssuredIdentity"` (camelCase) or a `"Assured"` `displayLabel`. The vct is now the URI `https://sorcha.dev/vc/assured-identity/v1` (hyphenated) and `displayLabel` is empty in the summary projection — so neither matched a credential that was genuinely delivered. Now matches the vct URI slug OR `credentialType` OR label.
2. **Timeout**: 60s is tight for the **first** credential on a cold post-genesis node (register seal + wallet sync). Bumped the delivery-timeout default to 120s.

Not a platform regression — the issuance/delivery path works; the harness was out of date.

## Verification

`./demos/AIAS/rehearse.ps1 -Target n1` now **PASSES all three paths** (approval issues + delivers a credential; bad-postcode and unverified-email both reject with no credential) on a fresh genesis running current master — the same run that surfaced the bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)