### PR TITLE
fix: [UT-008] - persona provenance, the unselectable Default radio, and an autofill cue that never lit (#1271)

### DIFF
--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Forms/PersonaFillSummary.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Forms/PersonaFillSummary.razor
@@ -5,6 +5,7 @@
 @using MudBlazor
 @using Sorcha.Tenant.Models.Persona
 @using Sorcha.UI.Core.Models.Forms
+@using Sorcha.UI.Core.Models.Persona
 
 @* Feature 092 / US3 + US5 — one-line disclosure summary above the form.
    Two modes:
@@ -72,6 +73,16 @@ else if (Count > 0)
                                 </MudText>
                                 <MudText Typo="Typo.caption" Color="Color.Secondary">
                                     @fill.AttributeName — @FormatValue(fill.Value)
+                                </MudText>
+                                @* Issue #1271: PersonaFillResult has carried Source since Feature 092
+                                   and nothing ever rendered it, so a citizen reviewing what was
+                                   filled could not tell a value they typed themselves from one backed
+                                   by a credential. That is the same confusion that produced the
+                                   wrongful rejection in UT-001, so the review states it outright. *@
+                                <MudText Typo="Typo.caption" Color="Color.Secondary"
+                                         Class="persona-fill-review-provenance"
+                                         data-testid="@($"persona-fill-provenance-{pointer}")">
+                                    @PersonaProvenance.Describe(fill.Source, verifiedBy: null)
                                 </MudText>
                             </div>
                             <MudIconButton Icon="@Icons.Material.Filled.Clear"

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Forms/SorchaFormRenderer.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Forms/SorchaFormRenderer.razor
@@ -804,12 +804,15 @@
         InvokeAsync(StateHasChanged);
     }
 
+    // Issue #1271: this compared a LAYOUT field name ("email", "address") for exact equality against
+    // the resolver's filled set, which holds full JSON Pointers to leaves ("/email/email",
+    // "/address/postcode"). So the cream tint and the "self" tick only ever lit up for a fill that
+    // landed on a top-level scalar — and every real form, the AIAS application included, groups its
+    // fields into objects, so in practice they never lit up at all. PersonaFillScope matches on
+    // pointer segments (never a bare string prefix, or "/addressLine1" would light up "address" and
+    // tell the citizen something untrue about where their address came from).
     private bool IsPersonaFilled(string fieldName)
-    {
-        if (_personaFilledPaths.Count == 0) return false;
-        var key = fieldName.StartsWith('/') ? fieldName : "/" + fieldName;
-        return _personaFilledPaths.Contains(key);
-    }
+        => PersonaFillScope.CoversField(_personaFilledPaths, fieldName);
 
     private static string PersonaFilledAriaId(string fieldName)
     {

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Persona/PersonaEditor.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Persona/PersonaEditor.razor
@@ -5,6 +5,7 @@
 
 @using Microsoft.Extensions.Logging
 @using Sorcha.Tenant.Models.Persona
+@using Sorcha.UI.Core.Models.Persona
 @using Sorcha.UI.Core.Services.Feedback
 @using Sorcha.UI.Core.Services.Persona
 
@@ -13,10 +14,25 @@
         <MudIcon Icon="@Icons.Material.Filled.Person" Class="mr-2" />
         My Profile
     </MudText>
-    <MudText Typo="Typo.body1" Color="Color.Secondary" Class="mb-4">
+    <MudText Typo="Typo.body1" Color="Color.Secondary" Class="mb-2">
         Saved once, filled everywhere. Your profile is encrypted at rest and only ever
         used to autofill forms you open — nothing is shared with anyone else.
     </MudText>
+
+    @* Issue #1271: PersonaAttribute carries Source/VerifiedBy and nothing rendered them, so a
+       citizen could not tell a value they typed from one backed by a credential. That is not
+       cosmetic — UT-001 was a wrongful rejection caused by exactly this confusion between a
+       self-asserted profile value and a verified ACCOUNT claim. The statement is derived from the
+       provenance actually loaded rather than hardcoded, so it starts telling the truth about
+       credential-backed values the moment any exist rather than needing to be remembered. *@
+    @if (_provenanceSummary is not null)
+    {
+        <MudText Typo="Typo.body2" Color="Color.Secondary" Class="mb-4"
+                 data-testid="persona-provenance-summary">
+            <MudIcon Icon="@Icons.Material.Filled.EditNote" Size="Size.Small" Class="mr-1" />
+            @_provenanceSummary
+        </MudText>
+    }
 
     @if (_loadError is not null)
     {
@@ -321,8 +337,52 @@
         }
     }
 
+    /// <summary>
+    /// Issue #1271 — one sentence naming where the values on this page came from, derived from the
+    /// attributes actually loaded. Null when the profile is empty, so a blank page makes no claim.
+    /// </summary>
+    private string? _provenanceSummary;
+
+    private void BuildProvenanceSummary(PersonaReadModelV1 read)
+    {
+        var verified = new List<string>();
+        var anySelfAsserted = false;
+
+        void Note(PersonaAttributeSource source, string? verifiedBy)
+        {
+            if (source == PersonaAttributeSource.VerifiedCredential)
+            {
+                verified.Add(PersonaProvenance.Describe(source, verifiedBy));
+            }
+            else
+            {
+                anySelfAsserted = true;
+            }
+        }
+
+        if (read.GivenName is { } gn) Note(gn.Source, gn.VerifiedBy);
+        if (read.FamilyName is { } fn) Note(fn.Source, fn.VerifiedBy);
+        if (read.FullName is { } full) Note(full.Source, full.VerifiedBy);
+        if (read.DateOfBirth is { } dob) Note(dob.Source, dob.VerifiedBy);
+        if (read.DefaultEmail is { } de) Note(de.Source, de.VerifiedBy);
+        if (read.DefaultPhone is { } dp) Note(dp.Source, dp.VerifiedBy);
+        if (read.DefaultAddress is { } da) Note(da.Source, da.VerifiedBy);
+
+        if (!anySelfAsserted && verified.Count == 0)
+        {
+            _provenanceSummary = null;
+            return;
+        }
+
+        _provenanceSummary = verified.Count == 0
+            ? "You entered everything here yourself. Sorcha hasn't checked any of it — "
+              + "that's separate from your verified account details."
+            : $"Mostly entered by you. {string.Join("; ", verified.Distinct())}.";
+    }
+
     private void HydrateFromRead(PersonaReadModelV1 read)
     {
+        BuildProvenanceSummary(read);
         _givenName = read.GivenName?.Value;
         _familyName = read.FamilyName?.Value;
         _fullName = read.FullName?.Value;
@@ -334,6 +394,15 @@
         _phones.AddRange(read.AllPhones);
         _addresses.Clear();
         _addresses.AddRange(read.AllAddresses);
+
+        // Issue #1271: the read model does not promise that any row is flagged default, so a citizen
+        // with exactly ONE email saw a Default radio with nothing selected — which reads as a broken
+        // control, not as a meaningful state. Normalised at hydrate rather than at render so the
+        // value shown selected is the value that gets saved.
+        PersonaDefaultSelection.EnsureOne(_emails, r => r.IsDefault, (r, d) => r with { IsDefault = d });
+        PersonaDefaultSelection.EnsureOne(_phones, r => r.IsDefault, (r, d) => r with { IsDefault = d });
+        PersonaDefaultSelection.EnsureOne(_addresses, r => r.IsDefault, (r, d) => r with { IsDefault = d });
+
         _nationalities.Clear();
         _nationalities.AddRange(read.AllNationalities);
         _defaultNationality = read.DefaultNationality?.Value ?? _nationalities.FirstOrDefault();

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Models/User/Forms/PersonaFillScope.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Models/User/Forms/PersonaFillScope.cs
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+namespace Sorcha.UI.Core.Models.Forms;
+
+/// <summary>
+/// Decides whether a layout field is covered by the persona-autofill result set.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Issue #1271 (UT-008): the per-field "filled from your profile" cue never appeared. The markup and
+/// the CSS both existed — <c>SorchaFormRenderer</c> emits <c>class="… autofilled"</c> plus a
+/// <c>persona-tick</c> pill, and the scoped stylesheet carries the cream background and warm border.
+/// What was broken is the MATCH: the renderer asks about a field name from the layout's
+/// <c>x-sections</c> ("email", "address") and compared it for exact equality against the resolver's
+/// filled set, which holds full JSON Pointers to leaves ("/email/email", "/address/postcode").
+/// </para>
+/// <para>
+/// The cue therefore only ever lit up for a fill that landed on a top-level scalar. Every real form
+/// groups fields into objects, so in practice it never lit up at all — and the citizen got no
+/// per-field indication that a value came from their profile.
+/// </para>
+/// <para>
+/// Matching is on pointer SEGMENTS, not on a bare string prefix: "/addressLine1" must not satisfy
+/// "address", or the form would tell the citizen their address came from their profile when it did
+/// not. A false cue about provenance is worse than no cue.
+/// </para>
+/// </remarks>
+public static class PersonaFillScope
+{
+    /// <summary>
+    /// True when any filled pointer is the field itself or sits beneath it.
+    /// <paramref name="fieldName"/> may be a bare name or already pointer-shaped.
+    /// </summary>
+    public static bool CoversField(IReadOnlyCollection<string> filledPointers, string fieldName)
+    {
+        if (filledPointers is null || filledPointers.Count == 0) return false;
+        if (string.IsNullOrWhiteSpace(fieldName)) return false;
+
+        var root = fieldName.StartsWith('/') ? fieldName : "/" + fieldName;
+        var beneath = root + "/";
+
+        foreach (var pointer in filledPointers)
+        {
+            if (string.Equals(pointer, root, StringComparison.Ordinal)) return true;
+            if (pointer.StartsWith(beneath, StringComparison.Ordinal)) return true;
+        }
+
+        return false;
+    }
+}

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Models/User/Persona/PersonaDefaultSelection.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Models/User/Persona/PersonaDefaultSelection.cs
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+namespace Sorcha.UI.Core.Models.Persona;
+
+/// <summary>
+/// Normalises a persona list so exactly one row is flagged as the default.
+/// </summary>
+/// <remarks>
+/// Issue #1271 (UT-008): the Default radio rendered with nothing selected even when the citizen had
+/// exactly one email. The editor hydrates its rows verbatim from the read model, and a persona whose
+/// default was never explicitly set comes back with every row's <c>IsDefault</c> false. "One value,
+/// and it is not the default" is not a state that means anything to a citizen — it just reads as a
+/// broken control. Applied at hydrate rather than at render so the value the citizen sees selected is
+/// the value that gets saved.
+/// </remarks>
+public static class PersonaDefaultSelection
+{
+    /// <summary>
+    /// Ensures exactly one row is default, in place. An explicit default is preserved; when none is
+    /// set the first row is promoted; when several are set all but the first are cleared (the read
+    /// model does not promise exactly one, and two selected radios in one group is a worse control
+    /// than none). An empty list is left empty — a default is never invented out of nothing.
+    /// </summary>
+    public static void EnsureOne<T>(IList<T> rows, Func<T, bool> isDefault, Func<T, bool, T> withDefault)
+    {
+        ArgumentNullException.ThrowIfNull(rows);
+        ArgumentNullException.ThrowIfNull(isDefault);
+        ArgumentNullException.ThrowIfNull(withDefault);
+
+        if (rows.Count == 0) return;
+
+        var chosen = -1;
+        for (var i = 0; i < rows.Count; i++)
+        {
+            if (!isDefault(rows[i])) continue;
+            chosen = i;
+            break;
+        }
+
+        if (chosen < 0) chosen = 0;
+
+        for (var i = 0; i < rows.Count; i++)
+        {
+            var shouldBeDefault = i == chosen;
+            if (isDefault(rows[i]) != shouldBeDefault)
+            {
+                rows[i] = withDefault(rows[i], shouldBeDefault);
+            }
+        }
+    }
+}

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Models/User/Persona/PersonaProvenance.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Models/User/Persona/PersonaProvenance.cs
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using Sorcha.Tenant.Models.Persona;
+
+namespace Sorcha.UI.Core.Models.Persona;
+
+/// <summary>
+/// Turns a persona attribute's provenance into citizen-facing words.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Issue #1271 (UT-008): <see cref="PersonaAttribute{T}.Source"/> and
+/// <see cref="PersonaAttribute{T}.VerifiedBy"/> are carried all the way to the UI and then dropped —
+/// nothing rendered them, so a citizen could not tell a value they had typed themselves from one
+/// backed by a credential.
+/// </para>
+/// <para>
+/// That gap is not cosmetic. UT-001 was a wrongful rejection caused by exactly this confusion
+/// between two different notions of "verified": a self-asserted persona value and a verified account
+/// claim. The wording is deliberately blunt — "You entered this" makes no claim of verification, and
+/// an unrecognised source falls back to it, because over-claiming verification is the dangerous
+/// direction.
+/// </para>
+/// </remarks>
+public static class PersonaProvenance
+{
+    /// <summary>Short provenance label, e.g. "You entered this" or "Verified by did:sorcha:aias".</summary>
+    public static string Describe(PersonaAttributeSource source, string? verifiedBy) =>
+        source switch
+        {
+            PersonaAttributeSource.VerifiedCredential when !string.IsNullOrWhiteSpace(verifiedBy)
+                => $"Verified by {verifiedBy}",
+            PersonaAttributeSource.VerifiedCredential => "Verified by a credential",
+            _ => "You entered this",
+        };
+}

--- a/tests/Sorcha.UI.Components.User.Tests/Forms/PersonaFillScopeTests.cs
+++ b/tests/Sorcha.UI.Components.User.Tests/Forms/PersonaFillScopeTests.cs
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Collections.Generic;
+using FluentAssertions;
+using Sorcha.UI.Core.Models.Forms;
+using Xunit;
+
+namespace Sorcha.UI.Components.User.Tests.Forms;
+
+/// <summary>
+/// Issue #1271 (UT-008, point 4) — "no per-field cream tint / self tick on autofilled fields".
+/// <para>
+/// The markup and the CSS both existed all along: <c>SorchaFormRenderer</c> emits
+/// <c>class="… autofilled"</c> plus a <c>persona-tick</c> pill, and the scoped stylesheet carries the
+/// cream background and warm border for both. What was broken is the MATCH. The renderer asks
+/// "is this field persona-filled?" using the field name from the layout's <c>x-sections</c>
+/// (<c>"email"</c>, <c>"address"</c>) and compared it for EXACT equality against the resolver's
+/// filled set, which holds full JSON Pointers to leaves (<c>"/email/email"</c>,
+/// <c>"/address/postcode"</c>).
+/// </para>
+/// <para>
+/// So the cue only ever lit up for a persona fill that landed on a TOP-LEVEL scalar. Every real form
+/// — the AIAS application included — groups its fields into objects, so it never lit up at all. The
+/// citizen was given no per-field indication that a value had come from their profile.
+/// </para>
+/// </summary>
+public sealed class PersonaFillScopeTests
+{
+    [Fact]
+    public void ANestedFillMarksItsContainingField()
+    {
+        // Exactly the AIAS shape: the layout section names "email", the resolver fills "/email/email".
+        var filled = new HashSet<string> { "/email/email" };
+
+        PersonaFillScope.CoversField(filled, "email").Should().BeTrue(
+            "the citizen's email WAS filled from their profile — the field must say so");
+    }
+
+    [Fact]
+    public void ADeeplyNestedFillStillMarksTheTopLevelField()
+    {
+        var filled = new HashSet<string> { "/address/postcode", "/address/town" };
+
+        PersonaFillScope.CoversField(filled, "address").Should().BeTrue();
+    }
+
+    [Fact]
+    public void ATopLevelFillStillMatches()
+    {
+        var filled = new HashSet<string> { "/fullName" };
+
+        PersonaFillScope.CoversField(filled, "fullName").Should().BeTrue();
+        PersonaFillScope.CoversField(filled, "/fullName").Should().BeTrue(
+            "callers pass the layout's field name, which may or may not be pointer-shaped");
+    }
+
+    [Fact]
+    public void AFieldWhoseNameIsAPrefixOfAnotherIsNotMarked()
+    {
+        // The decisive case for prefix matching: "/addressLine1" must NOT satisfy "address".
+        // A bare StartsWith would light up the wrong field and quietly tell the citizen their
+        // address came from their profile when it did not.
+        var filled = new HashSet<string> { "/addressLine1" };
+
+        PersonaFillScope.CoversField(filled, "address").Should().BeFalse();
+    }
+
+    [Fact]
+    public void AnUnfilledFieldIsNotMarked()
+    {
+        var filled = new HashSet<string> { "/email/email" };
+
+        PersonaFillScope.CoversField(filled, "portrait").Should().BeFalse();
+    }
+
+    [Fact]
+    public void NothingFilledMarksNothing()
+        => PersonaFillScope.CoversField(new HashSet<string>(), "email").Should().BeFalse();
+}

--- a/tests/Sorcha.UI.Components.User.Tests/Persona/PersonaDefaultSelectionTests.cs
+++ b/tests/Sorcha.UI.Components.User.Tests/Persona/PersonaDefaultSelectionTests.cs
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Collections.Generic;
+using FluentAssertions;
+using Sorcha.Tenant.Models.Persona;
+using Sorcha.UI.Core.Models.Persona;
+using Xunit;
+
+namespace Sorcha.UI.Components.User.Tests.Persona;
+
+/// <summary>
+/// Issue #1271 (UT-008, point 3) — the Default radio rendered with nothing selected even when the
+/// citizen had exactly one email. The editor hydrates its rows verbatim from the read model, and a
+/// persona whose default was never explicitly set comes back with every row's <c>IsDefault</c>
+/// false. "One value, and it is not the default" is not a state that means anything to a citizen —
+/// it just reads as a broken control.
+/// </summary>
+public sealed class PersonaDefaultSelectionTests
+{
+    private static PersonaEmail Email(string address, bool isDefault) => new(address, isDefault);
+
+    [Fact]
+    public void ASingleRowWithNoDefaultBecomesTheDefault()
+    {
+        var rows = new List<PersonaEmail> { Email("a@example.test", false) };
+
+        PersonaDefaultSelection.EnsureOne(rows, r => r.IsDefault, (r, d) => r with { IsDefault = d });
+
+        rows[0].IsDefault.Should().BeTrue();
+    }
+
+    [Fact]
+    public void SeveralRowsWithNoDefaultPromoteTheFirst()
+    {
+        var rows = new List<PersonaEmail>
+        {
+            Email("a@example.test", false),
+            Email("b@example.test", false),
+        };
+
+        PersonaDefaultSelection.EnsureOne(rows, r => r.IsDefault, (r, d) => r with { IsDefault = d });
+
+        rows[0].IsDefault.Should().BeTrue();
+        rows[1].IsDefault.Should().BeFalse();
+    }
+
+    [Fact]
+    public void AnExplicitDefaultIsLeftAlone()
+    {
+        var rows = new List<PersonaEmail>
+        {
+            Email("a@example.test", false),
+            Email("b@example.test", true),
+        };
+
+        PersonaDefaultSelection.EnsureOne(rows, r => r.IsDefault, (r, d) => r with { IsDefault = d });
+
+        rows[0].IsDefault.Should().BeFalse("promoting the first would silently move the citizen's choice");
+        rows[1].IsDefault.Should().BeTrue();
+    }
+
+    [Fact]
+    public void SeveralDefaultsAreReducedToTheFirst()
+    {
+        // Defensive: the read model does not promise exactly one, and two selected radios in one
+        // group is a worse control than none.
+        var rows = new List<PersonaEmail>
+        {
+            Email("a@example.test", true),
+            Email("b@example.test", true),
+        };
+
+        PersonaDefaultSelection.EnsureOne(rows, r => r.IsDefault, (r, d) => r with { IsDefault = d });
+
+        rows.Should().SatisfyRespectively(
+            first => first.IsDefault.Should().BeTrue(),
+            second => second.IsDefault.Should().BeFalse());
+    }
+
+    [Fact]
+    public void AnEmptyListIsLeftEmpty_NoDefaultIsInvented()
+    {
+        var rows = new List<PersonaEmail>();
+
+        PersonaDefaultSelection.EnsureOne(rows, r => r.IsDefault, (r, d) => r with { IsDefault = d });
+
+        rows.Should().BeEmpty();
+    }
+}

--- a/tests/Sorcha.UI.Components.User.Tests/Persona/PersonaProvenanceTests.cs
+++ b/tests/Sorcha.UI.Components.User.Tests/Persona/PersonaProvenanceTests.cs
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using FluentAssertions;
+using Sorcha.Tenant.Models.Persona;
+using Sorcha.UI.Core.Models.Persona;
+using Xunit;
+
+namespace Sorcha.UI.Components.User.Tests.Persona;
+
+/// <summary>
+/// Issue #1271 (UT-008, point 2) — <c>PersonaAttribute&lt;T&gt;.Source</c> and <c>VerifiedBy</c> are
+/// carried all the way to the UI and then dropped on the floor. Nothing rendered them, so the
+/// citizen could not tell a value they had typed themselves from one backed by a credential.
+/// <para>
+/// That gap is not cosmetic. UT-001 was a wrongful rejection caused by exactly this confusion
+/// between two different notions of "verified" — a self-asserted persona value versus a verified
+/// account claim. The wording here is deliberately blunt about which one it is.
+/// </para>
+/// </summary>
+public sealed class PersonaProvenanceTests
+{
+    [Fact]
+    public void ASelfAssertedValueSaysSo_WithoutClaimingVerification()
+    {
+        var label = PersonaProvenance.Describe(PersonaAttributeSource.SelfAsserted, verifiedBy: null);
+
+        label.Should().Be("You entered this");
+        label.Should().NotContainEquivalentOf("verified",
+            "the whole point is that a self-asserted value has NOT been verified by anyone");
+    }
+
+    [Fact]
+    public void ACredentialBackedValueNamesItsIssuer()
+    {
+        var label = PersonaProvenance.Describe(
+            PersonaAttributeSource.VerifiedCredential, verifiedBy: "did:sorcha:aias");
+
+        label.Should().Be("Verified by did:sorcha:aias");
+    }
+
+    [Fact]
+    public void ACredentialBackedValueWithNoIssuerStillReadsAsVerified()
+    {
+        // VerifiedBy is nullable on the contract, so the label must not degrade into
+        // "Verified by " with a dangling preposition.
+        PersonaProvenance.Describe(PersonaAttributeSource.VerifiedCredential, verifiedBy: null)
+            .Should().Be("Verified by a credential");
+    }
+
+    [Fact]
+    public void AnUnknownSourceIsDescribedAsSelfAsserted_TheSaferClaim()
+    {
+        // Overclaiming verification is the dangerous direction: it is what let a self-asserted value
+        // read as assured. An unrecognised source therefore falls back to the weaker statement.
+        PersonaProvenance.Describe((PersonaAttributeSource)99, verifiedBy: null)
+            .Should().Be("You entered this");
+    }
+}


### PR DESCRIPTION
Points **2–4** of #1271 (UT-008). **Point 1 is disproved** — `PersonaEditor` has had unconditional Addresses and Nationalities sections all along; they were hidden by #1274's overlap. Recorded on the issue.

## Point 4 — the cue was not missing, the MATCH was broken

"No per-field cream tint / `self` tick" was **not a missing feature**. The markup and the CSS both existed: `SorchaFormRenderer` emits `class="… autofilled"` plus a `persona-tick` pill, and the scoped stylesheet carries the cream background and warm border for both, light and dark.

What was broken: `IsPersonaFilled` was handed a field name from the layout's `x-sections` (`"email"`, `"address"`) and compared it for **exact equality** against the resolver's filled set, which holds full JSON Pointers to leaves (`"/email/email"`, `"/address/postcode"`). So the cue only ever lit for a fill landing on a **top-level scalar** — and every real form, the AIAS application included, groups its fields into objects. In practice it never lit at all.

`PersonaFillScope` matches on pointer **segments**, never a bare string prefix: `"/addressLine1"` must not satisfy `"address"`, because a **false** cue about provenance is worse than no cue.

## Point 3 — a Default radio with nothing selected

The editor hydrates rows verbatim, and the read model does not promise any row is flagged default. "One value, and it is not the default" is not a state that means anything to a citizen — it just reads as a broken control.

`PersonaDefaultSelection` normalises **at hydrate, not at render**, so the value shown selected is the value that gets saved. An explicit default is preserved; several are reduced to the first; an empty list never has one invented.

## Point 2 — provenance was carried to the UI and dropped on the floor

`PersonaAttribute.Source` / `.VerifiedBy` reached the UI and nothing rendered them. **Not cosmetic:** UT-001 was a wrongful rejection caused by exactly this confusion between a self-asserted profile value and a verified **account** claim.

- The autofill review now states provenance **per field**.
- The profile carries one sentence **derived from the attributes actually loaded**, not hardcoded — so it starts naming credential-backed values the moment any exist, rather than needing to be remembered at v2.
- Wording is deliberately blunt: **"You entered this"** claims no verification, and an unrecognised source falls back to it, because **over-claiming verification is the dangerous direction**.

## Verification

All red-verified first (helpers moved aside, build failed on the missing types).

| Guard | |
|---|---|
| `PersonaFillScopeTests` | 6 — incl. the decisive `/addressLine1` vs `address` case |
| `PersonaDefaultSelectionTests` | 5 |
| `PersonaProvenanceTests` | 4 |

| Suite | Result |
|---|---|
| `Sorcha.UI.Core.Tests` | 1540 / 1540 |
| `Sorcha.UI.Components.User.Tests` | 96 / 96 |
| Web client + Wallet PWA | build clean |

`MASTER-TASKS.md` deliberately untouched; Theme 9 doc updates are batched into one final pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RboWP2TKvm1nBG22nqsWek