### PR TITLE
fix: [UT-017] - web Present signposts the phone instead of denying the feature (#1280)

### DIFF
--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Presentation/PresentOnPhoneNotice.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Presentation/PresentOnPhoneNotice.razor
@@ -1,0 +1,121 @@
+@*
+    SPDX-License-Identifier: MIT
+    Copyright (c) 2026 Sorcha Contributors
+
+    Issue #1280 (UT-017) — the companion-first answer to "Present" on the web.
+
+    Presentation is NOT an unbuilt feature: it ships on the wallet PWA
+    (Present.razor / PresentProximity.razor). Sorcha is companion-first — the web
+    owns account, wallet and application surfaces; the phone owns holding and
+    presenting. So the web "Present" affordance is a signpost, not a dead end,
+    and it must never claim presentation is "planned for a future release".
+
+    Self-gating on IHasPairedDeviceProbe, the same aggregate signal that drives
+    the F128 nag banner and the F149 PairingTakeover, so the route offered
+    matches the citizen's actual situation. HasAnyDevice is tri-state and the
+    null arm is load-bearing: telling a citizen who already carries a paired
+    phone to go and pair one is exactly as wrong as sending a citizen who never
+    installed the wallet to go and open it. Unknown therefore offers both routes
+    instead of guessing.
+*@
+
+@using Sorcha.UI.Core.Services.User.Devices
+@inject IHasPairedDeviceProbe Probe
+@inject NavigationManager Nav
+@implements IDisposable
+
+<MudAlert Severity="Severity.Info"
+          Class="mb-4"
+          data-testid="present-on-phone-notice">
+    <div class="notice-row">
+        <div class="notice-text">
+            <MudText Typo="Typo.subtitle2">Presenting happens on your phone</MudText>
+            <MudText Typo="Typo.body2">@BodyText</MudText>
+        </div>
+
+        @if (ShowOpenWallet)
+        {
+            <MudButton Variant="Variant.Filled"
+                       Color="Color.Primary"
+                       StartIcon="@Icons.Material.Filled.PhoneIphone"
+                       OnClick="HandleOpenWallet"
+                       data-testid="present-on-phone-open-wallet">
+                Open Sorcha Wallet
+            </MudButton>
+        }
+
+        @if (ShowPair)
+        {
+            <MudButton Variant="@(ShowOpenWallet ? Variant.Outlined : Variant.Filled)"
+                       Color="Color.Primary"
+                       StartIcon="@Icons.Material.Filled.QrCode2"
+                       OnClick="HandlePairPhone"
+                       data-testid="present-on-phone-pair">
+                Pair my phone
+            </MudButton>
+        }
+
+        <MudButton Variant="Variant.Text"
+                   Color="Color.Default"
+                   OnClick="HandleDismiss"
+                   data-testid="present-on-phone-dismiss">
+            Not now
+        </MudButton>
+    </div>
+</MudAlert>
+
+@code {
+    /// <summary>
+    /// Human name of the credential the citizen asked to present, so the notice
+    /// answers the question they actually asked. Optional — the copy degrades to
+    /// the generic phrasing when the caller has no name to hand.
+    /// </summary>
+    [Parameter] public string? CredentialName { get; set; }
+
+    /// <summary>Raised when the citizen dismisses the notice, so the host can retract it.</summary>
+    [Parameter] public EventCallback OnDismiss { get; set; }
+
+    private bool? _hasDevice;
+
+    // Unknown offers both routes; see the header comment for why that is not
+    // hedging but the only honest answer while the probe is unresolved.
+    private bool ShowOpenWallet => _hasDevice is true or null;
+    private bool ShowPair => _hasDevice is false or null;
+
+    private string CredentialLabel =>
+        string.IsNullOrWhiteSpace(CredentialName) ? "this credential" : CredentialName!;
+
+    private string BodyText => _hasDevice switch
+    {
+        true => $"{CredentialLabel} is held in the Sorcha Wallet on your phone — open it there to show it to a verifier.",
+        false => $"You haven't paired a phone yet. Sorcha credentials are shown from the wallet on your phone, so pair one to present {CredentialLabel}.",
+        _ => $"Sorcha credentials are shown from the wallet on your phone. Open it there to present {CredentialLabel} — or pair a phone if you haven't set one up yet.",
+    };
+
+    protected override async Task OnInitializedAsync()
+    {
+        Probe.Changed += HandleProbeChanged;
+        _hasDevice = Probe.HasAnyDevice;
+        await Probe.EnsureLoadedAsync();
+        _hasDevice = Probe.HasAnyDevice;
+    }
+
+    private void HandleProbeChanged()
+    {
+        _hasDevice = Probe.HasAnyDevice;
+        InvokeAsync(StateHasChanged);
+    }
+
+    // Rooted + forceLoad on purpose: the wallet PWA is a separate app mounted
+    // outside this client's "/app/" base, so a base-relative navigation would
+    // resolve inside the web client and 404.
+    private void HandleOpenWallet() => Nav.NavigateTo("/wallet/", forceLoad: true);
+
+    // Base-relative on purpose: /setup/add-device is a page of THIS client.
+    private void HandlePairPhone() => Nav.NavigateTo("setup/add-device");
+
+    private Task HandleDismiss() =>
+        OnDismiss.HasDelegate ? OnDismiss.InvokeAsync() : Task.CompletedTask;
+
+    public void Dispose() => Probe.Changed -= HandleProbeChanged;
+}

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Presentation/PresentOnPhoneNotice.razor.css
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Presentation/PresentOnPhoneNotice.razor.css
@@ -1,0 +1,36 @@
+/* SPDX-License-Identifier: MIT */
+/* Copyright (c) 2026 Sorcha Contributors */
+
+/*
+ * Same reflow rule as PairingNagBanner (issue #1275): a banner with trailing
+ * actions must WRAP, not compress. A flex item's default `min-width: auto`
+ * lets the text column shrink below its content while the buttons keep their
+ * intrinsic width — which is what wrapped the pair-a-phone nag over nine lines
+ * on an iPhone. This notice can carry up to three actions, so it is even more
+ * exposed to that failure.
+ *
+ * Deliberately breakpoint-free above 480px: the text asks for a 260px basis and
+ * the browser wraps the actions beneath as soon as they cannot all be seated on
+ * one line. That adapts to any width and to any future label change, where a
+ * hard-coded media query would not.
+ */
+
+.notice-row {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 12px;
+}
+
+.notice-text {
+    flex: 1 1 260px;
+    min-width: 0;
+}
+
+/* Once wrapped, actions span the row so they read as the notice's actions
+   rather than stray fragments floating beneath the text. */
+@media (max-width: 480px) {
+    .notice-row > .mud-button-root {
+        flex: 1 1 100%;
+    }
+}

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/MyCredentials.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/MyCredentials.razor
@@ -7,6 +7,7 @@
 @using Microsoft.AspNetCore.Authorization
 @using MudBlazor
 @using Sorcha.UI.Core.Components.Credentials
+@using Sorcha.UI.Core.Components.Presentation
 @using Sorcha.UI.Core.Components.Shared
 @using Sorcha.UI.Core.Components.Workflows
 @using Sorcha.UI.Core.Models.Credentials
@@ -47,6 +48,15 @@
             </div>
         }
     </MudStack>
+
+    @* Issue #1280: "Present" on the web is a signpost to the phone, not a dead end. Rendered above
+       the bands so it is visible wherever the citizen pressed Present from — a card in "Your
+       credentials", a card in the Archive, or the detail dialog (which closes itself first). *@
+    @if (_presentNoticeFor is not null)
+    {
+        <PresentOnPhoneNotice CredentialName="@_presentNoticeFor"
+                              OnDismiss="@(() => _presentNoticeFor = null)" />
+    }
 
     @if (_serviceError)
     {
@@ -165,6 +175,11 @@
     private bool _loading = true;
     private bool _serviceError;
     private string? _acceptingCredentialId;
+
+    // Issue #1280: name of the credential the citizen asked to present, or null when the
+    // companion-first notice is not showing. Holding the name (rather than a bare bool) lets the
+    // notice answer the question the citizen actually asked.
+    private string? _presentNoticeFor;
 
     protected override async Task OnInitializedAsync()
     {
@@ -368,9 +383,23 @@
             return;
         }
 
+        // Issue #1280: the dialog's Present button was never wired on the web host at all, so it
+        // was a button that did nothing — worse than the misleading message on the card. The
+        // reference is captured after ShowAsync and closed over here; the callback can only fire
+        // once the dialog exists, so it is always assigned by the time it runs.
+        IDialogReference? dialogRef = null;
+
         var parameters = new DialogParameters<CredentialDetailView>
         {
             { x => x.Credential, detail },
+            { x => x.OnPresent, EventCallback.Factory.Create(this, () =>
+                {
+                    // Close first: the notice renders on the page behind the dialog, so leaving the
+                    // dialog open would hide the very thing the citizen was just sent to read.
+                    dialogRef?.Close();
+                    _presentNoticeFor = detail.DisplayName;
+                })
+            },
             { x => x.OnDelete, EventCallback.Factory.Create(this, async () =>
                 {
                     var deleted = await CredentialApi.DeleteCredentialAsync(
@@ -395,12 +424,18 @@
             CloseOnEscapeKey = true
         };
 
-        await DialogService.ShowAsync<CredentialDetailView>("Credential Details", parameters, options);
+        dialogRef = await DialogService.ShowAsync<CredentialDetailView>(
+            "Credential Details", parameters, options);
     }
 
+    // Issue #1280: this used to answer "presentation is planned for a future release", which was
+    // simply untrue — it ships on the wallet PWA (Present.razor). Sorcha is companion-first: the
+    // phone holds and presents, the web does account and application work. So the honest answer is
+    // a route to the phone, not a denial. PresentOnPhoneNotice picks that route from the citizen's
+    // actual pairing state.
     private Task OnPresentCredential(CredentialCardViewModel credential)
     {
-        Feedback.ShowInfo("Verifiable credential presentation is planned for a future release.");
+        _presentNoticeFor = credential.DisplayName;
         return Task.CompletedTask;
     }
 

--- a/tests/Sorcha.UI.Components.User.Tests/Components/Presentation/PresentOnPhoneNoticeTests.cs
+++ b/tests/Sorcha.UI.Components.User.Tests/Components/Presentation/PresentOnPhoneNoticeTests.cs
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Threading;
+using System.Threading.Tasks;
+using Bunit;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using MudBlazor.Services;
+using Sorcha.UI.Core.Components.Presentation;
+using Sorcha.UI.Core.Services.User.Devices;
+using Xunit;
+
+namespace Sorcha.UI.Components.User.Tests.Components.Presentation;
+
+/// <summary>
+/// Issue #1280 (UT-017) — the web "Present" affordance told the citizen that verifiable-credential
+/// presentation was "planned for a future release". It is not: it ships on the wallet PWA
+/// (<c>Present.razor</c>). Sorcha is companion-first, so web is deliberately not the presenting
+/// surface — which makes this copy-and-redirect, not a missing feature.
+/// <para>
+/// These tests pin the three states the notice must distinguish. The pairing state comes from
+/// <see cref="IHasPairedDeviceProbe"/>, whose <c>HasAnyDevice</c> is deliberately tri-state: the
+/// <c>null</c> arm means "the probe has not resolved", and telling a citizen who already has a
+/// phone to go pair one is exactly as wrong as telling a citizen with no phone to go open a wallet
+/// they never installed. So unknown offers both routes rather than guessing.
+/// </para>
+/// </summary>
+public sealed class PresentOnPhoneNoticeTests : BunitContext
+{
+    private readonly Mock<IHasPairedDeviceProbe> _probe = new();
+
+    public PresentOnPhoneNoticeTests()
+    {
+        Services.AddMudServices();
+        Services.AddSingleton(_probe.Object);
+        JSInterop.Mode = JSRuntimeMode.Loose;
+    }
+
+    private void ProbeReports(bool? hasAnyDevice) =>
+        _probe.SetupGet(p => p.HasAnyDevice).Returns(hasAnyDevice);
+
+    [Fact]
+    public void PairedCitizen_IsPointedAtTheirPhone_NotToldPresentationIsUnbuilt()
+    {
+        ProbeReports(true);
+
+        var cut = Render<PresentOnPhoneNotice>(ps => ps.Add(p => p.CredentialName, "Assured Identity"));
+
+        cut.WaitForAssertion(() =>
+        {
+            cut.Markup.Should().NotContain("future release",
+                "presentation ships on the PWA — claiming otherwise is false");
+            cut.FindAll("[data-testid='present-on-phone-open-wallet']").Should().ContainSingle(
+                "a citizen who already paired a phone needs the route to their wallet");
+            cut.FindAll("[data-testid='present-on-phone-pair']").Should().BeEmpty(
+                "they have a paired phone already — offering to pair one is noise");
+        });
+    }
+
+    [Fact]
+    public void UnpairedCitizen_IsOfferedPairing_NotAWalletTheyHaveNotInstalled()
+    {
+        ProbeReports(false);
+
+        var cut = Render<PresentOnPhoneNotice>();
+
+        cut.WaitForAssertion(() =>
+        {
+            cut.FindAll("[data-testid='present-on-phone-pair']").Should().ContainSingle();
+            cut.FindAll("[data-testid='present-on-phone-open-wallet']").Should().BeEmpty(
+                "there is no wallet to open on a phone that was never paired");
+        });
+    }
+
+    [Fact]
+    public void UnresolvedProbe_OffersBothRoutes_RatherThanGuessing()
+    {
+        ProbeReports(null);
+
+        var cut = Render<PresentOnPhoneNotice>();
+
+        cut.WaitForAssertion(() =>
+        {
+            cut.FindAll("[data-testid='present-on-phone-open-wallet']").Should().ContainSingle();
+            cut.FindAll("[data-testid='present-on-phone-pair']").Should().ContainSingle();
+        });
+    }
+
+    [Fact]
+    public void CredentialName_IsNamedSoTheCitizenKnowsWhichOneTheyAskedFor()
+    {
+        ProbeReports(true);
+
+        var cut = Render<PresentOnPhoneNotice>(ps => ps.Add(p => p.CredentialName, "Assured Identity"));
+
+        cut.WaitForAssertion(() => cut.Markup.Should().Contain("Assured Identity"));
+    }
+
+    [Fact]
+    public void Dismiss_RaisesTheCallback_SoTheHostCanRetractTheNotice()
+    {
+        ProbeReports(true);
+        var dismissed = false;
+
+        var cut = Render<PresentOnPhoneNotice>(ps => ps
+            .Add(p => p.OnDismiss, () => dismissed = true));
+
+        cut.WaitForAssertion(() => cut.FindAll("[data-testid='present-on-phone-dismiss']").Should().ContainSingle());
+        cut.Find("[data-testid='present-on-phone-dismiss']").Click();
+
+        dismissed.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Notice_AwaitsTheProbe_SoItNeverRendersTheUnknownArmForAResolvableCitizen()
+    {
+        ProbeReports(null);
+        _probe.Setup(p => p.EnsureLoadedAsync(It.IsAny<CancellationToken>()))
+            .Callback(() => ProbeReports(true))
+            .Returns(Task.CompletedTask);
+
+        var cut = Render<PresentOnPhoneNotice>();
+
+        await cut.InvokeAsync(() => { });
+
+        cut.WaitForAssertion(() =>
+            cut.FindAll("[data-testid='present-on-phone-pair']").Should().BeEmpty(
+                "the probe resolved to true during load — the unknown arm must not linger"));
+    }
+}

--- a/tests/Sorcha.UI.Core.Tests/Pages/Credentials/MyCredentialsPresentTests.cs
+++ b/tests/Sorcha.UI.Core.Tests/Pages/Credentials/MyCredentialsPresentTests.cs
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Bunit;
+using FluentAssertions;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using MudBlazor;
+using Sorcha.UI.Core.Models.Credentials;
+using Sorcha.UI.Core.Services;
+using Sorcha.UI.Core.Services.Credentials;
+using Sorcha.UI.Core.Services.Feedback;
+using Sorcha.UI.Core.Services.User.Devices;
+using Sorcha.UI.Core.Services.Wallet;
+using Sorcha.UI.Testing;
+using Sorcha.UI.Testing.Builders;
+using Xunit;
+using MyCredentialsPage = Sorcha.UI.Web.Client.Pages.MyCredentials;
+
+namespace Sorcha.UI.Core.Tests.Pages.Credentials;
+
+/// <summary>
+/// Issue #1280 (UT-017) — pressing Present on the web told the citizen that verifiable-credential
+/// presentation was "planned for a future release". It ships on the wallet PWA; Sorcha is
+/// companion-first, so the web is deliberately not the presenting surface. The affordance must
+/// therefore signpost the phone, not deny the feature exists.
+/// </summary>
+public sealed class MyCredentialsPresentTests : ComponentTestFixture
+{
+    private readonly Mock<ICredentialApiService> _credentialApi = new();
+    private readonly Mock<IWalletApiService> _walletApi = new();
+    private readonly Mock<IWorkflowService> _workflowService = new();
+    private readonly Mock<IDialogService> _dialogService = new();
+    private readonly Mock<IHasPairedDeviceProbe> _probe = new();
+
+    private const string WalletAddress = "0x0000000000000000000000000000000000000001";
+
+    public MyCredentialsPresentTests()
+    {
+        Services.AddSingleton(_credentialApi.Object);
+        Services.AddSingleton(_walletApi.Object);
+        Services.AddSingleton(_workflowService.Object);
+        Services.AddSingleton(_dialogService.Object);
+        Services.AddSingleton(Mock.Of<IInlineFeedback>());
+        Services.AddSingleton(_probe.Object);
+        Services.AddSingleton(new WalletHubConnection(
+            "https://localhost",
+            Mock.Of<Sorcha.UI.Core.Services.Authentication.IAuthenticationService>(),
+            Mock.Of<Sorcha.UI.Core.Services.Configuration.IConfigurationService>(),
+            Microsoft.Extensions.Logging.Abstractions.NullLogger<WalletHubConnection>.Instance));
+
+        _probe.SetupGet(p => p.HasAnyDevice).Returns(true);
+
+        _walletApi.Setup(w => w.GetWalletsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<WalletDto>
+            {
+                new WalletDtoBuilder().WithAddress(WalletAddress).Build(),
+            });
+
+        _credentialApi.Setup(c => c.GetCredentialsAsync(WalletAddress, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<CredentialCardViewModel> { ActiveCredential() });
+    }
+
+    private static CredentialCardViewModel ActiveCredential() => new()
+    {
+        CredentialId = "cred-1",
+        Type = "https://sorcha.dev/vc/assured-identity/v1",
+        DisplayName = "Assured Identity",
+        IssuerOrgName = "Acme Identity Assurance",
+        Status = CredentialStatus.Active,
+        IsPending = false,
+        IssuedAt = DateTimeOffset.Parse("2026-07-01T00:00:00Z"),
+        AvailableActions = new List<string> { "Present" },
+    };
+
+    /// <summary>
+    /// bUnit's default WaitForAssertion timeout is 1s. This page's OnInitializedAsync awaits
+    /// <c>WalletHubConnection.StartAsync</c> against an unreachable host before it loads anything,
+    /// and on a Windows dev box that handshake alone can outlast the default — the wait then
+    /// reports the loading skeleton rather than the real assertion. An explicit budget keeps the
+    /// failure message about the behaviour under test.
+    /// </summary>
+    private static readonly TimeSpan LoadBudget = TimeSpan.FromSeconds(30);
+
+    private static readonly RenderFragment Page = builder =>
+    {
+        builder.OpenComponent<MudPopoverProvider>(0);
+        builder.CloseComponent();
+        builder.OpenComponent<MyCredentialsPage>(1);
+        builder.CloseComponent();
+    };
+
+    [Fact]
+    public void PressingPresent_SignpostsThePhone_NeverClaimsPresentationIsUnbuilt()
+    {
+        var cut = Render(Page);
+
+        cut.WaitForAssertion(() => cut.Markup.Should().Contain("Your credentials"), LoadBudget);
+
+        var present = cut.FindAll("button")
+            .First(b => b.TextContent.Trim().Equals("Present", StringComparison.Ordinal));
+        present.Click();
+
+        cut.WaitForAssertion(() =>
+        {
+            cut.FindAll("[data-testid='present-on-phone-notice']").Should().ContainSingle(
+                "the citizen asked to present — they must be told where presenting happens");
+            cut.Markup.Should().NotContain("future release");
+        });
+    }
+
+    [Fact]
+    public void TheNotice_NamesTheCredentialTheCitizenPickedFrom()
+    {
+        var cut = Render(Page);
+
+        cut.WaitForAssertion(() => cut.Markup.Should().Contain("Your credentials"), LoadBudget);
+
+        cut.FindAll("button")
+            .First(b => b.TextContent.Trim().Equals("Present", StringComparison.Ordinal))
+            .Click();
+
+        cut.WaitForAssertion(() =>
+            cut.Find("[data-testid='present-on-phone-notice']").TextContent
+                .Should().Contain("Assured Identity"));
+    }
+
+    [Fact]
+    public void DismissingTheNotice_RetractsIt()
+    {
+        var cut = Render(Page);
+
+        cut.WaitForAssertion(() => cut.Markup.Should().Contain("Your credentials"), LoadBudget);
+
+        cut.FindAll("button")
+            .First(b => b.TextContent.Trim().Equals("Present", StringComparison.Ordinal))
+            .Click();
+
+        cut.WaitForAssertion(() =>
+            cut.FindAll("[data-testid='present-on-phone-dismiss']").Should().ContainSingle());
+        cut.Find("[data-testid='present-on-phone-dismiss']").Click();
+
+        cut.WaitForAssertion(() =>
+            cut.FindAll("[data-testid='present-on-phone-notice']").Should().BeEmpty());
+    }
+}

--- a/tests/Sorcha.UI.Core.Tests/Pages/Credentials/MyCredentialsTests.cs
+++ b/tests/Sorcha.UI.Core.Tests/Pages/Credentials/MyCredentialsTests.cs
@@ -125,7 +125,13 @@ public sealed class MyCredentialsTests : ComponentTestFixture
         var cut = Render(Page);
 
         // Sanity: the pending band rendered before we decline anything.
-        cut.WaitForAssertion(() => cut.Markup.Should().Contain("Needs you"));
+        //
+        // Explicit budget, not bUnit's 1s default: OnInitializedAsync awaits
+        // WalletHubConnection.StartAsync against an unreachable host before it loads
+        // anything, and on Windows that handshake alone outlasts the default — which
+        // is why this test was a standing local red while passing in CI on Linux. The
+        // wait then reported the loading skeleton instead of the behaviour under test.
+        cut.WaitForAssertion(() => cut.Markup.Should().Contain("Needs you"), TimeSpan.FromSeconds(30));
 
         var declineButton = cut.FindAll("button")
             .First(b => b.TextContent.Trim().Equals("Decline", StringComparison.Ordinal));


### PR DESCRIPTION
Closes #1280.

The web "Present" affordance answered **"Verifiable credential presentation is planned for a future release."** That is false — presentation ships on the wallet PWA (`Present.razor` / `PresentProximity.razor`). Sorcha is companion-first: the phone holds and presents, the web does account and application work. So this is **copy + redirect**, not presentation being built on web.

## What changed

- **New shared `PresentOnPhoneNotice`**, self-gating on `IHasPairedDeviceProbe` — the same aggregate signal behind the F128 nag banner and the F149 `PairingTakeover` — so the route offered matches the citizen's actual situation.
- **The `null` arm of `HasAnyDevice` is load-bearing.** Telling a citizen who already carries a paired phone to go and pair one is exactly as wrong as telling a citizen who never installed the wallet to go and open it. An unresolved probe therefore offers **both** routes rather than guessing.
- **A second instance of the same defect, found while tracing it:** the `Present` button inside the credential *detail dialog* was never wired on the web host at all — it did nothing. A dead button is worse than a misleading message. Now wired, and it closes the dialog first so the notice it raises is not hidden behind it.
- Scoped CSS carries the #1275 reflow rule (wrap, don't compress). This notice can carry three actions, so it is more exposed to that failure than the nag banner was.

## Incidental: the standing local red is fixed

`MyCredentialsTests.DeclineOnlyPendingCredential_NeverRendersBlankPage` was a permanent local failure believed to be Windows-specific. It is not a platform behaviour difference: the page's `OnInitializedAsync` awaits a SignalR handshake against an unreachable host **before** it loads anything, and that outlasts bUnit's **1 second** default `WaitForAssertion` timeout on Windows — so the wait reported the loading skeleton instead of the assertion. An explicit budget makes it pass everywhere and keeps future failures about the behaviour under test.

## Verification

| Suite | Result |
|---|---|
| `PresentOnPhoneNoticeTests` (new, 6) | pass — verified red first (component absent) |
| `MyCredentialsPresentTests` (new, 3) | pass — verified red first (notice absent after click) |
| `Sorcha.UI.Core.Tests` (1530) | **0 failed** (was 1) |
| `Sorcha.UI.Components.User.Tests` (81) | 0 failed |

`MASTER-TASKS.md` is deliberately **not** touched — Theme 9 doc updates are batched into one final pass, because per-PR edits caused three rebase conflicts whose auto-resolutions duplicated rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RboWP2TKvm1nBG22nqsWek