### PR TITLE
fix: [T032] - persist and restore the verifier-session fields in RedisPendingPresentationStore

### DIFF
--- a/.claude/skills/sorcha-architecture/SKILL.md
+++ b/.claude/skills/sorcha-architecture/SKILL.md
@@ -474,6 +474,44 @@ Three-event on-register lifecycle for timebound evidence presentations. HAIP ext
 
 **Runtime source:** `src/Common/Sorcha.PresentationLifecycle.Abstractions/` (cross-consumer contract), `src/Services/Sorcha.Blueprint.Service/Services/Implementation/PresentationLifecycleService.cs`, `src/Services/Sorcha.Blueprint.Service/Storage/Presentations/` (pending store + rate limiter), `src/Services/Sorcha.Blueprint.Service/Endpoints/PresentationEndpoints.cs`, `src/Services/Sorcha.Haip.Service/Services/HaipPresentationConsumer.cs`, `src/Services/Sorcha.Haip.Service/Services/PresentationCallbackRelay.cs`. Spec: `specs/111-presentation-lifecycle/`.
 
+### Three traps this surface has already sprung (found by first live execution, 2026-07-27)
+
+All three were invisible to unit tests and to static review. Each sits at a seam where both sides are
+individually correct.
+
+**1. `/api/presentations/**` needs an API-Gateway route.** It did not have one until #1309. The whole
+surface — request object, `direct_post` callback, status poll, F127 disclosed-claims — was
+unreachable through the gateway; requests fell through to the `ui-static` catch-all. **The fastest
+diagnosis is one curl**: `GET /api/presentations/{any-guid}/status` must return Blueprint's **JSON**
+`{"error":"Presentation request not found or expired."}`. A **bodiless** 404 means the gateway is not
+routing it. The route carries **no `AuthorizationPolicy`** deliberately — these endpoints are
+mixed-auth (request-object GET and status are `.AllowAnonymous()`; the `sorcha-wallet` callback is
+`RequireConsumerAudience`), so an edge policy stricter than the endpoints breaks the anonymous ones.
+
+**2. Lifecycle transactions must be exempt from action-data schema validation** (#1312). A
+`PresentationInitiated` carries lifecycle metadata, never the gated action's payload — so applying
+that action's schema made **any `presentationSource: "SorchaWallet"` action whose schema declares a
+`required` array permanently unsealable** (`VAL_SCHEMA_004`). Now skipped via
+`TransactionTypeClassifier.IsLifecycleTransaction`. **Only** the action-data schema check is
+exempted; chain integrity, signatures, sender authorisation and the `VAL_BP_003` route-reachability
+check all still apply — and `PresentationInitiated` deliberately keeps its **full** reachability
+check, because it genuinely advances action N-1 → N (that is why `IsIntraActionLifecycleTerminal`
+excludes it; do not "tidy" the two predicates together).
+
+**3. `PendingPresentation`'s fields must round-trip through the store.**
+`RedisPendingPresentationStore` hand-maintains an explicit `HashEntry[]` write list and an explicit
+read reconstruction. When #1195/T032 added `Nonce`, `VerifierClientId`, `CredentialType` and
+`RequiredClaimNames`, neither hand-list was updated — the service wrote them, the consumer read them,
+Redis never carried them, and **every** SorchaWallet presentation declined with *"the pending state
+carries no nonce/credentialType (pre-T032 entry?)"*. The diagnostic's guess was wrong: no row had
+ever carried them. The in-memory store holds the object directly and round-trips fine, which is why
+tests stayed green. **Adding a field to `PendingPresentation` means editing both hand-lists and
+adding a round-trip test over the Redis implementation.**
+
+**Why none of this surfaced earlier:** the SorchaWallet consumer is the only path that rebuilds a
+`VerifierSession`, and it had never been exercised end to end. The only other SorchaWallet-gated
+blueprint (`aias-device-registration`) declares no `required` array, so trap 2 never fired for it.
+
 ### Seal-aware ordering (Feature 119)
 
 Two pre-existing chain-integrity races in the lifecycle outcome path are closed by **Feature 119**:

--- a/src/Services/Sorcha.Blueprint.Service/Services/Implementation/SorchaWalletPresentationConsumer.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Services/Implementation/SorchaWalletPresentationConsumer.cs
@@ -100,11 +100,15 @@ public sealed class SorchaWalletPresentationConsumer : IPresentationConsumer
         {
             if (string.IsNullOrEmpty(context.Nonce) || string.IsNullOrEmpty(context.CredentialType))
             {
-                // Legacy pending entry (pre-session-wiring) or a caller that never initiated —
-                // no nonce means nothing the KB-JWT could be verified against. Named decline.
+                // No nonce/credentialType on the pending state means nothing the KB-JWT could be
+                // verified against. Since T032 the store persists these on every entry, so this is
+                // NOT a legacy row — it means the pending presentation expired/was deleted before
+                // this callback arrived (TTL or post-outcome cleanup), or initiation never ran for
+                // this requestId. Named decline either way.
                 _logger.LogWarning(
                     "Sorcha-wallet consumer cannot rebuild a VerifierSession for requestId={RequestId}: " +
-                    "the pending state carries no nonce/credentialType (pre-T032 entry?).",
+                    "the pending state carries no nonce/credentialType (expired/deleted pending entry, " +
+                    "or initiation never ran for this requestId).",
                     context.PresentationRequestId);
                 return new PresentationOutcome(
                     Kind: PresentationOutcomeKind.Decline,

--- a/src/Services/Sorcha.Blueprint.Service/Storage/Presentations/RedisPendingPresentationStore.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Storage/Presentations/RedisPendingPresentationStore.cs
@@ -49,7 +49,16 @@ public sealed class RedisPendingPresentationStore : IPendingPresentationStore
             new("outcomeDetailLevel",             pending.OutcomeDetailLevel),
             new("validityWindowSeconds",          pending.ValidityWindowSeconds),
             new("createdAt",                      pending.CreatedAt.ToString("o")),
-            new("initiatedTxId",                  pending.InitiatedTransactionId ?? string.Empty)
+            new("initiatedTxId",                  pending.InitiatedTransactionId ?? string.Empty),
+            // #1195 Phase 2 (Task 6b, T032) — verifier-session fields. Nonce/VerifierClientId/
+            // CredentialType follow the same nullable-string convention as delegationToken above
+            // (empty string on the wire ⇒ null on read). RequiredClaimNames is a List<string>? —
+            // Redis hash values are flat strings, so it is JSON-encoded; JsonSerializer.Serialize(null)
+            // round-trips as the literal "null" (distinct from "[]"), so null vs empty-list survives.
+            new("nonce",                          pending.Nonce ?? string.Empty),
+            new("verifierClientId",               pending.VerifierClientId ?? string.Empty),
+            new("credentialType",                 pending.CredentialType ?? string.Empty),
+            new("requiredClaimNames",             JsonSerializer.Serialize(pending.RequiredClaimNames))
         };
 
         // Pipeline the HSET and EXPIRE so a crash between them cannot leave a
@@ -136,7 +145,22 @@ public sealed class RedisPendingPresentationStore : IPendingPresentationStore
             CreatedAt = createdAt,
             InitiatedTransactionId = string.IsNullOrEmpty(map.GetValueOrDefault("initiatedTxId"))
                 ? null
-                : map["initiatedTxId"]
+                : map["initiatedTxId"],
+            // #1195 Phase 2 (Task 6b, T032) — verifier-session fields. Missing field (entries
+            // written before this fix, or genuinely absent values) reads back as null, matching
+            // the "legacy pending entry" fallback the consumer already handles.
+            Nonce = string.IsNullOrEmpty(map.GetValueOrDefault("nonce"))
+                ? null
+                : map["nonce"],
+            VerifierClientId = string.IsNullOrEmpty(map.GetValueOrDefault("verifierClientId"))
+                ? null
+                : map["verifierClientId"],
+            CredentialType = string.IsNullOrEmpty(map.GetValueOrDefault("credentialType"))
+                ? null
+                : map["credentialType"],
+            RequiredClaimNames = string.IsNullOrEmpty(map.GetValueOrDefault("requiredClaimNames"))
+                ? null
+                : JsonSerializer.Deserialize<List<string>?>(map["requiredClaimNames"])
         };
     }
 

--- a/tests/Sorcha.Blueprint.Service.Tests/Storage/Presentations/RedisPendingPresentationStoreTests.cs
+++ b/tests/Sorcha.Blueprint.Service.Tests/Storage/Presentations/RedisPendingPresentationStoreTests.cs
@@ -138,6 +138,142 @@ public class RedisPendingPresentationStoreTests
     }
 
     [Fact]
+    public async Task StoreAsync_ThenGetAsync_RoundTripsT032VerifierSessionFields()
+    {
+        // Regression test for the #1195 Phase 2 / T032 field-drop bug: PendingPresentation
+        // grew Nonce/VerifierClientId/CredentialType/RequiredClaimNames, but the store's
+        // hand-maintained field list on the way into Redis and the hand-maintained
+        // reconstruction on the way out never picked them up. Every field was silently
+        // dropped, so every sorcha-wallet presentation declined in production ("the
+        // pending state carries no nonce/credentialType"). This drives the real
+        // StoreAsync path (capturing exactly what would be HSET to Redis) and feeds
+        // those captured fields back through HashGetAllAsync, so it fails the moment
+        // StoreAsync and GetAsync drift on any field again.
+        var id = Guid.NewGuid();
+        var pending = MakePending(id, validitySeconds: 300) with
+        {
+            Nonce = "nonce-abc123",
+            VerifierClientId = "did:sorcha:org:ws11qcouncil",
+            CredentialType = "urn:eu.europa.ec.eudi:pid:1",
+            RequiredClaimNames = new List<string> { "given_name", "birth_date" }
+        };
+
+        var capturedFields = await CaptureStoredFieldsAsync(pending);
+        SetupHashGetAllFromCapturedFields(capturedFields);
+
+        var result = await _store.GetAsync(id);
+
+        result.Should().NotBeNull();
+        result!.Nonce.Should().Be("nonce-abc123");
+        result.VerifierClientId.Should().Be("did:sorcha:org:ws11qcouncil");
+        result.CredentialType.Should().Be("urn:eu.europa.ec.eudi:pid:1");
+        result.RequiredClaimNames.Should().BeEquivalentTo(new[] { "given_name", "birth_date" });
+
+        // Pre-existing fields must still round-trip alongside the new ones.
+        result.InstanceId.Should().Be(pending.InstanceId);
+        result.SubmitterWallet.Should().Be(pending.SubmitterWallet);
+        result.CredentialRequirementDigestHex.Should().Be(pending.CredentialRequirementDigestHex);
+    }
+
+    [Fact]
+    public async Task StoreAsync_ThenGetAsync_RoundTripsRequiredClaimNamesNull()
+    {
+        var id = Guid.NewGuid();
+        var pending = MakePending(id, validitySeconds: 300) with
+        {
+            Nonce = "nonce-1",
+            VerifierClientId = "did:sorcha:org:x",
+            CredentialType = "urn:vct:x",
+            RequiredClaimNames = null
+        };
+
+        var capturedFields = await CaptureStoredFieldsAsync(pending);
+        SetupHashGetAllFromCapturedFields(capturedFields);
+
+        var result = await _store.GetAsync(id);
+
+        result.Should().NotBeNull();
+        result!.RequiredClaimNames.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task StoreAsync_ThenGetAsync_RoundTripsRequiredClaimNamesEmptyList_DistinctFromNull()
+    {
+        var id = Guid.NewGuid();
+        var pending = MakePending(id, validitySeconds: 300) with
+        {
+            Nonce = "nonce-2",
+            VerifierClientId = "did:sorcha:org:x",
+            CredentialType = "urn:vct:x",
+            RequiredClaimNames = new List<string>()
+        };
+
+        var capturedFields = await CaptureStoredFieldsAsync(pending);
+        SetupHashGetAllFromCapturedFields(capturedFields);
+
+        var result = await _store.GetAsync(id);
+
+        result.Should().NotBeNull();
+        result!.RequiredClaimNames.Should().NotBeNull();
+        result.RequiredClaimNames.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task StoreAsync_ThenGetAsync_RoundTripsRequiredClaimNamesPopulated()
+    {
+        var id = Guid.NewGuid();
+        var pending = MakePending(id, validitySeconds: 300) with
+        {
+            Nonce = "nonce-3",
+            VerifierClientId = "did:sorcha:org:x",
+            CredentialType = "urn:vct:x",
+            RequiredClaimNames = new List<string> { "family_name", "age_over_18", "document_number" }
+        };
+
+        var capturedFields = await CaptureStoredFieldsAsync(pending);
+        SetupHashGetAllFromCapturedFields(capturedFields);
+
+        var result = await _store.GetAsync(id);
+
+        result.Should().NotBeNull();
+        result!.RequiredClaimNames.Should().BeEquivalentTo(
+            new[] { "family_name", "age_over_18", "document_number" });
+    }
+
+    /// <summary>
+    /// Drives the real <c>StoreAsync</c> path and captures the <see cref="HashEntry"/>[]
+    /// it would HSET to Redis, so round-trip tests exercise the actual write logic
+    /// instead of hand-crafting the expected wire shape.
+    /// </summary>
+    private async Task<HashEntry[]> CaptureStoredFieldsAsync(PendingPresentation pending)
+    {
+        var mockBatch = new Mock<IBatch>();
+        _mockDb.Setup(d => d.CreateBatch(It.IsAny<object>())).Returns(mockBatch.Object);
+
+        HashEntry[]? captured = null;
+        mockBatch.Setup(b => b.HashSetAsync(
+                It.IsAny<RedisKey>(), It.IsAny<HashEntry[]>(),
+                It.IsAny<CommandFlags>()))
+            .Callback<RedisKey, HashEntry[], CommandFlags>((_, f, _) => captured = f)
+            .Returns(Task.CompletedTask);
+        mockBatch.Setup(b => b.KeyExpireAsync(
+                It.IsAny<RedisKey>(), It.IsAny<TimeSpan?>(),
+                It.IsAny<ExpireWhen>(), It.IsAny<CommandFlags>()))
+            .ReturnsAsync(true);
+
+        await _store.StoreAsync(pending);
+
+        return captured!;
+    }
+
+    /// <summary>Wires HashGetAllAsync to return exactly the fields StoreAsync wrote.</summary>
+    private void SetupHashGetAllFromCapturedFields(HashEntry[] fields)
+    {
+        _mockDb.Setup(d => d.HashGetAllAsync(It.IsAny<RedisKey>(), It.IsAny<CommandFlags>()))
+            .ReturnsAsync(fields);
+    }
+
+    [Fact]
     public async Task TryClaimOutcomeSentinelAsync_UsesSetNx()
     {
         var id = Guid.NewGuid();


### PR DESCRIPTION
## The bug — every SorchaWallet presentation declines

Found running the AIAS cyber rehearsal end to end against a live host. Blueprint service logs:

```
Sorcha-wallet consumer cannot rebuild a VerifierSession for requestId=…:
the pending state carries no nonce/credentialType (pre-T032 entry?).
```

## Root cause

`RedisPendingPresentationStore` hand-maintains an explicit `HashEntry[]` on write and an explicit reconstruction on read. When #1195 Phase 2 / T032 added four fields to `PendingPresentation` — `Nonce`, `VerifierClientId`, `CredentialType`, `RequiredClaimNames` — **neither hand-list was updated**.

So `PresentationLifecycleService` populated them at initiation, `PresentationInitiationContext` passed them back to the consumer at verify time, and the store between the two silently dropped them. They were always null on the far side, and the consumer declined **every** presentation.

The diagnostic's guess — *"(pre-T032 entry?)"* — is wrong and is corrected here: it was never a legacy row. **No row had ever carried these fields.**

**Effect: the F127 SorchaWallet presentation gate has never worked.**

## Why the test suite stayed green

`InMemoryPendingPresentationStore` (the test double) holds the `PendingPresentation` record **directly** — no field marshalling — so it round-trips everything by construction and was never affected. The Redis implementation was the only one that dropped fields, and nothing tested its round-trip.

That is the real defect behind the defect: **a hand-maintained mapping between a type and its serialised form, with no round-trip test.** Adding a property to the record silently loses it in transit — no compiler error, no test failure, no runtime error.

## The fix

- `Nonce`, `VerifierClientId`, `CredentialType` — written and read following the existing `delegationToken` nullable-string convention in this file (`?? string.Empty` on write, empty ⇒ null on read).
- `RequiredClaimNames` (`List<string>?`) — JSON-encoded, round-tripping null and `[]` distinctly. JSON rather than a delimiter because claim names are author-supplied and could collide with any separator. (The consumer currently coalesces null → `[]`, so the distinction isn't load-bearing today, but the store shouldn't lose information the record models.)
- Reworded the consumer's misleading `"(pre-T032 entry?)"` diagnostic so a genuinely missing nonce doesn't send the next person hunting for a legacy row.

## Tests

- **New round-trip tests over the Redis store**, covering all four fields plus the pre-existing ones — the test that would have caught this the day T032 landed.
- Seen **RED** before the fix (`Expected result!.Nonce to be "nonce-abc123", but found <null>`, 3 of 4 failing), **GREEN** after.
- `RequiredClaimNames` covered for null, empty and populated.
- `Sorcha.Blueprint.Service.Tests`: 1033 passed, 0 failed, 5 skipped.

## Also included

A docs commit recording this and two sibling traps from the same surface in `.claude/skills/sorcha-architecture/SKILL.md`, including the one-curl gateway-route diagnosis and a note not to merge the two lifecycle predicates.

## Related

- #1312 — validator lifecycle carve-out (same surface, previous layer)
- #1313 — validator review: audit which checks apply to which transaction types
- #1310 — F127 QR path, to confirm on a real device
- #1309 — AIAS M2, the milestone whose deploy surfaced all of these

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RboWP2TKvm1nBG22nqsWek