### PR TITLE
fix: [UT-013] - My Transactions drill-down, and a Sender column that named the wrong thing (#1276)

### DIFF
--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/MyTransactions.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/MyTransactions.razor
@@ -9,6 +9,10 @@
 @using Sorcha.UI.Core.Models.Registers
 @using Sorcha.UI.Core.Models.Wallet
 @using Sorcha.UI.Core.Components.Shared
+@* TransactionDetail / PayloadViewer live in the register-explorer library. Reused rather than
+   re-implemented for the citizen page: a second renderer of the same ledger facts is a second place
+   for them to drift, and both components are purely presentational over the same view model. *@
+@using Sorcha.UI.Core.Components.Registers
 @using Sorcha.UI.Core.Services
 @using Sorcha.UI.Core.Services.Wallet
 @inject ITransactionService TransactionService
@@ -73,13 +77,23 @@
         else
         {
             <MudPaper Class="pa-4" Elevation="2">
-                <MudTable Items="@FilteredTransactions" Hover="true" Striped="true" Dense="true">
+                @* Issue #1276: the "Sender" column named the wrong thing. This page lists the
+                   transactions that INVOLVE the selected wallet, so on a received transaction the
+                   sender legitimately is somebody else — which made the citizen's own history read
+                   as a list of strangers. Direction + Counterparty describe the same two facts from
+                   the citizen's point of view, and both were already computed by the query mapper
+                   (TransactionViewModel.Direction / .CounterpartyAddress); they were simply never
+                   rendered. *@
+                <MudTable Items="@FilteredTransactions" Hover="true" Striped="true" Dense="true"
+                          T="TransactionQueryResultItem">
                     <HeaderContent>
                         <MudTh>Transaction ID</MudTh>
                         <MudTh>Register</MudTh>
-                        <MudTh>Sender</MudTh>
+                        <MudTh>Direction</MudTh>
+                        <MudTh>Counterparty</MudTh>
                         <MudTh>Timestamp</MudTh>
                         <MudTh>Docket</MudTh>
+                        <MudTh></MudTh>
                     </HeaderContent>
                     <RowTemplate>
                         <MudTd DataLabel="Transaction ID">
@@ -88,8 +102,27 @@
                         <MudTd DataLabel="Register">
                             <TruncatedId Value="@context.RegisterId" />
                         </MudTd>
-                        <MudTd DataLabel="Sender">
-                            <TruncatedId Value="@context.Transaction.SenderWallet" />
+                        <MudTd DataLabel="Direction">
+                            <MudChip T="string" Size="MudBlazor.Size.Small" Variant="Variant.Text"
+                                     Color="@(IsSent(context.Transaction) ? Color.Primary : Color.Success)"
+                                     Icon="@(IsSent(context.Transaction) ? Icons.Material.Filled.NorthEast : Icons.Material.Filled.SouthWest)"
+                                     data-testid="@($"tx-direction-{context.Transaction.TxId}")">
+                                @(IsSent(context.Transaction) ? "Sent" : "Received")
+                            </MudChip>
+                        </MudTd>
+                        <MudTd DataLabel="Counterparty">
+                            <span data-testid="@($"tx-counterparty-{context.Transaction.TxId}")">
+                                @if (Counterparty(context.Transaction) is { Length: > 0 } address)
+                                {
+                                    <TruncatedId Value="@address" />
+                                }
+                                else
+                                {
+                                    @* A control/genesis transaction has no other party. An em dash
+                                       says "none" — a blank cell reads as a rendering fault. *@
+                                    <MudText Typo="Typo.body2" Color="Color.Secondary">—</MudText>
+                                }
+                            </span>
                         </MudTd>
                         <MudTd DataLabel="Timestamp">
                             @context.Transaction.TimeStamp.ToString("MMM dd, yyyy HH:mm")
@@ -97,7 +130,50 @@
                         <MudTd DataLabel="Docket">
                             @context.Transaction.DocketNumber
                         </MudTd>
+                        <MudTd>
+                            @* Issue #1276: the list had no way through to a transaction at all. The
+                               detail is disclosed INLINE rather than in a dialog on purpose — #1279
+                               showed how badly a dialog of this density fares on a phone, and an
+                               expanding row keeps the citizen's place in the list. *@
+                            <MudIconButton Size="MudBlazor.Size.Small"
+                                           Icon="@(_openTxId == context.Transaction.TxId ? Icons.Material.Filled.ExpandLess : Icons.Material.Filled.ExpandMore)"
+                                           aria-label="@(_openTxId == context.Transaction.TxId ? "Hide transaction detail" : "Show transaction detail")"
+                                           OnClick="@(() => ToggleDetailAsync(context))"
+                                           data-testid="@($"tx-open-{context.Transaction.TxId}")" />
+                        </MudTd>
                     </RowTemplate>
+                    <ChildRowContent>
+                        @if (_openTxId == context.Transaction.TxId)
+                        {
+                            <MudTr>
+                                <td colspan="7">
+                                    <div data-testid="@($"tx-detail-{context.Transaction.TxId}")" class="pa-4">
+                                        @if (_detailLoading)
+                                        {
+                                            <MudProgressLinear Indeterminate="true" />
+                                        }
+                                        else if (_detailError)
+                                        {
+                                            <MudAlert Severity="Severity.Error" Dense="true">
+                                                Couldn't load this transaction. Try again.
+                                            </MudAlert>
+                                        }
+                                        else if (_openTransaction is not null)
+                                        {
+                                            <TransactionDetail Transaction="_openTransaction" />
+                                            @if (_openTransaction.Payloads.Count > 0)
+                                            {
+                                                <MudDivider Class="my-3" />
+                                                <PayloadViewer Payloads="_openTransaction.Payloads"
+                                                               BlueprintId="@_openTransaction.BlueprintId"
+                                                               ActionId="@_openTransaction.ActionId" />
+                                            }
+                                        }
+                                    </div>
+                                </td>
+                            </MudTr>
+                        }
+                    </ChildRowContent>
                     <PagerContent>
                         <MudTablePager PageSizeOptions="new int[] { 10, 25, 50 }" />
                     </PagerContent>
@@ -114,6 +190,62 @@
     private string _searchText = "";
     private bool _loading = true;
     private bool _serviceError;
+
+    // Issue #1276 — inline drill-down. One row open at a time: the detail is dense, and two open at
+    // once turns the table into a wall.
+    private string? _openTxId;
+    private TransactionViewModel? _openTransaction;
+    private bool _detailLoading;
+    private bool _detailError;
+
+    /// <summary>
+    /// Whether the transaction went OUT from the selected wallet. Prefers the direction the query
+    /// mapper already computed, and falls back to comparing the sender — so a projection that
+    /// predates <c>Direction</c> (or any future caller that doesn't set it) still labels the row
+    /// correctly instead of silently calling everything "Received".
+    /// </summary>
+    private bool IsSent(TransactionViewModel tx) =>
+        string.Equals(tx.Direction, "Outbound", StringComparison.OrdinalIgnoreCase)
+        || (tx.Direction is null
+            && string.Equals(tx.SenderWallet, _selectedWalletAddress, StringComparison.OrdinalIgnoreCase));
+
+    /// <summary>The other party, from the selected wallet's point of view. Null when there isn't one.</summary>
+    private string? Counterparty(TransactionViewModel tx) =>
+        tx.CounterpartyAddress
+        ?? (IsSent(tx) ? tx.RecipientsWallets.FirstOrDefault() : tx.SenderWallet);
+
+    private async Task ToggleDetailAsync(TransactionQueryResultItem item)
+    {
+        if (_openTxId == item.Transaction.TxId)
+        {
+            _openTxId = null;
+            _openTransaction = null;
+            return;
+        }
+
+        _openTxId = item.Transaction.TxId;
+        _openTransaction = null;
+        _detailError = false;
+        _detailLoading = true;
+
+        try
+        {
+            // Deliberately re-fetched rather than reusing the list projection: the by-wallet query
+            // returns transaction headers, and the point of opening a row is to see the caller's own
+            // decrypted disclosure group, which only the per-transaction endpoint carries.
+            _openTransaction = await TransactionService.GetTransactionAsync(
+                item.RegisterId, item.Transaction.TxId);
+            _detailError = _openTransaction is null;
+        }
+        catch
+        {
+            _detailError = true;
+        }
+        finally
+        {
+            _detailLoading = false;
+        }
+    }
 
     private IEnumerable<TransactionQueryResultItem> FilteredTransactions =>
         string.IsNullOrWhiteSpace(_searchText)

--- a/tests/Sorcha.UI.Core.Tests/Pages/MyTransactionsTests.cs
+++ b/tests/Sorcha.UI.Core.Tests/Pages/MyTransactionsTests.cs
@@ -1,0 +1,199 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Bunit;
+using FluentAssertions;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Sorcha.UI.Core.Models.Registers;
+using Sorcha.UI.Core.Services;
+using Sorcha.UI.Core.Services.Wallet;
+using Sorcha.UI.Testing;
+using Sorcha.UI.Testing.Builders;
+using Xunit;
+using MyTransactionsPage = Sorcha.UI.Web.Client.Pages.MyTransactions;
+
+namespace Sorcha.UI.Core.Tests.Pages;
+
+/// <summary>
+/// Issue #1276 (UT-013) — My Transactions had no drill-down at all, and its "Sender" column showed
+/// other people's wallet addresses. The second is not a data bug: the page is really "transactions
+/// involving my wallet", so on a RECEIVED transaction the sender legitimately IS someone else.
+/// Labelling that column "Sender" made the citizen's own history read as a list of strangers.
+/// <para>
+/// Both halves were already answerable from data the page had in hand. <c>Direction</c> and
+/// <c>CounterpartyAddress</c> are computed by <c>MapToViewModel</c> for exactly this query and were
+/// simply never rendered; and <c>GET /api/registers/{registerId}/transactions/{txId}</c> already
+/// exists behind <see cref="ITransactionService.GetTransactionAsync"/>.
+/// </para>
+/// </summary>
+public sealed class MyTransactionsTests : ComponentTestFixture
+{
+    private readonly Mock<ITransactionService> _transactions = new();
+    private readonly Mock<IWalletApiService> _walletApi = new();
+
+    private const string MyWallet = "ws11qzxrmine0000000000000000000000000000";
+    private const string OtherWallet = "ws11qzxrtheirs00000000000000000000000000";
+    private const string RegisterId = "020fa3d14ac44ad0b9d54f7d010be7f3";
+
+    private static readonly TimeSpan LoadBudget = TimeSpan.FromSeconds(30);
+
+    public MyTransactionsTests()
+    {
+        Services.AddSingleton(_transactions.Object);
+        Services.AddSingleton(_walletApi.Object);
+        // PayloadViewer's schema overlay. Production gets this from AddCoreServices →
+        // AddRegisterServices, which the web client calls; the mock only stands in for the network.
+        Services.AddSingleton(Mock.Of<IBlueprintSchemaService>());
+        Services.AddSingleton(Mock.Of<ICurrentUserWalletService>());
+        Services.AddSingleton(Mock.Of<IPayloadDecoderService>());
+
+        _walletApi.Setup(w => w.GetWalletsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<WalletDto> { new WalletDtoBuilder().WithAddress(MyWallet).Build() });
+    }
+
+    private static TransactionViewModel Tx(
+        string txId, string sender, string? direction, string? counterparty,
+        IReadOnlyList<PayloadViewModel>? payloads = null) => new()
+    {
+        TxId = txId,
+        RegisterId = RegisterId,
+        SenderWallet = sender,
+        RecipientsWallets = sender == MyWallet ? [OtherWallet] : [MyWallet],
+        TimeStamp = DateTime.UtcNow.AddHours(-2),
+        DocketNumber = 14,
+        Signature = "sig",
+        Direction = direction,
+        CounterpartyAddress = counterparty,
+        Payloads = payloads ?? [],
+    };
+
+    // MudTablePager renders a MudSelect, whose popover needs a provider in the render tree —
+    // without it MudPopoverService throws during OnInitializedAsync and the page never renders.
+    private static readonly RenderFragment Page = builder =>
+    {
+        builder.OpenComponent<MudBlazor.MudPopoverProvider>(0);
+        builder.CloseComponent();
+        builder.OpenComponent<MyTransactionsPage>(1);
+        builder.CloseComponent();
+    };
+
+    private void ListReturns(params TransactionViewModel[] txs) =>
+        _transactions.Setup(t => t.QueryByWalletAsync(
+                MyWallet, It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new TransactionQueryResponse
+            {
+                Items = txs.Select(t => new TransactionQueryResultItem
+                {
+                    Transaction = t,
+                    RegisterId = RegisterId,
+                    RegisterName = "AIAS Assured Identity",
+                }).ToList(),
+                TotalCount = txs.Length,
+            });
+
+    [Fact]
+    public void AReceivedTransaction_ReadsAsReceivedFromTheCounterparty()
+    {
+        ListReturns(Tx("aa11", sender: OtherWallet, direction: "Inbound", counterparty: OtherWallet));
+
+        var cut = Render(Page);
+
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find("[data-testid='tx-direction-aa11']").TextContent.Should().Contain("Received");
+            cut.Find("[data-testid='tx-counterparty-aa11']").Should().NotBeNull();
+        }, LoadBudget);
+    }
+
+    [Fact]
+    public void ASentTransaction_ReadsAsSent()
+    {
+        ListReturns(Tx("bb22", sender: MyWallet, direction: "Outbound", counterparty: OtherWallet));
+
+        var cut = Render(Page);
+
+        cut.WaitForAssertion(
+            () => cut.Find("[data-testid='tx-direction-bb22']").TextContent.Should().Contain("Sent"),
+            LoadBudget);
+    }
+
+    [Fact]
+    public void TheTableNoLongerLabelsAColumnSender()
+    {
+        ListReturns(Tx("cc33", sender: OtherWallet, direction: "Inbound", counterparty: OtherWallet));
+
+        var cut = Render(Page);
+
+        cut.WaitForAssertion(() =>
+        {
+            cut.Markup.Should().Contain("Counterparty");
+            // "Sender" named the wrong thing on a page of the citizen's OWN transactions: on a
+            // received transaction it is a stranger's address, which is what made the list read as
+            // other people's business.
+            cut.Markup.Should().NotContain(">Sender<");
+        }, LoadBudget);
+    }
+
+    [Fact]
+    public void AMissingCounterparty_RendersAPlaceholder_NotABlankCell()
+    {
+        // A control/genesis transaction has no recipients, so MapToViewModel leaves the
+        // counterparty null. A blank cell reads as a rendering fault rather than an absence.
+        ListReturns(Tx("dd44", sender: MyWallet, direction: "Outbound", counterparty: null));
+
+        var cut = Render(Page);
+
+        cut.WaitForAssertion(
+            () => cut.Find("[data-testid='tx-counterparty-dd44']").TextContent.Trim()
+                .Should().NotBeNullOrWhiteSpace(),
+            LoadBudget);
+    }
+
+    [Fact]
+    public void OpeningARow_FetchesTheFullTransaction_AndShowsWhatWasSubmitted()
+    {
+        ListReturns(Tx("ee55", sender: MyWallet, direction: "Outbound", counterparty: OtherWallet));
+
+        // The list projection carries no payloads — the whole point of the drill-down is that it
+        // goes back for the caller's own decrypted disclosure group.
+        _transactions.Setup(t => t.GetTransactionAsync(RegisterId, "ee55", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Tx("ee55", MyWallet, "Outbound", OtherWallet, payloads:
+            [
+                new PayloadViewModel
+                {
+                    Index = 0,
+                    Hash = "h",
+                    IsAccessible = true,
+                    DecodedContent = "{\"postcode\":\"EH9 1JA\"}",
+                    IsJson = true,
+                    PrettyJson = "{\n  \"postcode\": \"EH9 1JA\"\n}",
+                },
+            ]));
+
+        var cut = Render(Page);
+
+        cut.WaitForAssertion(
+            () => cut.FindAll("[data-testid='tx-open-ee55']").Should().ContainSingle(),
+            LoadBudget);
+
+        cut.Find("[data-testid='tx-open-ee55']").Click();
+
+        cut.WaitForAssertion(() =>
+        {
+            cut.FindAll("[data-testid='tx-detail-ee55']").Should().ContainSingle(
+                "opening a row must reveal that transaction's detail");
+            cut.Markup.Should().Contain("EH9 1JA",
+                "the citizen opened their own transaction to see what it actually said");
+        }, LoadBudget);
+
+        _transactions.Verify(
+            t => t.GetTransactionAsync(RegisterId, "ee55", It.IsAny<CancellationToken>()), Times.Once);
+    }
+}


### PR DESCRIPTION
Closes #1276 (UT-013). Two defects — **both answerable from data the page already had in hand.**

## 1. The "Sender" column named the wrong thing

Not a data bug. The page lists transactions that **involve** the selected wallet, so on a *received* transaction the sender legitimately **is** someone else. Labelling that column "Sender" made the citizen's own history read as a list of strangers.

Replaced with **Direction** (Sent / Received) + **Counterparty** — the same two facts from the citizen's point of view. Both were **already computed** by the query mapper (`TransactionViewModel.Direction` / `.CounterpartyAddress`, set by `MapToViewModel` for exactly this query) and simply never rendered.

- `IsSent` prefers the mapper's `Direction` but **falls back to comparing the sender**, so a projection that doesn't set it labels rows correctly instead of silently calling everything "Received".
- A **null counterparty** (control/genesis transactions have no other party) renders an em dash. A blank cell reads as a rendering fault rather than an absence.

## 2. No drill-down at all

`GET /api/registers/{registerId}/transactions/{txId}` already existed behind `ITransactionService.GetTransactionAsync`, so this is purely UI.

- Disclosed **inline as an expanding row, not a dialog**: #1279 showed how badly a dialog of this density fares on a phone, and an expanding row keeps the citizen's place in the list.
- The detail is **re-fetched** rather than reused from the list projection — the by-wallet query returns headers, and the point of opening a row is to see the caller's own decrypted disclosure group, which only the per-transaction endpoint carries. Asserted with `Times.Once`.
- `TransactionDetail` and `PayloadViewer` are **reused** from the register-explorer library rather than re-implemented. Both are purely presentational over the same view model, and a second renderer of the same ledger facts is a second place for them to drift. Their DI dependencies (`IBlueprintSchemaService`, `ICurrentUserWalletService`, `IPayloadDecoderService`) were **verified registered for this host** — `AddCoreServices` → `AddRegisterServices` registers all three.

## Verification

| Suite | Result |
|---|---|
| `MyTransactionsTests` (new, 5) | pass — **all five verified red first**, failing on absent testids after the page rendered |
| `Sorcha.UI.Core.Tests` (1532) | 2 failed, neither mine: the pre-existing `MyCredentialsTests` red (fixed in #1293), and `RehearsalStepperTests.SwitchRole_DifferentRole_InvokesOnSwitchRole`, which **passes 9/9 in isolation** — flaky under parallel load, unrelated Designer component |

`MASTER-TASKS.md` deliberately untouched; Theme 9 doc updates are batched into one final pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RboWP2TKvm1nBG22nqsWek