### PR TITLE
fix: [UT-002] PWA enrol wizard told signed-in passkey citizens to sign in (#1265)

### DIFF
--- a/.specify/MASTER-TASKS.md
+++ b/.specify/MASTER-TASKS.md
@@ -291,6 +291,48 @@ These are the **Tier 1** trust improvements identified in the transaction archit
 
 ---
 
+## Theme 9: Citizen Journey Trial Findings (2026-07-25) — P1
+
+> **Priority:** P1 (Pre-release — first real end-to-end citizen journey)
+> **Estimated Effort:** 60-90h
+> **Goal:** Close the defects found around the AIAS M1 happy path during the first real human
+> citizen run on n1 (`2.869.1`): passkey signup → wallet → profile → AIAS application → agent
+> decision → claim → credential held, plus the PWA.
+> **Related:** Issues #1264-#1282 (19 filed) + #1256 (from DRIFT-004). The happy path itself
+> **worked end to end**; everything here is *around* it.
+
+| # | Task | Priority | Effort | Status | Notes |
+|---|------|----------|--------|--------|-------|
+| UT-001 | Wrongful AIAS rejection — `x-claim-source` stamps a stale `email_verified` | P0 | 8h | 📋 | #1264. Token minted at signup (12:30:29Z) carried `false`; user verified at 12:39:06Z; submitted 12:44Z. `ClaimSourceSeeder` runs **client-side**, so the value is only ever as fresh as the client's token. Fix: resolve server-side at submission via a single batch live-claims read, overwriting the client value (mirrors the existing step-8a-bis `presentedCredential` precedence rule). Lookup failure **fails the submission** — signing `false` writes an irreversible wrongful rejection. |
+| UT-002 | PWA enrol-device says "You need to sign in first" while signed in | P0 | 4h | ✅ | #1265. **Two** defects, one visible: (a) `Enrol.razor` derived auth state from `AccessTokenRecord.Email`, which is display-only and **null on the passkey/social paths** — the same defect already fixed in `Settings.razor`; (b) the file lacked `@using Microsoft.AspNetCore.Components.Authorization`, so `AuthorizeView` emitted as a **literal HTML element with no compile error** and rendered both branches. Using moved to `_Imports.razor` so no other PWA page can hit it. The issue's ambient-`HttpClient` hypothesis was wrong — no HTTP request is involved. Guard: `EnrolPageAuthStateTests`. |
+| UT-003 | Inbox notice `detailHref` navigates the browser to a raw API route | P1 | 4h | 📋 | #1266. Stored `detailHref` is `/api/instances/{id}`; the client hands it to the browser → `about:blank` + 0 KB download. F118's thin-signal contract is right (it names the authenticated REST detail endpoint); the **client** must translate it to an in-app view and never navigate to it. |
+| UT-004 | Rejections invisible to the citizen on every web surface | P1 | 8h | 📋 | #1267. F184 delivery **works** — the notice was written with correct catalogue wording; only web surfacing failed. Scope this session: badge the web bell for unread entries + surface decision notices on the web home. Durable "My Applications" history remains follow-up #1163. |
+| UT-005 | Pending Actions — completed action still actionable; no removal push | P1 | 8h | 📋 | #1268. Own just-submitted starting action still offers **Take Action** pre-seal (F145 returns 202; projection still has action 1 current). Separately, F118 emits *action-available* / *workflow-completed* only — there is no "your action went away" event, so the list only ever grows. Either emit a removal/refresh signal or reconcile on hub events; if removals genuinely can't be pushed, soften the "Real-time updates enabled" copy. |
+| UT-006 | AIAS device-registration blueprint never published; status check blind | P2 | 4h | 📋 | #1269. Repo carries two templates; provisioning publishes one. `state.json` tracks a **scalar** `blueprintId`, so `Get-AiasDemoStatus` is structurally unable to notice. Track a **set** and verify all of them. |
+| UT-007 | F128 pairing surface shows the desktop QR variant on mobile | P1 | 8h | 📋 | #1270. FR-008 exists to give same-device mobile prominence; "Open on this device" sits below a two-screenful QR. Plus: affordances render as plain body text with no hit-target styling, `Email me a link Skip for now` runs together, stray focus ring on a non-interactive heading, and the nag banner shows above the pairing page itself. Nag also isn't wallet-aware the way F149 made `PairingTakeover`. |
+| UT-008 | Persona: no address/nationality, no provenance, no default shown | P1 | 12h | 📋 | #1271. `PersonaAttributesV1` carries addresses + nationalities but the form stops at phone, so AIAS has nothing to prefill for address. `PersonaAttribute<T>.Source`/`VerifiedBy` are never rendered. Two different "verified" notions (persona self-asserted vs account `email_verified`) are indistinguishable — which fed UT-001. Default radio unselected with a single value. No per-field cream tint / `self` tick. |
+| UT-009 | `x-review` renders section title and field label twice | P2 | 2h | 📋 | #1272. Three of five sections are exact repeats (ADDRESS/ADDRESS, EMAIL/EMAIL). Suppress the field label when a single-field section's label matches the section title. |
+| UT-010 | PWA Activity ignores inbox `severity` and `iconKey` | P2 | 3h | 📋 | #1273. A rejection chips as "Informational" though the row carries `severity: warning` + `iconKey: workflow.rejected`; all entries draw the same generic bell glyph. |
+| UT-011 | PWA storage bar renders full at 0%; bottom nav overlaps Profile form | P2 | 3h | 📋 | #1274. Bar not bound to the computed percentage ("5.1 KB of 9.60 GB (0.0%)" drawn solid). Bottom nav padding is applied per-page rather than by the layout, so Profile's phone field and version string are obscured. |
+| UT-012 | Narrow viewport: banners with trailing actions never reflow | P1 | 8h | 📋 | #1275. Systemic, not several bugs: pair-a-phone nag wrapped over **nine** lines beside its button; autofill summary and My Pending Actions likewise. Plus clipped "New Submissions" heading under the sticky header, and the `normal` priority chip rendered amber (reads as a warning for the neutral default). |
+| UT-013 | My Transactions: no drill-down; Sender column shows other parties | P2 | 6h | 📋 | #1276. `GET /api/registers/{registerId}/transactions/{txId}` already exists and returns the caller's own decrypted disclosure group — pure UI addition. Page is really "transactions involving my wallet", so show direction (sent/received) or counterparty rather than Sender. |
+| UT-014 | Portrait oversize silently drops the claim; no framing guidance | P1 | 10h | 📋 | #1277. ≤27KB base64 gate in `BuildClaimsFromMappings` omits the `portrait` claim with only `WARN_CRED_PORTRAIT_OVERSIZE_001` — nothing user-visible — and a 240×320 JPEG already lands 15-25KB, so any quality increase starts silently issuing portrait-less credentials that degrade the F174 verifier. **Theoretical in this trial** (the real capture passed). Fix: downscale-and-retry + surface the drop, plus a post-capture review overlay (oval + head-height bounds, Retake) with the rules authored in `x-file`. |
+| UT-015 | Credential display: vct URI as title, `text-transform` corrupts values | P1 | 8h | 📋 | #1278. Five surfaces render `https://sorcha.dev/vc/assured-identity/v1` as the title though `displayMeta.credentialName` carries "Assured Identity"; post-#1187 the vct is a URI **by design** so it must never be a label. A title-case transform corrupts claim **values** (`EH91JA`→`Eh91ja`, `GB`→`Gb`) — reference data, not cosmetics. Id-card names the issuer with an uppercased wallet address. Claim labels use raw camelCase on one surface and humanised on the adjacent one. |
+| UT-016 | Credential View dialog overflows the viewport on mobile | P1 | 6h | 📋 | #1279. Title clipped mid-word, portrait clipped at the dialog boundary, five non-wrapping action buttons overflow both edges ("evoke"), status chip pushed off-screen. Constrain to viewport, scale the card, wrap/collapse the action row below a breakpoint. |
+| UT-017 | Web "Present" claims presentation is a future release | P2 | 2h | 📋 | #1280. It ships on the PWA (`Present.razor`). Companion-first means web isn't the presenting surface, so this is copy + redirect ("presenting happens on your phone" with a pair/open link), **not** building presentation on web. |
+| UT-018 | iOS inbox overlay ignores safe-area inset and traps the user | P1 | 4h | 📋 | #1281. Header drawn into the status-bar strip (`Inbo14:13x`); the ✕ is unreachable and there is no other dismiss affordance — app restart was the only way out. Apply `env(safe-area-inset-top)` and audit every other full-screen overlay for the same missing inset. |
+| UT-019 | PWA verify surface throws, and renders the raw `openid4vp://` URI | P1 | 6h | 📋 | #1282. Request generation is correct and current (F181 US6: `client_id=x509_san_dns:n1.sorcha.dev` + served `request_uri`), so this is a UI failure: an unhandled exception suppresses the F174 verdict/consent treatment, and the protocol URI is shown as body text. **Needs a console-attached repro** before fixing. |
+| UT-020 | Org invitations have no resend endpoint | P2 | 4h | 📋 | #1256, split from DRIFT-004. The button + phantom `ResendInvitationAsync` were removed rather than faking success; `OrgInvitationWireContractTests` now fails the build if a client operation has no endpoint behind it, so the endpoint must land first. Decide whether resend rotates the token (safer, invalidates links in flight) or reuses it. Rate-limit — it is an outbound-email trigger reachable by any org admin. |
+
+**Verified during the trial — do NOT re-litigate:** postcode `EH91JA` was fine (`postcodeExists: true`);
+the portrait passed the 27KB gate and is in the credential; F184 notice delivery works (only web
+surfacing failed); persona DOB autofill was never broken (there is no DOB in the persona); F145's
+instance projection is payload-free **by design** (`accumulatedData: {}`); F176's disclosure endpoint
+is prior-action-scoped **by design**; the F124 welcome takeover's empty body sections are deliberate
+pending Spec 2.
+
+---
+
 ## Summary
 
 | Theme | Priority | Tasks | Effort | Focus |
@@ -303,7 +345,8 @@ These are the **Tier 1** trust improvements identified in the transaction archit
 | 6. P2P Network & Consensus | P3 | 9 (1 ✅, 8 remaining) | 120-200h | Decentralization — relay comms done (060) |
 | 7. Public User Experience | P1 | 6 (1 ✅, 5 remaining) | 40-60h | Role model, register scoping, public UX |
 | 8. Mobile App Prerequisites | P1 | 8 (3 ✅, 1 ❌, 4 remaining) | 60-80h | Package portability, device inputs, white-label branding — Feature 084 done (MOB-002/003/004), MOB-001 eliminated |
-| **Total** | | **75** (17 ✅, 1 ❌, 57 remaining) | **565-825h** | |
+| 9. Citizen Journey Trial Findings | P0-P2 | 20 (1 ✅, 19 remaining) | 60-90h | First real human citizen run on n1 2026-07-25 (#1264-#1282 + #1256) — happy path worked; these are the defects around it. UT-002 (PWA enrol auth state) closed |
+| **Total** | | **95** (18 ✅, 1 ❌, 76 remaining) | **625-915h** | |
 
 ### Completed Features (not in themes above)
 

--- a/src/Apps/Sorcha.Wallet.Pwa/Pages/Enrol.razor
+++ b/src/Apps/Sorcha.Wallet.Pwa/Pages/Enrol.razor
@@ -4,8 +4,9 @@
 
     Enrolment wizard (Feature 114, T109 part 2). Multi-step ceremony for
     a freshly-installed wallet:
-      (1) Welcome — explains what enrolment does, defers sign-in to Settings
-          if the user isn't signed in yet.
+      (1) Welcome — explains what enrolment does, and routes to sign-in if the
+          user isn't signed in yet. Auth state comes from AuthorizeView, never
+          from the display-only email (issue #1265).
       (2) Device label — citizen-editable, sensible default suggested.
       (3) Confirmation — runs IEnrolmentService (generates device key,
           calls /devices/enrol, persists delegation, pulls /credentials).
@@ -21,6 +22,7 @@
 @inject IEnrolmentService Enrolment
 @inject IAccessTokenStore AccessTokenStore
 @inject IEnrolSessionRedeemer Redeemer
+@inject WalletAuthenticationStateProvider AuthState
 @inject IJSRuntime Js
 @inject NavigationManager Nav
 @inject ILogger<Enrol> Logger
@@ -53,33 +55,46 @@
     <MudStepper @ref="_stepper" NonLinear="false">
         <MudStep Title="Welcome">
             <MudText Typo="Typo.body2" Class="mb-3">
-                Enrolling registers this browser as a wallet device under your
-                Sorcha account. We generate a non-extractable device key in the
-                browser, ask the server to bind a delegation credential to it,
-                and pull your existing credentials onto the device.
+                Enrolling registers this device as a wallet device under your
+                Sorcha account. We generate a non-extractable device key here on
+                the device, ask the server to bind a delegation credential to it,
+                and pull your existing credentials onto it.
             </MudText>
-            @if (_signedIn is null)
-            {
-                <MudProgressCircular Indeterminate="true" Size="Size.Small" />
-            }
-            else if (_signedIn == false)
-            {
-                <MudAlert Severity="Severity.Warning" Class="mb-3">
-                    You need to sign in first.
-                    <MudLink Href="settings" data-testid="enrol-open-settings-link">Open Settings</MudLink> to sign in,
-                    then come back here.
-                </MudAlert>
-            }
-            else
-            {
-                <MudAlert Severity="Severity.Success" Dense="true" Class="mb-3">
-                    Signed in as <strong>@_signedInEmail</strong>.
-                </MudAlert>
-                <MudButton Variant="Variant.Filled" Color="Color.Primary"
-                           OnClick="@(() => _stepper!.NextStepAsync())">
-                    Continue
-                </MudButton>
-            }
+            @* Issue #1265 — gate on the SAME AuthenticationStateProvider the rest of the shell
+               uses (token presence + expiry via WalletAuthenticationStateProvider), NOT on
+               _signedInEmail. AccessTokenRecord.Email is captured "for display only" (see
+               IAccessTokenStore.cs) and is null for passkey/social sign-in, so a citizen signed
+               in with a passkey held a valid token but no email — and this step told them to sign
+               in while Settings, one tap away, correctly said they were signed in. That blocked
+               enrolment, and with it every downstream credential delivery to the wallet. This is
+               the same defect already fixed in Settings.razor; the email is now used only to
+               personalise the confirmation, never to decide auth state. *@
+            <AuthorizeView>
+                <Authorized>
+                    <MudAlert Severity="Severity.Success" Dense="true" Class="mb-3">
+                        @if (!string.IsNullOrEmpty(_signedInEmail))
+                        {
+                            <text>Signed in as <strong>@_signedInEmail</strong>.</text>
+                        }
+                        else
+                        {
+                            <text>You're signed in.</text>
+                        }
+                    </MudAlert>
+                    <MudButton Variant="Variant.Filled" Color="Color.Primary"
+                               OnClick="@(() => _stepper!.NextStepAsync())"
+                               data-testid="enrol-continue-button">
+                        Continue
+                    </MudButton>
+                </Authorized>
+                <NotAuthorized>
+                    <MudAlert Severity="Severity.Warning" Class="mb-3">
+                        You need to sign in first.
+                        <MudLink Href="signin" data-testid="enrol-open-settings-link">Sign in</MudLink>,
+                        then come back here.
+                    </MudAlert>
+                </NotAuthorized>
+            </AuthorizeView>
         </MudStep>
 
         <MudStep Title="Name this device">
@@ -162,7 +177,9 @@
 
 @code {
     private MudStepper? _stepper;
-    private bool? _signedIn;
+
+    // Display only — personalises the "Signed in as x" confirmation. NEVER the auth
+    // signal: it is null on the passkey and social paths (see #1265).
     private string? _signedInEmail;
     private string _label = "My Sorcha wallet";
     private bool _running;
@@ -206,7 +223,6 @@
         }
 
         _signedInEmail = await Auth.GetSignedInEmailAsync();
-        _signedIn = _signedInEmail is not null;
     }
 
     private string? TryReadSessionToken()
@@ -240,9 +256,14 @@
 
         // Drop the dialog and re-resolve signed-in state. The existing
         // stepper renders the welcome step with the citizen now signed in.
+        //
+        // The welcome step gates on AuthorizeView (issue #1265), so the freshly
+        // persisted token only counts once the provider re-reads the store —
+        // without this notify the citizen would redeem successfully and still be
+        // told to sign in. Same contract as SignIn.razor / Settings.razor.
         _awaitingConfirm = false;
         _signedInEmail = _redeemed.Email;
-        _signedIn = true;
+        AuthState.NotifyChanged();
         StateHasChanged();
     }
 

--- a/src/Apps/Sorcha.Wallet.Pwa/_Imports.razor
+++ b/src/Apps/Sorcha.Wallet.Pwa/_Imports.razor
@@ -1,5 +1,6 @@
 @using System.Net.Http
 @using System.Net.Http.Json
+@using Microsoft.AspNetCore.Components.Authorization
 @using Microsoft.AspNetCore.Components.Forms
 @using Microsoft.AspNetCore.Components.Routing
 @using Microsoft.AspNetCore.Components.Web

--- a/tests/Sorcha.Wallet.Pwa.Tests/Pages/EnrolPageAuthStateTests.cs
+++ b/tests/Sorcha.Wallet.Pwa.Tests/Pages/EnrolPageAuthStateTests.cs
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Threading;
+using System.Threading.Tasks;
+using Bunit;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Sorcha.UI.Testing;
+using Sorcha.Wallet.Pwa.Services;
+using Sorcha.Wallet.Pwa.Services.Enrolment;
+using Xunit;
+using EnrolPage = Sorcha.Wallet.Pwa.Pages.Enrol;
+
+namespace Sorcha.Wallet.Pwa.Tests.Pages;
+
+/// <summary>
+/// Guards issue #1265, found on a real citizen's phone (iOS TestFlight): the PWA's Enrol wizard
+/// told a signed-in citizen "You need to sign in first" while Settings, one tap away, correctly
+/// read "You're signed in." — blocking every downstream credential delivery.
+/// <para>
+/// The cause is the same defect class already fixed in Settings (see <see cref="SettingsPageTests"/>):
+/// <see cref="AccessTokenRecord.Email"/> is "captured at sign-in for display only" and is null on the
+/// passkey and social paths, so deriving auth state from email presence reports a passkey citizen as
+/// signed out. Enrol must gate on the same
+/// <see cref="Microsoft.AspNetCore.Components.Authorization.AuthorizeView"/> signal (token presence
+/// and expiry via <see cref="WalletAuthenticationStateProvider"/>) the rest of the shell uses.
+/// </para>
+/// <para>
+/// No HTTP request is involved in this check, so the ambient-HttpClient-without-bearer hypothesis
+/// recorded on the issue is not the cause — this is a purely local mis-derivation.
+/// </para>
+/// </summary>
+public sealed class EnrolPageAuthStateTests : ComponentTestFixture
+{
+    private readonly Mock<IAuthService> _auth = new();
+
+    public EnrolPageAuthStateTests()
+    {
+        Services.AddSingleton(_auth.Object);
+        Services.AddSingleton(new Mock<IEnrolmentService>().Object);
+        Services.AddSingleton<IAccessTokenStore>(new InMemoryAccessTokenStore());
+        Services.AddSingleton(new Mock<IEnrolSessionRedeemer>().Object);
+        Services.AddSingleton(new WalletAuthenticationStateProvider(new InMemoryAccessTokenStore()));
+        Services.AddSingleton<Microsoft.Extensions.Logging.ILogger<EnrolPage>>(
+            NullLogger<EnrolPage>.Instance);
+    }
+
+    /// <summary>
+    /// The reported bug, exactly: a valid non-expired token with no email — the passkey shape.
+    /// Enrol must treat this citizen as signed in.
+    /// </summary>
+    [Fact]
+    public void SignedIn_WithNullEmail_DoesNotDemandSignIn()
+    {
+        _auth.Setup(a => a.GetSignedInEmailAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string?)null);
+        var authContext = AddAuthorization();
+        authContext.SetAuthorized("citizen"); // authenticated, no email claim — passkey / social
+
+        var cut = Render<EnrolPage>();
+
+        cut.Markup.Should().NotContain(
+            "You need to sign in first",
+            "a citizen holding a valid token must never be told to sign in — this blocks all "
+            + "credential delivery to the wallet (#1265)");
+        cut.FindAll("[data-testid=enrol-open-settings-link]").Should().BeEmpty(
+            "the Open Settings escape hatch belongs only on the genuinely-signed-out path");
+        cut.FindAll("[data-testid=enrol-continue-button]").Should().ContainSingle(
+            "a signed-in citizen must be able to proceed through the wizard");
+    }
+
+    /// <summary>An email-and-password citizen keeps the existing "Signed in as x" affordance.</summary>
+    [Fact]
+    public void SignedIn_WithEmail_ShowsEmailAndAllowsContinue()
+    {
+        _auth.Setup(a => a.GetSignedInEmailAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync("citizen@example.test");
+        var authContext = AddAuthorization();
+        authContext.SetAuthorized("citizen@example.test");
+
+        var cut = Render<EnrolPage>();
+
+        cut.Markup.Should().Contain("citizen@example.test");
+        cut.Markup.Should().NotContain("You need to sign in first");
+        cut.FindAll("[data-testid=enrol-continue-button]").Should().ContainSingle();
+    }
+
+    /// <summary>
+    /// The genuinely-signed-out path must still refuse and route to sign-in — the fix must not
+    /// simply drop the gate.
+    /// </summary>
+    [Fact]
+    public void NotSignedIn_DemandsSignIn()
+    {
+        _auth.Setup(a => a.GetSignedInEmailAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string?)null);
+        var authContext = AddAuthorization();
+        authContext.SetNotAuthorized();
+
+        var cut = Render<EnrolPage>();
+
+        cut.Markup.Should().Contain("You need to sign in first");
+        cut.FindAll("[data-testid=enrol-continue-button]").Should().BeEmpty(
+            "a signed-out visitor must not be able to start the enrolment ceremony");
+    }
+
+    /// <summary>
+    /// #1265 second half: the wizard described what it registers as "this browser". In the
+    /// TestFlight / installed-app shell that is wrong and reads as if the wrong thing is being
+    /// enrolled.
+    /// </summary>
+    [Fact]
+    public void WelcomeCopy_DescribesADevice_NotABrowser()
+    {
+        _auth.Setup(a => a.GetSignedInEmailAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string?)null);
+        var authContext = AddAuthorization();
+        authContext.SetAuthorized("citizen");
+
+        var cut = Render<EnrolPage>();
+
+        cut.Markup.Should().NotContain(
+            "registers this browser",
+            "the PWA also runs as an installed app, where 'browser' is wrong (#1265)");
+    }
+}


### PR DESCRIPTION
Closes #1265.

## The bug

The PWA Enrol wizard told a citizen "You need to sign in first" while Settings, one tap away, correctly read "You're signed in." Enrolment is the gate for everything downstream — no enrolment, no device, no holder→device delegation, **no credential can ever land in the wallet** — so every other delivery symptom in the 2026-07-25 trial traced back here.

## Root cause — two defects, one visible

**1. Auth state derived from a display-only field.** `Enrol.razor` did:

```csharp
_signedInEmail = await Auth.GetSignedInEmailAsync();
_signedIn = _signedInEmail is not null;
```

`AccessTokenRecord.Email` is documented at `IAccessTokenStore.cs:54` as *"captured at sign-in for display only (**NOT used for auth**)"* and is **null on the passkey and social paths**. The tester signed up with a passkey, so a perfectly valid token carried no email. `Settings.razor` had this exact bug and was fixed by gating on `AuthorizeView`; Enrol never got the same treatment.

**2. `AuthorizeView` was rendering as literal HTML.** The file lacked `@using Microsoft.AspNetCore.Components.Authorization`, so the component compiled to a literal `<AuthorizeView>` element — **no compile error** — and emitted *both* `<Authorized>` and `<NotAuthorized>` branches at once. This surfaced only because the new tests caught it. The using now lives in `_Imports.razor` so no other PWA page can hit the same silent failure; an audit confirms Enrol was the only affected file.

### Note on the filed hypothesis

The issue's leading hypothesis was the ambient-`HttpClient`-without-bearer shape that killed pairing in #1165/#1166. That is **not** the cause here — no HTTP request is involved in this check. Reading the request headers first, as the issue instructed, is what ruled it out.

## Also in scope

- The "Open Settings to sign in" link pointed at a page that no longer offers sign-in — now routes to `/signin`.
- `WalletAuthenticationStateProvider.NotifyChanged()` after the F126 session redeem. Required now the gate reads the provider: without it a successful redeem would persist the token and still show "sign in".
- Wizard copy said enrolling registers "this browser" — wrong in the TestFlight/installed-app shell (second half of the issue).

## Verification

```
$ dotnet test --filter-class "*EnrolPageAuthStateTests*"   # before the fix
  Failed: 3, Passed: 1
    SignedIn_WithNullEmail_DoesNotDemandSignIn  -> markup contained "You need to sign in first"
    WelcomeCopy_DescribesADevice_NotABrowser    -> markup contained "registers this browser"

$ dotnet test --filter-class "*EnrolPageAuthStateTests*"   # after
  Passed! - Failed: 0, Passed: 4

$ dotnet test tests/Sorcha.Wallet.Pwa.Tests    # full suite, incl. the _Imports change
  Passed! - Failed: 0, Passed: 438, Skipped: 0, Total: 438
```

Red verified before green; the failures were for the reported reasons, not typos.

## Docs

`.specify/MASTER-TASKS.md` gains **Theme 9** tracking the whole 2026-07-25 citizen-trial backlog (#1264-#1282 + #1256) as UT-001..UT-020, including the "verified during the trial — do not re-litigate" list. UT-002 marked ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RboWP2TKvm1nBG22nqsWek