### PR TITLE
fix: [UT-007] - the pairing surface had no idea it was on a phone (#1270)

### DIFF
--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Pairing/PairingHandoffSurface.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Pairing/PairingHandoffSurface.razor
@@ -55,6 +55,35 @@
             Preparing your pairing code…
         </p>
     }
+    else if (_route == PairingHandoffRoute.OpenOnThisDevice)
+    {
+        @* Issue #1270 / FR-008 — the same-device path, which previously did not exist at all. A
+           mobile browser that cannot install (in-app browser, non-Safari iOS, or an Android device
+           that ALREADY installed the wallet so beforeinstallprompt never fires again) used to be
+           handed the desktop QR: a code to scan with the phone already in the citizen's hand.
+           The minted QrUrl is precisely the URL a scanning phone would open, so on this device we
+           simply follow it. *@
+        <p class="sorcha-pair-handoff__subhead">
+            Your Sorcha credentials live on this phone. Open the wallet here to finish setting up.
+        </p>
+        <a class="sorcha-pair-handoff__primary"
+           href="@_minted.QrUrl"
+           data-testid="pairing-handoff-open-here">
+            Open on this device
+        </a>
+        <p class="sorcha-pair-handoff__aside">
+            Setting up a different phone? <button type="button" class="sorcha-pair-handoff__link"
+                                                  @onclick="ShowQrAnyway"
+                                                  data-testid="pairing-handoff-show-qr">Show a QR code
+            to scan</button> instead.
+        </p>
+        @if (_qrRevealed)
+        {
+            <div class="sorcha-pair-handoff__qr-frame">
+                <HybridQrAffordance QrUrl="@_minted.QrUrl" ExpiresAt="@_minted.ExpiresAt" />
+            </div>
+        }
+    }
     else if (_installVerdict == PwaInstallabilityVerdict.CanInstallProgrammatically)
     {
         @* US3 install variant — Android Chrome / Edge with deferred prompt. *@
@@ -145,11 +174,18 @@
     private bool _emailLinkBusy;
     private bool _emailLinkSent;
     private bool _installBusy;
+    private bool _qrRevealed;
     private PwaInstallabilityVerdict _installVerdict = PwaInstallabilityVerdict.CannotInstall;
+    private PairingHandoffRoute _route = PairingHandoffRoute.ScanWithYourPhone;
+
+    private void ShowQrAnyway() => _qrRevealed = true;
 
     protected override async Task OnInitializedAsync()
     {
         _installVerdict = await InstallProbe.ProbeAsync();
+        // Issue #1270: installability alone cannot distinguish a desktop from a phone that simply
+        // offers no install affordance, and the surface used to conflate them.
+        _route = PairingHandoffRouting.Choose(_installVerdict, await InstallProbe.IsMobileAsync());
         await MintAsync();
 
         // Mint the short code only when the surface will render the

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Pairing/PairingHandoffSurface.razor.css
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Pairing/PairingHandoffSurface.razor.css
@@ -1,0 +1,184 @@
+/* SPDX-License-Identifier: MIT */
+/* Copyright (c) 2026 Sorcha Contributors */
+
+/*
+ * Issue #1270 — this stylesheet did not exist.
+ *
+ * Every `sorcha-pair-handoff__*` class in the component resolved to nothing, so
+ * the surface rendered as unstyled flow content: "Install Sorcha Wallet" and
+ * "Try again" were bare buttons with no hit target worth the name, and the two
+ * footer buttons sat inline with no separation — which is why the citizen read
+ * "Email me a link Skip for now" as a single run-together line.
+ *
+ * Mobile-first: this page is reached on a phone far more often than on a
+ * desktop, and it is the first thing a cold-start citizen sees.
+ */
+
+.sorcha-pair-handoff {
+    max-width: 32rem;
+    margin: 0 auto;
+    padding: 1.5rem 1.25rem 2rem;
+    text-align: center;
+}
+
+.sorcha-pair-handoff__headline {
+    font-size: 1.5rem;
+    line-height: 1.25;
+    font-weight: 600;
+    margin: 0 0 0.75rem;
+}
+
+/*
+ * The headline is a heading, not a control. It picked up a focus ring because
+ * the surface sits inside a scroll container that browsers make focusable —
+ * making the ring look like it belonged to the text. Headings never take focus
+ * here, so suppress it explicitly rather than leaving it to chance.
+ */
+.sorcha-pair-handoff__headline:focus,
+.sorcha-pair-handoff__headline:focus-visible {
+    outline: none;
+}
+
+.sorcha-pair-handoff__subhead {
+    font-size: 1rem;
+    line-height: 1.5;
+    margin: 0 0 1.25rem;
+    color: var(--mud-palette-text-secondary, #5f6368);
+}
+
+.sorcha-pair-handoff__aside {
+    font-size: 0.875rem;
+    line-height: 1.5;
+    margin: 1rem 0 0;
+    color: var(--mud-palette-text-secondary, #5f6368);
+}
+
+/* ---- Primary actions -------------------------------------------------- */
+
+/*
+ * 48px min-height is the floor for a comfortable touch target; these were
+ * previously default-height inline buttons.
+ */
+.sorcha-pair-handoff__primary,
+.sorcha-pair-handoff__install {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    min-height: 48px;
+    padding: 0.75rem 1.25rem;
+    border: none;
+    border-radius: 8px;
+    font-size: 1rem;
+    font-weight: 600;
+    text-decoration: none;
+    cursor: pointer;
+    background: var(--mud-palette-primary, #4f46e5);
+    color: var(--mud-palette-primary-text, #fff);
+}
+
+.sorcha-pair-handoff__primary:hover,
+.sorcha-pair-handoff__install:hover:not([disabled]) {
+    filter: brightness(0.94);
+}
+
+.sorcha-pair-handoff__install[disabled] {
+    opacity: 0.6;
+    cursor: default;
+}
+
+/* ---- Secondary / footer actions --------------------------------------- */
+
+/*
+ * The run-together line. These were two adjacent inline buttons with no gap;
+ * stacking them full-width both separates them and gives each a real target.
+ */
+.sorcha-pair-handoff__footer {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    margin-top: 2rem;
+}
+
+.sorcha-pair-handoff__email-link,
+.sorcha-pair-handoff__skip,
+.sorcha-pair-handoff__retry {
+    min-height: 44px;
+    padding: 0.625rem 1rem;
+    border-radius: 8px;
+    border: 1px solid var(--mud-palette-lines-default, #d8dae0);
+    background: transparent;
+    font-size: 0.9375rem;
+    cursor: pointer;
+    color: inherit;
+}
+
+.sorcha-pair-handoff__skip {
+    border-color: transparent;
+    color: var(--mud-palette-text-secondary, #5f6368);
+}
+
+.sorcha-pair-handoff__email-link[disabled] {
+    opacity: 0.6;
+    cursor: default;
+}
+
+/* An inline text button inside a sentence — must read as a link, not a button. */
+.sorcha-pair-handoff__link {
+    border: none;
+    background: none;
+    padding: 0;
+    font: inherit;
+    color: var(--mud-palette-primary, #4f46e5);
+    text-decoration: underline;
+    cursor: pointer;
+}
+
+/* ---- QR + short code --------------------------------------------------- */
+
+.sorcha-pair-handoff__qr-frame {
+    display: flex;
+    justify-content: center;
+    margin: 1rem 0;
+}
+
+.sorcha-pair-handoff__ios-instructions {
+    text-align: left;
+    margin: 0 0 1.25rem;
+    padding-left: 1.25rem;
+    line-height: 1.6;
+}
+
+.sorcha-pair-handoff__short-code {
+    margin-top: 1.25rem;
+    padding: 1rem;
+    border-radius: 8px;
+    background: var(--mud-palette-background-gray, #f5f5f7);
+}
+
+.sorcha-pair-handoff__short-code-value {
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 2rem;
+    font-weight: 700;
+    letter-spacing: 0.2em;
+    /* Trailing letter-spacing would push the code visibly off-centre. */
+    text-indent: 0.2em;
+    margin: 0.5rem 0;
+}
+
+.sorcha-pair-handoff__short-code-hint {
+    font-size: 0.8125rem;
+    color: var(--mud-palette-text-secondary, #5f6368);
+    margin: 0;
+}
+
+.sorcha-pair-handoff__error {
+    padding: 1rem;
+    border-radius: 8px;
+    background: var(--mud-palette-error-lighten, #fdecea);
+    color: var(--mud-palette-error-darken, #8c1c13);
+}
+
+.sorcha-pair-handoff__loading {
+    color: var(--mud-palette-text-secondary, #5f6368);
+}

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Pairing/PairingNagBanner.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Pairing/PairingNagBanner.razor
@@ -17,7 +17,9 @@
 
 @using Microsoft.Extensions.Logging
 @using Sorcha.UI.Core.Services.User.Devices
+@using Sorcha.UI.Core.Services.Wallet
 @inject IHasPairedDeviceProbe Probe
+@inject IWalletApiService WalletApi
 @inject NavigationManager Nav
 @inject ILogger<PairingNagBanner> Logger
 @implements IDisposable
@@ -52,9 +54,37 @@
     private bool _dismissed;
     private bool _visible;
 
+    // Issue #1270. Two reasons this banner must stay quiet that it did not know about:
+    //
+    //  * It rendered ABOVE the pairing page itself — nagging the citizen to go and do the thing
+    //    they are already doing, and pushing the actual instructions down the screen.
+    //  * It was not wallet-aware the way F149 made PairingTakeover. Pairing a phone before a wallet
+    //    exists dead-ends at the device-enrol 404; F149's answer on the PWA is "create your wallet
+    //    first". On the web the wallet CTA already owns that moment on Home, so the right move here
+    //    is silence, not a second competing call to action.
+    private bool _hasWallet = true;
+
+    // Path of the page this banner's own CTA leads to. Nagging on it is self-defeating.
+    private const string PairingPath = "setup/add-device";
+
     protected override async Task OnInitializedAsync()
     {
         Probe.Changed += HandleProbeChanged;
+
+        try
+        {
+            var wallets = await WalletApi.GetWalletsAsync();
+            _hasWallet = wallets.Count > 0;
+        }
+        catch (Exception ex)
+        {
+            // Fail-safe in the same direction as F149's IHasWalletProbe: assume a wallet exists, so
+            // a transient failure degrades to the pre-existing nag rather than silently suppressing
+            // a prompt the citizen genuinely needs.
+            Logger.LogDebug(ex, "PairingNagBanner wallet check failed — assuming a wallet exists");
+            _hasWallet = true;
+        }
+
         await Probe.EnsureLoadedAsync();
         UpdateVisibility();
     }
@@ -68,8 +98,19 @@
     private void UpdateVisibility()
     {
         // Show only when the probe has resolved AND reports no paired device
-        // AND the citizen hasn't dismissed this session.
-        _visible = !_dismissed && Probe.HasAnyDevice == false;
+        // AND the citizen hasn't dismissed this session AND they have a wallet
+        // for a paired phone to hold AND they aren't already on the pairing page.
+        _visible = !_dismissed
+                   && Probe.HasAnyDevice == false
+                   && _hasWallet
+                   && !IsOnPairingPage();
+    }
+
+    private bool IsOnPairingPage()
+    {
+        var relative = Nav.ToBaseRelativePath(Nav.Uri);
+        var path = relative.Split('?', '#')[0].TrimEnd('/');
+        return string.Equals(path, PairingPath, StringComparison.OrdinalIgnoreCase);
     }
 
     private void HandleDismiss()

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/Pairing/IPwaInstallabilityProbe.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/Pairing/IPwaInstallabilityProbe.cs
@@ -60,4 +60,14 @@ public interface IPwaInstallabilityProbe
     /// dismissal or any failure.
     /// </summary>
     Task<bool> TriggerInstallAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Whether the citizen is on a phone-shaped device, independent of whether the browser can
+    /// install anything. Issue #1270: without this second axis the handoff surface could only ask
+    /// "installable?" and treated "no" as "desktop", so a mobile browser with no install affordance
+    /// was shown a QR code to scan with the phone it was running on. Coarse by design — it decides
+    /// which affordance leads, never anything security-relevant. Fails safe to <c>false</c>
+    /// (desktop), which is the pre-existing behaviour.
+    /// </summary>
+    Task<bool> IsMobileAsync(CancellationToken ct = default);
 }

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/Pairing/PairingHandoffRouting.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/Pairing/PairingHandoffRouting.cs
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+namespace Sorcha.UI.Core.Services.User.Pairing;
+
+/// <summary>Which handoff path the F128 surface should lead with.</summary>
+public enum PairingHandoffRoute
+{
+    /// <summary>Install the wallet PWA on the device the citizen is holding.</summary>
+    InstallOnThisPhone = 0,
+
+    /// <summary>
+    /// Open the already-reachable wallet on this device. The same-device path for a mobile browser
+    /// that offers no install affordance — FR-008's case, and the one that was missing.
+    /// </summary>
+    OpenOnThisDevice = 1,
+
+    /// <summary>Desktop: mint a QR and let the citizen scan it with their phone.</summary>
+    ScanWithYourPhone = 2,
+}
+
+/// <summary>
+/// Chooses the handoff path from the two facts that actually matter: can this browser install the
+/// PWA, and is this a phone.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Issue #1270: the surface only ever had ONE axis. <see cref="IPwaInstallabilityProbe"/> answers
+/// "can this browser install the PWA?" and the surface treated "no" as "this is a desktop".
+/// <b>Mobile-but-not-installable is neither.</b> An Android citizen who already installed the wallet
+/// (so <c>beforeinstallprompt</c> never fires again), anyone in an in-app browser, and every
+/// non-Safari iOS browser all land there — and were shown a QR code to scan with the phone they were
+/// already holding, with the same-device route buried below two screenfuls of it.
+/// </para>
+/// <para>
+/// A positive install verdict is NOT overridden by the mobile axis: Chromium on a desktop genuinely
+/// does fire <c>beforeinstallprompt</c>, and installing there is a real outcome.
+/// </para>
+/// </remarks>
+public static class PairingHandoffRouting
+{
+    /// <summary>Picks the route. Unknown verdicts on mobile stay on a same-device path by design.</summary>
+    public static PairingHandoffRoute Choose(PwaInstallabilityVerdict verdict, bool isMobile) =>
+        verdict switch
+        {
+            PwaInstallabilityVerdict.CanInstallProgrammatically or
+            PwaInstallabilityVerdict.CanInstallManually => PairingHandoffRoute.InstallOnThisPhone,
+
+            _ when isMobile => PairingHandoffRoute.OpenOnThisDevice,
+            _ => PairingHandoffRoute.ScanWithYourPhone,
+        };
+}

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/Pairing/PwaInstallabilityProbe.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/Pairing/PwaInstallabilityProbe.cs
@@ -20,6 +20,7 @@ public sealed class PwaInstallabilityProbe : IPwaInstallabilityProbe
     private readonly ILogger<PwaInstallabilityProbe> _logger;
     private IJSObjectReference? _module;
     private PwaInstallabilityVerdict? _cachedVerdict;
+    private bool? _cachedIsMobile;
 
     public PwaInstallabilityProbe(IJSRuntime js, ILogger<PwaInstallabilityProbe> logger)
     {
@@ -58,6 +59,32 @@ public sealed class PwaInstallabilityProbe : IPwaInstallabilityProbe
                 "PwaInstallabilityProbe failed — defaulting to CannotInstall");
             _cachedVerdict = PwaInstallabilityVerdict.CannotInstall;
             return _cachedVerdict.Value;
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> IsMobileAsync(CancellationToken ct = default)
+    {
+        if (_cachedIsMobile.HasValue)
+        {
+            return _cachedIsMobile.Value;
+        }
+
+        try
+        {
+            _module ??= await _js.InvokeAsync<IJSObjectReference>("import", ct, ModulePath)
+                .ConfigureAwait(false);
+
+            _cachedIsMobile = await _module.InvokeAsync<bool>("isMobile", ct).ConfigureAwait(false);
+            return _cachedIsMobile.Value;
+        }
+        catch (Exception ex)
+        {
+            // Fail-safe to desktop, which is what the surface did before this axis existed — so a
+            // JS-interop failure degrades to the previous behaviour rather than to a new one.
+            _logger.LogWarning(ex, "PwaInstallabilityProbe mobile check failed — assuming desktop");
+            _cachedIsMobile = false;
+            return false;
         }
     }
 

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/wwwroot/js/pwa-install-probe.js
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/wwwroot/js/pwa-install-probe.js
@@ -37,6 +37,22 @@ function isAlreadyInstalled() {
         || window.navigator.standalone === true;
 }
 
+// Issue #1270: the surface previously had only one axis — installable or not —
+// and treated "not installable" as "this is a desktop". Mobile-but-not-installable
+// is neither: an in-app browser, a non-Safari iOS browser, or an Android device
+// that ALREADY installed the wallet (so `beforeinstallprompt` never fires again)
+// all land there, and were shown a QR code to scan with the phone in their hand.
+// Coarse on purpose — this only decides which affordance leads, never anything
+// security-relevant, so a pointer/UA heuristic is proportionate.
+export function isMobile() {
+    if (window.matchMedia('(pointer: coarse)').matches
+        && window.matchMedia('(max-width: 820px)').matches) {
+        return true;
+    }
+    const ua = navigator.userAgent || '';
+    return /Android|iPad|iPhone|iPod|Mobile|Silk|Kindle/i.test(ua);
+}
+
 export async function probe() {
     if (isAlreadyInstalled()) {
         return 'installed';

--- a/tests/Sorcha.UI.Components.User.Tests/Pairing/PairingHandoffRoutingTests.cs
+++ b/tests/Sorcha.UI.Components.User.Tests/Pairing/PairingHandoffRoutingTests.cs
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System;
+using FluentAssertions;
+using Sorcha.UI.Core.Services.User.Pairing;
+using Xunit;
+
+namespace Sorcha.UI.Components.User.Tests.Pairing;
+
+/// <summary>
+/// Issue #1270 (UT-007) — the F128 handoff surface showed the DESKTOP QR variant on a phone.
+/// <para>
+/// The cause is that the surface only ever had one axis to switch on: <c>IPwaInstallabilityProbe</c>
+/// answers "can this browser install the PWA?", and the surface treated "no" as "this is a desktop".
+/// <b>Mobile-but-not-installable is neither.</b> An Android citizen who already installed the wallet
+/// (so <c>beforeinstallprompt</c> never fires again), anyone in an in-app browser, and every
+/// non-Safari iOS browser all land there — and are shown a QR code to scan with the phone they are
+/// already holding.
+/// </para>
+/// <para>
+/// FR-008 exists to give the same-device path prominence on mobile. Adding the mobile axis is what
+/// makes that expressible.
+/// </para>
+/// </summary>
+public sealed class PairingHandoffRoutingTests
+{
+    [Theory]
+    [InlineData(PwaInstallabilityVerdict.CanInstallProgrammatically)]
+    [InlineData(PwaInstallabilityVerdict.CanInstallManually)]
+    public void AnInstallableBrowserInstallsOnThisPhone(PwaInstallabilityVerdict verdict)
+        => PairingHandoffRouting.Choose(verdict, isMobile: true)
+            .Should().Be(PairingHandoffRoute.InstallOnThisPhone);
+
+    [Fact]
+    public void AMobileBrowserThatCannotInstall_OpensOnThisDevice_NotAQrToScanWithItself()
+    {
+        PairingHandoffRouting.Choose(PwaInstallabilityVerdict.CannotInstall, isMobile: true)
+            .Should().Be(PairingHandoffRoute.OpenOnThisDevice,
+                "a QR code is useless to the phone that would have to scan it");
+    }
+
+    [Fact]
+    public void ADesktopBrowserScansWithAPhone()
+        => PairingHandoffRouting.Choose(PwaInstallabilityVerdict.CannotInstall, isMobile: false)
+            .Should().Be(PairingHandoffRoute.ScanWithYourPhone);
+
+    [Fact]
+    public void ADesktopThatSomehowReportsInstallable_StillInstallsRatherThanScanning()
+    {
+        // Chromium on a desktop genuinely does fire beforeinstallprompt. Installing there is a real
+        // and useful outcome, so the mobile axis must not override a positive install verdict.
+        PairingHandoffRouting.Choose(PwaInstallabilityVerdict.CanInstallProgrammatically, isMobile: false)
+            .Should().Be(PairingHandoffRoute.InstallOnThisPhone);
+    }
+
+    [Fact]
+    public void EveryVerdictIsRouted_NoneFallsThroughToTheDesktopDefaultByAccident()
+    {
+        // Derived from the real enum: a verdict added later must be routed deliberately, not inherit
+        // "scan with your phone" — which is precisely the silent mis-routing this issue was.
+        foreach (var verdict in Enum.GetValues<PwaInstallabilityVerdict>())
+        {
+            var mobile = PairingHandoffRouting.Choose(verdict, isMobile: true);
+            mobile.Should().NotBe(PairingHandoffRoute.ScanWithYourPhone,
+                $"'{verdict}' on a phone must never ask the citizen to scan a code with that phone");
+        }
+    }
+}

--- a/tests/Sorcha.UI.Core.Tests/Components/Pairing/PairingNagBannerTests.cs
+++ b/tests/Sorcha.UI.Core.Tests/Components/Pairing/PairingNagBannerTests.cs
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using Bunit;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Sorcha.UI.Core.Components.Pairing;
+using Sorcha.UI.Core.Services.User.Devices;
+using Sorcha.UI.Core.Services.Wallet;
+using Sorcha.UI.Testing;
+using Sorcha.UI.Testing.Builders;
+using Xunit;
+
+namespace Sorcha.UI.Core.Tests.Components.Pairing;
+
+/// <summary>
+/// Issue #1270 (UT-007) — two ways the F128 nag banner nagged when it should have stayed quiet.
+/// <list type="bullet">
+///   <item>It rendered ABOVE the pairing page itself, telling the citizen to go and do the thing
+///   they were already doing — and pushing the actual instructions down the screen.</item>
+///   <item>It was not wallet-aware the way F149 made <c>PairingTakeover</c>. Pairing a phone before
+///   a wallet exists dead-ends at the device-enrol 404. On the web the wallet call-to-action already
+///   owns that moment on Home, so the right answer here is silence rather than a second competing
+///   prompt.</item>
+/// </list>
+/// </summary>
+public sealed class PairingNagBannerTests : ComponentTestFixture
+{
+    private readonly Mock<IHasPairedDeviceProbe> _probe = new();
+    private readonly Mock<IWalletApiService> _walletApi = new();
+
+    public PairingNagBannerTests()
+    {
+        Services.AddLogging();
+        Services.AddSingleton(_probe.Object);
+        Services.AddSingleton(_walletApi.Object);
+
+        // The state the banner exists for: signed in, no paired device.
+        _probe.SetupGet(p => p.HasAnyDevice).Returns(false);
+        HasWallets(true);
+    }
+
+    private void HasWallets(bool any) =>
+        _walletApi.Setup(w => w.GetWalletsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(any
+                ? new List<WalletDto> { new WalletDtoBuilder().Build() }
+                : new List<WalletDto>());
+
+    private Microsoft.AspNetCore.Components.NavigationManager Nav =>
+        Services.GetRequiredService<Microsoft.AspNetCore.Components.NavigationManager>();
+
+    [Fact]
+    public void OnAnOrdinaryPage_TheBannerStillNags()
+    {
+        var cut = Render<PairingNagBanner>();
+
+        cut.WaitForAssertion(() =>
+            cut.FindAll("[data-testid='pairing-nag-banner']").Should().ContainSingle(
+                "this is exactly the state the banner exists for"));
+    }
+
+    [Fact]
+    public void OnThePairingPageItself_TheBannerStaysQuiet()
+    {
+        Nav.NavigateTo("setup/add-device");
+
+        var cut = Render<PairingNagBanner>();
+
+        cut.FindAll("[data-testid='pairing-nag-banner']").Should().BeEmpty(
+            "nagging a citizen to do the thing they are already doing just pushes the instructions down");
+    }
+
+    [Fact]
+    public void WithoutAWallet_TheBannerStaysQuiet()
+    {
+        HasWallets(false);
+
+        var cut = Render<PairingNagBanner>();
+
+        cut.WaitForAssertion(() =>
+            cut.FindAll("[data-testid='pairing-nag-banner']").Should().BeEmpty(
+                "a paired phone with no wallet behind it dead-ends — F149 made the PWA takeover "
+                + "wallet-aware for the same reason"));
+    }
+
+    [Fact]
+    public void WhenTheWalletCheckFails_TheBannerStillNags()
+    {
+        // Fail-safe in the same direction as F149's IHasWalletProbe: a transient failure must
+        // degrade to the pre-existing prompt, never silently suppress one the citizen needs.
+        _walletApi.Setup(w => w.GetWalletsAsync(It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("network"));
+
+        var cut = Render<PairingNagBanner>();
+
+        cut.WaitForAssertion(() =>
+            cut.FindAll("[data-testid='pairing-nag-banner']").Should().ContainSingle());
+    }
+
+    [Fact]
+    public void WithAPairedDevice_TheBannerStaysQuiet()
+    {
+        _probe.SetupGet(p => p.HasAnyDevice).Returns(true);
+
+        var cut = Render<PairingNagBanner>();
+
+        cut.FindAll("[data-testid='pairing-nag-banner']").Should().BeEmpty();
+    }
+}


### PR DESCRIPTION
Closes #1270 (UT-007).

## The QR-on-mobile bug: one missing axis

The surface only ever had **one** axis. `IPwaInstallabilityProbe` answers "can this browser install the PWA?", and the surface treated **"no" as "this is a desktop"**. *Mobile-but-not-installable is neither* — an in-app browser, any non-Safari iOS browser, and an Android device that **already installed the wallet** (so `beforeinstallprompt` never fires again) all land there. Each was handed a QR code to scan with the phone in the citizen's hand, and there was **no same-device route on any code path**. FR-008 exists to prevent exactly this.

- **New `isMobile()` axis** on the probe (coarse pointer + narrow viewport, UA fallback). Deliberately coarse: it decides which affordance leads, never anything security-relevant — and it **fails safe to "desktop"**, so a JS-interop failure degrades to the *previous* behaviour rather than a new one.
- **`PairingHandoffRouting.Choose(verdict, isMobile)`** makes the three real outcomes explicit. A positive install verdict is **not** overridden by the mobile axis: Chromium on a desktop genuinely fires `beforeinstallprompt`, and installing there is a real outcome.
- **"Open on this device" now exists.** The minted `QrUrl` *is* the URL a scanning phone would open, so on this device we simply follow it. The QR moves behind "Setting up a different phone?".

## The unstyled affordances and the run-together footer: one cause

**`PairingHandoffSurface.razor.css` did not exist.** Every `sorcha-pair-handoff__*` class resolved to nothing, so the surface rendered as unstyled flow content — bare buttons with no hit target, and two footer buttons inline with no separation, which is precisely why the citizen read **"Email me a link Skip for now"** as one line.

Added mobile-first: 48px/44px touch targets, a stacked footer, and an explicit `outline: none` on the headline. That heading is never focusable — the stray focus ring came from the focusable scroll container around it.

## The nag banner: two reasons to stay quiet it didn't know

- It rendered **above the pairing page itself**, nagging the citizen to go and do the thing they were already doing, and pushing the real instructions down the screen.
- It was not **wallet-aware** the way F149 made `PairingTakeover`. Pairing before a wallet exists dead-ends at the device-enrol 404. On web, the wallet CTA already owns that moment on Home, so the right answer here is **silence**, not a second competing prompt. The wallet check **fails safe toward showing** the nag, matching `IHasWalletProbe`'s direction.

## Verification

| Guard | |
|---|---|
| `PairingHandoffRoutingTests` (6) | incl. one **derived from the real verdict enum**, so a verdict added later cannot silently inherit "scan with your phone" — the exact shape of this bug |
| `PairingNagBannerTests` (5) | **red-verified** by disabling the two new conditions (2 failed, 3 passed) |

| Suite | Result |
|---|---|
| `Sorcha.UI.Core.Tests` | 1545 / 1545 |
| `Sorcha.UI.Components.User.Tests` | 87 / 87 |
| Web client + Wallet PWA | build clean |

`MASTER-TASKS.md` deliberately untouched; Theme 9 doc updates are batched into one final pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RboWP2TKvm1nBG22nqsWek