### PR TITLE
fix: [VAL_SCHEMA_004] - skip action-data schema validation for presentation lifecycle transactions

### DIFF
--- a/src/Services/Sorcha.Validator.Service/Services/ValidationEngine.cs
+++ b/src/Services/Sorcha.Validator.Service/Services/ValidationEngine.cs
@@ -509,6 +509,26 @@ public class ValidationEngine : IValidationEngine
                     sw.Elapsed);
             }
 
+            // Skip schema validation for presentation lifecycle transactions (PresentationInitiated,
+            // PresentationOutcome, PresentationAbandoned). These carry lifecycle metadata — submitter
+            // wallet, requirements digest, presentation request id, consumer name — never the gated
+            // action's data payload, so the action's `required` schema properties can never be present.
+            // Applying the action's data schema to them is a validator bug, not a real violation:
+            // a SorchaWallet-gated action whose schema declares `required` fields would otherwise
+            // never seal (VAL_SCHEMA_004 on every PresentationInitiated). Chain integrity, signature
+            // verification, sender authorisation and route reachability all still apply — this skips
+            // ONLY the action-data-payload schema check.
+            if (TransactionTypeClassifier.IsLifecycleTransaction(transaction))
+            {
+                _logger.LogDebug(
+                    "Skipping schema validation for presentation lifecycle transaction {TransactionId}",
+                    transaction.TransactionId);
+                return ValidationEngineResult.Success(
+                    transaction.TransactionId,
+                    transaction.RegisterId,
+                    sw.Elapsed);
+            }
+
             // Get the blueprint
             var blueprint = await ResolveBlueprintAsync(transaction.BlueprintId!, ct);
             if (blueprint == null)

--- a/tests/Sorcha.Validator.Service.Tests/Services/ValidationEngineTests.cs
+++ b/tests/Sorcha.Validator.Service.Tests/Services/ValidationEngineTests.cs
@@ -823,6 +823,55 @@ public class ValidationEngineTests
     }
 
     [Fact]
+    public async Task ValidateSchemaAsync_PresentationInitiatedLifecycleTransaction_SkipsActionPayloadSchema()
+    {
+        // Arrange — a PresentationInitiated lifecycle transaction targets a gated action whose
+        // schema declares required properties (mirrors the live AIAS bug: a SorchaWallet-gated
+        // action's `required` array applied to lifecycle metadata that never carries those
+        // fields). The lifecycle payload here carries only submitter/requirements metadata —
+        // none of the action's required fields ("name", "amount") — and must NOT be evaluated
+        // against the action's data schema.
+        var tx = CreateValidTransaction(
+            payloadJson: """{"submitterWallet":"addr-1","requirementsDigest":"abc123","presentationRequestId":"req-1","consumer":"sorcha-wallet"}""");
+        tx.Metadata["Type"] = "PresentationInitiated";
+
+        var blueprint = CreateTestBlueprintWithSchema(tx.BlueprintId!);
+        _blueprintCacheMock.Setup(c => c.GetBlueprintAsync(tx.BlueprintId!, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(blueprint);
+
+        // Act
+        var result = await _engine.ValidateSchemaAsync(tx);
+
+        // Assert
+        result.IsValid.Should().BeTrue();
+        _blueprintCacheMock.Verify(
+            c => c.GetBlueprintAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never,
+            "lifecycle transactions should short-circuit before any blueprint/schema lookup");
+    }
+
+    [Theory]
+    [InlineData("PresentationOutcome")]
+    [InlineData("PresentationAbandoned")]
+    public async Task ValidateSchemaAsync_OtherLifecycleTransactionTypes_SkipActionPayloadSchema(string lifecycleType)
+    {
+        // Arrange — the other two lifecycle transaction types (Feature 119) must also be
+        // exempted; the predicate (IsLifecycleTransaction) covers all three uniformly.
+        var tx = CreateValidTransaction(payloadJson: """{"outcome":"accepted"}""");
+        tx.Metadata["Type"] = lifecycleType;
+
+        var blueprint = CreateTestBlueprintWithSchema(tx.BlueprintId!);
+        _blueprintCacheMock.Setup(c => c.GetBlueprintAsync(tx.BlueprintId!, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(blueprint);
+
+        // Act
+        var result = await _engine.ValidateSchemaAsync(tx);
+
+        // Assert
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
     public async Task ValidateSchemaAsync_FieldLevelDisclosures_MergesAllViews_Passes()
     {
         // Arrange — a plaintext envelope carrying one disclosure-filtered view per


### PR DESCRIPTION
## The bug — found by first live execution, not by inspection

Running the AIAS cyber rehearsal against n1, all four paths failed. The validator rejected them:

```
VAL_SCHEMA_004: Schema violation at '': Required properties
["passwordStorage","emailSecondStep","passwordChangeHabit","phoneUpdates",
 "suspiciousEmail","laptopLoss","sharedPasswordCount","streamingPasswordSharers"]
are not present
```

The rejected transaction ids are the **`PresentationInitiated` lifecycle transactions** — confirmed by cross-referencing the Blueprint service log, which shows `PresentationLifecycleService` submitting exactly those ids.

The validator was applying **the gated action's payload schema** to a **presentation lifecycle transaction**. A `PresentationInitiated` carries lifecycle metadata — submitter wallet, requirements digest, presentation request id, consumer name — and never the citizen's form payload. The required properties are legitimately absent, so the transaction could never seal.

**Effect: any `presentationSource: "SorchaWallet"` gated action whose data schema declares a `required` array is unsealable, and therefore unusable.**

## Why it went unnoticed

It needs *both* a SorchaWallet gate and a `required` array. The only other SorchaWallet-gated blueprint in the repo (`aias-device-registration.template.json`) declares properties but no `required` array, so `VAL_SCHEMA_004` never fired for it — and that flow has never been exercised end to end. The AIAS cyber questionnaire is the first to have both, because "all eight answers required" is what guarantees its no-could-not-score scoring design.

## The fix

The seam already existed and was unused. `TransactionTypeClassifier.IsLifecycleTransaction` covers all three lifecycle types and is documented as *"the general predicate — useful for routing lifecycle events to the lifecycle-specific code paths in Blueprint and Validator services"* — with no caller in `ValidationEngine`.

This wires it into the action-data schema check only, in the same shape as the neighbouring genesis/control, participant and rejection carve-outs.

**Deliberately unchanged:**
- `IsIntraActionLifecycleTerminal` and the Feature 119 `VAL_BP_003` route-reachability carve-out. `PresentationInitiated` keeps its **full** reachability check — it genuinely advances from action N-1 to action N, and that exclusion is correct.
- Chain integrity, signature verification and sender authorisation continue to apply to lifecycle transactions. Only the action-data JSON-Schema evaluation is exempted.

Verified there is a single code path emitting `VAL_SCHEMA_004` (`ValidateSchemaAsync`, one caller); two other methods reference "same logic as ValidateSchemaAsync" but never call `.Evaluate`, so they cannot raise it.

## Tests

- New regression tests seen **RED** with the fix reverted (`Expected result.IsValid to be True, but found False`), **GREEN** with it restored.
- **Negative control**: the pre-existing `ValidateSchemaAsync_MissingRequiredField_ReturnsSchemaError` is untouched and still fails `VAL_SCHEMA_004` for a normal action with an incomplete payload. This is the important one — the fix must not disable payload validation for real submissions.
- `Sorcha.Validator.Service.Tests`: 1003 passed, 0 failed, 21 skipped.

## Related

Found while deploying #1309 (AIAS M2). Blocks that milestone's rehearsal until deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RboWP2TKvm1nBG22nqsWek