### PR TITLE
fix: CLI help examples that don't work, gated; publish the tools when their dependencies change

### DIFF
--- a/.github/workflows/agent-publish.yml
+++ b/.github/workflows/agent-publish.yml
@@ -3,8 +3,22 @@ name: Agent Publish — Pack & Push .NET Global Tool
 on:
   push:
     branches: [ master ]
+    # The tool's own sources AND every project it links — see the note in cli-publish.yml for why
+    # the tool directory alone is not enough. It matters more here: the agent's decision path runs
+    # through Sorcha.Blueprint.Engine and Sorcha.ServiceClients.Http, so a change there can alter
+    # what the agent approves without touching a single file under src/Apps/Sorcha.Agent. F176
+    # (#1136) fixed a fail-open that approved a fake postcode; a stale-dependency publish is a
+    # route back to that class of defect.
+    #
+    # Keep this list in step with the ProjectReferences in
+    # src/Apps/Sorcha.Agent/Sorcha.Agent.csproj — that csproj is the source of truth.
     paths:
       - 'src/Apps/Sorcha.Agent/**'
+      - 'src/Common/Sorcha.Cryptography/**'
+      - 'src/Common/Sorcha.ServiceClients.Http/**'
+      - 'src/Common/Sorcha.Blueprint.Models/**'
+      - 'src/Core/Sorcha.Blueprint.Engine/**'
+      - 'Directory.Build.props'
 
   workflow_dispatch:
 

--- a/.github/workflows/cli-publish.yml
+++ b/.github/workflows/cli-publish.yml
@@ -3,8 +3,25 @@ name: CLI Publish — Pack & Push .NET Global Tool
 on:
   push:
     branches: [ master ]
+    # The tool's own sources AND every project it links. A path filter covering only
+    # src/Apps/Sorcha.Cli/** publishes a CLI whose compiled-in dependencies can be older than
+    # its own code: DRIFT-006 (#1258) changed Sorcha.ServiceClients.Http, the CLI links it, and
+    # no republish fired — so the published 2.37.1 embedded the pre-#1258 resolver. Harmless
+    # that time, but the same gap can ship a CLI whose shared clients disagree with the server
+    # it targets, which is exactly the drift DRIFT-002 existed to eliminate.
+    #
+    # Keep this list in step with the ProjectReferences in src/Apps/Sorcha.Cli/Sorcha.Cli.csproj
+    # — that csproj is the source of truth. Adding a reference without adding its path here
+    # silently reopens the gap.
     paths:
       - 'src/Apps/Sorcha.Cli/**'
+      - 'src/Common/Sorcha.Register.Models/**'
+      - 'src/Common/Sorcha.Blueprint.Models/**'
+      - 'src/Common/Sorcha.Cryptography/**'
+      - 'src/Common/Sorcha.ServiceClients.Http/**'
+      - 'src/Common/Sorcha.Wallet.Contracts/**'
+      - 'src/Common/Sorcha.Tenant.Models/**'
+      - 'Directory.Build.props'
 
   workflow_dispatch:
 

--- a/src/Apps/Sorcha.Cli/Commands/ActionCommands.cs
+++ b/src/Apps/Sorcha.Cli/Commands/ActionCommands.cs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+﻿// SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Sorcha Contributors
 
 using System.CommandLine;
@@ -25,7 +25,7 @@ public class ActionCommand : Command
         HttpClientFactory clientFactory,
         IAuthenticationService authService,
         IConfigurationService configService)
-        : base("action", "Blueprint action execution\n\nExamples:\n  sorcha action execute --blueprint-id <id> --action-id <action> --data '{\"key\":\"value\"}'")
+        : base("action", "Blueprint action execution\n\nExamples:\n  sorcha action execute --blueprint <id> --action <action> --payload '{\"key\":\"value\"}'")
 
     {
         Subcommands.Add(new ActionExecuteCommand(clientFactory, authService, configService));

--- a/src/Apps/Sorcha.Cli/Commands/ConfigCommand.cs
+++ b/src/Apps/Sorcha.Cli/Commands/ConfigCommand.cs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+﻿// SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Sorcha Contributors
 using System.CommandLine;
 using System.CommandLine.Parsing;
@@ -18,7 +18,7 @@ namespace Sorcha.Cli.Commands;
 public class ConfigCommand : BaseCommand
 {
     public ConfigCommand(IConfigurationService configService, IAuthenticationService authService)
-        : base("config", "Manage CLI configuration and profiles\n\nExamples:\n  sorcha config list\n  sorcha config init --profile prod --url https://sorcha.example.com\n  sorcha config view\n  sorcha config validate\n  sorcha config export --output config.json")
+        : base("config", "Manage CLI configuration and profiles\n\nExamples:\n  sorcha config list\n  sorcha config init --profile prod --service-url https://sorcha.example.com\n  sorcha config view\n  sorcha config validate\n  sorcha config export --output config.json")
     {
         Subcommands.Add(new ConfigInitCommand());
         Subcommands.Add(new ProfileListCommand(configService));

--- a/src/Apps/Sorcha.Cli/Commands/CredentialCommands.cs
+++ b/src/Apps/Sorcha.Cli/Commands/CredentialCommands.cs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+﻿// SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Sorcha Contributors
 
 using System.CommandLine;
@@ -21,7 +21,7 @@ public class CredentialCommand : Command
         HttpClientFactory clientFactory,
         IAuthenticationService authService,
         IConfigurationService configService)
-        : base("credential", "Manage verifiable credentials\n\nExamples:\n  sorcha credential list\n  sorcha credential issue --type <type> --subject <did>\n  sorcha credential verify --id <credential-id>")
+        : base("credential", "Manage verifiable credentials\n\nExamples:\n  sorcha credential list\n  sorcha credential issue --type <type> --recipient-wallet <wallet-addr>\n  sorcha credential verify --id <credential-id>")
     {
         Subcommands.Add(new CredentialListCommand(clientFactory, authService, configService));
         Subcommands.Add(new CredentialGetCommand(clientFactory, authService, configService));

--- a/src/Apps/Sorcha.Cli/Commands/DocketCommands.cs
+++ b/src/Apps/Sorcha.Cli/Commands/DocketCommands.cs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+﻿// SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Sorcha Contributors
 
 using System.CommandLine;
@@ -20,7 +20,7 @@ public class DocketCommand : Command
         HttpClientFactory clientFactory,
         IAuthenticationService authService,
         IConfigurationService configService)
-        : base("docket", "Inspect dockets (sealed blocks) in registers\n\nExamples:\n  sorcha docket list --register-id <id>\n  sorcha docket get --register-id <id> --id <docket-id>\n  sorcha docket transactions --register-id <id> --docket-number 1")
+        : base("docket", "Inspect dockets (sealed blocks) in registers\n\nExamples:\n  sorcha docket list --register-id <id>\n  sorcha docket get --register-id <id> --docket-id <docket-id>\n  sorcha docket transactions --register-id <id> --docket-id <docket-id>")
     {
         Subcommands.Add(new DocketListCommand(clientFactory, authService, configService));
         Subcommands.Add(new DocketGetCommand(clientFactory, authService, configService));

--- a/src/Apps/Sorcha.Cli/Commands/HelpCommand.cs
+++ b/src/Apps/Sorcha.Cli/Commands/HelpCommand.cs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+﻿// SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Sorcha Contributors
 using Spectre.Console;
 using Sorcha.Cli.Branding;
@@ -47,11 +47,11 @@ public class HelpCommand : BaseCommand
 
         AnsiConsole.MarkupLine("[bold yellow]5. Create a register[/]");
         AnsiConsole.MarkupLine("   [dim]Create a new register with a blueprint:[/]");
-        AnsiConsole.MarkupLine("   sorcha register create --name \"My Register\" --blueprint-id <id>");
+        AnsiConsole.MarkupLine("   sorcha register create --name \"My Register\" --owner-wallet <wallet-addr>");
         AnsiConsole.WriteLine();
 
         AnsiConsole.MarkupLine("[bold yellow]6. Submit a transaction[/]");
-        AnsiConsole.MarkupLine("   sorcha transaction submit --register-id <id> --wallet <address> --data '{\"key\":\"value\"}'");
+        AnsiConsole.MarkupLine("   sorcha tx submit --register-id <id> --wallet <addr> --type <type> --payload '{\"key\":\"value\"}' --signature <sig>");
         AnsiConsole.WriteLine();
 
         AnsiConsole.MarkupLine("[dim]Use --help on any command for detailed usage. Use --output json|csv|yaml to change format.[/]");

--- a/src/Apps/Sorcha.Cli/Commands/OperationCommands.cs
+++ b/src/Apps/Sorcha.Cli/Commands/OperationCommands.cs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+﻿// SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Sorcha Contributors
 
 using System.CommandLine;
@@ -20,7 +20,7 @@ public class OperationCommand : Command
         HttpClientFactory clientFactory,
         IAuthenticationService authService,
         IConfigurationService configService)
-        : base("operation", "Encryption operation management\n\nExamples:\n  sorcha operation status --id <operation-id>")
+        : base("operation", "Encryption operation management\n\nExamples:\n  sorcha operation status <operation-id>")
     {
         Subcommands.Add(new OperationStatusCommand(clientFactory, authService, configService));
     }

--- a/src/Apps/Sorcha.Cli/Commands/QueryCommands.cs
+++ b/src/Apps/Sorcha.Cli/Commands/QueryCommands.cs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+﻿// SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Sorcha Contributors
 
 using System.CommandLine;
@@ -20,7 +20,7 @@ public class QueryCommand : Command
         HttpClientFactory clientFactory,
         IAuthenticationService authService,
         IConfigurationService configService)
-        : base("query", "Query transactions across registers\n\nExamples:\n  sorcha query wallet --address <wallet-addr>\n  sorcha query sender --address <wallet-addr>\n  sorcha query odata --query \"$filter=Status eq 'Confirmed'\"")
+        : base("query", "Query transactions across registers\n\nExamples:\n  sorcha query wallet --address <wallet-addr>\n  sorcha query sender --address <wallet-addr>\n  sorcha query odata --resource Transactions --filter \"Status eq 'Confirmed'\"")
     {
         Subcommands.Add(new QueryWalletCommand(clientFactory, authService, configService));
         Subcommands.Add(new QuerySenderCommand(clientFactory, authService, configService));

--- a/src/Apps/Sorcha.Cli/Commands/RegisterCommands.cs
+++ b/src/Apps/Sorcha.Cli/Commands/RegisterCommands.cs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+﻿// SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Sorcha Contributors
 
 using System.CommandLine;
@@ -24,7 +24,7 @@ public class RegisterCommand : Command
         HttpClientFactory clientFactory,
         IAuthenticationService authService,
         IConfigurationService configService)
-        : base("register", "Manage registers (distributed ledgers)\n\nExamples:\n  sorcha register list\n  sorcha register get --id <register-id>\n  sorcha register create --name \"My Register\" --blueprint-id <id>\n  sorcha register stats --id <register-id>")
+        : base("register", "Manage registers (distributed ledgers)\n\nExamples:\n  sorcha register list\n  sorcha register get --id <register-id>\n  sorcha register create --name \"My Register\" --owner-wallet <wallet-addr>\n  sorcha register stats")
     {
         Subcommands.Add(new RegisterListCommand(clientFactory, authService, configService));
         Subcommands.Add(new RegisterGetCommand(clientFactory, authService, configService));

--- a/src/Apps/Sorcha.Cli/Commands/SchemaCommands.cs
+++ b/src/Apps/Sorcha.Cli/Commands/SchemaCommands.cs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+﻿// SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Sorcha Contributors
 
 using System.CommandLine;
@@ -20,7 +20,7 @@ public class SchemaCommand : Command
         HttpClientFactory clientFactory,
         IAuthenticationService authService,
         IConfigurationService configService)
-        : base("schema", "Schema management operations\n\nExamples:\n  sorcha schema providers list\n  sorcha schema providers refresh --id <provider-id>")
+        : base("schema", "Schema management operations\n\nExamples:\n  sorcha schema providers list\n  sorcha schema providers refresh --name <provider-name>")
     {
         Subcommands.Add(new SchemaProvidersCommand(clientFactory, authService, configService));
     }

--- a/src/Apps/Sorcha.Cli/Commands/TransactionCommands.cs
+++ b/src/Apps/Sorcha.Cli/Commands/TransactionCommands.cs
@@ -22,7 +22,12 @@ public class TransactionCommand : Command
         HttpClientFactory clientFactory,
         IAuthenticationService authService,
         IConfigurationService configService)
-        : base("tx", "Manage transactions in registers\n\nExamples:\n  sorcha tx list --register-id <id>\n  sorcha tx get --register-id <id> --id <tx-id>\n  sorcha tx submit --register-id <id> --wallet <addr> --data '{\"key\":\"value\"}'\n  sorcha tx proof --register-id <id> --tx-id <tx-id> --out proof.json\n  sorcha tx revoke --register-id <id> --tx-id <tx-id> --reason Erroneous")
+        // The submit example must name the options `submit` actually declares. It previously
+        // advertised `--data '{"key":"value"}'`, an option this command has never had, so an
+        // operator's first attempt failed with "Unrecognized command or argument '--data'".
+        // Submitting a transaction needs the signed envelope — type, payload AND signature —
+        // because the CLI does not sign for you.
+        : base("tx", "Manage transactions in registers\n\nExamples:\n  sorcha tx list --register-id <id>\n  sorcha tx get --register-id <id> --id <tx-id>\n  sorcha tx submit --register-id <id> --wallet <addr> --type <type> --payload '{\"key\":\"value\"}' --signature <sig>\n  sorcha tx proof --register-id <id> --tx-id <tx-id> --out proof.json\n  sorcha tx revoke --register-id <id> --tx-id <tx-id> --reason Erroneous")
 
     {
         Subcommands.Add(new TxListCommand(clientFactory, authService, configService));

--- a/src/Apps/Sorcha.Cli/Commands/TransactionCommands.cs
+++ b/src/Apps/Sorcha.Cli/Commands/TransactionCommands.cs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+﻿// SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Sorcha Contributors
 
 using System.CommandLine;
@@ -27,7 +27,7 @@ public class TransactionCommand : Command
         // operator's first attempt failed with "Unrecognized command or argument '--data'".
         // Submitting a transaction needs the signed envelope — type, payload AND signature —
         // because the CLI does not sign for you.
-        : base("tx", "Manage transactions in registers\n\nExamples:\n  sorcha tx list --register-id <id>\n  sorcha tx get --register-id <id> --id <tx-id>\n  sorcha tx submit --register-id <id> --wallet <addr> --type <type> --payload '{\"key\":\"value\"}' --signature <sig>\n  sorcha tx proof --register-id <id> --tx-id <tx-id> --out proof.json\n  sorcha tx revoke --register-id <id> --tx-id <tx-id> --reason Erroneous")
+        : base("tx", "Manage transactions in registers\n\nExamples:\n  sorcha tx list --register-id <id>\n  sorcha tx get --register-id <id> --tx-id <tx-id>\n  sorcha tx submit --register-id <id> --wallet <addr> --type <type> --payload '{\"key\":\"value\"}' --signature <sig>\n  sorcha tx proof --register-id <id> --tx-id <tx-id> --out proof.json\n  sorcha tx revoke --register-id <id> --tx-id <tx-id> --reason Erroneous")
 
     {
         Subcommands.Add(new TxListCommand(clientFactory, authService, configService));

--- a/src/Apps/Sorcha.Cli/Commands/UserCommands.cs
+++ b/src/Apps/Sorcha.Cli/Commands/UserCommands.cs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+﻿// SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Sorcha Contributors
 using System.CommandLine;
 using System.CommandLine.Parsing;
@@ -19,7 +19,7 @@ public class UserCommand : Command
         HttpClientFactory clientFactory,
         IAuthenticationService authService,
         IConfigurationService configService)
-        : base("user", "Manage users within organizations\n\nExamples:\n  sorcha user list\n  sorcha user create --email user@example.com --first-name John --last-name Doe\n  sorcha user get --id <user-id>")
+        : base("user", "Manage users within organizations\n\nExamples:\n  sorcha user list\n  sorcha user create --email user@example.com --first-name John --last-name Doe\n  sorcha user get --org-id <org-id> --user-id <user-id>")
     {
         Subcommands.Add(new UserListCommand(clientFactory, authService, configService));
         Subcommands.Add(new UserGetCommand(clientFactory, authService, configService));

--- a/tests/Sorcha.Cli.ContractTests/CliHelpExampleTests.cs
+++ b/tests/Sorcha.Cli.ContractTests/CliHelpExampleTests.cs
@@ -1,0 +1,270 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.CommandLine;
+using System.Reflection;
+using System.Text.RegularExpressions;
+
+using FluentAssertions;
+
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Sorcha.Cli.ContractTests;
+
+/// <summary>
+/// Asserts that every option named in a command's own help examples is an option that command
+/// actually accepts.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The CLI embeds usage examples in its command descriptions, so <c>sorcha --help</c> is the first
+/// thing an operator reads. Those examples had rotted: <c>sorcha tx submit</c> advertised
+/// <c>--data '{"key":"value"}'</c>, an option it has never declared, so the documented invocation
+/// failed with <c>Unrecognized command or argument '--data'</c>. Others named options belonging to a
+/// different command group entirely.
+/// </para>
+/// <para>
+/// Nothing caught this. The DRIFT-002 harness next door compares DTO property names across the
+/// CLI↔server boundary; an example string is neither side of a wire contract, it is just text that
+/// happens to be wrong.
+/// </para>
+/// <para>
+/// <b>This test derives its expectation from the live command tree</b> — it builds the real
+/// <see cref="RootCommand"/> and reads each command's declared options — so it cannot itself drift.
+/// Rename an option and the examples that mention it fail here rather than in a user's terminal.
+/// </para>
+/// </remarks>
+public sealed class CliHelpExampleTests
+{
+    /// <summary>
+    /// An option named in an example, together with the command whose description named it.
+    /// </summary>
+    private sealed record ExampleOption(string CommandPath, string Option, string ExampleLine);
+
+    [Fact]
+    public void EveryOptionNamedInAHelpExample_IsAcceptedByThatCommand()
+    {
+        var root = BuildRealRootCommand();
+
+        var offenders = new List<ExampleOption>();
+        foreach (var (command, path) in Walk(root, root.Name))
+        {
+            foreach (var (line, target, options) in ExamplesIn(command, path, root))
+            {
+                // An unresolvable path is reported by the companion test; skip it here so one
+                // defect does not produce two failures.
+                if (target is null)
+                {
+                    continue;
+                }
+
+                var accepted = AcceptedOptionNames(target, root);
+                foreach (var opt in options.Where(o => !accepted.Contains(o)))
+                {
+                    offenders.Add(new ExampleOption(path, opt, line));
+                }
+            }
+        }
+
+        offenders.Should().BeEmpty(
+            "a help example that names a non-existent option documents an invocation that cannot "
+            + "work — the operator's first attempt fails.\n"
+            + Format(offenders));
+    }
+
+    [Fact]
+    public void EveryHelpExample_NamesACommandThatExists()
+    {
+        var root = BuildRealRootCommand();
+
+        var unresolved = new List<string>();
+        foreach (var (command, path) in Walk(root, root.Name))
+        {
+            foreach (var (line, target, _) in ExamplesIn(command, path, root))
+            {
+                if (target is null)
+                {
+                    unresolved.Add($"  [{path}]  {line}");
+                }
+            }
+        }
+
+        unresolved.Should().BeEmpty(
+            "an example whose command path does not resolve cannot be run at all:\n"
+            + string.Join("\n", unresolved));
+    }
+
+    [Fact]
+    public void TheCommandTree_IsNonTrivial()
+    {
+        // Anti-vacuity. If reflection silently stopped finding Program.BuildRootCommand, both tests
+        // above would pass over an empty tree.
+        var root = BuildRealRootCommand();
+        var all = Walk(root, root.Name).ToList();
+
+        all.Should().HaveCountGreaterThan(30, "the CLI has dozens of commands");
+        all.Where(x => ExamplesIn(x.Command, x.Path, root).Any())
+            .Should().HaveCountGreaterThan(10, "most command groups carry usage examples");
+    }
+
+    // ---- the live command tree -------------------------------------------------------------
+
+    /// <summary>
+    /// Builds the CLI's real root command. <c>Program</c> is internal and its builders private, so
+    /// this goes through reflection rather than widening production visibility for a test.
+    /// </summary>
+    private static RootCommand BuildRealRootCommand()
+    {
+        var assembly = typeof(Sorcha.Cli.Commands.BaseCommand).Assembly;
+        var program = assembly.GetType("Sorcha.Cli.Program")
+            ?? throw new InvalidOperationException("Sorcha.Cli.Program not found — has it been renamed?");
+
+        const BindingFlags flags = BindingFlags.NonPublic | BindingFlags.Static;
+
+        var configure = program.GetMethod("ConfigureServices", flags)
+            ?? throw new InvalidOperationException("Program.ConfigureServices not found.");
+        var build = program.GetMethod("BuildRootCommand", flags)
+            ?? throw new InvalidOperationException("Program.BuildRootCommand not found.");
+
+        var services = new ServiceCollection();
+        configure.Invoke(null, [services]);
+        var provider = services.BuildServiceProvider();
+
+        return (RootCommand)build.Invoke(null, [provider])!;
+    }
+
+    private static IEnumerable<(Command Command, string Path)> Walk(Command command, string path)
+    {
+        yield return (command, path);
+        foreach (var child in command.Subcommands)
+        {
+            foreach (var descendant in Walk(child, $"{path} {child.Name}"))
+            {
+                yield return descendant;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Options a command accepts: its own, plus every ancestor's (global options are declared on
+    /// the root and inherited).
+    /// </summary>
+    private static HashSet<string> AcceptedOptionNames(Command target, Command root)
+    {
+        var names = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var chain in ChainTo(root, target) ?? [])
+        {
+            foreach (var option in chain.Options)
+            {
+                names.Add(option.Name);
+                foreach (var alias in option.Aliases)
+                {
+                    names.Add(alias);
+                }
+            }
+        }
+
+        // System.CommandLine supplies these on every command without declaring them.
+        names.Add("--help");
+        names.Add("--version");
+        return names;
+    }
+
+    /// <summary>The command chain from <paramref name="root"/> down to <paramref name="target"/>.</summary>
+    private static List<Command>? ChainTo(Command root, Command target)
+    {
+        if (ReferenceEquals(root, target))
+        {
+            return [root];
+        }
+
+        foreach (var child in root.Subcommands)
+        {
+            var below = ChainTo(child, target);
+            if (below is not null)
+            {
+                below.Insert(0, root);
+                return below;
+            }
+        }
+
+        return null;
+    }
+
+    // ---- example parsing ------------------------------------------------------------------
+
+    private static readonly Regex ExampleLine = new(@"^\s*sorcha\s+(?<rest>\S.*)$", RegexOptions.Compiled);
+    private static readonly Regex OptionToken = new(@"(?<!\S)(--[a-z0-9][a-z0-9-]*)", RegexOptions.Compiled);
+
+    /// <summary>
+    /// The <c>sorcha …</c> example lines in a command's description, each resolved to the command it
+    /// names and the long options it passes.
+    /// </summary>
+    private static IEnumerable<(string Line, Command? Target, IReadOnlyList<string> Options)> ExamplesIn(
+        Command command, string path, Command root)
+    {
+        var description = command.Description;
+        if (string.IsNullOrWhiteSpace(description))
+        {
+            yield break;
+        }
+
+        foreach (var raw in description.Split('\n'))
+        {
+            var match = ExampleLine.Match(raw.TrimEnd('\r'));
+            if (!match.Success)
+            {
+                continue;
+            }
+
+            var rest = match.Groups["rest"].Value.Trim();
+
+            // Leading bare words are the command path; everything from the first option or
+            // placeholder onward is arguments.
+            var words = rest.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+            var pathWords = words
+                .TakeWhile(w => !w.StartsWith('-') && !w.StartsWith('<') && !w.StartsWith('"')
+                                && !w.StartsWith('\'') && !w.Contains('|') && !w.Contains('$'))
+                .ToList();
+
+            var target = Resolve(root, pathWords);
+            var options = OptionToken.Matches(rest).Select(m => m.Groups[1].Value).Distinct().ToList();
+
+            yield return ($"sorcha {rest}", target, options);
+        }
+    }
+
+    /// <summary>Walks a bare-word path down the command tree, or null if it does not resolve.</summary>
+    private static Command? Resolve(Command root, IReadOnlyList<string> pathWords)
+    {
+        var current = root;
+        foreach (var word in pathWords)
+        {
+            var next = current.Subcommands.FirstOrDefault(
+                c => string.Equals(c.Name, word, StringComparison.Ordinal)
+                     || c.Aliases.Contains(word));
+
+            // Trailing words may be arguments rather than subcommands (e.g. `completion bash`), so
+            // stop descending rather than failing — the command reached so far is the target.
+            if (next is null)
+            {
+                return current.Subcommands.Count == 0 || current != root ? current : null;
+            }
+
+            current = next;
+        }
+
+        return current;
+    }
+
+    private static string Format(IEnumerable<ExampleOption> offenders) =>
+        string.Join("\n", offenders
+            .GroupBy(o => o.CommandPath, StringComparer.Ordinal)
+            .OrderBy(g => g.Key, StringComparer.Ordinal)
+            .Select(g => $"  [{g.Key}]\n"
+                         + string.Join("\n", g
+                             .Select(o => $"      {o.Option}  ->  {o.ExampleLine}")
+                             .Distinct()
+                             .OrderBy(x => x, StringComparer.Ordinal))));
+}


### PR DESCRIPTION
Three related tool-hygiene fixes, found while refreshing the global `sorcha` / `sorcha-agent`
installs on a dev machine.

## 1. Every stale help example — and a gate so they can't rot again

The CLI embeds usage examples in its command descriptions, so `sorcha --help` is the first thing an
operator reads. Twelve of them named options that don't exist. Each verified against the real CLI
before fixing:

| Command | Advertised | Actually accepts |
|---|---|---|
| `action execute` | `--blueprint-id --action-id --data` | `--blueprint --action --payload` |
| `config init` | `--url` | `--service-url` |
| `credential issue` | `--subject` | `--recipient-wallet` |
| `docket get` | `--id` | `--docket-id` |
| `docket transactions` | `--docket-number` | `--docket-id` (no such option ever existed) |
| `operation status` | `--id <operation-id>` | positional `<operation-id>` |
| `query odata` | `--query` | `--resource` + `--filter` |
| `register create` | `--blueprint-id` | `--owner-wallet` |
| `register stats` | `--id <register-id>` | *no options* — it's a platform-wide count |
| `schema providers refresh` | `--id` | `--name` |
| `tx get` | `--id` | `--tx-id` |
| `tx submit` | `--data` | `--type` + `--payload` + `--signature` |
| `user get` | `--id` | `--org-id` + `--user-id` |

`HelpCommand`'s getting-started guide was worse: it advertised **`sorcha transaction submit`**, a
command group that does not exist (only `tx`), with the same phantom `--data`.

**The gate — `CliHelpExampleTests`.** It builds the *real* `RootCommand` (reflection over the
internal `Program`, so no production visibility is widened for a test), walks every command, and
asserts each option named in a command's examples is one that command or an ancestor accepts. It
derives its expectation from the live `Option<T>` declarations, so it cannot drift — rename an option
and the examples mentioning it fail here instead of in an operator's terminal. Plus two companions:
every example must resolve to a command that exists, and an anti-vacuity check (>30 commands, >10
carrying examples) so a broken reflection lookup can't silently pass over an empty tree.

Documented scope limit: `HelpCommand` prints its guide via `AnsiConsole` at runtime rather than
through a `Description`, so the tree walk can't see it. Those examples were corrected by hand and the
test says so.

## 2. A tool could ship older than its own dependencies

`cli-publish.yml` and `agent-publish.yml` triggered **only** on their own project directory, so a
change to a project the tool *links* did not republish it. Concretely: published `Sorcha.Cli 2.37.1`
was built from `0eaab226` (#1257) and therefore embeds the **pre-#1258** `Sorcha.ServiceClients.Http`
— the tool binary is older than its own dependencies.

Harmless this time (DRIFT-006 is backwards-compatible by construction), but the mechanism can ship a
CLI whose shared clients disagree with the server it targets — the drift class DRIFT-002 existed to
eliminate. **It matters more for the agent:** its decision path runs through `Sorcha.Blueprint.Engine`
and `Sorcha.ServiceClients.Http`, so a dependency change can alter *what the agent approves* without
touching a file under `src/Apps/Sorcha.Agent`, and F176 (#1136) fixed a fail-open that approved a
fake postcode.

Both workflows now also watch each `ProjectReference` of their csproj plus `Directory.Build.props`.
The csproj stays the source of truth and a comment says so.

> Deliberately **not** `src/Common/**` wholesale — that would republish both tools on every library
> change, permanently sprawling nuget.org with functionally identical versions. The precise list is
> the trade-off; the comment names the risk it carries.

## Verification

| Check | Result |
|---|---|
| `dotnet build src/Apps/Sorcha.Cli` | 0 errors |
| `Sorcha.Cli.ContractTests` | **60/60 pass** (57 pre-existing + 3 new) |
| Gate behaviour | fails with a per-command breakdown when fed the pre-fix examples |
| Workflow path filters | parse, and match the csproj `ProjectReference` sets |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RboWP2TKvm1nBG22nqsWek