### PR TITLE
fix: tool publish workflows push only their own package

### DIFF
--- a/.github/workflows/agent-publish.yml
+++ b/.github/workflows/agent-publish.yml
@@ -1,4 +1,4 @@
-name: Agent Publish — Pack & Push .NET Global Tool
+﻿name: Agent Publish — Pack & Push .NET Global Tool
 
 on:
   push:
@@ -42,4 +42,9 @@ jobs:
         run: dotnet pack src/Apps/Sorcha.Agent/ --configuration Release -o ./nupkg
 
       - name: Publish to NuGet.org
-        run: dotnet nuget push ./nupkg/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+        # Push ONLY the tool package. `dotnet pack` on the tool also packs every project it
+        # references — they set GeneratePackageOnBuild — so a `*.nupkg` glob published eight
+        # packages, versioning the shared libraries with THIS workflow's run number instead of
+        # nuget-publish.yml's. That is how Sorcha.Tenant.Models acquired 2.30.1-2.37.1 alongside
+        # its real 2.291.1: non-monotonic duplicates of libraries this workflow does not own.
+        run: dotnet nuget push ./nupkg/Sorcha.Agent.*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate

--- a/.github/workflows/cli-publish.yml
+++ b/.github/workflows/cli-publish.yml
@@ -1,4 +1,4 @@
-name: CLI Publish — Pack & Push .NET Global Tool
+﻿name: CLI Publish — Pack & Push .NET Global Tool
 
 on:
   push:
@@ -47,4 +47,9 @@ jobs:
         run: dotnet pack src/Apps/Sorcha.Cli/ --configuration Release -o ./nupkg
 
       - name: Publish to NuGet.org
-        run: dotnet nuget push ./nupkg/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+        # Push ONLY the tool package. `dotnet pack` on the tool also packs every project it
+        # references — they set GeneratePackageOnBuild — so a `*.nupkg` glob published eight
+        # packages, versioning the shared libraries with THIS workflow's run number instead of
+        # nuget-publish.yml's. That is how Sorcha.Tenant.Models acquired 2.30.1-2.37.1 alongside
+        # its real 2.291.1: non-monotonic duplicates of libraries this workflow does not own.
+        run: dotnet nuget push ./nupkg/Sorcha.Cli.*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate


### PR DESCRIPTION
Caught by watching what #1260's widened trigger actually did.

## The defect

`dotnet pack src/Apps/Sorcha.Cli/` also packs every project the tool *references* — those projects
set `GeneratePackageOnBuild` — and the push step globbed `./nupkg/*.nupkg`. So a single CLI release
published **eight** packages:

```
Sorcha.Cli.2.38.1            <- correct, this workflow owns it
Sorcha.Blueprint.Models.2.38.1
Sorcha.CitizenWallet.Abstractions.2.38.1
Sorcha.Cryptography.2.38.1
Sorcha.Register.Models.2.38.1
Sorcha.ServiceClients.Http.2.38.1
Sorcha.Tenant.Models.2.38.1
Sorcha.Wallet.Contracts.2.38.1
```

Those libraries are owned by `nuget-publish.yml`, which has its own run counter — currently at
**291**. Publishing them from `cli-publish` stamps them with *its* counter instead, so
`Sorcha.Tenant.Models` on nuget.org now reads:

```
2.1.0, 2.30.1, 2.31.1, 2.32.1, 2.33.1, 2.34.1, 2.35.1, 2.36.1, 2.37.1, ... 2.291.1
```

The 2.3x.x entries are non-monotonic duplicates from cli-publish runs 30–37 — a different build of
the same library under a number that means nothing in its own version line.

## Why now

**Pre-existing**, but #1260 widened the trigger so the tool workflows also fire on dependency
changes. That was the right fix for *shipping a tool older than its own dependencies*, but it turns
this from "happens when the CLI changes" into "happens on most library commits". I amplified it, so
I'm fixing it together with the original.

## The fix

Both workflows now push `./nupkg/<PackageId>.*.nupkg` instead of `*.nupkg`. Pack is left alone —
building the dependency packages is harmless, they simply must not be pushed.

## Not addressed

The already-published low-numbered duplicates. nuget.org allows unlisting but not deletion, and
since the real versions are numerically higher they don't win `latest` resolution, so nothing
resolves wrongly today. Worth unlisting by hand if it ever confuses a consumer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RboWP2TKvm1nBG22nqsWek