### PR TITLE
fix: [rehearse] - resolve relative presentation URIs against the gateway origin

### DIFF
--- a/demos/AIAS/rehearse.ps1
+++ b/demos/AIAS/rehearse.ps1
@@ -398,6 +398,30 @@ function Get-QueryStringValue {
     return $null
 }
 
+function Resolve-DemoServerUri {
+    # PresentationLifecycleOptions.PublicBaseUrl is unset on every rehearsal target — its documented
+    # behaviour is "null => relative URIs" (Sorcha.Blueprint.Service.Configuration.
+    # PresentationLifecycleOptions), so SorchaWalletPresentationConsumer.BuildInitiationAsync emits
+    # BOTH request_uri and response_uri as relative paths, e.g.
+    # "/api/presentations/{id}/request-object". The real wallet (Sorcha.Wallet.Pwa) never notices:
+    # its HttpClient carries BaseAddress set to the gateway origin, so the relative URI resolves
+    # same-origin before the request leaves the client (see
+    # Sorcha.Wallet.Pwa.Services.Presentation.PresentationDirectPostClient's doc comment — it makes
+    # no assumption either way, relative or absolute, because HttpClient resolves both). PowerShell's
+    # Invoke-RestMethod/Invoke-WebRequest have no BaseAddress concept — a bare relative URI throws
+    # "Invalid URI: The hostname could not be parsed." This script is standing in for the wallet, so
+    # it must do the SAME resolution HttpClient.BaseAddress does. A deployment that DOES set
+    # PublicBaseUrl emits absolute URIs instead — those must pass through unchanged, so do not remove
+    # this helper because it looks like a no-op on such a deployment.
+    param(
+        [Parameter(Mandatory)][string]$Uri,
+        [Parameter(Mandatory)][string]$GatewayBase
+    )
+    $parsed = [System.Uri]$Uri
+    if ($parsed.IsAbsoluteUri) { return $Uri }
+    return ([System.Uri]::new([System.Uri]$GatewayBase, $Uri)).AbsoluteUri
+}
+
 function Select-SdJwtDisclosures {
     # Filter an SD-JWT's raw disclosure segments down to the ones whose claim name is approved,
     # returning the ORIGINAL base64url segment strings (never decoded/re-encoded — the presentation
@@ -486,6 +510,7 @@ function Complete-SorchaWalletPresentation {
 
     $requestObjectUri = Get-QueryStringValue -Url $AuthorizationRequestUri -Name 'request_uri'
     if (-not $requestObjectUri) { throw "AuthorizationRequestUri carried no request_uri: $AuthorizationRequestUri" }
+    $requestObjectUri = Resolve-DemoServerUri -Uri $requestObjectUri -GatewayBase $gateway
 
     # NOT -RawResponse: the endpoint serves 'application/oauth-authz-req+jwt'
     # (PresentationEndpoints.cs), a content type Invoke-WebRequest does not classify as text, so
@@ -505,6 +530,13 @@ function Complete-SorchaWalletPresentation {
     $nonce = $requestPayload.nonce
     $clientId = $requestPayload.client_id
     if (-not $nonce -or -not $clientId) { throw "Request object payload for $PresentationRequestId is missing nonce/client_id." }
+
+    # response_uri is the direct_post target the request object itself names (mirrors
+    # PresentationEngine.ParseAsync reading the same field) — read it from the server rather than
+    # rebuilding the callback path locally, and resolve it exactly like request_uri above.
+    $responseUri = $requestPayload.response_uri
+    if (-not $responseUri) { throw "Request object payload for $PresentationRequestId is missing response_uri." }
+    $responseUri = Resolve-DemoServerUri -Uri $responseUri -GatewayBase $gateway
 
     # The DCQL credential-query id the response envelope must be keyed by (Present.razor reads the
     # SAME field off its parsed request — `_request.Query.Credentials[0].Id`). Single-ask requests
@@ -581,9 +613,8 @@ function Complete-SorchaWalletPresentation {
     $vpTokenEnvelope = $envelopeHash | ConvertTo-Json -Compress -Depth 5
     $formBody = "vp_token=$([Uri]::EscapeDataString($vpTokenEnvelope))&state=$([Uri]::EscapeDataString($PresentationRequestId))"
 
-    $callbackUri = "$api/presentations/callbacks/sorcha-wallet/$PresentationRequestId"
     $callbackResp = Invoke-SorchaApi -Method POST `
-        -Uri $callbackUri `
+        -Uri $responseUri `
         -Body $formBody `
         -ContentType 'application/x-www-form-urlencoded' `
         -Headers $Applicant.Session.Headers


### PR DESCRIPTION
## The failure

All four AIAS cyber rehearsal paths throw:

```
Invalid URI: The hostname could not be parsed.
```

## Root cause

`PresentationLifecycleOptions.PublicBaseUrl` is unset on the deployment — verified by `docker inspect`, and its documented behaviour is "Null ⇒ relative URIs". So `SorchaWalletPresentationConsumer` emits `request_uri` and `response_uri` as **relative paths**.

The Citizen Wallet PWA copes because its `HttpClient` has `BaseAddress` set to the gateway origin, so relative URIs are resolved before the request goes out. PowerShell's `Invoke-RestMethod` / `Invoke-WebRequest` have no `BaseAddress` concept — a relative URI throws.

**This is a script gap, not a server bug.** Relative URIs are the configured, intended behaviour here. The rehearsal stands in for a wallet, so it has to do what the wallet's `BaseAddress` does for it.

Deliberately **not** fixed by setting `PublicBaseUrl`: that would change the path the same-origin bearer guard was verified against, and would be making a deployment change to paper over a script shortcoming.

## The fix

A helper that resolves relative URIs against the gateway base the rehearsal already talks to, leaving absolute URIs untouched (a deployment that *does* set `PublicBaseUrl` emits absolute URIs and must keep working). Uses `[System.Uri]::new([Uri]$base, $relative)` rather than string concatenation, so `/api/...` joined to a base ending in `/api` cannot produce `/api/api/...`.

Applied at both call sites in `Complete-SorchaWalletPresentation`. The direct-post site now also reads `response_uri` off the **parsed request object** rather than hand-building the callback path, mirroring `PresentationEngine.ParseAsync` in the PWA — so the script follows the same discovery the real wallet does.

Verified against both shapes:
- `/api/presentations/abc/request-object` → `https://n1.sorcha.dev/api/presentations/abc/request-object` (one `/api`, checked with plain and trailing-slash bases)
- `https://example.test/api/presentations/abc/request-object` → unchanged

## Note for future readers

There is a comment at the helper explaining why it exists. Without it, the next person sees a pointless-looking URI helper and deletes it.

Separately worth knowing: **an external/EUDI wallet given that same QR has nothing to resolve a relative URI against.** That is a real gap for non-Sorcha wallets, tracked as a follow-up rather than fixed here — the Sorcha PWA resolves it via `BaseAddress`, and this rehearsal now does the equivalent.

## Scope

`demos/AIAS/rehearse.ps1` only. No fixture, assertion, band expectation or timeout changed.

## Related

#1309, #1312, #1314 — the other layers of this same presentation path, all found by first live execution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RboWP2TKvm1nBG22nqsWek