### PR TITLE
fix: [DRIFT-002] repair the three worst CLI wire contracts

### DIFF
--- a/src/Apps/Sorcha.Cli/Commands/AuditCommands.cs
+++ b/src/Apps/Sorcha.Cli/Commands/AuditCommands.cs
@@ -109,7 +109,7 @@ public class AuditListCommand : Command
                     orgId, since, until, action, user, page, pageSize,
                     $"Bearer {token}");
 
-                if (response.Entries.Count == 0)
+                if (response.Events.Count == 0)
                 {
                     ConsoleHelper.WriteInfo("No audit entries found matching the criteria.");
                     return ExitCodes.Success;
@@ -122,22 +122,28 @@ public class AuditListCommand : Command
                     return ExitCodes.Success;
                 }
 
-                ConsoleHelper.WriteSuccess($"Found {response.Entries.Count} audit entries (Total: {response.TotalCount}, Page: {response.Page}/{((response.TotalCount + response.PageSize - 1) / Math.Max(response.PageSize, 1))}):");
+                ConsoleHelper.WriteSuccess($"Found {response.Events.Count} audit entries (Total: {response.TotalCount}, Page: {response.Page}/{((response.TotalCount + response.PageSize - 1) / Math.Max(response.PageSize, 1))}):");
                 Console.WriteLine();
-                Console.WriteLine($"{"Timestamp",-22} {"Action",-25} {"User",-30} {"Resource",-15} {"Details"}");
-                Console.WriteLine(new string('-', 110));
+                Console.WriteLine($"{"Timestamp",-22} {"Event",-30} {"Identity",-38} {"OK",-4} {"Details"}");
+                Console.WriteLine(new string('-', 120));
 
-                foreach (var entry in response.Entries)
+                foreach (var entry in response.Events)
                 {
                     var timestamp = entry.Timestamp.ToString("yyyy-MM-dd HH:mm:ss");
-                    var resourceInfo = !string.IsNullOrEmpty(entry.ResourceType)
-                        ? $"{entry.ResourceType}"
-                        : "-";
-                    var details = !string.IsNullOrEmpty(entry.Details)
-                        ? (entry.Details.Length > 30 ? entry.Details[..30] + "..." : entry.Details)
-                        : "-";
+                    var identity = entry.IdentityId?.ToString() ?? "-";
+                    var ok = entry.Success ? "yes" : "NO";
 
-                    Console.WriteLine($"{timestamp,-22} {entry.Action,-25} {entry.UserName,-30} {resourceInfo,-15} {details}");
+                    // Details is a JSON object server-side, not a string. Render it compactly rather
+                    // than relying on ToString(), which would print the dictionary's type name.
+                    var details = entry.Details is { Count: > 0 }
+                        ? string.Join(", ", entry.Details.Select(kv => $"{kv.Key}={kv.Value}"))
+                        : "-";
+                    if (details.Length > 40)
+                    {
+                        details = details[..40] + "...";
+                    }
+
+                    Console.WriteLine($"{timestamp,-22} {entry.EventType,-30} {identity,-38} {ok,-4} {details}");
                 }
 
                 return ExitCodes.Success;
@@ -262,7 +268,7 @@ public class AuditExportCommand : Command
                         orgId, since, until, action, user, currentPage, batchSize,
                         $"Bearer {token}");
 
-                    allEntries.AddRange(response.Entries);
+                    allEntries.AddRange(response.Events);
                     totalCount = response.TotalCount;
                     currentPage++;
                 } while (allEntries.Count < totalCount);
@@ -285,14 +291,22 @@ public class AuditExportCommand : Command
                 {
                     var lines = new List<string>
                     {
-                        "Id,Timestamp,Action,UserId,UserName,ResourceType,ResourceId,Details"
+                        "Id,Timestamp,EventType,IdentityId,Success,IpAddress,Details"
                     };
 
                     foreach (var entry in allEntries)
                     {
-                        var details = EscapeCsvField(entry.Details ?? string.Empty);
-                        var userName = EscapeCsvField(entry.UserName);
-                        lines.Add($"{entry.Id},{entry.Timestamp:O},{EscapeCsvField(entry.Action)},{entry.UserId},{userName},{entry.ResourceType ?? string.Empty},{entry.ResourceId ?? string.Empty},{details}");
+                        // Details is a JSON object server-side; flatten it to k=v pairs so the CSV
+                        // column carries the content rather than a type name.
+                        var details = EscapeCsvField(entry.Details is { Count: > 0 }
+                            ? string.Join("; ", entry.Details.Select(kv => $"{kv.Key}={kv.Value}"))
+                            : string.Empty);
+
+                        lines.Add(
+                            $"{entry.Id},{entry.Timestamp:O},{EscapeCsvField(entry.EventType)},"
+                            + $"{entry.IdentityId?.ToString() ?? string.Empty},"
+                            + $"{entry.Success},"
+                            + $"{EscapeCsvField(entry.IpAddress ?? string.Empty)},{details}");
                     }
 
                     content = string.Join(Environment.NewLine, lines);

--- a/src/Apps/Sorcha.Cli/Commands/ParticipantCommands.cs
+++ b/src/Apps/Sorcha.Cli/Commands/ParticipantCommands.cs
@@ -936,12 +936,38 @@ public class ParticipantPublishCommand : Command
 
                 var client = await clientFactory.CreateParticipantServiceClientAsync(profileName);
 
+                // The register needs the participant's public key and algorithm, not just an
+                // address — that is what lets other participants encrypt to them. Resolve it from
+                // the Wallet Service rather than asking the operator to paste key material.
+                var walletClient = await clientFactory.CreateWalletServiceClientAsync(profileName);
+                WalletDto walletDetails;
+                try
+                {
+                    walletDetails = await walletClient.GetWalletAsync(wallet, $"Bearer {token}");
+                }
+                catch (ApiException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+                {
+                    ConsoleHelper.WriteError(
+                        $"Wallet '{wallet}' not found, so its public key cannot be published. "
+                        + "Check the address, or create the wallet first with 'sorcha wallet create'.");
+                    return ExitCodes.NotFound;
+                }
+
                 var request = new PublishParticipantRequest
                 {
                     RegisterId = registerId,
-                    Name = name,
+                    ParticipantName = name,
                     OrganizationName = orgName,
-                    WalletAddresses = [wallet],
+                    Addresses =
+                    [
+                        new ParticipantAddressRequest
+                        {
+                            WalletAddress = walletDetails.Address,
+                            PublicKey = walletDetails.PublicKey,
+                            Algorithm = walletDetails.Algorithm,
+                            Primary = true,
+                        }
+                    ],
                     SignerWalletAddress = signer
                 };
 

--- a/src/Apps/Sorcha.Cli/Commands/ServicePrincipalCommands.cs
+++ b/src/Apps/Sorcha.Cli/Commands/ServicePrincipalCommands.cs
@@ -553,12 +553,25 @@ public class PrincipalRotateSecretCommand : Command
 
                 ConsoleHelper.WriteSuccess($"Client secret rotated successfully!");
                 Console.WriteLine();
-                Console.WriteLine($"  Rotated At:      {response.RotatedAt:yyyy-MM-dd HH:mm:ss}");
-                Console.WriteLine();
                 ConsoleHelper.WriteWarning("IMPORTANT: Save the new client secret securely!");
-                Console.WriteLine($"  New Client Secret: {response.ClientSecret}");
+                Console.WriteLine($"  New Client Secret: {response.NewClientSecret}");
                 Console.WriteLine();
-                ConsoleHelper.WriteWarning("The new client secret will NEVER be displayed again.");
+
+                // Defensive: the rotation has already happened server-side by the time we get here,
+                // so an empty secret means the operator has just lost access to this principal.
+                // Say so loudly rather than printing a blank line and claiming success.
+                if (string.IsNullOrWhiteSpace(response.NewClientSecret))
+                {
+                    ConsoleHelper.WriteError(
+                        "The server did not return a new client secret. The old secret is no longer "
+                        + "valid, so this principal now has no usable credential — re-register it.");
+                    return ExitCodes.GeneralError;
+                }
+
+                ConsoleHelper.WriteWarning(
+                    string.IsNullOrWhiteSpace(response.Warning)
+                        ? "The new client secret will NEVER be displayed again."
+                        : response.Warning);
                 ConsoleHelper.WriteWarning("Update all applications using this service principal immediately.");
 
                 return ExitCodes.Success;

--- a/src/Apps/Sorcha.Cli/Models/Participant.cs
+++ b/src/Apps/Sorcha.Cli/Models/Participant.cs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Sorcha Contributors
 
+using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace Sorcha.Cli.Models;
@@ -107,22 +108,55 @@ public class WalletLinkChallengeResponse
 /// <summary>
 /// Request to publish a participant to a register.
 /// </summary>
+/// <remarks>
+/// Mirrors <c>Sorcha.Tenant.Service.Services.PublishParticipantRequest</c> exactly; the pairing is
+/// asserted by <c>CliWireContractTests</c>. This previously sent <c>name</c> and a bare
+/// <c>walletAddresses</c> string list, while the server requires <c>participantName</c> and a
+/// structured <c>addresses</c> list — every field <c>required</c>, so the request 400'd.
+/// </remarks>
 public class PublishParticipantRequest
 {
     [JsonPropertyName("registerId")]
     public string RegisterId { get; set; } = string.Empty;
 
-    [JsonPropertyName("name")]
-    public string Name { get; set; } = string.Empty;
+    [JsonPropertyName("participantName")]
+    public string ParticipantName { get; set; } = string.Empty;
 
     [JsonPropertyName("organizationName")]
     public string OrganizationName { get; set; } = string.Empty;
 
-    [JsonPropertyName("walletAddresses")]
-    public List<string> WalletAddresses { get; set; } = new();
+    /// <summary>
+    /// The participant's on-register addresses. Each carries the public key and algorithm the
+    /// register needs in order to encrypt to this participant, so an address cannot be published
+    /// as a bare string.
+    /// </summary>
+    [JsonPropertyName("addresses")]
+    public List<ParticipantAddressRequest> Addresses { get; set; } = new();
 
     [JsonPropertyName("signerWalletAddress")]
     public string SignerWalletAddress { get; set; } = string.Empty;
+
+    /// <summary>Optional free-form metadata published alongside the participant.</summary>
+    [JsonPropertyName("metadata")]
+    public JsonElement? Metadata { get; set; }
+}
+
+/// <summary>
+/// One address entry in a participant publish request.
+/// </summary>
+public class ParticipantAddressRequest
+{
+    [JsonPropertyName("walletAddress")]
+    public string WalletAddress { get; set; } = string.Empty;
+
+    [JsonPropertyName("publicKey")]
+    public string PublicKey { get; set; } = string.Empty;
+
+    [JsonPropertyName("algorithm")]
+    public string Algorithm { get; set; } = string.Empty;
+
+    [JsonPropertyName("primary")]
+    public bool Primary { get; set; }
 }
 
 /// <summary>

--- a/src/Apps/Sorcha.Cli/Models/ServicePrincipal.cs
+++ b/src/Apps/Sorcha.Cli/Models/ServicePrincipal.cs
@@ -93,15 +93,22 @@ public class CreateServicePrincipalResponse
 /// <summary>
 /// Response when rotating a service principal secret.
 /// </summary>
+/// <remarks>
+/// Mirrors <c>Sorcha.Tenant.Service.Models.Dtos.RotateSecretResponse</c> exactly; the pairing is
+/// asserted by <c>CliWireContractTests</c>. This previously declared <c>ClientSecret</c> and
+/// <c>RotatedAt</c>, neither of which the server sends — so the command printed an empty secret
+/// and a default timestamp while reporting success. The rotation itself had happened, leaving the
+/// operator with a rotated principal and no way to recover the new secret.
+/// </remarks>
 public class RotateSecretResponse
 {
     /// <summary>
-    /// New client secret.
+    /// The new client secret. Returned once and never again.
     /// </summary>
-    public string ClientSecret { get; set; } = string.Empty;
+    public string NewClientSecret { get; set; } = string.Empty;
 
     /// <summary>
-    /// When the secret was rotated.
+    /// Server-supplied warning shown alongside the secret.
     /// </summary>
-    public DateTimeOffset RotatedAt { get; set; }
+    public string Warning { get; set; } = string.Empty;
 }

--- a/src/Apps/Sorcha.Cli/Services/IAuditServiceClient.cs
+++ b/src/Apps/Sorcha.Cli/Services/IAuditServiceClient.cs
@@ -28,27 +28,57 @@ public interface IAuditServiceClient
 // --- Request/Response DTOs ---
 
 /// <summary>
-/// Audit log entry.
+/// A single audit event.
 /// </summary>
+/// <remarks>
+/// Mirrors <c>Sorcha.Tenant.Service.Models.Dtos.AuditEventResponse</c> exactly; the pairing is
+/// asserted by <c>CliWireContractTests</c>. This previously declared <c>Action</c>, <c>UserId</c>,
+/// <c>UserName</c>, <c>ResourceType</c> and <c>ResourceId</c> — none of which the server sends —
+/// so every column of <c>sorcha audit query</c> rendered blank even when events existed.
+/// </remarks>
 public class AuditLogEntry
 {
-    public string Id { get; set; } = string.Empty;
-    public string Action { get; set; } = string.Empty;
-    public string UserId { get; set; } = string.Empty;
-    public string UserName { get; set; } = string.Empty;
-    public string? ResourceType { get; set; }
-    public string? ResourceId { get; set; }
-    public string? Details { get; set; }
+    /// <summary>Monotonic audit event id.</summary>
+    public long Id { get; set; }
+
+    /// <summary>When the event occurred (UTC).</summary>
     public DateTimeOffset Timestamp { get; set; }
+
+    /// <summary>The event type, e.g. <c>identity.login</c>.</summary>
+    public string EventType { get; set; } = string.Empty;
+
+    /// <summary>The acting identity, when the event had one.</summary>
+    public Guid? IdentityId { get; set; }
+
+    /// <summary>Source IP, when recorded.</summary>
+    public string? IpAddress { get; set; }
+
+    /// <summary>Whether the audited operation succeeded.</summary>
+    public bool Success { get; set; }
+
+    /// <summary>Free-form event detail.</summary>
+    public Dictionary<string, object>? Details { get; set; }
 }
 
 /// <summary>
 /// Paginated audit log response.
 /// </summary>
+/// <remarks>
+/// The collection is <c>events</c> on the wire, not <c>entries</c>. Reading the wrong name meant
+/// the list deserialised empty and <c>sorcha audit query</c> reported "No audit entries found"
+/// regardless of what the server returned.
+/// </remarks>
 public class AuditLogResponse
 {
-    public List<AuditLogEntry> Entries { get; set; } = new();
+    /// <summary>The audit events on this page.</summary>
+    public List<AuditLogEntry> Events { get; set; } = new();
+
+    /// <summary>Total events matching the query across all pages.</summary>
     public int TotalCount { get; set; }
+
+    /// <summary>1-based page number.</summary>
     public int Page { get; set; }
+
+    /// <summary>Page size used for this query.</summary>
     public int PageSize { get; set; }
 }

--- a/tests/Sorcha.Cli.ContractTests/CliWireContractTests.cs
+++ b/tests/Sorcha.Cli.ContractTests/CliWireContractTests.cs
@@ -74,10 +74,6 @@ public sealed class CliWireContractTests
     /// </remarks>
     private static readonly Dictionary<string, string> KnownMismatch = new(StringComparer.Ordinal)
     {
-        ["AuditLogEntry"] =
-            "Tenant.Service (vs AuditEventResponse) — CLI-only: action, resourceId, resourceType, userId, userName; server-only: eventType, identityId, ipAddress, success",
-        ["AuditLogResponse"] =
-            "Tenant.Service — server sends `events`, CLI reads `entries` -> `audit query` always reports nothing",
         ["AvailableRegisterInfo"] =
             "Peer.Service — server-only: description, name",
         ["BootstrapResponse"] =
@@ -106,16 +102,12 @@ public sealed class CliWireContractTests
             "Register.Service — server-only: policy",
         ["PublishBlueprintRequest"] =
             "ServiceClients.Http — CLI-only: blueprintId; server-only: override",
-        ["PublishParticipantRequest"] =
-            "Tenant.Service — CLI sends `name`/`walletAddresses`; server requires `participantName`/`addresses`/`signerWalletAddress` -> 400",
         ["RegisterPolicyResponse"] =
             "Register.Service — CLI-only: maxValidators, minValidators, registrationMode, signatureThreshold, transitionMode, updatedAt, updatedBy, version; server-only: isDefault...",
         ["RegisterStatsResponse"] =
             "ServiceClients.Http — CLI-only: count; server-only: registerCount, transactionCount",
         ["RegisterSyncStatus"] =
             "Peer.Service — CLI-only: currentDocket, docketsProcessed, isStale, lastError, progressPercent, status, targetDocket; server-only: canServeFullReplica, lastSyncAt,...",
-        ["RotateSecretResponse"] =
-            "Tenant.Service — server sends `newClientSecret`, CLI reads `clientSecret` -> `service-principal rotate-secret` prints an EMPTY secret and looks successful",
         ["SchemaSector"] =
             "Blueprint.Service — CLI-only: name, schemaCount, status; server-only: displayName, icon",
         ["ServicePrincipal"] =


### PR DESCRIPTION
Stacked on #1247 (the harness). First shrink of the baseline: **30 → 27**.

These three were verified end-to-end before the harness existed, and they're the ones that cost an operator something real.

## 1. `service-principal rotate-secret` — the worst of the set

Server returns `newClientSecret`; the CLI read `clientSecret` and printed the empty string, then reported success. **The rotation has already happened by that point**, so the operator was left with a principal whose old secret is dead and whose new one they never saw. It also printed `RotatedAt`, which the server never sends — rendering `0001-01-01`.

Fixed the DTO to `NewClientSecret`/`Warning`, surfaced the server's own warning text, and — belt and braces — made an empty secret a **hard error** explaining the principal now needs re-registering, rather than a blank line under a success banner.

## 2. `audit query` / `audit export` — silently empty

Server sends `events`; the CLI read `entries`, so the list deserialised empty and the command reported *"No audit entries found"* regardless of what came back.

Every column was wrong too — the CLI expected `action`/`userId`/`userName`/`resourceType`/`resourceId`, none of which `AuditEventResponse` carries. Realigned to the real shape (`eventType`/`identityId`/`ipAddress`/`success`/`details`) across both the table and the CSV export. `Details` is a JSON object server-side, not a string, so it's now flattened to `k=v` pairs instead of being interpolated as a type name.

## 3. `participant publish` — 400 every time

The CLI sent `name` and a bare `walletAddresses` string list; the server requires `participantName` and a structured `addresses` list carrying public key and algorithm, every field `required`.

This one couldn't just be renamed — the CLI never collected the key material. Rather than make the operator paste a public key on the command line, the command now **resolves it from the Wallet Service** for the given `--wallet` (the CLI already has that client, and `WalletDto` carries `PublicKey` + `Algorithm`), with a clear error when the address doesn't resolve.

## The harness earned its keep immediately

It caught me **over-correcting** `AuditLogEntry` with `organizationId`/`userAgent` — fields that belong to the Tenant `AuditLogEntry` *entity*, not the `AuditEventResponse` the endpoint actually returns. Without the detector that would have shipped as a fresh, invisible mismatch. That's the ratchet working in the direction that's hardest to get right by review alone.

## Verification

- `dotnet build Sorcha.sln` — clean, 0 errors.
- Contract harness **59 green**, baseline **27** (down from 30).
- CLI **408** ✅ · Tenant.Service **1,561** ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HMQZDe2uWBLimHabrHM6yf