### PR TITLE
fix: [F120/F149] - give the org DID document a real repair path, and fail closed without one

### DIFF
--- a/src/Common/Sorcha.ServiceClients.Http/OrgDidDocument/IOrgDidDocumentClient.cs
+++ b/src/Common/Sorcha.ServiceClients.Http/OrgDidDocument/IOrgDidDocumentClient.cs
@@ -11,11 +11,22 @@ public interface IOrgDidDocumentClient
 {
     /// <summary>
     /// Triggers regeneration of the org's published DID document with the supplied
-    /// key snapshot. Returns silently on success; logs and swallows on failure
-    /// (key derivation is the source of truth — DID-doc regeneration is a derived
-    /// projection that can be lazily rebuilt later).
+    /// key snapshot. Idempotent — the Tenant side no-ops when the recomputed
+    /// key-version fingerprint is unchanged.
     /// </summary>
-    Task RegenerateAsync(OrgDidRegenerateRequest request, CancellationToken ct = default);
+    /// <returns>
+    /// <c>true</c> when the Tenant Service accepted the snapshot; <c>false</c> on any
+    /// transport or non-success response. Never throws.
+    /// </returns>
+    /// <remarks>
+    /// The return value is load-bearing: callers that are about to SIGN with the key
+    /// this document publishes MUST fail closed on <c>false</c> unless they can confirm
+    /// a correctly-anchored document is already published. There is no background
+    /// rebuild — an earlier revision of this contract claimed a "lazy rebuild will
+    /// recover" and none existed, so a failed publish left the org permanently
+    /// unverifiable while issuance carried on succeeding.
+    /// </remarks>
+    Task<bool> RegenerateAsync(OrgDidRegenerateRequest request, CancellationToken ct = default);
 
     /// <summary>
     /// Resolves an organisation's canonical DID by fetching its published W3C DID

--- a/src/Common/Sorcha.ServiceClients.Http/OrgDidDocument/OrgDidDocumentClient.cs
+++ b/src/Common/Sorcha.ServiceClients.Http/OrgDidDocument/OrgDidDocumentClient.cs
@@ -25,7 +25,7 @@ public sealed class OrgDidDocumentClient : IOrgDidDocumentClient
     }
 
     /// <inheritdoc />
-    public async Task RegenerateAsync(OrgDidRegenerateRequest request, CancellationToken ct = default)
+    public async Task<bool> RegenerateAsync(OrgDidRegenerateRequest request, CancellationToken ct = default)
     {
         ArgumentNullException.ThrowIfNull(request);
         try
@@ -37,16 +37,22 @@ public sealed class OrgDidDocumentClient : IOrgDidDocumentClient
 
             if (!resp.IsSuccessStatusCode)
             {
+                // NOT recoverable on its own — there is no background rebuild. The caller
+                // decides whether to fail closed; see IOrgDidDocumentClient.RegenerateAsync.
                 _logger.LogWarning(
                     "OrgDidDocument regenerate returned {Status} for org {OrgId} reason {Reason}",
                     resp.StatusCode, request.OrganizationId, request.KeyEventReason);
+                return false;
             }
+
+            return true;
         }
         catch (Exception ex)
         {
             _logger.LogWarning(ex,
-                "OrgDidDocument regenerate failed for org {OrgId} reason {Reason}; lazy rebuild will recover",
+                "OrgDidDocument regenerate failed for org {OrgId} reason {Reason}",
                 request.OrganizationId, request.KeyEventReason);
+            return false;
         }
     }
 

--- a/src/Services/Sorcha.Tenant.Service/Services/IOrgDidDocumentService.cs
+++ b/src/Services/Sorcha.Tenant.Service/Services/IOrgDidDocumentService.cs
@@ -20,10 +20,17 @@ public interface IOrgDidDocumentService
     /// </summary>
     Task<OrgDidDocument?> GetByPrimaryDidAsync(string primaryDid, CancellationToken ct = default);
 
-    /// <summary>
-    /// Regenerates the DID document for the org. Idempotent — returns the existing row
-    /// unchanged when the recomputed key-version fingerprint matches the persisted one.
-    /// </summary>
-    Task<OrgDidDocument> RegenerateAsync(
-        Guid organizationId, KeyEventReason reason, CancellationToken ct = default);
+    // NOTE: there is deliberately NO RegenerateAsync(orgId, reason) here.
+    //
+    // It existed, was never called, and unconditionally threw NotSupportedException — Tenant
+    // holds no key material, so it cannot rebuild a document from an orgId alone. Its presence
+    // implied a server-side rebuild capability that does not exist, and the Wallet-side client
+    // documented a matching "lazy rebuild will recover" that was equally untrue. Together they
+    // made a failed publish look self-healing when it was permanent.
+    //
+    // Regeneration is snapshot-driven and Wallet-initiated: the key holder POSTs its current
+    // active-key snapshot to /orgs/{orgId}/did-document/regenerate
+    // (OrgDidDocumentService.RegenerateFromSnapshotAsync, idempotent on the key-version
+    // fingerprint). The repair path lives in IssuanceKeyService.EnsureDidDocumentPublishedAsync,
+    // which re-ensures publication before every signature and fails closed if it cannot.
 }

--- a/src/Services/Sorcha.Tenant.Service/Services/OrgDidDocumentService.cs
+++ b/src/Services/Sorcha.Tenant.Service/Services/OrgDidDocumentService.cs
@@ -114,14 +114,6 @@ public sealed class OrgDidDocumentService : IOrgDidDocumentService
         return existing;
     }
 
-    /// <inheritdoc />
-    public Task<OrgDidDocument> RegenerateAsync(
-        Guid organizationId, KeyEventReason reason, CancellationToken ct = default)
-        => throw new NotSupportedException(
-            "RegenerateAsync(orgId, reason) requires a key snapshot — use the snapshot overload " +
-            "via the regenerate endpoint. Direct in-process regeneration without keys is not " +
-            "supported in v1 (no Tenant→Wallet readback path).");
-
     private static List<DidVerificationMethod> BuildVerificationMethods(
         string primaryDid, IReadOnlyList<OrgDidActiveKey> keys)
     {

--- a/src/Services/Sorcha.Wallet.Service/Services/Implementation/IssuanceKeyService.cs
+++ b/src/Services/Sorcha.Wallet.Service/Services/Implementation/IssuanceKeyService.cs
@@ -126,35 +126,12 @@ public sealed class IssuanceKeyService : IIssuanceKeyService
             organizationId, state.Algorithm, state.RotationIndex);
 
         // Feature 149: publish the DID document anchored on the CANONICAL operational wallet (A),
-        // not the derived child (C). If A is unresolvable, skip the publish — the signing-material
-        // path fails closed, so an unanchored document would never be used.
-        var canonicalAddress = await _orgInfo
-            .ResolveCanonicalWalletAddressAsync(organizationId, ct)
-            .ConfigureAwait(false);
-        if (string.IsNullOrWhiteSpace(canonicalAddress))
-        {
-            _logger.LogWarning(
-                "Derived issuance key for org {OrgId} but no canonical wallet address to anchor the " +
-                "DID document; skipping publish (issuance fails closed until the org is provisioned).",
-                organizationId);
-        }
-        else
-        {
-            // Fire-and-forget DID-document regeneration trigger; the client is non-throwing.
-            var snapshot = new OrgDidRegenerateRequest(
-                OrganizationId: organizationId,
-                KeyEventReason: "IssuanceKeyDerived",
-                WalletAddress: canonicalAddress,
-                ActiveKeys:
-                [
-                    new OrgDidActiveKey(
-                        RotationIndex: state.RotationIndex,
-                        Algorithm: state.Algorithm,
-                        PublicKeyJwk: jwkJson,
-                        Thumbprint: state.Thumbprint)
-                ]);
-            await _didDocClient.RegenerateAsync(snapshot, ct).ConfigureAwait(false);
-        }
+        // not the derived child (C). Best-effort here — a failure is NOT fatal to derivation,
+        // because GetActiveSigningMaterialAsync re-ensures publication before every signature
+        // and fails closed there. That is what makes a failed publish recoverable rather than
+        // permanent; this call just gets the common case done early.
+        await EnsureDidDocumentPublishedAsync(
+            organizationId, "IssuanceKeyDerived", canonicalAddress: null, ct).ConfigureAwait(false);
 
         return state;
     }
@@ -267,6 +244,25 @@ public sealed class IssuanceKeyService : IIssuanceKeyService
             return null;
         }
 
+        // THE REPAIR PATH. Publication used to fire only on first key derivation, and the
+        // client swallowed failures, so a document that never published stayed missing forever
+        // while issuance carried on minting credentials no verifier could resolve. Ensuring it
+        // here — the last gate before signing — makes every mint self-healing and fails closed
+        // when the document backing this kid cannot be published or confirmed.
+        //
+        // No new availability coupling: resolving canonicalAddress above already requires Tenant.
+        if (!await EnsureDidDocumentPublishedAsync(
+                organizationId, "IssuanceKeyDerived", canonicalAddress, ct).ConfigureAwait(false))
+        {
+            _logger.LogError(
+                "Refusing to supply issuance signing material for org {OrgId}: the issuer DID "
+                + "document could not be published or confirmed, so a credential signed with "
+                + "kid #vc-issuance-{Rotation} would be unverifiable.",
+                organizationId, state.RotationIndex);
+            Array.Clear(privateKey); // drop the decrypted key we will not use
+            return null;
+        }
+
         var issuerDid = $"did:sorcha:org:{canonicalAddress}";
         var kid = $"{issuerDid}#vc-issuance-{state.RotationIndex}";
 
@@ -351,8 +347,8 @@ public sealed class IssuanceKeyService : IIssuanceKeyService
             .ConfigureAwait(false);
         if (derivedRecord is not null)
         {
-            await PushDidDocumentSnapshotAsync(
-                organizationId, "IssuanceKeyRotated", ct)
+            await EnsureDidDocumentPublishedAsync(
+                organizationId, "IssuanceKeyRotated", canonicalAddress: null, ct)
                 .ConfigureAwait(false);
         }
 
@@ -407,8 +403,8 @@ public sealed class IssuanceKeyService : IIssuanceKeyService
             .ConfigureAwait(false);
         if (derivedRecord is not null)
         {
-            await PushDidDocumentSnapshotAsync(
-                organizationId, "IssuanceKeyRevoked", ct)
+            await EnsureDidDocumentPublishedAsync(
+                organizationId, "IssuanceKeyRevoked", canonicalAddress: null, ct)
                 .ConfigureAwait(false);
         }
 
@@ -416,15 +412,25 @@ public sealed class IssuanceKeyService : IIssuanceKeyService
     }
 
     /// <summary>
-    /// Builds an active-keys snapshot from the current persisted state and pushes it
-    /// to the Tenant Service via <see cref="IOrgDidDocumentClient"/>. Used after
-    /// rotation/revocation to regenerate the published DID document.
+    /// Builds an active-keys snapshot from the current persisted state, publishes it to the
+    /// Tenant Service, and reports whether the org now has a correctly-anchored published DID
+    /// document. Idempotent — the Tenant side no-ops on an unchanged key-version fingerprint,
+    /// so this is safe to call on every issuance and is the org's only repair path.
     /// </summary>
-    private async Task PushDidDocumentSnapshotAsync(
-        Guid organizationId, string keyEventReason, CancellationToken ct)
+    /// <returns>
+    /// <c>true</c> when the snapshot was accepted, or when the publish failed but a document
+    /// anchored on the expected canonical wallet is already published and serving (a transient
+    /// Tenant write failure must not block issuance). <c>false</c> otherwise — callers about to
+    /// sign MUST fail closed.
+    /// </returns>
+    private async Task<bool> EnsureDidDocumentPublishedAsync(
+        Guid organizationId,
+        string keyEventReason,
+        string? canonicalAddress,
+        CancellationToken ct)
     {
         // Feature 149: anchor the regenerated document on the canonical operational wallet (A).
-        var canonicalAddress = await _orgInfo
+        canonicalAddress ??= await _orgInfo
             .ResolveCanonicalWalletAddressAsync(organizationId, ct)
             .ConfigureAwait(false);
         if (string.IsNullOrWhiteSpace(canonicalAddress))
@@ -432,7 +438,7 @@ public sealed class IssuanceKeyService : IIssuanceKeyService
             _logger.LogWarning(
                 "Cannot publish DID document for org {OrgId} ({Reason}) — no canonical wallet address.",
                 organizationId, keyEventReason);
-            return;
+            return false;
         }
 
         var activeKeys = await _db.IssuanceKeyStates
@@ -456,7 +462,35 @@ public sealed class IssuanceKeyService : IIssuanceKeyService
             KeyEventReason: keyEventReason,
             WalletAddress: canonicalAddress,
             ActiveKeys: snapshotKeys);
-        await _didDocClient.RegenerateAsync(snapshot, ct).ConfigureAwait(false);
+
+        if (await _didDocClient.RegenerateAsync(snapshot, ct).ConfigureAwait(false))
+            return true;
+
+        // The publish failed. Before failing closed, check whether a correctly-anchored
+        // document is ALREADY published — a transient Tenant write failure must not block
+        // issuance for an org whose document is present and serving.
+        var publishedDid = await _didDocClient
+            .ResolveCanonicalDidAsync(organizationId, ct)
+            .ConfigureAwait(false);
+        var expectedDid = $"did:sorcha:org:{canonicalAddress}";
+
+        if (string.Equals(publishedDid, expectedDid, StringComparison.Ordinal))
+        {
+            _logger.LogWarning(
+                "DID document publish failed for org {OrgId} ({Reason}), but the already-published "
+                + "document is correctly anchored on {ExpectedDid} — continuing.",
+                organizationId, keyEventReason, expectedDid);
+            return true;
+        }
+
+        // Either nothing is published, or what IS published is anchored elsewhere and therefore
+        // does not back the kid we are about to sign with.
+        _logger.LogError(
+            "DID document publish failed for org {OrgId} ({Reason}) and no correctly-anchored "
+            + "document is published (expected {ExpectedDid}, found {PublishedDid}). There is no "
+            + "background rebuild — issuance must fail closed until this succeeds.",
+            organizationId, keyEventReason, expectedDid, publishedDid ?? "(none)");
+        return false;
     }
 
     /// <summary>

--- a/tests/Sorcha.Wallet.Service.Tests/Services/IssuanceKeyServiceLifecycleTests.cs
+++ b/tests/Sorcha.Wallet.Service.Tests/Services/IssuanceKeyServiceLifecycleTests.cs
@@ -58,7 +58,7 @@ public sealed class IssuanceKeyServiceLifecycleTests : IDisposable
                 "Active", "Custodial", DateTime.UtcNow));
 
         _didClient.Setup(x => x.RegenerateAsync(It.IsAny<OrgDidRegenerateRequest>(), It.IsAny<CancellationToken>()))
-            .Returns(Task.CompletedTask);
+            .ReturnsAsync(true);
 
         // Feature 149: resolve the org's canonical operational wallet (A) for DID anchoring.
         _orgInfo.Setup(x => x.ResolveCanonicalWalletAddressAsync(_orgId, It.IsAny<CancellationToken>()))
@@ -163,6 +163,108 @@ public sealed class IssuanceKeyServiceLifecycleTests : IDisposable
             Times.Never);
     }
 
+    /// <summary>
+    /// Seeds the wallet row holding the issuance key's private material, so
+    /// <see cref="IssuanceKeyService.GetActiveSigningMaterialAsync"/> reaches the
+    /// DID-document gate instead of bailing on a missing/undecryptable wallet.
+    /// </summary>
+    private void SeedIssuanceWallet()
+    {
+        _db.Wallets.Add(new WalletEntity
+        {
+            Address = _walletAddress,
+            Algorithm = "ED25519",
+            PublicKey = Convert.ToBase64String(new byte[32]),
+            EncryptedPrivateKey = Convert.ToBase64String(new byte[48]),
+            EncryptionKeyId = "test-key",
+            Owner = "org",
+            Tenant = "system",
+            Name = "issuance-key-wallet"
+        });
+        _db.SaveChanges();
+
+        _protection.Setup(x => x.DecryptSeedAsync(
+                It.IsAny<byte[]>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new byte[32]);
+    }
+
+    [Fact]
+    public async Task GetActiveSigningMaterialAsync_RepublishesDidDocument_WhenKeyAlreadyExists()
+    {
+        // The repair path. Publication used to fire ONLY on first key derivation, so a
+        // document that failed to publish (or was lost) stayed missing forever while
+        // issuance carried on minting credentials no verifier could check.
+        SeedActiveKey();
+        SeedIssuanceWallet();
+
+        var material = await _sut.GetActiveSigningMaterialAsync(_orgId);
+
+        material.Should().NotBeNull();
+        _didClient.Verify(x => x.RegenerateAsync(
+            It.Is<OrgDidRegenerateRequest>(r => r.OrganizationId == _orgId
+                                             && r.WalletAddress == _canonicalAddress),
+            It.IsAny<CancellationToken>()),
+            Times.AtLeastOnce,
+            "signing must ensure the issuer's DID document is published, not assume it");
+    }
+
+    [Fact]
+    public async Task GetActiveSigningMaterialAsync_UnpublishableDidDocument_ReturnsNull()
+    {
+        // Fail closed. Signing already refuses when the canonical address is unresolvable;
+        // it must equally refuse when the document backing the kid cannot be published,
+        // rather than mint a credential whose issuer DID resolves to nothing.
+        SeedActiveKey();
+        SeedIssuanceWallet();
+        _didClient.Setup(x => x.RegenerateAsync(
+                It.IsAny<OrgDidRegenerateRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+        _didClient.Setup(x => x.ResolveCanonicalDidAsync(_orgId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string?)null); // and none was previously published
+
+        var material = await _sut.GetActiveSigningMaterialAsync(_orgId);
+
+        material.Should().BeNull(
+            "minting against an unpublishable issuer DID produces an unverifiable credential");
+    }
+
+    [Fact]
+    public async Task GetActiveSigningMaterialAsync_PublishFailsButDocumentAlreadyPublished_ReturnsMaterial()
+    {
+        // Availability guard: a transient Tenant write failure must NOT block issuance when
+        // a correctly-anchored document is already published and serving.
+        SeedActiveKey();
+        SeedIssuanceWallet();
+        _didClient.Setup(x => x.RegenerateAsync(
+                It.IsAny<OrgDidRegenerateRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+        _didClient.Setup(x => x.ResolveCanonicalDidAsync(_orgId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync($"did:sorcha:org:{_canonicalAddress}");
+
+        var material = await _sut.GetActiveSigningMaterialAsync(_orgId);
+
+        material.Should().NotBeNull();
+        material!.IssuerDid.Should().Be($"did:sorcha:org:{_canonicalAddress}");
+    }
+
+    [Fact]
+    public async Task GetActiveSigningMaterialAsync_PublishedDocumentAnchoredElsewhere_ReturnsNull()
+    {
+        // Drift guard: a stale document anchored on a DIFFERENT address does not back the kid
+        // we are about to sign with, so it must not be accepted as confirmation.
+        SeedActiveKey();
+        SeedIssuanceWallet();
+        _didClient.Setup(x => x.RegenerateAsync(
+                It.IsAny<OrgDidRegenerateRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+        _didClient.Setup(x => x.ResolveCanonicalDidAsync(_orgId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync("did:sorcha:org:ws11qpsomeotherwalletentirely");
+
+        var material = await _sut.GetActiveSigningMaterialAsync(_orgId);
+
+        material.Should().BeNull();
+    }
+
     [Fact]
     public async Task RevokeAsync_UnknownRotation_ReturnsNull()
     {
@@ -256,7 +358,21 @@ public sealed class IssuanceKeyServiceLifecycleTests : IDisposable
             // Ignore every other entity type — they bring jsonb / Postgres-specific
             // mappings the relational test provider can't satisfy. We only need
             // IssuanceKeyState + DerivedKeyRecord for IssuanceKeyService coverage.
-            modelBuilder.Ignore<WalletEntity>();
+            // Wallet IS mapped (minimally): GetActiveSigningMaterialAsync reads it for the
+            // issuance private key, so ignoring it left that whole method uncovered. Only the
+            // jsonb dictionaries and navigations are dropped — they are what the relational
+            // test provider cannot satisfy, not the scalar columns we assert on.
+            modelBuilder.Entity<WalletEntity>(e =>
+            {
+                e.ToTable("Wallets");
+                e.HasKey(w => w.Address);
+                e.Ignore(w => w.Metadata);
+                e.Ignore(w => w.Tags);
+                e.Ignore(w => w.Addresses);
+                e.Ignore(w => w.Delegates);
+                e.Ignore(w => w.Transactions);
+                e.Ignore(w => w.RecoveryKeyWraps);
+            });
             modelBuilder.Ignore<Sorcha.Wallet.Core.Domain.Entities.WalletAddress>();
             modelBuilder.Ignore<Sorcha.Wallet.Core.Domain.Entities.WalletAccess>();
             modelBuilder.Ignore<Sorcha.Wallet.Core.Domain.Entities.WalletTransaction>();


### PR DESCRIPTION
## What

Gives the org DID document a real repair path, and makes signing fail closed when it doesn't have one.

## Why

Found while fixing #1316 — the same class of defect one layer up. A failed publish was **permanent and silent**:

- Publication fired **only on the first key derivation** (`GetOrDeriveAsync` early-returns on an existing Active row).
- `OrgDidDocumentClient` swallowed failures, logging *"lazy rebuild will recover"*.
- The rebuild it named — `IOrgDidDocumentService.RegenerateAsync(orgId, reason)` — **unconditionally threw `NotSupportedException`** and had **no callers**. Tenant holds no key material, so it never could work.
- Signing failed closed on the canonical address but **not** on "is the document actually published".

Net effect: an org whose publish failed once kept minting credentials no verifier could resolve, indefinitely, with nothing in the logs saying so. Exactly the shape of bug that produced the AIAS outage — a join nothing verified.

## Changes

| | |
|---|---|
| `IOrgDidDocumentClient.RegenerateAsync` | returns `Task<bool>` (still never throws); the false "lazy rebuild" claim removed from contract **and** log |
| `EnsureDidDocumentPublishedAsync` | the single publish path — derive / rotate / revoke / pre-sign all route through it. Idempotent (Tenant no-ops on unchanged fingerprint), so safe per issuance |
| `GetActiveSigningMaterialAsync` | ensures publication before returning material; returns `null` when it can't. **This is both the repair path and the missing gate** |
| `IOrgDidDocumentService.RegenerateAsync(orgId, reason)` | **removed** rather than left as a throwing stub implying a capability Tenant cannot have |

## Availability

A transient publish failure does **not** block issuance when a document anchored on the expected canonical wallet is already published and serving. A document anchored **elsewhere** does not back the kid being signed with, and is rejected. No new availability coupling — resolving the canonical address on this path already required Tenant.

## Tests (TDD — each watched failing first)

- `RepublishesDidDocument_WhenKeyAlreadyExists` — the repair path
- `UnpublishableDidDocument_ReturnsNull` — fail closed
- `PublishFailsButDocumentAlreadyPublished_ReturnsMaterial` — availability guard
- `PublishedDocumentAnchoredElsewhere_ReturnsNull` — drift guard

The test `DbContext` now maps `Wallet` minimally. Ignoring it had left `GetActiveSigningMaterialAsync` **entirely uncovered** — which is why none of this was caught.

Wallet 963 · ServiceClients 336 · Tenant 1593 · Verifier 117 — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)