### PR TITLE
fix: [DRIFT-002] repair the Tenant read/write CLI contracts

### DIFF
--- a/src/Apps/Sorcha.Cli/Commands/PlatformCommands.cs
+++ b/src/Apps/Sorcha.Cli/Commands/PlatformCommands.cs
@@ -164,9 +164,10 @@ public class PlatformSettingsCommand : Command
 
                 ConsoleHelper.WriteInfo("Platform Settings:");
                 Console.WriteLine($"  Public Org Enabled:     {settings.PublicOrgEnabled}");
+                Console.WriteLine($"  Public Org ID:          {settings.PublicOrgId}");
+                Console.WriteLine($"  Public Org Status:      {settings.PublicOrgStatus}");
                 Console.WriteLine($"  Max Orgs Per User:      {settings.MaxOrgsPerUser}");
-                Console.WriteLine($"  Registration Open:      {settings.RegistrationOpen}");
-                Console.WriteLine($"  Social Login Enabled:   {settings.SocialLoginEnabled}");
+                Console.WriteLine($"  Updated At:             {settings.UpdatedAt:yyyy-MM-dd HH:mm:ss}");
 
                 return ExitCodes.Success;
             }

--- a/src/Apps/Sorcha.Cli/Commands/ServicePrincipalCommands.cs
+++ b/src/Apps/Sorcha.Cli/Commands/ServicePrincipalCommands.cs
@@ -90,13 +90,12 @@ public class PrincipalListCommand : Command
 
                 ConsoleHelper.WriteSuccess($"Found {principals.Count} service principal(s) in organization '{orgId}':");
                 Console.WriteLine();
-                Console.WriteLine($"{"Client ID",-40} {"Name",-30} {"Active",-8} {"Scopes",-20}");
-                Console.WriteLine(new string('-', 100));
+                Console.WriteLine($"{"Client ID",-40} {"Service Name",-30} {"Status",-10} {"Scopes",-20}");
+                Console.WriteLine(new string('-', 102));
                 foreach (var sp in principals)
                 {
-                    var scopes = sp.Scopes != null && sp.Scopes.Count > 0 ? string.Join(", ", sp.Scopes) : "(none)";
-                    var active = sp.IsActive ? "Yes" : "No";
-                    Console.WriteLine($"{sp.ClientId,-40} {sp.Name,-30} {active,-8} {scopes,-20}");
+                    var scopes = sp.Scopes is { Length: > 0 } ? string.Join(", ", sp.Scopes) : "(none)";
+                    Console.WriteLine($"{sp.ClientId,-40} {sp.ServiceName,-30} {sp.Status,-10} {scopes,-20}");
                 }
 
                 return ExitCodes.Success;
@@ -189,27 +188,16 @@ public class PrincipalGetCommand : Command
 
                 ConsoleHelper.WriteSuccess("Service principal details:");
                 Console.WriteLine();
+                Console.WriteLine($"  ID:              {sp.Id}");
                 Console.WriteLine($"  Client ID:       {sp.ClientId}");
-                Console.WriteLine($"  Organization ID: {sp.OrganizationId}");
-                Console.WriteLine($"  Name:            {sp.Name}");
-                if (!string.IsNullOrEmpty(sp.Description))
-                {
-                    Console.WriteLine($"  Description:     {sp.Description}");
-                }
-                Console.WriteLine($"  Active:          {(sp.IsActive ? "Yes" : "No")}");
-                if (sp.Scopes != null && sp.Scopes.Count > 0)
+                Console.WriteLine($"  Service Name:    {sp.ServiceName}");
+                Console.WriteLine($"  Status:          {sp.Status}");
+                if (sp.Scopes is { Length: > 0 })
                 {
                     Console.WriteLine($"  Scopes:          {string.Join(", ", sp.Scopes)}");
                 }
+
                 Console.WriteLine($"  Created:         {sp.CreatedAt:yyyy-MM-dd HH:mm:ss}");
-                if (sp.UpdatedAt.HasValue)
-                {
-                    Console.WriteLine($"  Updated:         {sp.UpdatedAt:yyyy-MM-dd HH:mm:ss}");
-                }
-                if (sp.SecretRotatedAt.HasValue)
-                {
-                    Console.WriteLine($"  Secret Rotated:  {sp.SecretRotatedAt:yyyy-MM-dd HH:mm:ss}");
-                }
 
                 return ExitCodes.Success;
             }
@@ -327,14 +315,11 @@ public class PrincipalCreateCommand : Command
 
                 ConsoleHelper.WriteSuccess($"Service principal created successfully!");
                 Console.WriteLine();
+                Console.WriteLine($"  ID:              {response.ServicePrincipal.Id}");
                 Console.WriteLine($"  Client ID:       {response.ServicePrincipal.ClientId}");
-                Console.WriteLine($"  Organization ID: {response.ServicePrincipal.OrganizationId}");
-                Console.WriteLine($"  Name:            {response.ServicePrincipal.Name}");
-                if (!string.IsNullOrEmpty(response.ServicePrincipal.Description))
-                {
-                    Console.WriteLine($"  Description:     {response.ServicePrincipal.Description}");
-                }
-                if (response.ServicePrincipal.Scopes != null && response.ServicePrincipal.Scopes.Count > 0)
+                Console.WriteLine($"  Service Name:    {response.ServicePrincipal.ServiceName}");
+                Console.WriteLine($"  Status:          {response.ServicePrincipal.Status}");
+                if (response.ServicePrincipal.Scopes is { Length: > 0 })
                 {
                     Console.WriteLine($"  Scopes:          {string.Join(", ", response.ServicePrincipal.Scopes)}");
                 }

--- a/src/Apps/Sorcha.Cli/Commands/UserCommands.cs
+++ b/src/Apps/Sorcha.Cli/Commands/UserCommands.cs
@@ -411,10 +411,8 @@ public class UserUpdateCommand : Command
 {
     private readonly Option<string> _orgIdOption;
     private readonly Option<string> _userIdOption;
-    private readonly Option<string?> _emailOption;
-    private readonly Option<string?> _firstNameOption;
-    private readonly Option<string?> _lastNameOption;
-    private readonly Option<bool?> _isActiveOption;
+    private readonly Option<string?> _displayNameOption;
+    private readonly Option<string?> _statusOption;
     private readonly Option<string?> _rolesOption;
 
     public UserUpdateCommand(
@@ -435,24 +433,14 @@ public class UserUpdateCommand : Command
             Required = true
         };
 
-        _emailOption = new Option<string?>("--email", "-e")
+        _displayNameOption = new Option<string?>("--display-name", "-n")
         {
-            Description = "New email address"
+            Description = "New display name"
         };
 
-        _firstNameOption = new Option<string?>("--first-name", "-f")
+        _statusOption = new Option<string?>("--status", "-s")
         {
-            Description = "New first name"
-        };
-
-        _lastNameOption = new Option<string?>("--last-name", "-l")
-        {
-            Description = "New last name"
-        };
-
-        _isActiveOption = new Option<bool?>("--active", "-a")
-        {
-            Description = "Set active status (true/false)"
+            Description = "New account status (e.g. Active, Suspended)"
         };
 
         _rolesOption = new Option<string?>("--roles", "-r")
@@ -462,29 +450,25 @@ public class UserUpdateCommand : Command
 
         Options.Add(_orgIdOption);
         Options.Add(_userIdOption);
-        Options.Add(_emailOption);
-        Options.Add(_firstNameOption);
-        Options.Add(_lastNameOption);
-        Options.Add(_isActiveOption);
+        Options.Add(_displayNameOption);
+        Options.Add(_statusOption);
         Options.Add(_rolesOption);
 
         this.SetAction(async (ParseResult parseResult, CancellationToken ct) =>
         {
             var orgId = parseResult.GetValue(_orgIdOption)!;
             var userId = parseResult.GetValue(_userIdOption)!;
-            var email = parseResult.GetValue(_emailOption);
-            var firstName = parseResult.GetValue(_firstNameOption);
-            var lastName = parseResult.GetValue(_lastNameOption);
-            var isActive = parseResult.GetValue(_isActiveOption);
+            var displayName = parseResult.GetValue(_displayNameOption);
+            var status = parseResult.GetValue(_statusOption);
             var roles = parseResult.GetValue(_rolesOption);
 
             try
             {
                 // Validate that at least one field is provided
-                if (string.IsNullOrEmpty(email) && string.IsNullOrEmpty(firstName) &&
-                    string.IsNullOrEmpty(lastName) && !isActive.HasValue && string.IsNullOrEmpty(roles))
+                if (string.IsNullOrEmpty(displayName) && string.IsNullOrEmpty(status) &&
+                    string.IsNullOrEmpty(roles))
                 {
-                    ConsoleHelper.WriteError("At least one field (--email, --first-name, --last-name, --active, or --roles) must be provided.");
+                    ConsoleHelper.WriteError("At least one field (--display-name, --status, or --roles) must be provided.");
                     return ExitCodes.ValidationError;
                 }
 
@@ -506,12 +490,10 @@ public class UserUpdateCommand : Command
                 // Build request
                 var request = new UpdateUserRequest
                 {
-                    Email = email,
-                    FirstName = firstName,
-                    LastName = lastName,
-                    IsActive = isActive,
+                    DisplayName = displayName,
+                    Status = status,
                     Roles = !string.IsNullOrEmpty(roles)
-                        ? roles.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ToList()
+                        ? roles.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
                         : null
                 };
 

--- a/src/Apps/Sorcha.Cli/Models/Bootstrap.cs
+++ b/src/Apps/Sorcha.Cli/Models/Bootstrap.cs
@@ -104,6 +104,21 @@ public class BootstrapResponse
     public string? ServicePrincipalClientSecret { get; set; }
 
     /// <summary>
+    /// The system administration organisation created by bootstrap.
+    /// </summary>
+    public Guid SystemAdminOrgId { get; set; }
+
+    /// <summary>
+    /// The well-known public organisation created by bootstrap.
+    /// </summary>
+    public Guid PublicOrgId { get; set; }
+
+    /// <summary>
+    /// The cross-org platform user created for the administrator.
+    /// </summary>
+    public Guid PlatformUserId { get; set; }
+
+    /// <summary>
     /// Timestamp of bootstrap operation.
     /// </summary>
     public DateTime CreatedAt { get; set; }

--- a/src/Apps/Sorcha.Cli/Models/Organization.cs
+++ b/src/Apps/Sorcha.Cli/Models/Organization.cs
@@ -56,6 +56,12 @@ public class Organization
     /// <summary>
     /// Branding configuration.
     /// </summary>
+    /// <summary>
+    /// The organisation's wallet address, when it has been provisioned. Present on the wire since
+    /// the org-wallet work; the CLI previously dropped it silently.
+    /// </summary>
+    public string? WalletAddress { get; set; }
+
     public BrandingConfiguration? Branding { get; set; }
 }
 

--- a/src/Apps/Sorcha.Cli/Models/ServicePrincipal.cs
+++ b/src/Apps/Sorcha.Cli/Models/ServicePrincipal.cs
@@ -5,52 +5,33 @@ namespace Sorcha.Cli.Models;
 /// <summary>
 /// Represents a service principal (application identity) in the Sorcha platform.
 /// </summary>
+/// <remarks>
+/// Mirrors <c>Sorcha.Tenant.Service.Models.Dtos.ServicePrincipalResponse</c> exactly; the pairing
+/// is asserted by <c>CliWireContractTests</c>. This previously declared <c>name</c>,
+/// <c>description</c>, <c>isActive</c>, <c>organizationId</c>, <c>updatedAt</c> and
+/// <c>secretRotatedAt</c> — none of which the server sends — so `service-principal list` and `get`
+/// showed a blank name and an always-true active flag, while the server's real <c>id</c>,
+/// <c>serviceName</c> and <c>status</c> were discarded.
+/// </remarks>
 public class ServicePrincipal
 {
-    /// <summary>
-    /// Unique identifier (client ID) for the service principal.
-    /// </summary>
+    /// <summary>The service principal's unique id.</summary>
+    public Guid Id { get; set; }
+
+    /// <summary>Display name for the service principal.</summary>
+    public string ServiceName { get; set; } = string.Empty;
+
+    /// <summary>OAuth2 client id used when authenticating as this principal.</summary>
     public string ClientId { get; set; } = string.Empty;
 
-    /// <summary>
-    /// Organization ID the service principal belongs to.
-    /// </summary>
-    public string OrganizationId { get; set; } = string.Empty;
+    /// <summary>Scopes granted to this service principal.</summary>
+    public string[] Scopes { get; set; } = [];
 
-    /// <summary>
-    /// Display name for the service principal.
-    /// </summary>
-    public string Name { get; set; } = string.Empty;
+    /// <summary>Current status, e.g. <c>Active</c>.</summary>
+    public string Status { get; set; } = "Active";
 
-    /// <summary>
-    /// Description of the service principal's purpose.
-    /// </summary>
-    public string? Description { get; set; }
-
-    /// <summary>
-    /// Whether the service principal is active.
-    /// </summary>
-    public bool IsActive { get; set; } = true;
-
-    /// <summary>
-    /// Scopes/permissions granted to this service principal.
-    /// </summary>
-    public List<string> Scopes { get; set; } = new();
-
-    /// <summary>
-    /// Creation timestamp.
-    /// </summary>
+    /// <summary>Creation timestamp.</summary>
     public DateTimeOffset CreatedAt { get; set; }
-
-    /// <summary>
-    /// Last update timestamp.
-    /// </summary>
-    public DateTimeOffset? UpdatedAt { get; set; }
-
-    /// <summary>
-    /// When the client secret was last rotated.
-    /// </summary>
-    public DateTimeOffset? SecretRotatedAt { get; set; }
 }
 
 /// <summary>

--- a/src/Apps/Sorcha.Cli/Models/User.cs
+++ b/src/Apps/Sorcha.Cli/Models/User.cs
@@ -97,30 +97,28 @@ public class CreateUserRequest
 /// <summary>
 /// Request to update a user.
 /// </summary>
+/// <remarks>
+/// Mirrors <c>Sorcha.Tenant.Service.Models.Dtos.UpdateUserRequest</c> exactly; the pairing is
+/// asserted by <c>CliWireContractTests</c>. This previously sent <c>email</c>, <c>firstName</c>,
+/// <c>lastName</c> and <c>isActive</c>, none of which the server binds — so <c>sorcha user update</c>
+/// posted a body the server ignored entirely, then reported success having changed nothing.
+/// </remarks>
 public class UpdateUserRequest
 {
     /// <summary>
-    /// Email address.
+    /// The user's display name. Replaces the separate first/last name fields the CLI used to send;
+    /// the server has only ever had a single display name.
     /// </summary>
-    public string? Email { get; set; }
+    public string? DisplayName { get; set; }
 
     /// <summary>
-    /// First name.
+    /// Replacement role set. Serialised as strings; the server binds them to its UserRole enum.
     /// </summary>
-    public string? FirstName { get; set; }
+    public string[]? Roles { get; set; }
 
     /// <summary>
-    /// Last name.
+    /// Account status, e.g. <c>Active</c> or <c>Suspended</c>. Replaces the CLI's boolean
+    /// <c>isActive</c>, which the server never accepted.
     /// </summary>
-    public string? LastName { get; set; }
-
-    /// <summary>
-    /// Whether the user is active.
-    /// </summary>
-    public bool? IsActive { get; set; }
-
-    /// <summary>
-    /// User roles.
-    /// </summary>
-    public List<string>? Roles { get; set; }
+    public string? Status { get; set; }
 }

--- a/src/Apps/Sorcha.Cli/Services/IPlatformServiceClient.cs
+++ b/src/Apps/Sorcha.Cli/Services/IPlatformServiceClient.cs
@@ -43,10 +43,27 @@ public class PlatformOrganizationResponse
 /// <summary>
 /// Platform settings response.
 /// </summary>
+/// <remarks>
+/// Mirrors <c>Sorcha.Tenant.Service.Models.Dtos.PlatformSettingsResponse</c> exactly; the pairing
+/// is asserted by <c>CliWireContractTests</c>. This previously declared <c>registrationOpen</c> and
+/// <c>socialLoginEnabled</c>, which the server does not send — so both rendered <c>false</c>
+/// regardless of the platform's actual configuration — while omitting the public-org fields the
+/// server does send.
+/// </remarks>
 public class PlatformSettingsResponse
 {
+    /// <summary>Whether the public organisation is enabled for self-registration.</summary>
     public bool PublicOrgEnabled { get; set; }
+
+    /// <summary>Maximum organisations a single user may belong to.</summary>
     public int MaxOrgsPerUser { get; set; }
-    public bool RegistrationOpen { get; set; }
-    public bool SocialLoginEnabled { get; set; }
+
+    /// <summary>The well-known public organisation's id.</summary>
+    public Guid PublicOrgId { get; set; }
+
+    /// <summary>The public organisation's current status.</summary>
+    public string PublicOrgStatus { get; set; } = string.Empty;
+
+    /// <summary>When these settings were last changed.</summary>
+    public DateTimeOffset UpdatedAt { get; set; }
 }

--- a/tests/Sorcha.Cli.ContractTests/CliWireContractTests.cs
+++ b/tests/Sorcha.Cli.ContractTests/CliWireContractTests.cs
@@ -76,22 +76,16 @@ public sealed class CliWireContractTests
     {
         ["AvailableRegisterInfo"] =
             "Peer.Service — server-only: description, name",
-        ["BootstrapResponse"] =
-            "Tenant.Service — server-only: platformUserId, publicOrgId, systemAdminOrgId",
         ["InitiateWalletLinkRequest"] =
             "Tenant.Service — server-only: algorithm",
         ["IssueCredentialRequest"] =
             "Wallet.Service — CLI-only: expiresInDays, subject, type, walletAddress; server-only: credentialType, disclosableClaims, displayName, expiryDuration, holderJwk, issu...",
         ["LinkedWalletAddress"] =
             "Tenant.Service (vs LinkedWalletAddressResponse) — CLI-only: verifiedAt; server-only: algorithm, linkedAt, revokedAt",
-        ["Organization"] =
-            "Tenant.Service (vs OrganizationResponse) — server-only: walletAddress",
         ["ParticipantIdentity"] =
             "Tenant.Service (vs ParticipantResponse) — CLI-only: updatedAt, walletLinks; server-only: email, hasLinkedWallet",
         ["PeerStatistics"] =
             "Peer.Service — CLI-only: bootstrapNodes; server-only: seedNodes",
-        ["PlatformSettingsResponse"] =
-            "Tenant.Service — CLI-only: registrationOpen, socialLoginEnabled; server-only: publicOrgId, publicOrgStatus, updatedAt",
         ["PolicyHistoryResponse"] =
             "Register.Service — server-only: totalPages",
         ["PolicyUpdateRequest"] =
@@ -110,14 +104,10 @@ public sealed class CliWireContractTests
             "Peer.Service — CLI-only: currentDocket, docketsProcessed, isStale, lastError, progressPercent, status, targetDocket; server-only: canServeFullReplica, lastSyncAt,...",
         ["SchemaSector"] =
             "Blueprint.Service — CLI-only: name, schemaCount, status; server-only: displayName, icon",
-        ["ServicePrincipal"] =
-            "Tenant.Service (vs ServicePrincipalResponse) — CLI-only: description, isActive, name, organizationId, secretRotatedAt, updatedAt; server-only: id, serviceName, status",
         ["SubmitTransactionRequest"] =
             "Peer.Service — CLI-only: payload, previousTxId, senderWallet, signature, txType; server-only: originPeerId, submissionJson, submittedAtUnixMs",
         ["SubmitTransactionResponse"] =
             "Peer.Service — CLI-only: error, status, transactionId; server-only: accepted, receiverIsValidator, rejectReason",
-        ["UpdateUserRequest"] =
-            "Tenant.Service — CLI-only: email, firstName, isActive, lastName; server-only: displayName, status",
         ["ValidatorAuditEntry"] =
             "Validator.Service — server-only: id, registerId",
         ["ValidatorStatus"] =

--- a/tests/Sorcha.Cli.Tests/Commands/UserCommandsTests.cs
+++ b/tests/Sorcha.Cli.Tests/Commands/UserCommandsTests.cs
@@ -169,22 +169,24 @@ public class UserCommandsTests
         // Arrange & Act
         var command = new UserUpdateCommand(_clientFactory, AuthService, ConfigService);
 
-        // Assert
-        var emailOption = command.Options.FirstOrDefault(o => o.Name == "--email");
-        emailOption.Should().NotBeNull();
-        emailOption!.Required.Should().BeFalse();
+        // Assert — these mirror what the Tenant Service's UpdateUserRequest actually binds.
+        // The command previously offered --email/--first-name/--last-name/--active, none of which
+        // the server reads, so the update silently changed nothing (see CliWireContractTests).
+        var displayNameOption = command.Options.FirstOrDefault(o => o.Name == "--display-name");
+        displayNameOption.Should().NotBeNull();
+        displayNameOption!.Required.Should().BeFalse();
 
-        var firstNameOption = command.Options.FirstOrDefault(o => o.Name == "--first-name");
-        firstNameOption.Should().NotBeNull();
-        firstNameOption!.Required.Should().BeFalse();
+        var statusOption = command.Options.FirstOrDefault(o => o.Name == "--status");
+        statusOption.Should().NotBeNull();
+        statusOption!.Required.Should().BeFalse();
 
-        var lastNameOption = command.Options.FirstOrDefault(o => o.Name == "--last-name");
-        lastNameOption.Should().NotBeNull();
-        lastNameOption!.Required.Should().BeFalse();
+        var rolesOption = command.Options.FirstOrDefault(o => o.Name == "--roles");
+        rolesOption.Should().NotBeNull();
+        rolesOption!.Required.Should().BeFalse();
 
-        var activeOption = command.Options.FirstOrDefault(o => o.Name == "--active");
-        activeOption.Should().NotBeNull();
-        activeOption!.Required.Should().BeFalse();
+        command.Options.Select(o => o.Name).Should().NotContain(
+            ["--email", "--first-name", "--last-name", "--active"],
+            "options the server never bound were removed rather than left to mislead");
     }
 
     [Fact]

--- a/tests/Sorcha.Cli.Tests/Integration/HttpClientFactoryIntegrationTests.cs
+++ b/tests/Sorcha.Cli.Tests/Integration/HttpClientFactoryIntegrationTests.cs
@@ -285,8 +285,8 @@ public class HttpClientFactoryIntegrationTests : IDisposable
         // Arrange
         var principals = new List<ServicePrincipal>
         {
-            new() { ClientId = "sp-1", Name = "API Service 1", OrganizationId = "org-123", IsActive = true, CreatedAt = DateTimeOffset.UtcNow },
-            new() { ClientId = "sp-2", Name = "API Service 2", OrganizationId = "org-123", IsActive = true, CreatedAt = DateTimeOffset.UtcNow }
+            new() { Id = Guid.NewGuid(), ClientId = "sp-1", ServiceName = "API Service 1", Status = "Active", CreatedAt = DateTimeOffset.UtcNow },
+            new() { Id = Guid.NewGuid(), ClientId = "sp-2", ServiceName = "API Service 2", Status = "Active", CreatedAt = DateTimeOffset.UtcNow }
         };
 
         _mockHandler.SetupResponse(HttpMethod.Get, "/api/organizations/org-123/principals", HttpStatusCode.OK, principals);
@@ -304,8 +304,8 @@ public class HttpClientFactoryIntegrationTests : IDisposable
         // Assert
         result.Should().NotBeNull();
         result.Should().HaveCount(2);
-        result[0].Name.Should().Be("API Service 1");
-        result[1].Name.Should().Be("API Service 2");
+        result[0].ServiceName.Should().Be("API Service 1");
+        result[1].ServiceName.Should().Be("API Service 2");
 
         _mockHandler.Requests.Should().HaveCount(1);
         _mockHandler.Requests[0].Method.Should().Be(HttpMethod.Get);


### PR DESCRIPTION
Second shrink of the baseline: **27 → 22**.

The first batch (#1249) fixed commands that *lost* data. This batch fixes commands that quietly reported **the wrong thing** — arguably worse, because there's nothing to notice.

## 1. `platform settings` — showed configuration the platform doesn't have

The CLI declared `registrationOpen` and `socialLoginEnabled`. The server sends **neither**, so both rendered `false` regardless of the real configuration. An operator checking whether registration was open got a confident, meaningless `False`. Meanwhile the server's actual public-org fields were discarded.

Now shows `publicOrgId` / `publicOrgStatus` / `updatedAt`.

## 2. `principal list` / `get` / `create` — blank names, fictional status

The CLI declared `name`, `description`, `isActive`, `organizationId`, `updatedAt`, `secretRotatedAt`; the server sends `id`, `serviceName`, `status`.

So the **Name column was always empty**, and **every principal displayed as Active — including revoked ones**.

## 3. `bootstrap` — dropped three identifiers it had just created

`systemAdminOrgId`, `publicOrgId` and `platformUserId` are returned by the server and were silently discarded, so a scripted bootstrap couldn't learn the ids of the things it had just provisioned without a follow-up query.

## 4. `user update` — posted a body the server ignored entirely

The CLI sent `email`/`firstName`/`lastName`/`isActive`; `UpdateUserRequest` binds `displayName`/`roles`/`status`. **Nothing the operator passed was ever applied**, and the command reported success.

⚠️ **This changes the command surface**: `--email` / `--first-name` / `--last-name` / `--active` are replaced by `--display-name` and `--status`. Those flags never did anything, so this is a correction rather than a regression — but it's the one behavioural break in the batch. The unit test that pinned the old names now asserts the new ones **and** asserts the dead flags are gone, so they can't quietly return.

## 5. `org get` / `list`

Now surfaces the organisation's `walletAddress`, which the server has been sending and the CLI dropped.

## Verification

- `dotnet build Sorcha.sln` — clean, 0 errors.
- Contract harness **59 green**, baseline **22** (down from 27).
- CLI **408** ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HMQZDe2uWBLimHabrHM6yf