### PR TITLE
fix: [DRIFT-002] repair the register-policy CLI contracts

### DIFF
--- a/src/Apps/Sorcha.Cli/Commands/RegisterCommands.cs
+++ b/src/Apps/Sorcha.Cli/Commands/RegisterCommands.cs
@@ -1309,8 +1309,10 @@ public class RegisterPolicyUpdateCommand : Command
     private readonly Option<string> _registerIdOption;
     private readonly Option<int?> _minValidatorsOption;
     private readonly Option<int?> _maxValidatorsOption;
-    private readonly Option<int?> _signatureThresholdOption;
+    private readonly Option<int?> _signatureThresholdMinOption;
+    private readonly Option<int?> _signatureThresholdMaxOption;
     private readonly Option<string?> _registrationModeOption;
+    private readonly Option<string?> _updatedByOption;
     private readonly Option<bool> _confirmOption;
 
     public RegisterPolicyUpdateCommand(
@@ -1335,14 +1337,26 @@ public class RegisterPolicyUpdateCommand : Command
             Description = "Maximum number of validators"
         };
 
-        _signatureThresholdOption = new Option<int?>("--signature-threshold")
+        // PolicyConsensusConfig bounds the threshold with a min and a max rather than carrying a
+        // single value, so the old --signature-threshold had no unambiguous target.
+        _signatureThresholdMinOption = new Option<int?>("--signature-threshold-min")
         {
-            Description = "Signature threshold for consensus"
+            Description = "Minimum signature threshold for consensus"
+        };
+
+        _signatureThresholdMaxOption = new Option<int?>("--signature-threshold-max")
+        {
+            Description = "Maximum signature threshold for consensus"
         };
 
         _registrationModeOption = new Option<string?>("--registration-mode")
         {
-            Description = "Registration mode (open or consent)"
+            Description = "Registration mode (Public or Consent)"
+        };
+
+        _updatedByOption = new Option<string?>("--updated-by")
+        {
+            Description = "DID of the proposer (sent to the server as updatedBy)"
         };
 
         _confirmOption = new Option<bool>("--yes", "-y")
@@ -1353,8 +1367,10 @@ public class RegisterPolicyUpdateCommand : Command
         Options.Add(_registerIdOption);
         Options.Add(_minValidatorsOption);
         Options.Add(_maxValidatorsOption);
-        Options.Add(_signatureThresholdOption);
+        Options.Add(_signatureThresholdMinOption);
+        Options.Add(_signatureThresholdMaxOption);
         Options.Add(_registrationModeOption);
+        Options.Add(_updatedByOption);
         Options.Add(_confirmOption);
 
         this.SetAction(async (ParseResult parseResult, CancellationToken ct) =>
@@ -1362,13 +1378,16 @@ public class RegisterPolicyUpdateCommand : Command
             var registerId = parseResult.GetValue(_registerIdOption)!;
             var minValidators = parseResult.GetValue(_minValidatorsOption);
             var maxValidators = parseResult.GetValue(_maxValidatorsOption);
-            var signatureThreshold = parseResult.GetValue(_signatureThresholdOption);
+            var signatureThresholdMin = parseResult.GetValue(_signatureThresholdMinOption);
+            var signatureThresholdMax = parseResult.GetValue(_signatureThresholdMaxOption);
             var registrationMode = parseResult.GetValue(_registrationModeOption);
+            var updatedBy = parseResult.GetValue(_updatedByOption);
             var confirm = parseResult.GetValue(_confirmOption);
 
-            if (minValidators == null && maxValidators == null && signatureThreshold == null && registrationMode == null)
+            if (minValidators == null && maxValidators == null && signatureThresholdMin == null
+                && signatureThresholdMax == null && registrationMode == null)
             {
-                ConsoleHelper.WriteError("At least one policy field must be specified (--min-validators, --max-validators, --signature-threshold, --registration-mode).");
+                ConsoleHelper.WriteError("At least one policy field must be specified (--min-validators, --max-validators, --signature-threshold-min, --signature-threshold-max, --registration-mode).");
                 return ExitCodes.ValidationError;
             }
 
@@ -1379,7 +1398,8 @@ public class RegisterPolicyUpdateCommand : Command
                     ConsoleHelper.WriteWarning("You are about to propose a policy update:");
                     if (minValidators.HasValue) Console.WriteLine($"  Min Validators:     {minValidators}");
                     if (maxValidators.HasValue) Console.WriteLine($"  Max Validators:     {maxValidators}");
-                    if (signatureThreshold.HasValue) Console.WriteLine($"  Signature Threshold:{signatureThreshold}");
+                    if (signatureThresholdMin.HasValue) Console.WriteLine($"  Sig Threshold Min:  {signatureThresholdMin}");
+                    if (signatureThresholdMax.HasValue) Console.WriteLine($"  Sig Threshold Max:  {signatureThresholdMax}");
                     if (registrationMode != null) Console.WriteLine($"  Registration Mode:  {registrationMode}");
 
                     if (!ConsoleHelper.Confirm("Propose policy update?", defaultYes: false))
@@ -1401,12 +1421,51 @@ public class RegisterPolicyUpdateCommand : Command
 
                 var client = await clientFactory.CreateRegisterServiceClientAsync(profileName);
 
+                // The server replaces the policy wholesale - it binds a complete RegisterPolicy, not
+                // a set of deltas. So read the current policy, apply the requested changes to it,
+                // and propose the result. Sending only the changed fields (as this command used to)
+                // would leave every other setting at its type default.
+                var currentResponse = await client.GetPolicyAsync(registerId, $"Bearer {token}");
+                if (!currentResponse.IsSuccessStatusCode)
+                {
+                    var currentError = await currentResponse.Content.ReadAsStringAsync(ct);
+                    ConsoleHelper.WriteError(
+                        $"Could not read the current policy to base this proposal on ({currentResponse.StatusCode}): {currentError}");
+                    return ExitCodes.GeneralError;
+                }
+
+                var current = JsonSerializer.Deserialize<RegisterPolicyResponse>(
+                    await currentResponse.Content.ReadAsStringAsync(ct), SorchaJsonOptions.Default);
+
+                if (current?.Policy is null)
+                {
+                    ConsoleHelper.WriteError("The current policy could not be parsed; refusing to propose a replacement.");
+                    return ExitCodes.GeneralError;
+                }
+
+                var proposed = current.Policy;
+                if (minValidators.HasValue) proposed.Validators.MinValidators = minValidators.Value;
+                if (maxValidators.HasValue) proposed.Validators.MaxValidators = maxValidators.Value;
+                if (signatureThresholdMin.HasValue) proposed.Consensus.SignatureThresholdMin = signatureThresholdMin.Value;
+                if (signatureThresholdMax.HasValue) proposed.Consensus.SignatureThresholdMax = signatureThresholdMax.Value;
+                if (!string.IsNullOrWhiteSpace(registrationMode))
+                {
+                    if (!Enum.TryParse<RegistrationMode>(registrationMode, ignoreCase: true, out var mode))
+                    {
+                        ConsoleHelper.WriteError($"Unknown registration mode '{registrationMode}'. Expected Public or Consent.");
+                        return ExitCodes.ValidationError;
+                    }
+
+                    proposed.Validators.RegistrationMode = mode;
+                }
+
+                // The server expects the proposal to carry an incremented version.
+                proposed.Version = current.Policy.Version + 1;
+
                 var request = new PolicyUpdateRequest
                 {
-                    MinValidators = minValidators,
-                    MaxValidators = maxValidators,
-                    SignatureThreshold = signatureThreshold,
-                    RegistrationMode = registrationMode
+                    Policy = proposed,
+                    UpdatedBy = updatedBy ?? string.Empty
                 };
 
                 var response = await client.ProposePolicyUpdateAsync(registerId, request, $"Bearer {token}");

--- a/src/Apps/Sorcha.Cli/Models/RegisterPolicy.cs
+++ b/src/Apps/Sorcha.Cli/Models/RegisterPolicy.cs
@@ -1,22 +1,42 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Sorcha Contributors
 
+using SorchaRegisterPolicy = Sorcha.Register.Models.RegisterPolicy;
+
 namespace Sorcha.Cli.Models;
 
 /// <summary>
 /// Register policy response from the API.
 /// </summary>
+/// <remarks>
+/// <para>
+/// Mirrors <c>Sorcha.Register.Service.Endpoints.RegisterPolicyResponse</c>; the pairing is asserted
+/// by <c>CliWireContractTests</c>.
+/// </para>
+/// <para>
+/// The whole policy family was previously modelled <b>flat</b> — <c>minValidators</c>,
+/// <c>maxValidators</c>, <c>signatureThreshold</c>, <c>registrationMode</c> and so on as scalars on
+/// the response. The server has never sent that shape: it nests the real
+/// <see cref="SorchaRegisterPolicy"/> under a <c>policy</c> property, with validator and consensus
+/// settings inside their own sub-objects. So <c>sorcha register policy get</c> deserialised every
+/// field to its default and confidently printed a policy of all zeros.
+/// </para>
+/// <para>
+/// The fix is to carry the real model rather than re-describe it. The CLI already references
+/// <c>Sorcha.Register.Models</c>, so it can use the same <c>RegisterPolicy</c> the server
+/// serialises — which also means nested policy changes cannot drift again.
+/// </para>
+/// </remarks>
 public record RegisterPolicyResponse
 {
+    /// <summary>Register the policy belongs to.</summary>
     public string RegisterId { get; init; } = string.Empty;
-    public int MinValidators { get; init; }
-    public int MaxValidators { get; init; }
-    public int SignatureThreshold { get; init; }
-    public string RegistrationMode { get; init; } = "Open";
-    public string TransitionMode { get; init; } = "Immediate";
-    public int Version { get; init; }
-    public DateTimeOffset UpdatedAt { get; init; }
-    public string UpdatedBy { get; init; } = string.Empty;
+
+    /// <summary>The effective policy.</summary>
+    public SorchaRegisterPolicy Policy { get; init; } = new();
+
+    /// <summary>True when no explicit policy is on-chain and defaults were generated.</summary>
+    public bool IsDefault { get; init; }
 }
 
 /// <summary>
@@ -24,11 +44,23 @@ public record RegisterPolicyResponse
 /// </summary>
 public record PolicyHistoryResponse
 {
+    /// <summary>Register the history belongs to.</summary>
     public string RegisterId { get; init; } = string.Empty;
+
+    /// <summary>The policy versions on this page.</summary>
     public List<PolicyVersionEntry> Versions { get; init; } = [];
-    public int TotalCount { get; init; }
+
+    /// <summary>1-based page number.</summary>
     public int Page { get; init; } = 1;
+
+    /// <summary>Page size used for this query.</summary>
     public int PageSize { get; init; } = 20;
+
+    /// <summary>Total versions across all pages.</summary>
+    public int TotalCount { get; init; }
+
+    /// <summary>Total number of pages available.</summary>
+    public int TotalPages { get; init; }
 }
 
 /// <summary>
@@ -36,19 +68,63 @@ public record PolicyHistoryResponse
 /// </summary>
 public record PolicyVersionEntry
 {
-    public int Version { get; init; }
-    public string UpdatedBy { get; init; } = string.Empty;
+    /// <summary>The policy version number.</summary>
+    public uint Version { get; init; }
+
+    /// <summary>The policy as it stood at this version.</summary>
+    public SorchaRegisterPolicy Policy { get; init; } = new();
+
+    /// <summary>When this version was committed.</summary>
     public DateTimeOffset UpdatedAt { get; init; }
+
+    /// <summary>DID of whoever proposed this version.</summary>
+    public string? UpdatedBy { get; init; }
+}
+
+/// <summary>
+/// Request to propose a register policy update.
+/// </summary>
+/// <remarks>
+/// The CLI previously sent flat scalars (<c>minValidators</c> and friends) that the server does not
+/// bind, so <c>policy</c> arrived null and the proposal did nothing.
+/// </remarks>
+public record PolicyUpdateRequest
+{
+    /// <summary>The proposed policy, with its version incremented.</summary>
+    public SorchaRegisterPolicy? Policy { get; init; }
+
+    /// <summary>
+    /// Transition mode when moving <c>registrationMode</c> from public to consent. Serialised as a
+    /// string; the server binds it to its TransitionMode enum.
+    /// </summary>
+    public string? TransitionMode { get; init; }
+
+    /// <summary>DID of the proposer.</summary>
+    public string UpdatedBy { get; init; } = string.Empty;
 }
 
 /// <summary>
 /// Response after proposing a policy update.
 /// </summary>
+/// <remarks>
+/// The CLI previously expected <c>proposalId</c>, <c>status</c>, <c>requiredVotes</c> and
+/// <c>currentVotes</c> — a governance-vote shape this endpoint does not return. It returns the
+/// version numbers and whether a governance vote is required at all.
+/// </remarks>
 public record PolicyUpdateResponse
 {
-    public string ProposalId { get; init; } = string.Empty;
-    public int ProposedVersion { get; init; }
-    public string Status { get; init; } = string.Empty;
-    public int RequiredVotes { get; init; }
-    public int CurrentVotes { get; init; }
+    /// <summary>Register the proposal applies to.</summary>
+    public string RegisterId { get; init; } = string.Empty;
+
+    /// <summary>The version being proposed.</summary>
+    public uint ProposedVersion { get; init; }
+
+    /// <summary>The version currently in force.</summary>
+    public uint CurrentVersion { get; init; }
+
+    /// <summary>Whether the change needs a governance vote before it takes effect.</summary>
+    public bool RequiresGovernanceVote { get; init; }
+
+    /// <summary>Server-supplied outcome message.</summary>
+    public string Message { get; init; } = string.Empty;
 }

--- a/src/Apps/Sorcha.Cli/Services/IRegisterServiceClient.cs
+++ b/src/Apps/Sorcha.Cli/Services/IRegisterServiceClient.cs
@@ -2,6 +2,7 @@
 // Copyright (c) 2026 Sorcha Contributors
 
 using Refit;
+using Sorcha.Cli.Models;
 using Sorcha.Register.Models;
 using Sorcha.Register.Models.LocalRelationship;
 
@@ -319,17 +320,10 @@ public class QueryStatsResponse
     public int TotalDockets { get; set; }
 }
 
-/// <summary>
-/// Request to propose a policy update.
-/// </summary>
-public class PolicyUpdateRequest
-{
-    public int? MinValidators { get; set; }
-    public int? MaxValidators { get; set; }
-    public int? SignatureThreshold { get; set; }
-    public string? RegistrationMode { get; set; }
-    public string? TransitionMode { get; set; }
-}
+// PolicyUpdateRequest previously had a SECOND definition here, flat and different again from the
+// one in Sorcha.Cli.Models. Two shapes for one request body inside a single assembly, neither
+// matching the server. The canonical one lives in Sorcha.Cli.Models.RegisterPolicy.cs and carries
+// the real Sorcha.Register.Models.RegisterPolicy.
 
 /// <summary>
 /// Request to verify a standalone Merkle inclusion proof.

--- a/tests/Sorcha.Cli.ContractTests/CliWireContractTests.cs
+++ b/tests/Sorcha.Cli.ContractTests/CliWireContractTests.cs
@@ -86,18 +86,8 @@ public sealed class CliWireContractTests
             "Tenant.Service (vs ParticipantResponse) — CLI-only: updatedAt, walletLinks; server-only: email, hasLinkedWallet",
         ["PeerStatistics"] =
             "Peer.Service — CLI-only: bootstrapNodes; server-only: seedNodes",
-        ["PolicyHistoryResponse"] =
-            "Register.Service — server-only: totalPages",
-        ["PolicyUpdateRequest"] =
-            "Register.Service — CLI-only: maxValidators, minValidators, registrationMode, signatureThreshold; server-only: policy, updatedBy",
-        ["PolicyUpdateResponse"] =
-            "Register.Service — CLI-only: currentVotes, proposalId, requiredVotes, status; server-only: currentVersion, message, registerId, requiresGovernanceVote",
-        ["PolicyVersionEntry"] =
-            "Register.Service — server-only: policy",
         ["PublishBlueprintRequest"] =
             "ServiceClients.Http — CLI-only: blueprintId; server-only: override",
-        ["RegisterPolicyResponse"] =
-            "Register.Service — CLI-only: maxValidators, minValidators, registrationMode, signatureThreshold, transitionMode, updatedAt, updatedBy, version; server-only: isDefault...",
         ["RegisterStatsResponse"] =
             "ServiceClients.Http — CLI-only: count; server-only: registerCount, transactionCount",
         ["RegisterSyncStatus"] =

--- a/tests/Sorcha.Cli.Tests/Commands/RegisterPolicyCommandTests.cs
+++ b/tests/Sorcha.Cli.Tests/Commands/RegisterPolicyCommandTests.cs
@@ -180,12 +180,23 @@ public class RegisterPolicyCommandTests
     }
 
     [Fact]
-    public void RegisterPolicyUpdateCommand_ShouldHaveOptionalThresholdOption()
+    public void RegisterPolicyUpdateCommand_ShouldHaveOptionalThresholdBoundOptions()
     {
+        // The server's PolicyConsensusConfig bounds the threshold with a min and a max rather than
+        // carrying one value, so the old single --signature-threshold had no unambiguous target.
         var command = new RegisterPolicyUpdateCommand(_clientFactory, AuthService, ConfigService);
-        var option = command.Options.FirstOrDefault(o => o.Name == "--signature-threshold");
-        option.Should().NotBeNull();
-        option!.Required.Should().BeFalse();
+
+        var min = command.Options.FirstOrDefault(o => o.Name == "--signature-threshold-min");
+        min.Should().NotBeNull();
+        min!.Required.Should().BeFalse();
+
+        var max = command.Options.FirstOrDefault(o => o.Name == "--signature-threshold-max");
+        max.Should().NotBeNull();
+        max!.Required.Should().BeFalse();
+
+        command.Options.Select(o => o.Name).Should().NotContain(
+            "--signature-threshold",
+            "the ambiguous single-value flag was replaced by the two bounds the policy actually has");
     }
 
     [Fact]


### PR DESCRIPTION
Third shrink of the baseline: **22 → 17**. The whole register-policy family in one batch, because they share a single root cause.

## The root cause

The CLI modelled the policy **flat** — `minValidators`, `maxValidators`, `signatureThreshold`, `registrationMode`, `version`, `updatedAt`, `updatedBy` as scalars directly on the response.

The server has never sent that shape. It nests the real `Sorcha.Register.Models.RegisterPolicy` under a `policy` property, with validator and consensus settings inside their own sub-objects.

Consequences, all silent:

| Command | What happened |
|---|---|
| `register policy get` | every field deserialised to its type default — printed a policy of **zeros and "Open"** regardless of the real configuration |
| `register policy history` | same per version entry; the policy itself was dropped entirely, `totalPages` ignored |
| `register policy update` | the flat body bound nothing, so `policy` arrived null and the proposal **did nothing** |

## The fix

Rather than re-describe the policy a third time, the CLI now **carries the real model**. It already references `Sorcha.Register.Models`, so it can use the same `RegisterPolicy` the server serialises — which means nested policy changes can't drift again, only the outer envelope can.

`register policy update` needed more than a DTO swap. The server binds a **complete** `RegisterPolicy` and replaces the stored one wholesale, so sending only the changed fields would reset everything else to type defaults. The command now does **read-modify-write**: reads the current policy, applies the requested changes, increments the version, proposes the result — and fails loudly if the current policy can't be read, rather than proposing a replacement built on nothing.

## Command surface changes

Both corrections of things that never worked:

- **`--signature-threshold` → `--signature-threshold-min` / `--signature-threshold-max`.** `PolicyConsensusConfig` bounds the threshold with a min and a max; there is no single value the old flag could have meant.
- **`--updated-by` added.** The server records the proposer DID and the CLI never sent one.

## Bonus: CLI-internal duplication

Found on the way — `PolicyUpdateRequest` was declared **twice inside `Sorcha.Cli`**, once in `Models` and once in `Services`, with two *different* flat shapes, neither matching the server. Two definitions of one request body inside a single assembly. Now one.

## A near miss worth recording

I nearly deleted `--min-validators`/`--max-validators` as invented, because a truncated read of `PolicyValidatorConfig` showed only `RegistrationMode` and `ApprovedValidators`. They do exist, a few lines further down. Checking the full type before removing user-facing flags was the difference between a fix and a regression.

## Verification

- `dotnet build Sorcha.sln` — clean, 0 errors.
- Contract harness **59 green**, baseline **17** (down from 22).
- CLI **408** ✅ · Register.Service **323** ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HMQZDe2uWBLimHabrHM6yf