### PR TITLE
fix: [F120] - an unreachable alsoKnownAs link no longer vetoes a verified issuer DID

### DIFF
--- a/specs/120-production-issuer-signature-verification/contracts/did-resolver-registry-contract.md
+++ b/specs/120-production-issuer-signature-verification/contracts/did-resolver-registry-contract.md
@@ -25,8 +25,10 @@ public interface IDidResolverRegistry
     /// <summary>
     /// Resolves the primary DID and any DIDs declared in its alsoKnownAs property,
     /// verifies the same verification key material appears in every linked document,
-    /// and returns the merged DidDocument. Returns null if any link fails to resolve,
-    /// or if verification keys diverge across the equivalence chain.
+    /// and returns the merged DidDocument. An unresolvable link is advisory — it is
+    /// skipped and equivalence is withheld from it, never invalidating the primary.
+    /// Returns null only if the primary fails to resolve, or if verification keys
+    /// diverge across the links that DID resolve.
     /// </summary>
     /// <param name="did">The primary DID to resolve.</param>
     /// <param name="ct">Cancellation token.</param>
@@ -63,10 +65,13 @@ public interface IDidResolverRegistry
 3. For each linked DID in primary.alsoKnownAs:
    a. Avoid cycles: if linked == did or already-visited, skip.
    b. Resolve linked via ResolveAsync(linked).
-      On null:
+      On null (ADVISORY — an unverifiable hint must never veto a verified identity;
+      W3C DID Core §5.1.3: "the presence of an alsoKnownAs assertion does not prove
+      that this assertion is true"):
         Log warning "alsoKnownAs link unreachable for {did}: {linked}".
-        Tag span did.alsoKnownAs.match=unreachable.
-        Return null.
+        Increment the alsoKnownAs-unreachable metric.
+        SKIP this link — equivalence is withheld from it and its key material is
+        never merged. Continue to the next link.
    c. Compute the intersection of verification-method key material between
       primary and linked:
         For each VM in primary.verificationMethod:
@@ -77,10 +82,13 @@ public interface IDidResolverRegistry
       A cross-verified VM is one whose public key bytes appear in every
       linked document. Other VMs are dropped.
 
-4. If, after step 3, primary.verificationMethod has ZERO cross-verified VMs:
+4. If at least one link resolved AND primary.verificationMethod has ZERO
+   cross-verified VMs:
    Log warning "alsoKnownAs cross-resolution found no shared keys for {did}".
    Tag span did.alsoKnownAs.match=mismatch.
    Return null.
+   (With no link resolved there was no intersection to survive, so this branch
+   does not apply — the primary passes through with its own key material.)
 
 5. Construct merged DidDocument:
    - id: primary.id
@@ -89,7 +97,8 @@ public interface IDidResolverRegistry
    - assertionMethod, authentication, etc.: preserved from primary, filtered
      to reference only cross-verified VMs
 
-6. Tag span did.alsoKnownAs.cross_resolved=true, did.alsoKnownAs.match=match.
+6. Tag span did.alsoKnownAs.cross_resolved=(any link verified),
+   did.alsoKnownAs.match=match when a link verified, else unreachable.
    Return merged document.
 ```
 

--- a/src/Common/Sorcha.ServiceClients.Http/Did/DidResolverRegistry.cs
+++ b/src/Common/Sorcha.ServiceClients.Http/Did/DidResolverRegistry.cs
@@ -142,16 +142,29 @@ public class DidResolverRegistry : IDidResolverRegistry
                 continue;
             }
 
-            // Step 3b — resolve linked doc.
+            // Step 3b — resolve linked doc. An unresolvable alsoKnownAs link is ADVISORY,
+            // never fatal: per W3C DID Core §5.1.3 alsoKnownAs is an unverifiable assertion
+            // ("the presence of an alsoKnownAs assertion does not prove that this assertion
+            // is true"), so it MUST NOT be able to veto a primary document that resolved and
+            // cross-verified on its own. Skipping the link withholds equivalence from the
+            // linked identity — which is exactly what the spec asks for — without discarding
+            // the identity that did verify.
+            //
+            // This previously returned null. That let any unreachable federation hint
+            // invalidate a cryptographically sound issuer DID: every Sorcha org publishes a
+            // did:web:{PlatformDomain}:orgs:{orgId} link that nothing serves, so EVERY
+            // org-issued credential failed issuer-signature verification once a verifier
+            // actually ran (found live on n1, 2026-07-28).
             var linkedDoc = await ResolveAsync(linked, ct).ConfigureAwait(false);
             if (linkedDoc is null)
             {
                 _logger.LogWarning(
-                    "alsoKnownAs link unreachable for {Primary}: {Linked}", did, linked);
-                activity?.SetTag("did.alsoKnownAs.match", "unreachable");
+                    "alsoKnownAs link unreachable for {Primary}: {Linked} — treating the link as "
+                    + "unverified (equivalence withheld); primary document is unaffected.",
+                    did, linked);
                 _metrics?.AlsoKnownAsUnreachable.Add(1,
                     new KeyValuePair<string, object?>("method", method));
-                return null;
+                continue;
             }
 
             // Step 3c — intersect: drop any primary VM whose key bytes do not
@@ -171,8 +184,11 @@ public class DidResolverRegistry : IDidResolverRegistry
             if (survivors.Count == 0) break; // short-circuit; step 4 will reject.
         }
 
-        // Step 4 — reject on zero shared keys.
-        if (survivors.Count == 0)
+        // Step 4 — reject on zero shared keys, but ONLY when at least one link actually
+        // resolved. With no verified link there was no intersection to survive, so an empty
+        // survivor set means "the primary declares no verification methods" — a different
+        // fault, and not one this branch's message or metric describes.
+        if (verifiedLinks.Count > 0 && survivors.Count == 0)
         {
             _logger.LogWarning(
                 "alsoKnownAs cross-resolution found no shared keys for {Primary}", did);
@@ -198,9 +214,12 @@ public class DidResolverRegistry : IDidResolverRegistry
             Service = primary.Service
         };
 
-        // Step 6 — tag span and return.
-        activity?.SetTag("did.alsoKnownAs.cross_resolved", true);
-        activity?.SetTag("did.alsoKnownAs.match", "match");
+        // Step 6 — tag span and return. `merged` always carries only the links that actually
+        // resolved AND cross-verified, so a caller can never mistake an advisory link for a
+        // verified one: with every link unreachable, AlsoKnownAs comes back empty and the
+        // document is the primary's own key material, unwidened.
+        activity?.SetTag("did.alsoKnownAs.cross_resolved", verifiedLinks.Count > 0);
+        activity?.SetTag("did.alsoKnownAs.match", verifiedLinks.Count > 0 ? "match" : "unreachable");
         return merged;
     }
 

--- a/tests/Sorcha.ServiceClients.Tests/Did/DidResolverRegistryCrossResolutionTests.cs
+++ b/tests/Sorcha.ServiceClients.Tests/Did/DidResolverRegistryCrossResolutionTests.cs
@@ -99,8 +99,13 @@ public sealed class DidResolverRegistryCrossResolutionTests
     }
 
     [Fact]
-    public async Task OneLinkUnreachable_ReturnsNull()
+    public async Task OneLinkUnreachable_ReturnsPrimaryWithEquivalenceWithheld()
     {
+        // W3C DID Core §5.1.3 — alsoKnownAs is an unverifiable assertion, so an
+        // unreachable link must NOT invalidate a primary document that resolved.
+        // It is skipped: the primary's own key material survives intact, and the
+        // unverified link is absent from the result so no caller can read it as
+        // verified equivalence.
         var primary = new DidDocument
         {
             Id = PrimaryDid,
@@ -113,7 +118,41 @@ public sealed class DidResolverRegistryCrossResolutionTests
 
         var result = await registry.ResolveWithAlsoKnownAsAsync(PrimaryDid);
 
-        result.Should().BeNull();
+        result.Should().NotBeNull();
+        result!.Id.Should().Be(PrimaryDid);
+        result.VerificationMethod.Should().HaveCount(1);
+        result.AlsoKnownAs.Should().NotContain(LinkedDidA,
+            "an unresolvable link must not be reported as verified equivalence");
+    }
+
+    [Fact]
+    public async Task OrgIssuerDid_WithUnservedDidWebLink_StillYieldsIssuanceKey()
+    {
+        // Regression for the live n1 failure (2026-07-28): every Sorcha org publishes a
+        // did:web:{PlatformDomain}:orgs:{orgId} alsoKnownAs that nothing serves. That
+        // unreachable hint was discarding the whole issuer document, so EVERY org-issued
+        // credential failed issuer-signature verification the first time a verifier ran.
+        const string orgDid = "did:sorcha:org:ws11qz8yulqml9wq";
+        const string unservedWebDid = "did:web:sorcha.dev:orgs:1065431a-a5b0-4c61-a7ed-38ec08337c81";
+        var kid = $"{orgDid}#vc-issuance-1";
+
+        var primary = new DidDocument
+        {
+            Id = orgDid,
+            AlsoKnownAs = [unservedWebDid],
+            VerificationMethod = [Vm(kid, orgDid, KeyJwkA)],
+            AssertionMethod = [kid]
+        };
+        var registry = BuildRegistry(
+            ("sorcha", new() { [orgDid] = primary }),
+            ("web", new() { [unservedWebDid] = null })); // nothing serves did:web
+
+        var result = await registry.ResolveWithAlsoKnownAsAsync(orgDid);
+
+        result.Should().NotBeNull("an unserved federation hint must not veto the issuer DID");
+        result!.AssertionMethod.Should().Contain(kid,
+            "the issuance key must remain usable for issuer-signature verification");
+        result.VerificationMethod.Should().ContainSingle(v => v.Id == kid);
     }
 
     [Fact]


### PR DESCRIPTION
## What

An unreachable `alsoKnownAs` link no longer invalidates a DID document that resolved and cross-verified on its own.

## Why

Every AIAS-issued credential declined on n1 with `Issuer DID could not be resolved` — while the org's DID document was published, correct, and carried the exact `#vc-issuance-1` key the credential's `kid` names.

`DidResolverRegistry.CrossResolveAsync` resolved the primary fine, then walked `alsoKnownAs`, failed to resolve the `did:web` federation hint, and returned `null`.

Every Sorcha org publishes `did:web:{PlatformDomain}:orgs:{orgId}`, and **nothing serves a `did:web`-shaped document** — so that link is unresolvable for every org on every node. Latent since #596/#597; it only fired now because the AIAS cyber questionnaire is the first flow that *verifies* an org-issued credential rather than only issuing one.

Repointing `PlatformDomain` would not have helped: `WebDidResolver` requires `doc.Id == did`, and the served document's `id` is the `did:sorcha` form.

## Standards

W3C DID Core §5.1.3 is explicit that `alsoKnownAs` is **not** a verifiable assertion and advises against treating linked identifiers as equivalent absent a reciprocal relationship. Letting an unverifiable hint veto the identity that *did* verify inverts that. An unreachable link is now skipped, its key material never merged, and it is absent from the returned document so no caller can read it as verified equivalence.

## Security property preserved

A link that **resolves** but whose keys diverge still fails closed — `OneLinkMismatch_ReturnsNull` is untouched. Only the *unreachable* case changes.

## Blast radius

**None on already-issued credentials.** This changes resolution only — no anchor, `iss`, `kid`, or published document moves. Live credentials verify against the exact DID they already carry; nothing is orphaned and there is no migration.

## Tests

- `OneLinkUnreachable_ReturnsNull` inverted to `OneLinkUnreachable_ReturnsPrimaryWithEquivalenceWithheld`
- New `OrgIssuerDid_WithUnservedDidWebLink_StillYieldsIssuanceKey` reproduces the live n1 shape
- `Sorcha.ServiceClients.Tests` 336/336, `Sorcha.Verifier.Tests` 117/117
- Contract (`did-resolver-registry-contract.md`) steps 3b/4/6 amended — the code was faithful to a wrong contract

## Follow-ups (not in this PR)

1. `did:web` is half-built — `FederatedDid` is computed, stored and **indexed**, but has no reader and no serving endpoint.
2. No gateway route for F149's `/orgs/by-did/{did}/did.json`.
3. `OrgDidDocumentClient` logs "lazy rebuild will recover" but `OrgDidDocumentService.RegenerateAsync(orgId, reason)` throws `NotSupportedException` — there is no repair path for a published document short of a key event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)