### PR TITLE
fix: [DRIFT-002] repair the remaining CLI wire contracts — baseline now empty

### DIFF
--- a/src/Apps/Sorcha.Cli/Commands/BlueprintCommands.cs
+++ b/src/Apps/Sorcha.Cli/Commands/BlueprintCommands.cs
@@ -323,6 +323,8 @@ public class BlueprintPublishCommand : Command
 {
     private readonly Option<string> _idOption;
     private readonly Option<string> _registerIdOption;
+    private readonly Option<bool> _overrideOption;
+    private readonly Option<string?> _reasonOption;
 
     public BlueprintPublishCommand(
         HttpClientFactory clientFactory,
@@ -342,13 +344,27 @@ public class BlueprintPublishCommand : Command
             Required = true
         };
 
+        _overrideOption = new Option<bool>("--override")
+        {
+            Description = "Force publish past the rehearsal soft-gate (requires publish authority)"
+        };
+
+        _reasonOption = new Option<string?>("--reason")
+        {
+            Description = "Reason recorded in the publish-override audit (used with --override)"
+        };
+
         Options.Add(_idOption);
         Options.Add(_registerIdOption);
+        Options.Add(_overrideOption);
+        Options.Add(_reasonOption);
 
         this.SetAction(async (ParseResult parseResult, CancellationToken ct) =>
         {
             var id = parseResult.GetValue(_idOption)!;
             var registerId = parseResult.GetValue(_registerIdOption)!;
+            var forceOverride = parseResult.GetValue(_overrideOption);
+            var reason = parseResult.GetValue(_reasonOption);
 
             try
             {
@@ -366,8 +382,10 @@ public class BlueprintPublishCommand : Command
 
                 var request = new PublishBlueprintRequest
                 {
-                    BlueprintId = id,
-                    RegisterId = registerId
+                    RegisterId = registerId,
+                    Override = forceOverride
+                        ? new PublishBlueprintOverride { Confirm = true, Reason = reason }
+                        : null
                 };
 
                 ConsoleHelper.WriteInfo($"Publishing blueprint '{id}' to register '{registerId}'...");

--- a/src/Apps/Sorcha.Cli/Commands/CredentialCommands.cs
+++ b/src/Apps/Sorcha.Cli/Commands/CredentialCommands.cs
@@ -218,10 +218,11 @@ public class CredentialGetCommand : Command
 public class CredentialIssueCommand : Command
 {
     private readonly Option<string> _typeOption;
-    private readonly Option<string> _subjectOption;
-    private readonly Option<string> _walletOption;
+    private readonly Option<string> _recipientWalletOption;
     private readonly Option<string> _claimsOption;
-    private readonly Option<int?> _expiresInDaysOption;
+    private readonly Option<string?> _displayNameOption;
+    private readonly Option<string?> _expiryDurationOption;
+    private readonly Option<string?> _disclosableOption;
 
     public CredentialIssueCommand(
         HttpClientFactory clientFactory,
@@ -235,50 +236,56 @@ public class CredentialIssueCommand : Command
             Required = true
         };
 
-        _subjectOption = new Option<string>("--subject", "-s")
+        _recipientWalletOption = new Option<string>("--recipient-wallet", "-w")
         {
-            Description = "Subject identifier (participant or wallet address)",
-            Required = true
-        };
-
-        _walletOption = new Option<string>("--wallet", "-w")
-        {
-            Description = "Issuer wallet address for signing",
+            Description = "The recipient's wallet address (the credential is issued to this wallet)",
             Required = true
         };
 
         _claimsOption = new Option<string>("--claims", "-c")
         {
-            Description = "Claims as JSON object (e.g., '{\"name\":\"John\",\"role\":\"admin\"}')",
+            Description = "Claims as a JSON object (e.g., '{\"name\":\"John\",\"ageOver18\":true}')",
             Required = true
         };
 
-        _expiresInDaysOption = new Option<int?>("--expires-in-days", "-e")
+        _displayNameOption = new Option<string?>("--display-name")
         {
-            Description = "Number of days until credential expires"
+            Description = "Optional display name for the credential"
+        };
+
+        _expiryDurationOption = new Option<string?>("--expiry-duration", "-e")
+        {
+            Description = "Optional ISO-8601 duration until expiry, e.g. P5Y. Omit for non-expiring."
+        };
+
+        _disclosableOption = new Option<string?>("--disclosable")
+        {
+            Description = "Comma-separated claim names the holder may selectively disclose"
         };
 
         Options.Add(_typeOption);
-        Options.Add(_subjectOption);
-        Options.Add(_walletOption);
+        Options.Add(_recipientWalletOption);
         Options.Add(_claimsOption);
-        Options.Add(_expiresInDaysOption);
+        Options.Add(_displayNameOption);
+        Options.Add(_expiryDurationOption);
+        Options.Add(_disclosableOption);
 
         this.SetAction(async (ParseResult parseResult, CancellationToken ct) =>
         {
             var type = parseResult.GetValue(_typeOption)!;
-            var subject = parseResult.GetValue(_subjectOption)!;
-            var wallet = parseResult.GetValue(_walletOption)!;
+            var recipientWallet = parseResult.GetValue(_recipientWalletOption)!;
             var claimsJson = parseResult.GetValue(_claimsOption)!;
-            var expiresInDays = parseResult.GetValue(_expiresInDaysOption);
+            var displayName = parseResult.GetValue(_displayNameOption);
+            var expiryDuration = parseResult.GetValue(_expiryDurationOption);
+            var disclosable = parseResult.GetValue(_disclosableOption);
 
             try
             {
                 // Parse claims JSON
-                Dictionary<string, string> claims;
+                Dictionary<string, object> claims;
                 try
                 {
-                    claims = JsonSerializer.Deserialize<Dictionary<string, string>>(claimsJson) ?? new();
+                    claims = JsonSerializer.Deserialize<Dictionary<string, object>>(claimsJson) ?? new();
                 }
                 catch (JsonException ex)
                 {
@@ -300,11 +307,14 @@ public class CredentialIssueCommand : Command
 
                 var request = new IssueCredentialRequest
                 {
-                    Type = type,
-                    Subject = subject,
-                    WalletAddress = wallet,
+                    CredentialType = type,
+                    RecipientWallet = recipientWallet,
                     Claims = claims,
-                    ExpiresInDays = expiresInDays
+                    DisplayName = displayName,
+                    ExpiryDuration = expiryDuration,
+                    DisclosableClaims = string.IsNullOrWhiteSpace(disclosable)
+                        ? null
+                        : disclosable.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ToList()
                 };
 
                 var credential = await client.IssueCredentialAsync(request, $"Bearer {token}");
@@ -318,17 +328,17 @@ public class CredentialIssueCommand : Command
 
                 ConsoleHelper.WriteSuccess("Credential issued successfully!");
                 Console.WriteLine();
-                Console.WriteLine($"  ID:      {credential.Id}");
-                Console.WriteLine($"  Type:    {credential.Type}");
-                Console.WriteLine($"  Subject: {credential.Subject}");
-                Console.WriteLine($"  Issuer:  {credential.Issuer}");
-                Console.WriteLine($"  Status:  {credential.Status}");
-                Console.WriteLine($"  Issued:  {credential.IssuedAt:yyyy-MM-dd HH:mm:ss}");
+                Console.WriteLine($"  Credential ID: {credential.CredentialId}");
+                Console.WriteLine($"  Type:          {credential.Type}");
+                Console.WriteLine($"  Issuer DID:    {credential.IssuerDid}");
+                Console.WriteLine($"  Subject DID:   {credential.SubjectDid}");
+                Console.WriteLine($"  Issued:        {credential.IssuedAt:yyyy-MM-dd HH:mm:ss}");
 
                 if (credential.ExpiresAt.HasValue)
                 {
-                    Console.WriteLine($"  Expires: {credential.ExpiresAt:yyyy-MM-dd HH:mm:ss}");
+                    Console.WriteLine($"  Expires:       {credential.ExpiresAt:yyyy-MM-dd HH:mm:ss}");
                 }
+
 
                 return ExitCodes.Success;
             }

--- a/src/Apps/Sorcha.Cli/Commands/ParticipantCommands.cs
+++ b/src/Apps/Sorcha.Cli/Commands/ParticipantCommands.cs
@@ -202,12 +202,13 @@ public class ParticipantListCommand : Command
 
                 ConsoleHelper.WriteSuccess($"Found {participants.Count} participant(s):");
                 Console.WriteLine();
-                Console.WriteLine($"{"ID",-38} {"Display Name",-30} {"Status",-12} {"Wallets",7} {"Created"}");
-                Console.WriteLine(new string('-', 105));
+                Console.WriteLine($"{"ID",-38} {"Display Name",-24} {"Email",-28} {"Status",-12} {"Wallet",7} {"Created"}");
+                Console.WriteLine(new string('-', 125));
 
                 foreach (var p in participants)
                 {
-                    Console.WriteLine($"{p.Id,-38} {p.DisplayName,-30} {p.Status,-12} {p.WalletLinks.Count,7} {p.CreatedAt:yyyy-MM-dd}");
+                    var hasWallet = p.HasLinkedWallet ? "yes" : "no";
+                    Console.WriteLine($"{p.Id,-38} {p.DisplayName,-24} {p.Email,-28} {p.Status,-12} {hasWallet,7} {p.CreatedAt:yyyy-MM-dd}");
                 }
 
                 return ExitCodes.Success;
@@ -298,20 +299,14 @@ public class ParticipantGetCommand : Command
                 Console.WriteLine($"  User ID:         {participant.UserId}");
                 Console.WriteLine($"  Organization:    {participant.OrganizationId}");
                 Console.WriteLine($"  Display Name:    {participant.DisplayName}");
+                Console.WriteLine($"  Email:           {participant.Email}");
                 Console.WriteLine($"  Status:          {participant.Status}");
+                Console.WriteLine($"  Has linked wallet: {(participant.HasLinkedWallet ? "Yes" : "No")}");
                 Console.WriteLine($"  Created:         {participant.CreatedAt:yyyy-MM-dd HH:mm:ss}");
-                Console.WriteLine($"  Updated:         {participant.UpdatedAt:yyyy-MM-dd HH:mm:ss}");
-
-                if (participant.WalletLinks.Count > 0)
-                {
-                    Console.WriteLine();
-                    Console.WriteLine($"  Linked Wallets ({participant.WalletLinks.Count}):");
-                    foreach (var link in participant.WalletLinks)
-                    {
-                        var verified = link.VerifiedAt.HasValue ? $"verified {link.VerifiedAt:yyyy-MM-dd}" : "unverified";
-                        Console.WriteLine($"    - {link.WalletAddress} ({link.Status}, {verified})");
-                    }
-                }
+                Console.WriteLine();
+                ConsoleHelper.WriteInfo(
+                    "Use 'sorcha participant wallet-links --participant-id " + participant.Id
+                    + "' to list this participant's linked wallets.");
 
                 return ExitCodes.Success;
             }
@@ -429,7 +424,6 @@ public class ParticipantUpdateCommand : Command
                 Console.WriteLine($"  ID:              {participant.Id}");
                 Console.WriteLine($"  Display Name:    {participant.DisplayName}");
                 Console.WriteLine($"  Status:          {participant.Status}");
-                Console.WriteLine($"  Updated:         {participant.UpdatedAt:yyyy-MM-dd HH:mm:ss}");
 
                 return ExitCodes.Success;
             }
@@ -563,6 +557,7 @@ public class ParticipantWalletLinkCommand : Command
 {
     private readonly Option<string> _participantIdOption;
     private readonly Option<string> _walletAddressOption;
+    private readonly Option<string> _algorithmOption;
 
     public ParticipantWalletLinkCommand(
         HttpClientFactory clientFactory,
@@ -582,13 +577,21 @@ public class ParticipantWalletLinkCommand : Command
             Required = true
         };
 
+        _algorithmOption = new Option<string>("--algorithm", "-a")
+        {
+            Description = "The wallet's signing algorithm (e.g. ED25519, NISTP256)",
+            Required = true
+        };
+
         Options.Add(_participantIdOption);
         Options.Add(_walletAddressOption);
+        Options.Add(_algorithmOption);
 
         this.SetAction(async (ParseResult parseResult, CancellationToken ct) =>
         {
             var participantId = parseResult.GetValue(_participantIdOption)!;
             var walletAddress = parseResult.GetValue(_walletAddressOption)!;
+            var algorithm = parseResult.GetValue(_algorithmOption)!;
 
             try
             {
@@ -606,7 +609,8 @@ public class ParticipantWalletLinkCommand : Command
 
                 var request = new InitiateWalletLinkRequest
                 {
-                    WalletAddress = walletAddress
+                    WalletAddress = walletAddress,
+                    Algorithm = algorithm
                 };
 
                 var challenge = await client.InitiateWalletLinkAsync(participantId, request, $"Bearer {token}");
@@ -621,7 +625,10 @@ public class ParticipantWalletLinkCommand : Command
                 ConsoleHelper.WriteSuccess("Wallet link challenge initiated!");
                 Console.WriteLine();
                 Console.WriteLine($"  Challenge ID:  {challenge.ChallengeId}");
-                Console.WriteLine($"  Nonce:         {challenge.Nonce}");
+                Console.WriteLine($"  Challenge:     {challenge.Challenge}");
+                Console.WriteLine($"  Wallet:        {challenge.WalletAddress}");
+                Console.WriteLine($"  Algorithm:     {challenge.Algorithm}");
+                Console.WriteLine($"  Status:        {challenge.Status}");
                 Console.WriteLine($"  Expires At:    {challenge.ExpiresAt:yyyy-MM-dd HH:mm:ss}");
                 Console.WriteLine();
                 ConsoleHelper.WriteInfo("Sign the nonce with your wallet and verify using:");

--- a/src/Apps/Sorcha.Cli/Commands/PeerCommands.cs
+++ b/src/Apps/Sorcha.Cli/Commands/PeerCommands.cs
@@ -247,7 +247,7 @@ public class PeerStatsCommand : Command
                 Console.WriteLine($"    Total Peers:     {stats.PeerStats.TotalPeers}");
                 Console.WriteLine($"    Healthy Peers:   {stats.PeerStats.HealthyPeers}");
                 Console.WriteLine($"    Unhealthy Peers: {stats.PeerStats.UnhealthyPeers}");
-                Console.WriteLine($"    Bootstrap Nodes: {stats.PeerStats.BootstrapNodes}");
+                Console.WriteLine($"    Seed Nodes:      {stats.PeerStats.SeedNodes}");
                 Console.WriteLine($"    Avg Latency:     {stats.PeerStats.AverageLatencyMs:F2}ms");
                 Console.WriteLine($"    Total Failures:  {stats.PeerStats.TotalFailures}");
 

--- a/src/Apps/Sorcha.Cli/Commands/TransactionCommands.cs
+++ b/src/Apps/Sorcha.Cli/Commands/TransactionCommands.cs
@@ -386,117 +386,34 @@ public class TxSubmitCommand : Command
         Options.Add(_signatureOption);
         Options.Add(_previousTxOption);
 
-        this.SetAction(async (ParseResult parseResult, CancellationToken ct) =>
+        this.SetAction((ParseResult parseResult, CancellationToken ct) =>
         {
-            var registerId = parseResult.GetValue(_registerIdOption)!;
-            var txType = parseResult.GetValue(_txTypeOption)!;
-            var wallet = parseResult.GetValue(_walletOption)!;
-            var payload = parseResult.GetValue(_payloadOption)!;
-            var signature = parseResult.GetValue(_signatureOption)!;
-            var previousTx = parseResult.GetValue(_previousTxOption);
+            // Raw transaction submission is intentionally NOT supported from the CLI.
+            //
+            // The register's POST /transactions endpoint consumes a complete, signed
+            // TransactionModel — Payloads[], MetaData, PayloadCount, chained previousTxId, and a
+            // signature computed over the canonical transaction bytes. That object is produced by
+            // executing a blueprint action (which builds and signs it correctly), not by pasting a
+            // payload string and a signature on a command line. The flags this command used to take
+            // (--payload / --signature) could never assemble a valid transaction, so the previous
+            // implementation reported success while the server rejected — or silently mis-stored —
+            // whatever it was sent.
+            //
+            // Removing the fake path rather than leaving it to mislead. The read side of the ledger
+            // (list / get / status / query) remains fully supported.
+            ConsoleHelper.WriteError("Raw transaction submission is not supported from the CLI.");
+            Console.WriteLine();
+            ConsoleHelper.WriteInfo(
+                "A register transaction is a complete signed object (payloads, metadata, chain "
+                + "linkage, signature) built by executing a blueprint action — not something that "
+                + "can be assembled from a payload string on the command line.");
+            Console.WriteLine();
+            ConsoleHelper.WriteInfo(
+                "To create transactions, execute the relevant blueprint action against a workflow "
+                + "instance. To inspect existing transactions, use 'sorcha tx list', 'sorcha tx get', "
+                + "'sorcha tx status', or 'sorcha query'.");
 
-            try
-            {
-                // Get active profile
-                var profile = await configService.GetActiveProfileAsync();
-                var profileName = profile?.Name ?? "dev";
-
-                // Get access token
-                var token = await authService.GetAccessTokenAsync(profileName);
-                if (string.IsNullOrEmpty(token))
-                {
-                    ConsoleHelper.WriteError("You must be authenticated to submit a transaction.");
-                    ConsoleHelper.WriteInfo("Run 'sorcha auth login' to authenticate.");
-                    return ExitCodes.AuthenticationError;
-                }
-
-                // Create Register Service client
-                var client = await clientFactory.CreateRegisterServiceClientAsync(profileName);
-
-                // Build request
-                var request = new SubmitTransactionRequest
-                {
-                    RegisterId = registerId,
-                    TxType = txType,
-                    SenderWallet = wallet,
-                    Payload = payload,
-                    Signature = signature,
-                    PreviousTxId = previousTx
-                };
-
-                // Call API
-                var response = await client.SubmitTransactionAsync(registerId, request, $"Bearer {token}");
-
-                // Check output format
-                var outputFormat = OutputHelper.GetOutputFormat(parseResult);
-                if (OutputHelper.IsStructuredFormat(outputFormat))
-                {
-                    OutputHelper.WriteSingle(parseResult, response);
-                    return ExitCodes.Success;
-                }
-
-                // Display results
-                if (response.Status == "Pending" || response.Status == "Confirmed")
-                {
-                    ConsoleHelper.WriteSuccess($"Transaction submitted successfully!");
-                    Console.WriteLine();
-                    Console.WriteLine($"  Transaction ID:  {response.TransactionId}");
-                    Console.WriteLine($"  Status:          {response.Status}");
-                    Console.WriteLine();
-                    ConsoleHelper.WriteInfo($"Use 'sorcha tx status --register-id {registerId} --tx-id {response.TransactionId}' to check status.");
-                    return ExitCodes.Success;
-                }
-                else
-                {
-                    ConsoleHelper.WriteError($"Transaction submission failed.");
-                    Console.WriteLine($"  Transaction ID:  {response.TransactionId}");
-                    Console.WriteLine($"  Status:          {response.Status}");
-                    if (!string.IsNullOrEmpty(response.Error))
-                    {
-                        Console.WriteLine($"  Error:           {response.Error}");
-                    }
-                    return ExitCodes.GeneralError;
-                }
-            }
-            catch (ApiException ex) when (ex.StatusCode == HttpStatusCode.BadRequest)
-            {
-                ConsoleHelper.WriteError("Invalid transaction. Please check your input.");
-                if (ex.Content != null)
-                {
-                    ConsoleHelper.WriteError($"Details: {ex.Content}");
-                }
-                return ExitCodes.ValidationError;
-            }
-            catch (ApiException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
-            {
-                ConsoleHelper.WriteError($"Register '{registerId}' not found.");
-                return ExitCodes.NotFound;
-            }
-            catch (ApiException ex) when (ex.StatusCode == HttpStatusCode.Unauthorized)
-            {
-                ConsoleHelper.WriteError("Authentication failed. Your access token may have expired.");
-                ConsoleHelper.WriteInfo("Run 'sorcha auth login' to re-authenticate.");
-                return ExitCodes.AuthenticationError;
-            }
-            catch (ApiException ex) when (ex.StatusCode == HttpStatusCode.Forbidden)
-            {
-                ConsoleHelper.WriteError("You do not have permission to submit transactions to this register.");
-                return ExitCodes.AuthorizationError;
-            }
-            catch (ApiException ex)
-            {
-                ConsoleHelper.WriteError($"API Error: {ex.Message}");
-                if (ex.Content != null)
-                {
-                    ConsoleHelper.WriteError($"Details: {ex.Content}");
-                }
-                return ExitCodes.GeneralError;
-            }
-            catch (Exception ex)
-            {
-                ConsoleHelper.WriteError($"Failed to submit transaction: {ex.Message}");
-                return ExitCodes.GeneralError;
-            }
+            return Task.FromResult(ExitCodes.GeneralError);
         });
     }
 }

--- a/src/Apps/Sorcha.Cli/Commands/ValidatorCommands.cs
+++ b/src/Apps/Sorcha.Cli/Commands/ValidatorCommands.cs
@@ -577,19 +577,23 @@ public class ValidatorStatusCommand : Command
                     return ExitCodes.Success;
                 }
 
-                ConsoleHelper.WriteSuccess("Validator service status:");
+                ConsoleHelper.WriteSuccess("Validator status:");
                 Console.WriteLine();
-                Console.WriteLine($"  Status:              {status.Status}");
-                Console.WriteLine($"  Running:             {(status.IsRunning ? "Yes" : "No")}");
-                Console.WriteLine($"  Registers Monitored: {status.RegistersMonitored}");
-                Console.WriteLine($"  Total Validations:   {status.TotalValidations}");
-                Console.WriteLine($"  Failed Validations:  {status.FailedValidations}");
-                Console.WriteLine($"  Consensus Protocol:  {status.ConsensusProtocol}");
-                Console.WriteLine($"  Uptime:              {status.Uptime}");
+                Console.WriteLine($"  Register:               {status.RegisterId}");
+                Console.WriteLine($"  Active:                 {(status.IsActive ? "Yes" : "No")}");
+                Console.WriteLine($"  Mempool transactions:   {status.TransactionsInMemPool}");
+                Console.WriteLine($"  Dockets proposed:       {status.DocketsProposed}");
+                Console.WriteLine($"  Dockets confirmed:      {status.DocketsConfirmed}");
+                Console.WriteLine($"  Dockets rejected:       {status.DocketsRejected}");
 
-                if (status.LastValidationAt.HasValue)
+                if (status.StartedAt.HasValue)
                 {
-                    Console.WriteLine($"  Last Validation:     {status.LastValidationAt:yyyy-MM-dd HH:mm:ss}");
+                    Console.WriteLine($"  Started:                {status.StartedAt:yyyy-MM-dd HH:mm:ss}");
+                }
+
+                if (status.LastDocketBuildAt.HasValue)
+                {
+                    Console.WriteLine($"  Last docket build:      {status.LastDocketBuildAt:yyyy-MM-dd HH:mm:ss}");
                 }
 
                 return ExitCodes.Success;

--- a/src/Apps/Sorcha.Cli/Commands/VerifyCommands.cs
+++ b/src/Apps/Sorcha.Cli/Commands/VerifyCommands.cs
@@ -90,18 +90,23 @@ public class VerifyReceiptCommand : Command
                 // Display verification result
                 if (verification.IsValid)
                 {
-                    ConsoleHelper.WriteSuccess($"Verification: VALID ({verification.Status})");
+                    ConsoleHelper.WriteSuccess("Verification: VALID");
                 }
                 else
                 {
-                    ConsoleHelper.WriteError($"Verification: INVALID ({verification.Status})");
+                    ConsoleHelper.WriteError("Verification: INVALID");
                     foreach (var error in verification.Errors)
                     {
                         ConsoleHelper.WriteError($"  - {error}");
                     }
                 }
 
-                Console.WriteLine($"  Verified at: {verification.VerifiedAt:yyyy-MM-dd HH:mm:ss}");
+                if (verification.Checks is { } checks)
+                {
+                    Console.WriteLine($"  Signature valid:        {checks.SignatureValid}");
+                    Console.WriteLine($"  Inclusion proof valid:  {checks.InclusionProofValid}");
+                    Console.WriteLine($"  Merkle root consistent: {checks.MerkleRootConsistent}");
+                }
 
                 return verification.IsValid ? ExitCodes.Success : ExitCodes.ValidationError;
             }
@@ -207,18 +212,23 @@ public class VerifyBundleCommand : Command
                 // Display verification result
                 if (verification.IsValid)
                 {
-                    ConsoleHelper.WriteSuccess($"Verification: VALID ({verification.Status})");
+                    ConsoleHelper.WriteSuccess("Verification: VALID");
                 }
                 else
                 {
-                    ConsoleHelper.WriteError($"Verification: INVALID ({verification.Status})");
+                    ConsoleHelper.WriteError("Verification: INVALID");
                     foreach (var error in verification.Errors)
                     {
                         ConsoleHelper.WriteError($"  - {error}");
                     }
                 }
 
-                Console.WriteLine($"  Verified at: {verification.VerifiedAt:yyyy-MM-dd HH:mm:ss}");
+                if (verification.Checks is { } checks)
+                {
+                    Console.WriteLine($"  Signature valid:        {checks.SignatureValid}");
+                    Console.WriteLine($"  Inclusion proof valid:  {checks.InclusionProofValid}");
+                    Console.WriteLine($"  Merkle root consistent: {checks.MerkleRootConsistent}");
+                }
 
                 return verification.IsValid ? ExitCodes.Success : ExitCodes.ValidationError;
             }

--- a/src/Apps/Sorcha.Cli/Models/Admin.cs
+++ b/src/Apps/Sorcha.Cli/Models/Admin.cs
@@ -41,26 +41,9 @@ public class HealthCheckResponse
     public DateTimeOffset CheckedAt { get; set; }
 }
 
-/// <summary>
-/// Schema sector information.
-/// </summary>
-public class SchemaSector
-{
-    [JsonPropertyName("id")]
-    public string Id { get; set; } = string.Empty;
-
-    [JsonPropertyName("name")]
-    public string Name { get; set; } = string.Empty;
-
-    [JsonPropertyName("description")]
-    public string Description { get; set; } = string.Empty;
-
-    [JsonPropertyName("schemaCount")]
-    public int SchemaCount { get; set; }
-
-    [JsonPropertyName("status")]
-    public string Status { get; set; } = string.Empty;
-}
+// SchemaSector (id/name/description/schemaCount/status) was a dead model — no command referenced
+// it, and it never matched the server's SchemaSectorDto (id/displayName/description/icon). Removed
+// rather than realigned: there is nothing to align it to a use for.
 
 /// <summary>
 /// Schema provider information.

--- a/src/Apps/Sorcha.Cli/Models/Blueprint.cs
+++ b/src/Apps/Sorcha.Cli/Models/Blueprint.cs
@@ -122,13 +122,34 @@ public class CreateBlueprintRequest
 /// <summary>
 /// Request to publish a blueprint to a register.
 /// </summary>
+/// <remarks>
+/// Mirrors the server's <c>PublishRequest</c> for <c>POST /api/blueprints/{id}/publish</c>. The
+/// blueprint id is a route parameter, so this body carries only <c>registerId</c> and an optional
+/// <c>override</c>. The CLI previously sent a <c>blueprintId</c> the server never reads and had no
+/// way to pass the rehearsal-gate override, so an operator could not force-publish from the CLI.
+/// </remarks>
 public class PublishBlueprintRequest
 {
-    [JsonPropertyName("blueprintId")]
-    public string BlueprintId { get; set; } = string.Empty;
-
     [JsonPropertyName("registerId")]
     public string RegisterId { get; set; } = string.Empty;
+
+    /// <summary>Optional rehearsal-gate override. Null means a normal, gated publish.</summary>
+    [JsonPropertyName("override")]
+    public PublishBlueprintOverride? Override { get; set; }
+}
+
+/// <summary>
+/// The override that lets an authorised caller publish past the rehearsal soft-gate.
+/// </summary>
+public class PublishBlueprintOverride
+{
+    /// <summary>Must be true to actually override.</summary>
+    [JsonPropertyName("confirm")]
+    public bool Confirm { get; set; }
+
+    /// <summary>Optional reason, recorded in the publish-override audit.</summary>
+    [JsonPropertyName("reason")]
+    public string? Reason { get; set; }
 }
 
 /// <summary>

--- a/src/Apps/Sorcha.Cli/Models/Credential.cs
+++ b/src/Apps/Sorcha.Cli/Models/Credential.cs
@@ -68,22 +68,80 @@ public class CredentialDetail
 /// <summary>
 /// Request to issue a verifiable credential.
 /// </summary>
+/// <remarks>
+/// Mirrors the required surface of <c>Sorcha.Wallet.Service</c>'s <c>IssueCredentialRequest</c> for
+/// <c>POST /api/v1/credentials/issue</c>. The previous shape (<c>type</c>/<c>subject</c>/
+/// <c>walletAddress</c>/<c>expiresInDays</c>) matched no server field, AND the command posted to
+/// <c>POST /api/v1/credentials</c> — which is <c>StoreCredential</c>, not issuance — so the command
+/// could never issue anything. Claims are objects, not strings, on the wire; the recipient is a
+/// wallet address, not a "subject". The many issuer-infrastructure fields (holderJwk, tenantId,
+/// trustAnchor, status-list wiring) are optional server-side and left to the server's defaults —
+/// blueprint-action-driven issuance remains the richer path; this covers the direct case.
+/// </remarks>
 public class IssueCredentialRequest
 {
+    /// <summary>The credential type, e.g. <c>IdentityCredential</c>.</summary>
+    [JsonPropertyName("credentialType")]
+    public string CredentialType { get; set; } = string.Empty;
+
+    /// <summary>The claims to embed. Values are arbitrary JSON, not just strings.</summary>
+    [JsonPropertyName("claims")]
+    public Dictionary<string, object> Claims { get; set; } = new();
+
+    /// <summary>The recipient's wallet address.</summary>
+    [JsonPropertyName("recipientWallet")]
+    public string RecipientWallet { get; set; } = string.Empty;
+
+    /// <summary>Optional display name for the credential.</summary>
+    [JsonPropertyName("displayName")]
+    public string? DisplayName { get; set; }
+
+    /// <summary>
+    /// Optional ISO-8601 duration until expiry, e.g. <c>P5Y</c>. Null issues a non-expiring
+    /// credential (subject to server policy).
+    /// </summary>
+    [JsonPropertyName("expiryDuration")]
+    public string? ExpiryDuration { get; set; }
+
+    /// <summary>Optional list of claim names the holder may selectively disclose.</summary>
+    [JsonPropertyName("disclosableClaims")]
+    public List<string>? DisclosableClaims { get; set; }
+}
+
+/// <summary>
+/// Response from issuing a verifiable credential — mirrors <c>Sorcha.Wallet.Service</c>'s
+/// <c>IssuedCredentialResponse</c> (what <c>POST /api/v1/credentials/issue</c> produces).
+/// </summary>
+public class IssuedCredentialResponse
+{
+    [JsonPropertyName("credentialId")]
+    public string CredentialId { get; set; } = string.Empty;
+
     [JsonPropertyName("type")]
     public string Type { get; set; } = string.Empty;
 
-    [JsonPropertyName("subject")]
-    public string Subject { get; set; } = string.Empty;
+    [JsonPropertyName("issuerDid")]
+    public string IssuerDid { get; set; } = string.Empty;
 
+    [JsonPropertyName("subjectDid")]
+    public string SubjectDid { get; set; } = string.Empty;
+
+    /// <summary>The issued claims. Values are arbitrary JSON.</summary>
     [JsonPropertyName("claims")]
-    public Dictionary<string, string> Claims { get; set; } = new();
+    public Dictionary<string, object> Claims { get; set; } = new();
 
-    [JsonPropertyName("walletAddress")]
-    public string WalletAddress { get; set; } = string.Empty;
+    [JsonPropertyName("issuedAt")]
+    public DateTimeOffset IssuedAt { get; set; }
 
-    [JsonPropertyName("expiresInDays")]
-    public int? ExpiresInDays { get; set; }
+    [JsonPropertyName("expiresAt")]
+    public DateTimeOffset? ExpiresAt { get; set; }
+
+    [JsonPropertyName("rawToken")]
+    public string RawToken { get; set; } = string.Empty;
+
+    /// <summary>Optional display configuration JSON for the credential.</summary>
+    [JsonPropertyName("displayConfigJson")]
+    public string? DisplayConfigJson { get; set; }
 }
 
 /// <summary>

--- a/src/Apps/Sorcha.Cli/Models/Participant.cs
+++ b/src/Apps/Sorcha.Cli/Models/Participant.cs
@@ -9,6 +9,14 @@ namespace Sorcha.Cli.Models;
 /// <summary>
 /// Participant identity record.
 /// </summary>
+/// <remarks>
+/// Mirrors <c>Sorcha.Tenant.Service.Models.Dtos.ParticipantResponse</c> (returned by the
+/// participant get / create / update endpoints); the pairing is asserted by
+/// <c>CliWireContractTests</c>. This previously carried <c>updatedAt</c> and a nested
+/// <c>walletLinks</c> list — neither of which the response sends — and omitted <c>email</c> and the
+/// <c>hasLinkedWallet</c> flag. The linked addresses come from the separate wallet-links list
+/// endpoint, not this record.
+/// </remarks>
 public class ParticipantIdentity
 {
     [JsonPropertyName("id")]
@@ -23,22 +31,30 @@ public class ParticipantIdentity
     [JsonPropertyName("displayName")]
     public string DisplayName { get; set; } = string.Empty;
 
+    /// <summary>The participant's email.</summary>
+    [JsonPropertyName("email")]
+    public string Email { get; set; } = string.Empty;
+
     [JsonPropertyName("status")]
     public string Status { get; set; } = string.Empty;
 
+    /// <summary>Whether the participant has at least one verified linked wallet.</summary>
+    [JsonPropertyName("hasLinkedWallet")]
+    public bool HasLinkedWallet { get; set; }
+
     [JsonPropertyName("createdAt")]
     public DateTimeOffset CreatedAt { get; set; }
-
-    [JsonPropertyName("updatedAt")]
-    public DateTimeOffset UpdatedAt { get; set; }
-
-    [JsonPropertyName("walletLinks")]
-    public List<LinkedWalletAddress> WalletLinks { get; set; } = new();
 }
 
 /// <summary>
 /// Linked wallet address for a participant.
 /// </summary>
+/// <remarks>
+/// Mirrors <c>Sorcha.Tenant.Service.Models.Dtos.LinkedWalletAddressResponse</c> (returned by
+/// verify-wallet-link and the wallet-links list); the pairing is asserted by
+/// <c>CliWireContractTests</c>. This previously carried <c>verifiedAt</c> (never sent) and omitted
+/// algorithm / linkedAt / revokedAt.
+/// </remarks>
 public class LinkedWalletAddress
 {
     [JsonPropertyName("id")]
@@ -47,11 +63,20 @@ public class LinkedWalletAddress
     [JsonPropertyName("walletAddress")]
     public string WalletAddress { get; set; } = string.Empty;
 
+    /// <summary>The wallet's signing algorithm.</summary>
+    [JsonPropertyName("algorithm")]
+    public string Algorithm { get; set; } = string.Empty;
+
     [JsonPropertyName("status")]
     public string Status { get; set; } = string.Empty;
 
-    [JsonPropertyName("verifiedAt")]
-    public DateTimeOffset? VerifiedAt { get; set; }
+    /// <summary>When the link was established.</summary>
+    [JsonPropertyName("linkedAt")]
+    public DateTimeOffset LinkedAt { get; set; }
+
+    /// <summary>When the link was revoked, if it has been.</summary>
+    [JsonPropertyName("revokedAt")]
+    public DateTimeOffset? RevokedAt { get; set; }
 }
 
 /// <summary>
@@ -93,16 +118,35 @@ public class SearchParticipantsRequest
 /// <summary>
 /// Response containing a wallet link challenge.
 /// </summary>
+/// <remarks>
+/// Mirrors <c>Sorcha.Tenant.Service.Models.Dtos.WalletLinkChallengeResponse</c>; the pairing is
+/// asserted by <c>CliWireContractTests</c>. This previously read <c>nonce</c> (the server sends
+/// <c>challenge</c>) and omitted walletAddress / algorithm / status — so the challenge to sign came
+/// back blank and the operator had nothing to sign.
+/// </remarks>
 public class WalletLinkChallengeResponse
 {
     [JsonPropertyName("challengeId")]
     public string ChallengeId { get; set; } = string.Empty;
 
-    [JsonPropertyName("nonce")]
-    public string Nonce { get; set; } = string.Empty;
+    /// <summary>The challenge string the wallet must sign.</summary>
+    [JsonPropertyName("challenge")]
+    public string Challenge { get; set; } = string.Empty;
+
+    /// <summary>The wallet address being linked.</summary>
+    [JsonPropertyName("walletAddress")]
+    public string WalletAddress { get; set; } = string.Empty;
+
+    /// <summary>The signing algorithm the wallet must use.</summary>
+    [JsonPropertyName("algorithm")]
+    public string Algorithm { get; set; } = string.Empty;
 
     [JsonPropertyName("expiresAt")]
     public DateTimeOffset ExpiresAt { get; set; }
+
+    /// <summary>The challenge's current status.</summary>
+    [JsonPropertyName("status")]
+    public string Status { get; set; } = string.Empty;
 }
 
 /// <summary>
@@ -180,10 +224,19 @@ public class PublishParticipantResult
 /// <summary>
 /// Request to initiate a wallet link.
 /// </summary>
+/// <remarks>
+/// Mirrors <c>Sorcha.Tenant.Service.Models.Dtos.InitiateWalletLinkRequest</c>. The server requires
+/// <c>algorithm</c> (the wallet's signing algorithm); the CLI omitted it, so the request relied on
+/// the server's default and could bind the wrong scheme for a non-default wallet.
+/// </remarks>
 public class InitiateWalletLinkRequest
 {
     [JsonPropertyName("walletAddress")]
     public string WalletAddress { get; set; } = string.Empty;
+
+    /// <summary>The wallet's signing algorithm, e.g. ED25519 or NISTP256.</summary>
+    [JsonPropertyName("algorithm")]
+    public string Algorithm { get; set; } = string.Empty;
 }
 
 /// <summary>

--- a/src/Apps/Sorcha.Cli/Models/Peer.cs
+++ b/src/Apps/Sorcha.Cli/Models/Peer.cs
@@ -55,7 +55,7 @@ public class PeerStatistics
     public int TotalPeers { get; set; }
     public int HealthyPeers { get; set; }
     public int UnhealthyPeers { get; set; }
-    public int BootstrapNodes { get; set; }
+    public int SeedNodes { get; set; }
     public double AverageLatencyMs { get; set; }
     public int TotalFailures { get; set; }
 }
@@ -148,6 +148,13 @@ public class SubscriptionInfo
 public class AvailableRegisterInfo
 {
     public string RegisterId { get; set; } = string.Empty;
+
+    /// <summary>The register's name, when advertised. Present on the wire; previously dropped.</summary>
+    public string? Name { get; set; }
+
+    /// <summary>The register's description, when advertised. Present on the wire; previously dropped.</summary>
+    public string? Description { get; set; }
+
     public int PeerCount { get; set; }
     public long LatestVersion { get; set; }
     public long LatestDocketVersion { get; set; }

--- a/src/Apps/Sorcha.Cli/Models/Validator.cs
+++ b/src/Apps/Sorcha.Cli/Models/Validator.cs
@@ -8,31 +8,47 @@ namespace Sorcha.Cli.Models;
 /// <summary>
 /// Validator service status.
 /// </summary>
+/// <remarks>
+/// Mirrors <c>Sorcha.Validator.Service.ValidatorStatus</c> (returned by
+/// <c>GET /api/admin/validators/{registerId}/status</c>); the pairing is asserted by
+/// <c>CliWireContractTests</c>. This was previously an invented shape — <c>status</c>,
+/// <c>isRunning</c>, <c>uptime</c>, <c>consensusProtocol</c>, <c>registersMonitored</c> — none of
+/// which the server sends. So <c>sorcha validator status</c> printed an empty status, "Running: No"
+/// and a blank uptime regardless of what the validator was actually doing.
+/// </remarks>
 public class ValidatorStatus
 {
-    [JsonPropertyName("status")]
-    public string Status { get; set; } = string.Empty;
+    /// <summary>The register this validator status is for.</summary>
+    [JsonPropertyName("registerId")]
+    public string RegisterId { get; set; } = string.Empty;
 
-    [JsonPropertyName("isRunning")]
-    public bool IsRunning { get; set; }
+    /// <summary>Whether the validator is actively sealing for this register.</summary>
+    [JsonPropertyName("isActive")]
+    public bool IsActive { get; set; }
 
-    [JsonPropertyName("registersMonitored")]
-    public int RegistersMonitored { get; set; }
+    /// <summary>Transactions currently waiting in this register's mempool.</summary>
+    [JsonPropertyName("transactionsInMemPool")]
+    public int TransactionsInMemPool { get; set; }
 
-    [JsonPropertyName("totalValidations")]
-    public long TotalValidations { get; set; }
+    /// <summary>Dockets this validator has proposed.</summary>
+    [JsonPropertyName("docketsProposed")]
+    public long DocketsProposed { get; set; }
 
-    [JsonPropertyName("failedValidations")]
-    public long FailedValidations { get; set; }
+    /// <summary>Dockets confirmed (sealed) for this register.</summary>
+    [JsonPropertyName("docketsConfirmed")]
+    public long DocketsConfirmed { get; set; }
 
-    [JsonPropertyName("lastValidationAt")]
-    public DateTimeOffset? LastValidationAt { get; set; }
+    /// <summary>Dockets this validator proposed that were rejected.</summary>
+    [JsonPropertyName("docketsRejected")]
+    public long DocketsRejected { get; set; }
 
-    [JsonPropertyName("uptime")]
-    public string Uptime { get; set; } = string.Empty;
+    /// <summary>When this validator started sealing for the register, if it has.</summary>
+    [JsonPropertyName("startedAt")]
+    public DateTimeOffset? StartedAt { get; set; }
 
-    [JsonPropertyName("consensusProtocol")]
-    public string ConsensusProtocol { get; set; } = string.Empty;
+    /// <summary>When this validator last built a docket, if ever.</summary>
+    [JsonPropertyName("lastDocketBuildAt")]
+    public DateTimeOffset? LastDocketBuildAt { get; set; }
 }
 
 /// <summary>
@@ -180,6 +196,14 @@ public class ValidatorAuditResponse
 /// </summary>
 public class ValidatorAuditEntry
 {
+    /// <summary>The audit entry's own id. Present on the wire; the CLI previously dropped it.</summary>
+    [JsonPropertyName("id")]
+    public string Id { get; set; } = string.Empty;
+
+    /// <summary>The register this roster change applies to. Present on the wire; previously dropped.</summary>
+    [JsonPropertyName("registerId")]
+    public string RegisterId { get; set; } = string.Empty;
+
     [JsonPropertyName("validatorId")]
     public string ValidatorId { get; set; } = string.Empty;
 

--- a/src/Apps/Sorcha.Cli/Services/ICredentialServiceClient.cs
+++ b/src/Apps/Sorcha.Cli/Services/ICredentialServiceClient.cs
@@ -27,8 +27,8 @@ public interface ICredentialServiceClient
     /// <summary>
     /// Issues a new verifiable credential.
     /// </summary>
-    [Post("/api/v1/credentials")]
-    Task<CredentialDetail> IssueCredentialAsync([Body] IssueCredentialRequest request, [Header("Authorization")] string authorization);
+    [Post("/api/v1/credentials/issue")]
+    Task<IssuedCredentialResponse> IssueCredentialAsync([Body] IssueCredentialRequest request, [Header("Authorization")] string authorization);
 
     /// <summary>
     /// Presents a credential to a verifier.

--- a/src/Apps/Sorcha.Cli/Services/IRegisterServiceClient.cs
+++ b/src/Apps/Sorcha.Cli/Services/IRegisterServiceClient.cs
@@ -81,15 +81,6 @@ public interface IRegisterServiceClient
         [Header("Authorization")] string authorization);
 
     /// <summary>
-    /// Submits a new transaction to a register.
-    /// </summary>
-    [Post("/api/registers/{registerId}/transactions")]
-    Task<SubmitTransactionResponse> SubmitTransactionAsync(
-        string registerId,
-        [Body] SubmitTransactionRequest request,
-        [Header("Authorization")] string authorization);
-
-    /// <summary>
     /// Gets the lifecycle status of a transaction (active / revoked / superseded).
     /// </summary>
     [Get("/api/registers/{registerId}/transactions/{transactionId}/status")]
@@ -286,28 +277,9 @@ public class RegisterCountResponse
     public int Count { get; set; }
 }
 
-/// <summary>
-/// Request to submit a new transaction.
-/// </summary>
-public class SubmitTransactionRequest
-{
-    public string RegisterId { get; set; } = string.Empty;
-    public string TxType { get; set; } = string.Empty;
-    public string SenderWallet { get; set; } = string.Empty;
-    public string Payload { get; set; } = string.Empty;
-    public string Signature { get; set; } = string.Empty;
-    public string? PreviousTxId { get; set; }
-}
-
-/// <summary>
-/// Response after submitting a transaction.
-/// </summary>
-public class SubmitTransactionResponse
-{
-    public string TransactionId { get; set; } = string.Empty;
-    public string Status { get; set; } = string.Empty;
-    public string? Error { get; set; }
-}
+// SubmitTransactionRequest / SubmitTransactionResponse were invented DTOs for a `transaction
+// submit` command that could never work: the endpoint consumes a full signed TransactionModel,
+// not a flat {payload, signature}. The command now explains that and refuses; the DTOs are gone.
 
 /// <summary>
 /// Paged query response.

--- a/src/Apps/Sorcha.Cli/Services/IRegisterServiceClient.cs
+++ b/src/Apps/Sorcha.Cli/Services/IRegisterServiceClient.cs
@@ -43,7 +43,7 @@ public interface IRegisterServiceClient
     /// Gets register statistics.
     /// </summary>
     [Get("/api/registers/stats/count")]
-    Task<RegisterStatsResponse> GetRegisterStatsAsync([Header("Authorization")] string authorization);
+    Task<RegisterCountResponse> GetRegisterStatsAsync([Header("Authorization")] string authorization);
 
     // --- Two-Phase Register Creation ---
 
@@ -270,8 +270,19 @@ public class UpdateRegisterRequest
 /// <summary>
 /// Response from register statistics.
 /// </summary>
-public class RegisterStatsResponse
+/// <summary>
+/// Response of <c>GET /api/registers/stats/count</c> — the register count only.
+/// </summary>
+/// <remarks>
+/// Named <c>RegisterCountResponse</c> to stop it colliding with the unrelated
+/// <c>Sorcha.ServiceClients.Http</c> <c>RegisterCountResponse</c>, which is a DIFFERENT endpoint's
+/// type (the org-scoped dashboard stats, carrying registerCount + transactionCount). The two share
+/// nothing but a name; the CLI's single-count shape is correct for the endpoint it actually calls,
+/// so the fix is to disambiguate, not to "align" it to a contract it never uses.
+/// </remarks>
+public class RegisterCountResponse
 {
+    /// <summary>Total number of registers.</summary>
     public int Count { get; set; }
 }
 

--- a/src/Apps/Sorcha.Cli/Services/IVerificationServiceClient.cs
+++ b/src/Apps/Sorcha.Cli/Services/IVerificationServiceClient.cs
@@ -82,8 +82,31 @@ public class VerificationBundleResponse
 /// </summary>
 public class VerificationResult
 {
+    /// <summary>Whether the receipt/bundle verified.</summary>
     public bool IsValid { get; set; }
-    public string Status { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The individual checks the server ran. The endpoint returns these under <c>checks</c>; the
+    /// CLI previously ignored them and invented a <c>status</c>/<c>verifiedAt</c> the server never
+    /// sends, so the operator saw an empty status and a default timestamp.
+    /// </summary>
+    public ReceiptVerificationChecks? Checks { get; set; }
+
+    /// <summary>Verification errors, if any.</summary>
     public List<string> Errors { get; set; } = new();
-    public DateTimeOffset VerifiedAt { get; set; }
+}
+
+/// <summary>
+/// The per-check breakdown the receipt/bundle verify endpoint returns under <c>checks</c>.
+/// </summary>
+public class ReceiptVerificationChecks
+{
+    /// <summary>Whether the validator signature verified.</summary>
+    public bool SignatureValid { get; set; }
+
+    /// <summary>Whether the Merkle inclusion proof verified.</summary>
+    public bool InclusionProofValid { get; set; }
+
+    /// <summary>Whether the Merkle root was consistent with the docket.</summary>
+    public bool MerkleRootConsistent { get; set; }
 }

--- a/tests/Sorcha.Cli.ContractTests/CliWireContractTests.cs
+++ b/tests/Sorcha.Cli.ContractTests/CliWireContractTests.cs
@@ -2,6 +2,7 @@
 // Copyright (c) 2026 Sorcha Contributors
 
 using System.Reflection;
+using System.Text.Json.Serialization;
 
 using FluentAssertions;
 
@@ -53,6 +54,17 @@ public sealed class CliWireContractTests
             + "object — not the Wallet Service's VerificationResult the name collides with. The CLI "
             + "type now matches that anonymous shape (isValid/checks/errors); there is no server type "
             + "to pair against, so this is not a wire-contract collision.",
+        ["IssueCredentialRequest"] =
+            "Deliberate curated SUBSET, not drift. The Wallet Service's issue request has 11 further "
+            + "OPTIONAL fields the CLI intentionally does not expose: holderJwk, tenantId, "
+            + "trustAnchor, issuerOrgName, skipRecipientStore, vct, issuanceBlueprintId, and the four "
+            + "statusList* wiring fields. Those are issuer-infrastructure and status-list plumbing "
+            + "supplied by blueprint-action-driven issuance, not sensible CLI flags. Every field the "
+            + "CLI DOES send (credentialType, claims, recipientWallet, displayName, expiryDuration, "
+            + "disclosableClaims) matches the server exactly, and the three the server REQUIRES "
+            + "(credentialType, claims, recipientWallet) are all present — verified by "
+            + "IssueCredentialRequest_SendsEveryRequiredServerField below. A future field the server "
+            + "makes required would be caught by that test, not silently dropped.",
         ["RegisterSyncStatus"] =
             "The CLI's /health/sync response models the Register Service's RegisterSyncStatus, which "
             + "is a PRIVATE record inside RecoveryHealthEndpoints and therefore invisible to this "
@@ -86,8 +98,6 @@ public sealed class CliWireContractTests
     /// </remarks>
     private static readonly Dictionary<string, string> KnownMismatch = new(StringComparer.Ordinal)
     {
-        ["IssueCredentialRequest"] =
-            "Wallet.Service — CLI-only: expiresInDays, subject, type, walletAddress; server-only: credentialType, disclosableClaims, displayName, expiryDuration, holderJwk, issu...",
     };
 
     /// <summary>
@@ -116,6 +126,10 @@ public sealed class CliWireContractTests
     /// </summary>
     private static readonly Dictionary<string, string> PreferredCounterpartAssembly = new(StringComparer.Ordinal)
     {
+        // Declared in BOTH Blueprint.Service (an action-submission nested type) and Wallet.Service.
+        // The CLI's credential issue command talks to the Wallet Service.
+        ["IssuedCredentialResponse"] = "Sorcha.Wallet.Service",
+
         // Declared in BOTH Register.Service and ServiceClients.Http. The server is the authority
         // for what the CLI must match. (That the shared client ALSO disagrees with the server is a
         // separate finding, recorded on DRIFT-002.)
@@ -207,6 +221,33 @@ public sealed class CliWireContractTests
 
         NotAWireContract.Keys.Where(k => !cliNames.Contains(k)).Should().BeEmpty(
             "NotAWireContract names a CLI type that no longer exists");
+    }
+
+    [Fact]
+    public void IssueCredentialRequest_SendsEveryRequiredServerField()
+    {
+        // IssueCredentialRequest is a deliberate curated subset (see its NotAWireContract entry):
+        // the CLI omits optional issuer-infrastructure fields on purpose. That is only safe as long
+        // as it still sends everything the server REQUIRES — a field the server later makes required
+        // must not slip through the subset. This is the guard that makes the subclaim honest.
+        var serverType = Type.GetType(
+            "Sorcha.Wallet.Service.Endpoints.IssueCredentialRequest, Sorcha.Wallet.Service");
+        serverType.Should().NotBeNull("the server request type must be resolvable");
+
+        var requiredServerNames = serverType!
+            .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Where(p => p.GetCustomAttribute<System.ComponentModel.DataAnnotations.RequiredAttribute>() is not null)
+            .Select(p => p.GetCustomAttribute<JsonPropertyNameAttribute>()?.Name
+                         ?? System.Text.Json.JsonNamingPolicy.CamelCase.ConvertName(p.Name))
+            .ToHashSet(StringComparer.Ordinal);
+
+        requiredServerNames.Should().NotBeEmpty("the server marks some fields [Required]");
+
+        var cliType = CliTypes().Single(t => t.Name == "IssueCredentialRequest");
+        var cliNames = WireShape.Of(cliType);
+
+        requiredServerNames.Except(cliNames).Should().BeEmpty(
+            "the CLI issue request may omit optional server fields, but never a required one");
     }
 
     // ---------------------------------------------------------------------------------------

--- a/tests/Sorcha.Cli.ContractTests/CliWireContractTests.cs
+++ b/tests/Sorcha.Cli.ContractTests/CliWireContractTests.cs
@@ -47,6 +47,12 @@ public sealed class CliWireContractTests
         ["AuthenticationService"] = "A service class, not a DTO.",
         ["ConfigurationService"] = "A service class, not a DTO.",
         ["HttpClientFactory"] = "A factory class, not a DTO.",
+        ["VerificationResult"] =
+            "The CLI's verify command posts to the REGISTER Service's /receipts/verify and "
+            + "/verification-bundles/verify, which return an anonymous { isValid, checks, errors } "
+            + "object — not the Wallet Service's VerificationResult the name collides with. The CLI "
+            + "type now matches that anonymous shape (isValid/checks/errors); there is no server type "
+            + "to pair against, so this is not a wire-contract collision.",
         ["LoginRequest"] =
             "Different concept, same name. The CLI's is the input to an OAuth2 password-grant, sent "
             + "form-encoded to the token endpoint (username/password/client_id/scope). The Tenant "
@@ -88,8 +94,6 @@ public sealed class CliWireContractTests
             "Peer.Service — CLI-only: bootstrapNodes; server-only: seedNodes",
         ["PublishBlueprintRequest"] =
             "ServiceClients.Http — CLI-only: blueprintId; server-only: override",
-        ["RegisterStatsResponse"] =
-            "ServiceClients.Http — CLI-only: count; server-only: registerCount, transactionCount",
         ["RegisterSyncStatus"] =
             "Peer.Service — CLI-only: currentDocket, docketsProcessed, isStale, lastError, progressPercent, status, targetDocket; server-only: canServeFullReplica, lastSyncAt,...",
         ["SchemaSector"] =
@@ -102,8 +106,6 @@ public sealed class CliWireContractTests
             "Validator.Service — server-only: id, registerId",
         ["ValidatorStatus"] =
             "Validator.Service — CLI-only: consensusProtocol, failedValidations, isRunning, lastValidationAt, registersMonitored, status, totalValidations, uptime; server-only: doc...",
-        ["VerificationResult"] =
-            "Wallet.Service — CLI-only: status, verifiedAt; server-only: credentialType, issuerDid, statusListCheck, verifiedClaims",
         ["WalletLinkChallengeResponse"] =
             "Tenant.Service — CLI-only: nonce; server-only: algorithm, challenge, status, walletAddress",
     };
@@ -134,9 +136,6 @@ public sealed class CliWireContractTests
     /// </summary>
     private static readonly Dictionary<string, string> PreferredCounterpartAssembly = new(StringComparer.Ordinal)
     {
-        // The CLI's verify command talks to the Wallet Service, not HAIP's external-wallet surface.
-        ["VerificationResult"] = "Sorcha.Wallet.Service",
-
         // Declared in BOTH Register.Service and ServiceClients.Http. The server is the authority
         // for what the CLI must match. (That the shared client ALSO disagrees with the server is a
         // separate finding, recorded on DRIFT-002.)

--- a/tests/Sorcha.Cli.ContractTests/CliWireContractTests.cs
+++ b/tests/Sorcha.Cli.ContractTests/CliWireContractTests.cs
@@ -98,14 +98,6 @@ public sealed class CliWireContractTests
             "Peer.Service — CLI-only: currentDocket, docketsProcessed, isStale, lastError, progressPercent, status, targetDocket; server-only: canServeFullReplica, lastSyncAt,...",
         ["SchemaSector"] =
             "Blueprint.Service — CLI-only: name, schemaCount, status; server-only: displayName, icon",
-        ["SubmitTransactionRequest"] =
-            "Peer.Service — CLI-only: payload, previousTxId, senderWallet, signature, txType; server-only: originPeerId, submissionJson, submittedAtUnixMs",
-        ["SubmitTransactionResponse"] =
-            "Peer.Service — CLI-only: error, status, transactionId; server-only: accepted, receiverIsValidator, rejectReason",
-        ["ValidatorAuditEntry"] =
-            "Validator.Service — server-only: id, registerId",
-        ["ValidatorStatus"] =
-            "Validator.Service — CLI-only: consensusProtocol, failedValidations, isRunning, lastValidationAt, registersMonitored, status, totalValidations, uptime; server-only: doc...",
         ["WalletLinkChallengeResponse"] =
             "Tenant.Service — CLI-only: nonce; server-only: algorithm, challenge, status, walletAddress",
     };

--- a/tests/Sorcha.Cli.ContractTests/CliWireContractTests.cs
+++ b/tests/Sorcha.Cli.ContractTests/CliWireContractTests.cs
@@ -86,20 +86,12 @@ public sealed class CliWireContractTests
     /// </remarks>
     private static readonly Dictionary<string, string> KnownMismatch = new(StringComparer.Ordinal)
     {
-        ["InitiateWalletLinkRequest"] =
-            "Tenant.Service — server-only: algorithm",
         ["IssueCredentialRequest"] =
             "Wallet.Service — CLI-only: expiresInDays, subject, type, walletAddress; server-only: credentialType, disclosableClaims, displayName, expiryDuration, holderJwk, issu...",
-        ["LinkedWalletAddress"] =
-            "Tenant.Service (vs LinkedWalletAddressResponse) — CLI-only: verifiedAt; server-only: algorithm, linkedAt, revokedAt",
-        ["ParticipantIdentity"] =
-            "Tenant.Service (vs ParticipantResponse) — CLI-only: updatedAt, walletLinks; server-only: email, hasLinkedWallet",
         ["PublishBlueprintRequest"] =
             "ServiceClients.Http — CLI-only: blueprintId; server-only: override",
         ["SchemaSector"] =
             "Blueprint.Service — CLI-only: name, schemaCount, status; server-only: displayName, icon",
-        ["WalletLinkChallengeResponse"] =
-            "Tenant.Service — CLI-only: nonce; server-only: algorithm, challenge, status, walletAddress",
     };
 
     /// <summary>

--- a/tests/Sorcha.Cli.ContractTests/CliWireContractTests.cs
+++ b/tests/Sorcha.Cli.ContractTests/CliWireContractTests.cs
@@ -53,6 +53,12 @@ public sealed class CliWireContractTests
             + "object — not the Wallet Service's VerificationResult the name collides with. The CLI "
             + "type now matches that anonymous shape (isValid/checks/errors); there is no server type "
             + "to pair against, so this is not a wire-contract collision.",
+        ["RegisterSyncStatus"] =
+            "The CLI's /health/sync response models the Register Service's RegisterSyncStatus, which "
+            + "is a PRIVATE record inside RecoveryHealthEndpoints and therefore invisible to this "
+            + "assembly. The CLI type matches it field-for-field. The public type the harness would "
+            + "otherwise pair against lives in Peer.Service and is a different surface entirely — a "
+            + "name collision, not a shared contract.",
         ["LoginRequest"] =
             "Different concept, same name. The CLI's is the input to an OAuth2 password-grant, sent "
             + "form-encoded to the token endpoint (username/password/client_id/scope). The Tenant "
@@ -80,8 +86,6 @@ public sealed class CliWireContractTests
     /// </remarks>
     private static readonly Dictionary<string, string> KnownMismatch = new(StringComparer.Ordinal)
     {
-        ["AvailableRegisterInfo"] =
-            "Peer.Service — server-only: description, name",
         ["InitiateWalletLinkRequest"] =
             "Tenant.Service — server-only: algorithm",
         ["IssueCredentialRequest"] =
@@ -90,12 +94,8 @@ public sealed class CliWireContractTests
             "Tenant.Service (vs LinkedWalletAddressResponse) — CLI-only: verifiedAt; server-only: algorithm, linkedAt, revokedAt",
         ["ParticipantIdentity"] =
             "Tenant.Service (vs ParticipantResponse) — CLI-only: updatedAt, walletLinks; server-only: email, hasLinkedWallet",
-        ["PeerStatistics"] =
-            "Peer.Service — CLI-only: bootstrapNodes; server-only: seedNodes",
         ["PublishBlueprintRequest"] =
             "ServiceClients.Http — CLI-only: blueprintId; server-only: override",
-        ["RegisterSyncStatus"] =
-            "Peer.Service — CLI-only: currentDocket, docketsProcessed, isStale, lastError, progressPercent, status, targetDocket; server-only: canServeFullReplica, lastSyncAt,...",
         ["SchemaSector"] =
             "Blueprint.Service — CLI-only: name, schemaCount, status; server-only: displayName, icon",
         ["WalletLinkChallengeResponse"] =

--- a/tests/Sorcha.Cli.ContractTests/CliWireContractTests.cs
+++ b/tests/Sorcha.Cli.ContractTests/CliWireContractTests.cs
@@ -88,10 +88,6 @@ public sealed class CliWireContractTests
     {
         ["IssueCredentialRequest"] =
             "Wallet.Service — CLI-only: expiresInDays, subject, type, walletAddress; server-only: credentialType, disclosableClaims, displayName, expiryDuration, holderJwk, issu...",
-        ["PublishBlueprintRequest"] =
-            "ServiceClients.Http — CLI-only: blueprintId; server-only: override",
-        ["SchemaSector"] =
-            "Blueprint.Service — CLI-only: name, schemaCount, status; server-only: displayName, icon",
     };
 
     /// <summary>

--- a/tests/Sorcha.Cli.Tests/Commands/CredentialCommandsTests.cs
+++ b/tests/Sorcha.Cli.Tests/Commands/CredentialCommandsTests.cs
@@ -108,21 +108,19 @@ public class CredentialCommandsTests
     }
 
     [Fact]
-    public void CredentialIssueCommand_ShouldHaveRequiredSubjectOption()
+    public void CredentialIssueCommand_ShouldHaveRequiredRecipientWalletOption()
     {
+        // Renamed from --subject/--wallet: the credential is issued TO a recipient wallet. The old
+        // options were mislabelled (--wallet claimed to be the "issuer wallet for signing") and
+        // mapped to server fields that did not exist (see CliWireContractTests).
         var command = new CredentialIssueCommand(_clientFactory, AuthService, ConfigService);
-        var option = command.Options.FirstOrDefault(o => o.Name == "--subject");
+        var option = command.Options.FirstOrDefault(o => o.Name == "--recipient-wallet");
         option.Should().NotBeNull();
         option!.Required.Should().BeTrue();
-    }
 
-    [Fact]
-    public void CredentialIssueCommand_ShouldHaveRequiredWalletOption()
-    {
-        var command = new CredentialIssueCommand(_clientFactory, AuthService, ConfigService);
-        var option = command.Options.FirstOrDefault(o => o.Name == "--wallet");
-        option.Should().NotBeNull();
-        option!.Required.Should().BeTrue();
+        command.Options.Select(o => o.Name).Should().NotContain(
+            ["--subject", "--wallet"],
+            "the mislabelled options that mapped to no server field were removed");
     }
 
     [Fact]
@@ -135,10 +133,12 @@ public class CredentialCommandsTests
     }
 
     [Fact]
-    public void CredentialIssueCommand_ShouldHaveOptionalExpiresInDaysOption()
+    public void CredentialIssueCommand_ShouldHaveOptionalExpiryDurationOption()
     {
+        // Replaced --expires-in-days: the server takes an ISO-8601 duration (expiryDuration, e.g.
+        // P5Y), not a day count that mapped to nothing.
         var command = new CredentialIssueCommand(_clientFactory, AuthService, ConfigService);
-        var option = command.Options.FirstOrDefault(o => o.Name == "--expires-in-days");
+        var option = command.Options.FirstOrDefault(o => o.Name == "--expiry-duration");
         option.Should().NotBeNull();
         option!.Required.Should().BeFalse();
     }


### PR DESCRIPTION
The rest of the CLI wire-contract work. Baseline **17 to 0** across six commits — every one of the 30 broken contracts the harness found on day one is now resolved.

## Genuine fixes
- **verify receipt/bundle** — endpoint returns { isValid, checks{...}, errors }; CLI invented status/verifiedAt (printed 'VALID ()' + 0001-01-01) and dropped the per-check breakdown.
- **validator status** — showed ENTIRELY invented fields; realigned to registerId/isActive/dockets*.
- **validator audit** — added id + registerId the CLI dropped.
- **peer stats** — bootstrapNodes -> seedNodes (was always 0).
- **register available** — added name + description.
- **participant wallet-link** — challenge came back blank (read nonce, server sends challenge); added the required algorithm field and the wallet/algorithm/status output.
- **participant get/list** — dropped invented updatedAt/walletLinks, added email + hasLinkedWallet.
- **blueprint publish** — could not force-publish (no override) and sent a phantom blueprintId; added --override/--reason.
- **credential issue** — targeted the WRONG endpoint (StoreCredential, not /issue), sent a request matching no server field, expected the wrong response. Fully rewired: correct endpoint, real request (credentialType/claims/recipientWallet + optionals), real response; --subject/--wallet -> --recipient-wallet, --expires-in-days -> --expiry-duration.

## Disabled honestly
- **transaction submit** — needs a complete signed TransactionModel a CLI flag can't build. Now explains that and errors; invented DTOs removed.

## False pairings documented (CLI was already correct)
- **RegisterStatsResponse** (renamed RegisterCountResponse), **VerificationResult**, **RegisterSyncStatus** — each collided by name with an unrelated server type; the CLI matched its real endpoint. The private-record / anonymous-response cases are a reflection blind spot, documented in NotAWireContract.

## Dead code removed
- **SchemaSector** — no command used it, matched no server type.

## The harness earned its keep repeatedly
It caught FOUR of my own mistakes across these batches — over-correcting AuditLogEntry against the entity, copying IssuedCredentialResponse from the wrong server type, a name collision needing an explicit pin, and more. Exactly the errors review alone misses.

## IssueCredentialRequest is a documented subset
The CLI omits 11 optional issuer-infrastructure fields (holderJwk, tenantId, trustAnchor, status-list wiring) that belong to blueprint-driven issuance. Recorded with the full omission list AND guarded by a test that fails if the server ever makes one required — auditable, not a silent gap.

## From here
The baseline is empty, so the harness now protects the contract outright: a new CLI/server mismatch fails CI with nowhere to hide.

## Verification
- build clean; harness **54 green, 0 baselined**; CLI **407**, Wallet.Service **959** green.

Generated with Claude Code — https://claude.ai/code/session_01HMQZDe2uWBLimHabrHM6yf