### PR TITLE
fix: [AIAS M2] - slider seeding caused an infinite render loop that froze the Cyber form

### DIFF
--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Forms/Controls/SliderRenderer.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Forms/Controls/SliderRenderer.razor
@@ -127,7 +127,23 @@ else
         // Write the seeded value straight back so an untouched slider still submits a real
         // integer. Without this, a citizen who accepts the default answer submits nothing and
         // the scoring check sees a missing field.
-        FormContext?.SetValue(Control.Scope, _value);
+        //
+        // The write MUST be idempotent. OnParametersSet runs on every re-render;
+        // FormContext.SetValue raises OnDataChanged; ControlDispatcher re-renders on
+        // OnDataChanged. Writing unconditionally therefore closes a feedback loop that never
+        // settles — it froze the browser tab on the AIAS Cyber form (two sliders, mutually
+        // reinforcing) with no console error and no further network requests. Skipping the
+        // write when the stored value is already this exact integer breaks the cycle while
+        // keeping the seed. A non-int stored value is still overwritten, so the field is
+        // normalised to a real integer (a stringly-typed answer scores 0 in every band).
+        var alreadySeeded =
+            FormContext is not null
+            && FormContext.FormData.TryGetValue(Control.Scope, out var stored)
+            && stored is int storedInt
+            && storedInt == _value;
+
+        if (!alreadySeeded)
+            FormContext?.SetValue(Control.Scope, _value);
 
         UpdateErrors();
     }

--- a/tests/Sorcha.UI.Core.Tests/Components/Forms/Controls/SliderRendererRenderTests.cs
+++ b/tests/Sorcha.UI.Core.Tests/Components/Forms/Controls/SliderRendererRenderTests.cs
@@ -91,6 +91,50 @@ public class SliderRendererRenderTests : BunitContext
     }
 
     [Fact]
+    public void Rerender_WithUnchangedValue_RaisesNoFurtherDataChange()
+    {
+        // THE RENDER-LOOP GUARD. The seed write lives in OnParametersSet, which runs on every
+        // re-render. FormContext.SetValue raises OnDataChanged; ControlDispatcher subscribes to
+        // OnDataChanged and calls StateHasChanged; that re-renders this component, running
+        // OnParametersSet again. Writing unconditionally therefore closes a feedback loop that
+        // never settles — it froze the browser tab on the AIAS Cyber form (two sliders, mutually
+        // reinforcing) with no error and no further network activity.
+        //
+        // ControlDispatcher is not in this render tree, so the loop cannot be reproduced here
+        // directly. What IS reproducible — and is precisely the condition that closes it — is a
+        // redundant write when nothing changed. Seeding must be idempotent.
+        var ctx = MakeContext();
+        var host = RenderSlider(ctx);
+        var slider = host.FindComponent<SliderRenderer>();
+
+        var writesAfterSeed = 0;
+        ctx.OnDataChanged += () => writesAfterSeed++;
+
+        // Drive OnParametersSet the way a parent re-render does. Re-rendering the CONTAINER is
+        // not enough — Blazor only re-runs a child's OnParametersSet when its parameters are
+        // actually set again, which is exactly what ControlDispatcher's StateHasChanged causes.
+        slider.Render(p => p.Add(c => c.Control, MakeControl()));
+
+        writesAfterSeed.Should().Be(0,
+            "an already-seeded slider must not write again on re-render; each redundant write "
+            + "re-raises OnDataChanged and drives another render");
+    }
+
+    [Fact]
+    public void Rerender_StillPreservesTheSeededValue()
+    {
+        // Guard the guard: suppressing the redundant write must not lose the seed.
+        var ctx = MakeContext();
+        var host = RenderSlider(ctx);
+
+        host.FindComponent<SliderRenderer>()
+            .Render(p => p.Add(c => c.Control, MakeControl()));
+
+        ctx.GetValue<int?>("/sharedPasswordCount").Should().Be(2);
+        ctx.FormData["/sharedPasswordCount"].Should().BeOfType<int>();
+    }
+
+    [Fact]
     public void OnInit_ExistingValue_IsPreserved()
     {
         var ctx = MakeContext();


### PR DESCRIPTION
Opening the AIAS Cyber questionnaire froze the browser tab: the page went
unresponsive and Chrome eventually reported a page timeout. The server was
healthy and idle throughout — it had already served the blueprint in 4.7ms and
saw no further requests. The hang was entirely client-side.

SliderRenderer seeded its field from OnParametersSet with an unconditional
FormContext.SetValue. SetValue raises OnDataChanged; ControlDispatcher
subscribes to OnDataChanged and calls StateHasChanged; that re-renders the
child, which runs OnParametersSet again:

  OnParametersSet -> SetValue -> OnDataChanged -> StateHasChanged -> OnParametersSet ...

The Cyber form declares TWO sliders, so the loop was mutually reinforcing. No
console error, no network activity, nothing in the server logs — it simply
stopped.

SliderRenderer is the ONLY control that writes to FormContext from a lifecycle
hook. Every other renderer writes solely from a user-driven OnValueChanged, and
HolderKeyRenderer writes once from OnInitializedAsync. That is why no other form
was affected, and why the identity blueprint (no sliders) was fine.

The seed itself is required — an untouched slider must still submit a real
integer or the scoring check sees a missing field — so the fix makes the write
idempotent rather than removing it: skip when the stored value is already this
exact integer. A non-int stored value is still overwritten, preserving the
normalisation that OnInit_AbsentValue_DoesNotWriteAString pins (a stringly-typed
answer scores 0 in every band).

Not caused by, and unrelated to, the DID resolver deploy (#1316) — issuer
verification runs on submit, and no request reached it.

Tests: Rerender_WithUnchangedValue_RaisesNoFurtherDataChange reproduces the
condition that closes the loop (a redundant write on re-render) and was watched
failing first; Rerender_StillPreservesTheSeededValue guards against the obvious
over-fix. Note bUnit re-rendering the CONTAINER does not re-run a child's
OnParametersSet — the test must Render() the child component itself, or it
passes vacuously. Sorcha.UI.Core.Tests 1577/1577.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RboWP2TKvm1nBG22nqsWek
