### PR TITLE
fix: scope designer-metrics listener to its own meter, not the meter name

### DIFF
--- a/tests/Sorcha.Blueprint.Service.Tests/Services/BlueprintDesignerMetricsTests.cs
+++ b/tests/Sorcha.Blueprint.Service.Tests/Services/BlueprintDesignerMetricsTests.cs
@@ -13,9 +13,29 @@ namespace Sorcha.Blueprint.Service.Tests.Services;
 /// Feature 142 T058 — asserts the <c>Sorcha.Blueprint.Designer</c> meter instruments record. Uses a
 /// raw <see cref="MeterListener"/> over a real <see cref="IMeterFactory"/> obtained from a service
 /// collection (the same way the host resolves <see cref="BlueprintDesignerMetrics"/>).
-/// Single-collection so concurrent listeners don't cross over.
 /// </summary>
-[Collection("Sorcha.Blueprint.Designer metrics")]
+/// <remarks>
+/// <para>
+/// <b>The listener is scoped to this test's own meter instance, not to the meter name.</b> That
+/// distinction is what makes these tests deterministic.
+/// </para>
+/// <para>
+/// The listener previously enabled any instrument whose <c>Meter.Name</c> matched
+/// <see cref="BlueprintDesignerMetrics.MeterName"/>. But <c>RehearsalOrchestrationServiceTests</c>
+/// and <c>SandboxRegisterProviderTests</c> also construct <see cref="BlueprintDesignerMetrics"/>,
+/// and xUnit runs them in parallel with this class — the <c>[Collection]</c> attribute serialised
+/// nothing, because this was the only class in that collection. Their measurements landed in this
+/// listener, so <c>ContainSingle</c> intermittently saw two and failed. It bit
+/// <c>RecordRehearsalTerminal</c> hardest, since the orchestration tests emit exactly
+/// <c>rehearsal_run_total{outcome=Passed}</c> and <c>rehearsal_duration_seconds</c>.
+/// </para>
+/// <para>
+/// <c>IMeterFactory.Create</c> stamps the factory onto <see cref="Meter.Scope"/>, so comparing
+/// scope by reference admits only the meter this instance created. No sleeps, no retries, no
+/// dependence on the runner's parallelism settings — a delay would have widened the contamination
+/// window rather than closed it.
+/// </para>
+/// </remarks>
 public sealed class BlueprintDesignerMetricsTests : IDisposable
 {
     private readonly ServiceProvider _provider;
@@ -27,13 +47,16 @@ public sealed class BlueprintDesignerMetricsTests : IDisposable
     public BlueprintDesignerMetricsTests()
     {
         _provider = new ServiceCollection().AddMetrics().BuildServiceProvider();
-        _metrics = new BlueprintDesignerMetrics(_provider.GetRequiredService<IMeterFactory>());
+        var meterFactory = _provider.GetRequiredService<IMeterFactory>();
+        _metrics = new BlueprintDesignerMetrics(meterFactory);
 
         _listener = new MeterListener
         {
             InstrumentPublished = (instrument, listener) =>
             {
-                if (instrument.Meter.Name == BlueprintDesignerMetrics.MeterName)
+                // Identity, not name: another test class's BlueprintDesignerMetrics publishes a
+                // meter with the SAME name, and runs concurrently with this one.
+                if (ReferenceEquals(instrument.Meter.Scope, meterFactory))
                 {
                     listener.EnableMeasurementEvents(instrument);
                 }


### PR DESCRIPTION
Fixes the intermittent `BlueprintDesignerMetricsTests.RecordRehearsalTerminal_WritesCounterAndHistogram_WithOutcomeTag` failure — roughly **1 run in 3**, present on master and unrelated to any recent change.

## Not a timing problem

Worth stating plainly, because the obvious reach is for a delay: **a sleep would have made this worse**, widening the contamination window rather than closing it.

## Root cause

The test's `MeterListener` enabled any instrument whose `Meter.Name` matched `BlueprintDesignerMetrics.MeterName`:

```csharp
if (instrument.Meter.Name == BlueprintDesignerMetrics.MeterName)
    listener.EnableMeasurementEvents(instrument);
```

`RehearsalOrchestrationServiceTests` and `SandboxRegisterProviderTests` **also** construct `BlueprintDesignerMetrics`, and xUnit runs them **in parallel** with this class — the `[Collection("Sorcha.Blueprint.Designer metrics")]` attribute serialised nothing, because this was the only class in that collection. Their measurements landed in this listener, so `ContainSingle` intermittently saw two and failed.

It bit `RecordRehearsalTerminal` hardest because the orchestration tests emit exactly `rehearsal_run_total{outcome=Passed}` and `rehearsal_duration_seconds` — the two instruments that assertion pins.

## Fix

Match the meter by **identity**, not by name. `IMeterFactory.Create` stamps the factory onto `Meter.Scope`, so a reference comparison admits only the meter this test instance created:

```csharp
if (ReferenceEquals(instrument.Meter.Scope, meterFactory))
    listener.EnableMeasurementEvents(instrument);
```

The `[Collection]` attribute is removed as the no-op it was — isolation no longer depends on the runner's parallelism settings at all.

The fix is **self-checking**: had the scope comparison matched nothing, every assertion in the class would fail on an empty measurement list rather than pass vacuously.

## Verification

**12 consecutive full-suite runs, zero failures**, against a baseline that failed 1-of-3 (and, on unmodified master, 1 then 0 across consecutive runs).

Found while verifying #1242; raised separately since it's unrelated to that change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HMQZDe2uWBLimHabrHM6yf