### PR TITLE
fix: [UT-004] - surface decision notices on the web home (#1267)

### DIFF
--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Activity/ActivityFeed.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Activity/ActivityFeed.razor
@@ -93,7 +93,7 @@
                 <MudDivider />
             }
         </MudList>
-        @if (_entries.Count < _totalCount)
+        @if (ShowLoadMore && _entries.Count < _totalCount)
         {
             <div class="d-flex justify-center pa-3" data-testid="activity-feed-load-more">
                 <MudButton Variant="Variant.Text"
@@ -114,6 +114,14 @@
 @code {
     /// <summary>Entries per incremental load (clamped 1..100 server-side).</summary>
     [Parameter] public int PageSize { get; set; } = 20;
+
+    /// <summary>
+    /// Whether to offer "Load more" when more entries exist than are shown. The full-history page
+    /// wants it; a fixed-size summary slice (the web home panel, issue #1267) does not — there the
+    /// route onward is "See all", and a Load more that grew the panel indefinitely would turn a
+    /// dashboard section into a second history page.
+    /// </summary>
+    [Parameter] public bool ShowLoadMore { get; set; } = true;
 
     private readonly List<InboxEntryDto> _entries = new();
     private bool _loading;

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/wwwroot/i18n/de.json
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/wwwroot/i18n/de.json
@@ -69,6 +69,7 @@
   "dashboard.viewWallets": "Wallets anzeigen",
   "dashboard.recentActivity": "Neueste Aktivität",
   "dashboard.noRecentActivity": "Keine neueste Aktivität",
+  "dashboard.seeAllActivity": "Alle anzeigen",
 
   "wallet.title": "Wallets",
   "wallet.create": "Wallet erstellen",

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/wwwroot/i18n/en.json
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/wwwroot/i18n/en.json
@@ -69,6 +69,7 @@
   "dashboard.viewWallets": "View Wallets",
   "dashboard.recentActivity": "Recent Activity",
   "dashboard.noRecentActivity": "No recent activity",
+  "dashboard.seeAllActivity": "See all",
 
   "wallet.title": "Wallets",
   "wallet.create": "Create Wallet",

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/wwwroot/i18n/es.json
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/wwwroot/i18n/es.json
@@ -69,6 +69,7 @@
   "dashboard.viewWallets": "Ver billeteras",
   "dashboard.recentActivity": "Actividad reciente",
   "dashboard.noRecentActivity": "Sin actividad reciente",
+  "dashboard.seeAllActivity": "Ver todo",
 
   "wallet.title": "Billeteras",
   "wallet.create": "Crear billetera",

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/wwwroot/i18n/fr.json
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/wwwroot/i18n/fr.json
@@ -69,6 +69,7 @@
   "dashboard.viewWallets": "Voir les portefeuilles",
   "dashboard.recentActivity": "Activité récente",
   "dashboard.noRecentActivity": "Aucune activité récente",
+  "dashboard.seeAllActivity": "Tout afficher",
 
   "wallet.title": "Portefeuilles",
   "wallet.create": "Créer un portefeuille",

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Home.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Home.razor
@@ -9,6 +9,7 @@
 @implements IDisposable
 @using System.Security.Claims
 @using Microsoft.AspNetCore.Components.Authorization
+@using Sorcha.UI.Components.User.Components.Activity
 @using Sorcha.UI.Components.User.Components.Onboarding
 @using Sorcha.UI.Core.Models.Admin
 @using Sorcha.UI.Core.Models.Dashboard
@@ -253,10 +254,29 @@ else
         </MudAlert>
     }
 
-    @* Recent Activity *@
-    <MudText Typo="Typo.h6" Class="mb-2">@Loc.T("dashboard.recentActivity")</MudText>
-    <MudPaper Elevation="1" Class="pa-4">
-        <MudText Typo="Typo.body2" Color="Color.Secondary">@Loc.T("dashboard.noRecentActivity")</MudText>
+    @* Recent Activity — issue #1267 (UT-004).
+
+       This panel used to render a hard-coded "no recent activity" line that was never wired to
+       anything. It was not merely empty, it was WRONG: a citizen whose identity application had
+       just been rejected got a dashboard telling them nothing had happened, while the very same
+       inbox entry was already listed by the PWA feed and by this host's own /activity route. Only
+       home lied — which is what made rejections invisible on the web.
+
+       Reusing the shared ActivityFeed rather than re-rendering entries here is deliberate: it
+       already carries the #1273 severity/glyph normalisation and the #1266 detail-href routing, and
+       a second hand-rolled renderer would be a second place for those to drift back out. Capped at
+       five with Load more suppressed, because this is a dashboard slice — "See all" is the route
+       onward to the full history. *@
+    <MudStack Row="true" Justify="Justify.SpaceBetween" AlignItems="AlignItems.Center" Class="mb-2">
+        <MudText Typo="Typo.h6">@Loc.T("dashboard.recentActivity")</MudText>
+        <MudButton Variant="Variant.Text" Color="Color.Primary" Size="Size.Small"
+                   Href="activity"
+                   data-testid="home-activity-see-all">
+            @Loc.T("dashboard.seeAllActivity")
+        </MudButton>
+    </MudStack>
+    <MudPaper Elevation="1" Class="pa-2">
+        <ActivityFeed PageSize="5" ShowLoadMore="false" />
     </MudPaper>
 }
 

--- a/tests/Sorcha.UI.Core.Tests/Components/Activity/ActivityFeedTests.cs
+++ b/tests/Sorcha.UI.Core.Tests/Components/Activity/ActivityFeedTests.cs
@@ -141,6 +141,29 @@ public sealed class ActivityFeedTests : ComponentTestFixture
             "the Load more affordance must appear when loaded entries < TotalCount");
     }
 
+    /// <summary>
+    /// Issue #1267: the web home panel (a fixed five-entry dashboard slice) hosts this same feed.
+    /// There the route onward is "See all" — a Load more that grew the panel indefinitely would turn
+    /// a dashboard section into a second history page. The suppression must survive the condition
+    /// that would otherwise show the button, so it is asserted with entries deliberately short of
+    /// TotalCount.
+    /// </summary>
+    [Fact]
+    public void WhenLoadMoreIsSuppressed_TheButtonIsAbsentEvenThoughMoreEntriesExist()
+    {
+        var entries = new List<InboxEntryDto> { Entry("System", "Info", "Entry 1") };
+        _api.Setup(a => a.ListAsync(
+                It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string?>(),
+                It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new InboxPageDto(entries, 1, 20, 50));
+
+        var cut = Render<ActivityFeed>(ps => ps.Add(p => p.ShowLoadMore, false));
+
+        cut.FindAll("[data-testid='activity-feed-load-more']").Should().BeEmpty();
+        cut.Markup.Should().Contain("Entry 1",
+            "suppressing Load more must not suppress the entries themselves");
+    }
+
     [Fact]
     public void WhenLoadedCountEqualsOrExceedsTotalCount_HidesLoadMoreButton()
     {

--- a/tests/Sorcha.UI.Core.Tests/Pages/HomeRecentActivityTests.cs
+++ b/tests/Sorcha.UI.Core.Tests/Pages/HomeRecentActivityTests.cs
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Bunit;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Sorcha.UI.Core.Models.Admin;
+using Sorcha.UI.Core.Models.Dashboard;
+using Sorcha.UI.Core.Services;
+using Sorcha.UI.Core.Services.Wallet;
+using Sorcha.UI.Testing;
+using Sorcha.UI.Testing.Builders;
+using Xunit;
+using HomePage = Sorcha.UI.Web.Client.Pages.Home;
+
+namespace Sorcha.UI.Core.Tests.Pages;
+
+/// <summary>
+/// Issue #1267 (UT-004) — decision notices were invisible to the citizen on every web surface.
+/// The bell-badge half is fixed (the count now includes <c>Workflow</c>+<c>Warning</c> entries,
+/// which is the shape F184 writes a rejection as). This is the remaining half: the web home page
+/// rendered a hard-coded "no recent activity" placeholder that was never wired to anything, so a
+/// citizen whose identity application had just been REJECTED landed on a dashboard cheerfully
+/// telling them nothing had happened.
+/// <para>
+/// The placeholder was not merely empty — it was wrong. The inbox entry existed, the PWA feed
+/// listed it, and the web <c>/activity</c> route rendered it. Only home lied.
+/// </para>
+/// </summary>
+public sealed class HomeRecentActivityTests : ComponentTestFixture
+{
+    private readonly Mock<IInboxApiService> _inbox = new();
+    private readonly Mock<IWalletApiService> _walletApi = new();
+    private readonly Mock<IWalletPreferenceService> _walletPrefs = new();
+    private readonly Mock<IDashboardService> _dashboard = new();
+    private readonly Mock<IAlertService> _alerts = new();
+    private readonly Mock<IAlertDismissalService> _alertDismissal = new();
+    private readonly Mock<ILocalizationService> _loc = new();
+
+    private const string WalletAddress = "0x0000000000000000000000000000000000000001";
+
+    public HomeRecentActivityTests()
+    {
+        Services.AddLogging();
+        Services.AddSingleton(_inbox.Object);
+        Services.AddSingleton(_walletApi.Object);
+        Services.AddSingleton(_walletPrefs.Object);
+        Services.AddSingleton(_dashboard.Object);
+        Services.AddSingleton(_alerts.Object);
+        Services.AddSingleton(_alertDismissal.Object);
+        Services.AddSingleton(_loc.Object);
+        Services.AddSingleton(new TenantHubConnection(
+            "http://test.local",
+            () => Task.FromResult<string?>(null),
+            NullLogger<TenantHubConnection>.Instance,
+            _inbox.Object));
+
+        // A plain signed-in citizen: no admin roles, so the stats grid and AlertsPanel stay out of
+        // the way and the assertions are about the activity region only.
+        AddAuthorization().SetAuthorized("citizen@example.test");
+
+        // Localisation is a pass-through here — the keys ARE the assertion targets elsewhere, and
+        // resolving them to themselves keeps this test about the activity region.
+        _loc.Setup(l => l.T(It.IsAny<string>())).Returns((string k) => k);
+        _loc.Setup(l => l.T(It.IsAny<string>(), It.IsAny<object[]>())).Returns((string k, object[] _) => k);
+
+        var wallet = new WalletDtoBuilder().WithAddress(WalletAddress).Build();
+        _walletApi.Setup(w => w.GetWalletsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<WalletDto> { wallet });
+        _walletPrefs.Setup(p => p.GetSmartDefaultAsync(It.IsAny<List<WalletDto>>()))
+            .ReturnsAsync(WalletAddress);
+
+        _dashboard.Setup(d => d.GetDashboardStatsAsync(It.IsAny<string>()))
+            .ReturnsAsync(new DashboardStatsViewModel());
+        _alerts.Setup(a => a.GetAlertsAsync()).ReturnsAsync(new AlertsResponse());
+        _alertDismissal.Setup(a => a.FilterDismissedAsync(It.IsAny<IReadOnlyList<ServiceAlert>>()))
+            .ReturnsAsync((IReadOnlyList<ServiceAlert> a) => a);
+    }
+
+    private static InboxEntryDto Rejection() => new()
+    {
+        Id = Guid.NewGuid(),
+        PlatformUserId = Guid.NewGuid(),
+        // Exactly the shape F184 writes a decision notice as — this pairing is what the bell badge
+        // used to miss, and it is what home must not miss either.
+        Category = "workflow",
+        Severity = "warning",
+        IconKey = "workflow.rejected",
+        CorrelationKey = "k",
+        DetailHref = "",
+        SourceEventId = Guid.NewGuid(),
+        OccurredAt = DateTimeOffset.UtcNow,
+        Title = "Your Assured Identity application was not approved",
+        Summary = "Confirm your email address and reapply.",
+    };
+
+    private void InboxReturns(params InboxEntryDto[] entries) =>
+        _inbox.Setup(a => a.ListAsync(
+                It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string?>(),
+                It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new InboxPageDto(entries, 1, 50, entries.Length));
+
+    private static readonly TimeSpan LoadBudget = TimeSpan.FromSeconds(30);
+
+    [Fact]
+    public void ARejectionInTheInbox_IsVisibleOnHome()
+    {
+        InboxReturns(Rejection());
+
+        var cut = Render<HomePage>();
+
+        cut.WaitForAssertion(
+            () => cut.Markup.Should().Contain("Your Assured Identity application was not approved",
+                "a citizen whose application was rejected must learn that from their home page"),
+            LoadBudget);
+    }
+
+    [Fact]
+    public void HomeNoLongerRendersAHardCodedEmptyPlaceholder()
+    {
+        InboxReturns(Rejection());
+
+        var cut = Render<HomePage>();
+
+        cut.WaitForAssertion(
+            () => cut.FindAll("[data-testid='activity-feed']").Should().ContainSingle(
+                "home must render the real inbox-backed feed, not a static panel"),
+            LoadBudget);
+
+        // The old placeholder resolved this key unconditionally — even with entries present.
+        cut.Markup.Should().NotContain("dashboard.noRecentActivity");
+    }
+
+    [Fact]
+    public void WithAnEmptyInbox_HomeSaysSo_ViaTheFeedsOwnEmptyState()
+    {
+        InboxReturns();
+
+        var cut = Render<HomePage>();
+
+        cut.WaitForAssertion(
+            () => cut.FindAll("[data-testid='activity-feed-empty']").Should().ContainSingle(
+                "an empty inbox is a real state — but it must come from the feed, not a hard-coded panel"),
+            LoadBudget);
+    }
+
+    [Fact]
+    public void HomeOffersARouteToTheFullHistory()
+    {
+        InboxReturns(Rejection());
+
+        var cut = Render<HomePage>();
+
+        cut.WaitForAssertion(
+            () => cut.FindAll("[data-testid='home-activity-see-all']").Should().ContainSingle(
+                "home shows a slice — the citizen needs a way to the full history"),
+            LoadBudget);
+    }
+}


### PR DESCRIPTION
Closes the remaining half of #1267 (UT-004). The bell-badge half shipped in #1289.

Home rendered a **hard-coded "no recent activity" line that was never wired to anything.** It was not merely empty — it was *wrong*: the inbox entry existed, the PWA activity feed listed it, and this host's own `/activity` route rendered it. Only home lied. So a citizen whose identity application had just been **rejected** landed on a dashboard cheerfully telling them nothing had happened.

## What changed

- **Home now hosts the shared `ActivityFeed`** instead of the static panel. Reusing it rather than re-rendering entries in the page is deliberate: it already carries the #1273 severity/glyph normalisation and the #1266 detail-href routing, and a second hand-rolled renderer would be a second place for those to drift back out.
- **Capped at five entries with Load more suppressed**, via a new `ShowLoadMore` parameter (default `true`, so `/activity` is unchanged). A dashboard slice that grew without bound would just be a second history page; **"See all"** is the route onward.
- `dashboard.seeAllActivity` added to all four locales (en/de/es/fr).

## Verification

| Suite | Result |
|---|---|
| `HomeRecentActivityTests` (new, 4) | pass — **verified red first**, all four failed because the feed was absent |
| `ActivityFeedTests` (+1 for the suppression) | pass — **red-verified by removing the guard** (`Expected … to be empty, but found at least one item`) |
| `Sorcha.UI.Core.Tests` (1532) | 1 failed — the pre-existing `MyCredentialsTests` red, whose fix is in #1293 and not on this branch |

The new tests use an **F184-shaped rejection** (`Category=workflow` + `Severity=warning`) — the exact pairing the bell badge used to miss — so home cannot regress into missing the same shape.

`MASTER-TASKS.md` is deliberately **not** touched; Theme 9 doc updates are batched into one final pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RboWP2TKvm1nBG22nqsWek