### PR TITLE
feat: [#1302] - implement x-holder-key.required so an unbindable application can't be submitted

### DIFF
--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/Forms/FormSchemaService.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/Forms/FormSchemaService.cs
@@ -174,6 +174,7 @@ public class FormSchemaService : IFormSchemaService
 
                 if (childType == "object")
                 {
+                    ValidateCarriedHolderKeys(prop.Value, data, scope, errors);
                     ValidateDataRecursive(prop.Value, data, scope, errors);
                     continue;
                 }
@@ -620,6 +621,62 @@ public class FormSchemaService : IFormSchemaService
         }
 
         return errors;
+    }
+
+    /// <summary>
+    /// Enforces <c>x-holder-key: { "required": true }</c> on a <c>sorcha-holder-key</c> field
+    /// (issue #1302). Opt-in: a field that doesn't declare it is untouched.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This cannot be expressed with the schema's own <c>required</c> array. The required-presence
+    /// check above deliberately <c>continue</c>s past object-typed entries, delegating to the
+    /// child's <c>properties</c>/<c>required</c> so errors land on precise leaves — and a
+    /// <c>sorcha-holder-key</c> field declares neither, because its value is written by the
+    /// renderer rather than authored. Listing it in <c>required</c> is silently a no-op.
+    /// </para>
+    /// <para>
+    /// Without this, a citizen whose wallet-key fetch failed saw a warning and a Retry but could
+    /// still submit — <c>HolderKeyRenderer</c> sets no <c>FormContext</c> error, and
+    /// <c>HandleSubmit</c> clears errors and rebuilds them from schema validation alone, so a
+    /// renderer-set error would be wiped regardless. The application sealed, and the ANALYST's
+    /// approval then threw <c>VAL_RUNTIME_CRED_005</c>: a cross-participant failure, on an approval
+    /// already granted, caused by a gap in someone else's earlier submission.
+    /// </para>
+    /// <para>
+    /// This is the early, actionable gate; it is not the guarantee. Issuance still fails closed
+    /// server-side (<c>VAL_RUNTIME_CRED_004</c>/<c>_005</c>) for submitters that never render a
+    /// form at all.
+    /// </para>
+    /// </remarks>
+    private static void ValidateCarriedHolderKeys(
+        JsonElement childSchema,
+        Dictionary<string, object?> data,
+        string scope,
+        Dictionary<string, List<string>> errors)
+    {
+        if (!HolderKeySchemaExtension.TryParseFromSchema(childSchema, out var extension)
+            || extension?.Required != true)
+        {
+            return;
+        }
+
+        foreach (var leaf in HolderKeySchemaExtension.CarriedLeafNames)
+        {
+            if (data.TryGetValue($"{scope}/{leaf}", out var value) && !IsEmptyValue(value))
+            {
+                continue;
+            }
+
+            // Deliberately names no internal leaf. The citizen never types these — the renderer
+            // fetches them — so the only actionable instruction is the control's own Retry.
+            errors[scope] =
+            [
+                "Your identity keys haven't been captured yet, so your credential could not be "
+                + "delivered. Use Retry on the identity-keys panel above, then submit."
+            ];
+            return;
+        }
     }
 
     private static bool IsEmptyValue(object? value)

--- a/src/Common/Sorcha.Blueprint.Models/Forms/FormKeywordClassifier.cs
+++ b/src/Common/Sorcha.Blueprint.Models/Forms/FormKeywordClassifier.cs
@@ -28,8 +28,9 @@ namespace Sorcha.Blueprint.Models.Forms;
 /// </para>
 /// <para>
 /// <b>Behavioural</b> keywords (re-lock): <c>x-file</c> (file-reference → chunked/encrypted
-/// transactions) and <c>x-credential-offer</c> (credential claim flow). These alter the
-/// executed pipeline.
+/// transactions), <c>x-credential-offer</c> (credential claim flow), and <c>x-holder-key</c>
+/// (whether the carried delivery keys must be captured before submission — see
+/// <see cref="HolderKeySchemaExtension"/>). These alter the executed pipeline.
 /// </para>
 /// <para>
 /// <b>Fail-safe default.</b> Any unrecognised <c>x-*</c> keyword is treated as
@@ -66,6 +67,12 @@ public static class FormKeywordClassifier
         {
             "x-file",
             "x-credential-offer",
+            // Issue #1302 — x-holder-key gates whether the citizen's carried delivery keys must be
+            // captured before submission, which decides whether a credential can be bound and
+            // delivered at all. Declared explicitly rather than left to the fail-safe: the
+            // classification is the same either way, but a "single source of truth" that omits a
+            // keyword the code consumes cannot be read as deliberate.
+            "x-holder-key",
         };
 
     /// <summary>

--- a/src/Common/Sorcha.Blueprint.Models/HolderKeySchemaExtension.cs
+++ b/src/Common/Sorcha.Blueprint.Models/HolderKeySchemaExtension.cs
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Sorcha.Blueprint.Models;
+
+/// <summary>
+/// Represents the <c>x-holder-key</c> extension on a <c>format: "sorcha-holder-key"</c> property.
+/// Declares whether the citizen's carried delivery keys MUST be captured before the form may be
+/// submitted.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Issue #1302. The keyword shipped in <c>aias-assured-identity</c> and <c>assured-identity</c> as
+/// <c>{ "required": true }</c> and, until now, nothing read it — the F137 contract introduced it as
+/// "optional config" and never gave it a consumer. It was not decoration: the declaration states a
+/// load-bearing fact.
+/// </para>
+/// <para>
+/// In those blueprints BOTH participants are open (<c>walletAddress: null</c>), so a walk-in citizen
+/// has no published participant record and the issuer has nowhere to look their keys up. The citizen
+/// must carry their own public keys in the starting action's payload; the issuing action reads them
+/// back via <c>holderKeySourceField</c> to bind the credential (SD-JWT <c>cnf</c>, FR-014) and wrap
+/// the delivery envelope (FR-012).
+/// </para>
+/// <para>
+/// <b>Why the schema's own <c>required</c> array cannot express this.</b>
+/// <c>FormSchemaService.ValidateDataRecursive</c> deliberately skips object-typed entries in a
+/// parent <c>required</c> array — it delegates to the child's own <c>properties</c>/<c>required</c>
+/// so the errors land on precise leaves. A <c>sorcha-holder-key</c> field declares neither (its
+/// value is written by the renderer, not authored), so listing it in <c>required</c> is silently a
+/// no-op. This keyword is how the requirement becomes expressible.
+/// </para>
+/// <para>
+/// <b>Client-side gate, not the guarantee.</b> Honouring this blocks submission early with an
+/// actionable message. The real guarantee remains server-side: issuance fails closed with
+/// <c>VAL_RUNTIME_CRED_004</c>/<c>_005</c> if the keys cannot be resolved. This exists so the
+/// citizen finds out at their own form rather than the analyst discovering it when an approval they
+/// have already made throws.
+/// </para>
+/// </remarks>
+public sealed class HolderKeySchemaExtension
+{
+    /// <summary>
+    /// When <see langword="true"/>, the carried key leaves must be present before the form may be
+    /// submitted. Defaults to <see langword="false"/> — the keyword is opt-in, so a bare
+    /// <c>x-holder-key: {}</c> does not retroactively block blueprints that never asked for it.
+    /// </summary>
+    [JsonPropertyName("required")]
+    public bool Required { get; init; }
+
+    /// <summary>
+    /// The sibling pointers a <c>sorcha-holder-key</c> renderer writes beneath the field, and which
+    /// <c>ActionExecutionService.ResolveCarriedHolderKeys</c> reads back at issuance. Enforcing
+    /// fewer than all three would admit a submission that still cannot be issued against.
+    /// </summary>
+    public static IReadOnlyList<string> CarriedLeafNames { get; } =
+        ["holderJwk", "encryptionPublicKey", "algorithm"];
+
+    /// <summary>
+    /// Attempts to read the <c>x-holder-key</c> extension from a JSON Schema element. Returns
+    /// <see langword="false"/> when absent or malformed — a broken declaration must not block a
+    /// citizen's submission, since the server-side fail-closed still protects correctness.
+    /// </summary>
+    public static bool TryParseFromSchema(JsonElement schema, out HolderKeySchemaExtension? extension)
+    {
+        extension = null;
+
+        if (schema.ValueKind != JsonValueKind.Object) return false;
+        if (!schema.TryGetProperty("x-holder-key", out var element)) return false;
+        if (element.ValueKind != JsonValueKind.Object) return false;
+
+        try
+        {
+            extension = JsonSerializer.Deserialize<HolderKeySchemaExtension>(element.GetRawText());
+            return extension is not null;
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
+    }
+}

--- a/tests/Sorcha.Blueprint.Engine.Tests/FormKeywordClassifierTests.cs
+++ b/tests/Sorcha.Blueprint.Engine.Tests/FormKeywordClassifierTests.cs
@@ -28,6 +28,11 @@ public class FormKeywordClassifierTests
     [Theory]
     [InlineData("x-file")]
     [InlineData("x-credential-offer")]
+    // Issue #1302 — x-holder-key now has a consumer: it gates whether the carried delivery keys
+    // must be captured before submission, so it is part of the executable definition rather than
+    // an unknown keyword riding the fail-safe. The classification is unchanged (behavioural either
+    // way), so this is a declaration, not a gate-behaviour change.
+    [InlineData("x-holder-key")]
     public void IsBehavioural_KnownBehaviouralKeyword_ReturnsTrue(string keyword)
     {
         FormKeywordClassifier.IsBehavioural(keyword).Should().BeTrue();
@@ -37,7 +42,6 @@ public class FormKeywordClassifierTests
     [Theory]
     [InlineData("x-foo")]
     [InlineData("x-unknown-future-keyword")]
-    [InlineData("x-holder-key")]
     public void IsBehavioural_UnknownExtensionKeyword_FailsSafeToBehavioural(string keyword)
     {
         FormKeywordClassifier.IsBehavioural(keyword).Should().BeTrue();
@@ -76,7 +80,10 @@ public class FormKeywordClassifierTests
     {
         FormKeywordClassifier.BehaviouralKeywords.Should().BeEquivalentTo(new[]
         {
-            "x-file", "x-credential-offer",
+            // x-holder-key joined the set in #1302 when it gained a consumer. Its effective
+            // classification is unchanged — it previously reached "behavioural" via the fail-safe —
+            // so no executable-definition hash or rehearsal-gate behaviour changes here.
+            "x-file", "x-credential-offer", "x-holder-key",
         });
     }
 

--- a/tests/Sorcha.Blueprint.Models.Tests/HolderKeySchemaExtensionTests.cs
+++ b/tests/Sorcha.Blueprint.Models.Tests/HolderKeySchemaExtensionTests.cs
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Text.Json;
+using FluentAssertions;
+using Sorcha.Blueprint.Models;
+using Xunit;
+
+namespace Sorcha.Blueprint.Models.Tests;
+
+/// <summary>
+/// Issue #1302 — <c>x-holder-key</c> shipped in two live blueprints with
+/// <c>{ "required": true }</c> and nothing read it. This type gives the keyword its first consumer.
+/// <para>
+/// The declaration is load-bearing, not decoration: in <c>aias-assured-identity</c> both
+/// participants are open (<c>walletAddress: null</c>), so a walk-in citizen has no published
+/// participant record and must CARRY their public keys in the application payload. Action 2's
+/// <c>holderKeySourceField: /holderKeys/holderJwk</c> reads them back to bind (SD-JWT <c>cnf</c>)
+/// and encrypt the credential. Without them the analyst's approval throws
+/// <c>VAL_RUNTIME_CRED_005</c> — a cross-participant failure caused by a gap in someone else's
+/// earlier submission.
+/// </para>
+/// </summary>
+public sealed class HolderKeySchemaExtensionTests
+{
+    private static JsonElement Schema(string json) => JsonDocument.Parse(json).RootElement.Clone();
+
+    [Fact]
+    public void ParsesTheRequiredFlagFromTheLiveBlueprintShape()
+    {
+        // Byte-for-byte the shape AIAS and AssuredIdentity ship today.
+        var ok = HolderKeySchemaExtension.TryParseFromSchema(
+            Schema("""{"type":"object","format":"sorcha-holder-key","x-holder-key":{"required":true}}"""),
+            out var ext);
+
+        ok.Should().BeTrue();
+        ext!.Required.Should().BeTrue();
+    }
+
+    [Fact]
+    public void AbsentExtensionIsNotParsed()
+        => HolderKeySchemaExtension.TryParseFromSchema(
+            Schema("""{"type":"object","format":"sorcha-holder-key"}"""), out _)
+            .Should().BeFalse();
+
+    [Fact]
+    public void RequiredDefaultsToFalse_SoTheKeywordIsOptIn()
+    {
+        // An author who writes a bare `x-holder-key: {}` has not asked for enforcement. Defaulting
+        // to true would retroactively block submissions on blueprints that never opted in.
+        HolderKeySchemaExtension.TryParseFromSchema(
+            Schema("""{"x-holder-key":{}}"""), out var ext).Should().BeTrue();
+
+        ext!.Required.Should().BeFalse();
+    }
+
+    [Fact]
+    public void AMalformedExtensionIsNotParsed_RatherThanThrowing()
+    {
+        HolderKeySchemaExtension.TryParseFromSchema(
+            Schema("""{"x-holder-key":"nonsense"}"""), out _).Should().BeFalse();
+        HolderKeySchemaExtension.TryParseFromSchema(
+            Schema("""{"x-holder-key":{"required":"yes"}}"""), out _).Should().BeFalse();
+    }
+
+    [Fact]
+    public void TheCarriedLeavesMatchWhatTheIssuerActuallyReads()
+    {
+        // ResolveCarriedHolderKeys needs the holder JWK (cnf binding, FR-014) plus the encryption
+        // key + algorithm (delivery envelope, FR-012). Enforcing anything less would let a
+        // submission through that still cannot be issued against.
+        HolderKeySchemaExtension.CarriedLeafNames.Should()
+            .BeEquivalentTo(["holderJwk", "encryptionPublicKey", "algorithm"]);
+    }
+}

--- a/tests/Sorcha.UI.Core.Tests/Components/Forms/HolderKeyRequiredValidationTests.cs
+++ b/tests/Sorcha.UI.Core.Tests/Components/Forms/HolderKeyRequiredValidationTests.cs
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Collections.Generic;
+using System.Text.Json;
+using FluentAssertions;
+using Sorcha.UI.Core.Services.Forms;
+using Xunit;
+
+namespace Sorcha.UI.Core.Tests.Components.Forms;
+
+/// <summary>
+/// Issue #1302 — enforcing <c>x-holder-key: { "required": true }</c> at the form.
+/// <para>
+/// Before this, a citizen whose wallet-key fetch failed saw a warning and a Retry but could still
+/// submit: <c>HolderKeyRenderer</c> set no <c>FormContext</c> error, and <c>HandleSubmit</c> clears
+/// errors and repopulates them from schema validation alone, so a renderer-set error would have
+/// been wiped anyway. The application sealed fine and then the <b>analyst's</b> approval threw
+/// <c>VAL_RUNTIME_CRED_005</c> — a cross-participant failure, on an approval already granted.
+/// </para>
+/// <para>
+/// Putting <c>holderKeys</c> in the parent <c>required</c> array cannot fix it:
+/// <c>ValidateDataRecursive</c> deliberately skips object-typed entries there. Hence the keyword.
+/// </para>
+/// </summary>
+public sealed class HolderKeyRequiredValidationTests
+{
+    private readonly FormSchemaService _sut = new();
+
+    private const string HolderKeyScope = "/holderKeys";
+
+    /// <summary>The exact shape the AIAS and AssuredIdentity starting actions ship.</summary>
+    private static JsonDocument LiveBlueprintSchema(bool required = true) => JsonDocument.Parse($$"""
+        {
+          "type": "object",
+          "properties": {
+            "name": { "type": "string" },
+            "holderKeys": {
+              "type": "object",
+              "title": "Your holder key",
+              "format": "sorcha-holder-key",
+              "x-holder-key": { "required": {{(required ? "true" : "false")}} }
+            }
+          },
+          "required": ["name"]
+        }
+        """);
+
+    private static Dictionary<string, object?> Captured() => new()
+    {
+        ["/name"] = "Ada",
+        [$"{HolderKeyScope}/holderJwk"] = """{"kty":"EC"}""",
+        [$"{HolderKeyScope}/encryptionPublicKey"] = "YmFzZTY0",
+        [$"{HolderKeyScope}/algorithm"] = "ED25519",
+    };
+
+    [Fact]
+    public void KeysNotCaptured_BlocksSubmission()
+    {
+        var data = new Dictionary<string, object?> { ["/name"] = "Ada" };
+
+        var errors = _sut.ValidateData(LiveBlueprintSchema(), data);
+
+        errors.Should().ContainKey(HolderKeyScope,
+            "an uncapturable application must not reach the analyst — they cannot complete an "
+            + "approval whose credential can never be bound");
+    }
+
+    [Fact]
+    public void TheMessageSendsTheCitizenToTheRetry_NotToAFieldTheyCannotType()
+    {
+        var errors = _sut.ValidateData(
+            LiveBlueprintSchema(), new Dictionary<string, object?> { ["/name"] = "Ada" });
+
+        var message = string.Join(" ", errors[HolderKeyScope]);
+        message.Should().NotContain("encryptionPublicKey",
+            "naming an internal leaf is useless — the citizen never types these");
+        message.Should().ContainEquivalentOf("retry");
+    }
+
+    [Fact]
+    public void KeysCaptured_Submits()
+    {
+        var errors = _sut.ValidateData(LiveBlueprintSchema(), Captured());
+
+        errors.Should().NotContainKey(HolderKeyScope);
+    }
+
+    [Theory]
+    [InlineData("holderJwk")]
+    [InlineData("encryptionPublicKey")]
+    [InlineData("algorithm")]
+    public void APartialCaptureStillBlocks(string missingLeaf)
+    {
+        // All three are read back at issuance — the cnf binding needs the JWK, the delivery
+        // envelope needs the key and its algorithm. Two out of three is still unissuable.
+        var data = Captured();
+        data.Remove($"{HolderKeyScope}/{missingLeaf}");
+
+        _sut.ValidateData(LiveBlueprintSchema(), data).Should().ContainKey(HolderKeyScope);
+    }
+
+    [Fact]
+    public void OptIn_NotDeclaredRequired_DoesNotBlock()
+    {
+        // Blueprints that never asked for enforcement must keep working exactly as before.
+        var errors = _sut.ValidateData(
+            LiveBlueprintSchema(required: false), new Dictionary<string, object?> { ["/name"] = "Ada" });
+
+        errors.Should().NotContainKey(HolderKeyScope);
+    }
+
+    [Fact]
+    public void AFieldWithNoHolderKeyExtensionIsUntouched()
+    {
+        var schema = JsonDocument.Parse("""
+            {"type":"object","properties":{"holderKeys":{"type":"object","format":"sorcha-holder-key"}}}
+            """);
+
+        _sut.ValidateData(schema, new Dictionary<string, object?>()).Should().NotContainKey(HolderKeyScope);
+    }
+
+    [Fact]
+    public void AnEmptyStringLeafCountsAsMissing()
+    {
+        // The renderer writes all three or none, but a resumed draft or a hand-built payload can
+        // carry blanks. A blank encryption key is not a key.
+        var data = Captured();
+        data[$"{HolderKeyScope}/algorithm"] = "";
+
+        _sut.ValidateData(LiveBlueprintSchema(), data).Should().ContainKey(HolderKeyScope);
+    }
+}


### PR DESCRIPTION
Closes #1302. `x-holder-key` shipped in two live blueprints as `{ "required": true }` and **nothing read it**. It was not decoration — the declaration states a load-bearing fact, and the requirement had no enforcement anywhere.

## What the field is for

In `aias-assured-identity` **both** participants are open (`walletAddress: null`), so a walk-in citizen has no published participant record and the issuer has nowhere to look their keys up. The citizen must **carry** their public keys in action 1's payload; action 2 reads them back via `holderKeySourceField: /holderKeys/holderJwk` to bind the credential (SD-JWT `cnf`, FR-014) and wrap the delivery envelope (FR-012).

## The failure this closes

`HolderKeyRenderer` shows a warning + Retry when the wallet-key fetch fails, but sets **no** `FormContext` error — and even if it did, `HandleSubmit` calls `ClearErrors()` and rebuilds from schema validation alone, so a renderer-set error is wiped regardless.

So the citizen could submit with the warning on screen. The application sealed fine. Then **the analyst's approval threw `VAL_RUNTIME_CRED_005`** — a cross-participant failure, on an approval already granted, caused by a gap in someone else's earlier submission. The citizen who caused it never saw anything.

## Why `required` couldn't fix it

`ValidateDataRecursive` deliberately `continue`s past **object-typed** entries in a parent `required` array, delegating to the child's own `properties`/`required` so errors land on precise leaves. A `sorcha-holder-key` field declares neither — its value is written by the renderer, not authored.

So listing `holderKeys` in `required` is **silently a no-op**. Verified against the live schema:

```
holderKeys sub-schema keys: ['type','title','description','format','x-holder-key']
has properties? False    has own required? False
```

## What this does

- **`HolderKeySchemaExtension`** gives the keyword its first consumer, mirroring `FileSchemaExtension`.
- **Enforced inside `ValidateData`**, so it survives `HandleSubmit`'s clear-and-rebuild cycle *by construction* rather than needing a new `FormContext` "blocker" concept.
- **All three carried leaves checked** — the issuer reads all three; two of three is still unissuable.
- **The message names no internal leaf** (the citizen never types these) and points at the control's Retry.
- **Opt-in throughout**: `Required` defaults to `false`; a field with no `x-holder-key` is untouched. **The two shipped blueprints need no edit** — they already declare it.

This is the early, actionable gate, **not** the guarantee: issuance still fails closed server-side for submitters that never render a form.

Also classifies `x-holder-key` as behavioural in `FormKeywordClassifier`. Effective classification is **unchanged** (it previously reached behavioural via the fail-safe), so **no executable-definition hash or rehearsal-gate behaviour changes** — but a "single source of truth" that omits a keyword the code consumes can't be read as deliberate. `x-rule` / `x-claim-source` / `x-sorcha-disclosure` remain open in #1303.

## Verification

Both guards red-verified first (`HolderKeyRequiredValidationTests` went 6-of-9 failing on exactly the blocking cases).

| Suite | Result |
|---|---|
| `Sorcha.UI.Core.Tests` | 1564 / 1564 |
| `Sorcha.Blueprint.Models.Tests` | 450 / 450 |
| `Sorcha.Blueprint.Engine.Tests` | 610 / 610 |
| `Sorcha.UI.Components.User.Tests` | 140 / 140 |
| web client, Wallet PWA, blueprint-service | build clean |

Stacks on #1301 (the skill already documents this behaviour).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RboWP2TKvm1nBG22nqsWek