### PR TITLE
fix: the agent start-time liveness check was inert past the 12th of the month

### DIFF
--- a/demos/AIAS/AiasDemo.psm1
+++ b/demos/AIAS/AiasDemo.psm1
@@ -479,14 +479,35 @@ function Test-AiasAgentAlive {
     }
 
     if ($props -contains 'agentStartedAt' -and $State.agentStartedAt) {
+        # ConvertFrom-Json coerces an ISO-8601 value into a [DateTime] (Kind=Utc), so the recorded
+        # value arrives here as EITHER a DateTime or a string depending on how the caller loaded
+        # state. Handle both explicitly.
+        #
+        # Do not collapse this to [DateTime]::Parse($State.agentStartedAt): when the value is
+        # already a DateTime, PowerShell stringifies it as MM/dd/yyyy before parsing, which THROWS
+        # under a non-US culture (en-GB reads month 25). The catch below then swallowed it and this
+        # whole check silently degraded to the name match — present in the source, inert at runtime.
+        $recorded = $null
         try {
-            $recorded = ([DateTime]::Parse($State.agentStartedAt)).ToUniversalTime()
-            if ([Math]::Abs((($proc.StartTime.ToUniversalTime()) - $recorded).TotalSeconds) -gt 5) {
-                return $false
+            $recorded = if ($State.agentStartedAt -is [DateTime]) {
+                ([DateTime]$State.agentStartedAt).ToUniversalTime()
+            }
+            else {
+                [DateTime]::Parse(
+                    [string]$State.agentStartedAt,
+                    [System.Globalization.CultureInfo]::InvariantCulture,
+                    [System.Globalization.DateTimeStyles]::RoundtripKind).ToUniversalTime()
             }
         }
         catch {
-            # Unreadable timestamp: fall back to the name match already made above.
+            # Unreadable timestamp: fall open to the name match already made above rather than
+            # declaring a live agent dead.
+            $recorded = $null
+        }
+
+        if ($null -ne $recorded `
+            -and [Math]::Abs((($proc.StartTime.ToUniversalTime()) - $recorded).TotalSeconds) -gt 5) {
+            return $false
         }
     }
 


### PR DESCRIPTION
Found while restarting the agent on n1 — the first real use of #1262 — and it's a defect in **that
PR's own guard**.

## What was wrong

`Write-DemoState` stores `agentStartedAt` as ISO-8601 UTC, correctly:

```json
"agentStartedAt": "2026-07-25T11:23:43.5615565Z"
```

But `ConvertFrom-Json` **coerces an ISO value into a `[DateTime]`**, so `Read-DemoState` hands the
helper a DateTime, not a string. The check then did:

```powershell
[DateTime]::Parse($State.agentStartedAt)
```

PowerShell stringifies the DateTime as `MM/dd/yyyy` before parsing, and `[DateTime]::Parse` uses the
**current culture**. Under en-GB, `07/25/2026` is month 25 → throws → the `catch` swallowed it → the
start-time comparison never ran. The guard was present in the source and did nothing at runtime.

## Why it's nasty: it's date-dependent

A/B against the merged version under en-GB, feeding a deliberately **wrong** recorded start time
(correct answer is always `False`):

| wrong recorded date | OLD | NEW |
|---|---|---|
| 2020-01-05 | False | False |
| 2020-01-11 | False | False |
| **2020-01-13** | **True** | False |
| **2020-01-25** | **True** | False |
| **2020-11-30** | **True** | False |

For roughly the first twelve days of a month the check worked. For the rest, a process that merely
inherited the PID passed as a live agent — the exact failure the check exists to prevent. Today is
the 25th, which is the only reason it surfaced.

## Fix

Branch on the actual type: use the `DateTime` as-is, or parse a string with `InvariantCulture` +
`RoundtripKind` so an ISO value parses regardless of locale. The `catch` still fails **open** to the
name match rather than declaring a live agent dead, but it is no longer load-bearing.

## Verification

Through a real `ConvertTo-Json`/`ConvertFrom-Json` round-trip — the shape the helper actually
receives. My original test hand-built a `pscustomobject` holding a *string*, which is precisely why
it missed this:

- correct identity → `True`
- wrong start time → `False` *(the defence that was inert)*
- wrong process name → `False`
- garbage timestamp → `True` (fails open to the name match)
- the live agent on n1 → `True`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RboWP2TKvm1nBG22nqsWek