### PR TITLE
fix: [CI] - publish rebuilds every image that consumes a changed shared component library

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -59,7 +59,22 @@ jobs:
             exit 0
           fi
 
-          # Check individual services and apps
+          # Check individual services and apps.
+          #
+          # Each entry is a SPACE-SEPARATED list of paths; the image is rebuilt when ANY of
+          # them changed. Multiple paths exist because an app can ProjectReference a library
+          # that lives under a DIFFERENT app's directory — changes under src/Common/ and
+          # src/Core/ already force a rebuild-all above, but cross-references inside
+          # src/Apps/ do not, so they must be listed explicitly here.
+          #
+          # Concretely: Sorcha.UI.Components.User (the Feature 122 shared user-facing
+          # component library) lives under src/Apps/Sorcha.UI/ but is consumed by
+          # wallet-pwa and verifier too. Listing only each app's own directory rebuilt
+          # ui-web and silently shipped a STALE wallet-pwa bundle — a slider render-loop
+          # fix (#1319) landed on web while the phone kept the frozen build, which reads
+          # as "the fix didn't work" rather than "the image wasn't rebuilt".
+          #
+          # ADDING A CROSS-APP ProjectReference? Add the referenced path here too.
           declare -A SERVICE_PATHS
           SERVICE_PATHS["blueprint-service"]="src/Services/Sorcha.Blueprint.Service/"
           SERVICE_PATHS["wallet-service"]="src/Services/Sorcha.Wallet.Service/"
@@ -71,13 +86,24 @@ jobs:
           SERVICE_PATHS["mcp-server"]="src/Apps/Sorcha.McpServer/"
           SERVICE_PATHS["ui-web"]="src/Apps/Sorcha.UI/"
           SERVICE_PATHS["haip-service"]="src/Services/Sorcha.Haip.Service/"
-          SERVICE_PATHS["wallet-pwa"]="src/Apps/Sorcha.Wallet.Pwa/"
-          SERVICE_PATHS["verifier"]="src/Apps/Sorcha.Verifier/"
+          # wallet-pwa + verifier both ProjectReference Sorcha.UI.Components.User.
+          SERVICE_PATHS["wallet-pwa"]="src/Apps/Sorcha.Wallet.Pwa/ src/Apps/Sorcha.UI/Sorcha.UI.Components.User/"
+          SERVICE_PATHS["verifier"]="src/Apps/Sorcha.Verifier/ src/Apps/Sorcha.UI/Sorcha.UI.Components.User/"
+
+          DIFF_FILES=$(git diff --name-only HEAD~1 HEAD)
 
           CHANGED="["
           FIRST=true
           for SVC in "${!SERVICE_PATHS[@]}"; do
-            if git diff --name-only HEAD~1 HEAD | grep -q "${SERVICE_PATHS[$SVC]}"; then
+            MATCHED=false
+            # Unquoted expansion is deliberate — word-split the space-separated path list.
+            for SVC_PATH in ${SERVICE_PATHS[$SVC]}; do
+              if echo "$DIFF_FILES" | grep -q "$SVC_PATH"; then
+                MATCHED=true
+                break
+              fi
+            done
+            if [ "$MATCHED" = true ]; then
               if [ "$FIRST" = true ]; then
                 FIRST=false
               else

--- a/.github/workflows/publish-paths-gate.yml
+++ b/.github/workflows/publish-paths-gate.yml
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Sorcha Contributors
+#
+# Publish-path coverage gate. Fails when an image ProjectReferences a project under
+# src/Apps/ that its docker-publish.yml SERVICE_PATHS entry does not watch.
+#
+# Such an image is never rebuilt when only that project changes — it publishes a STALE
+# bundle with no error anywhere. That happened with Sorcha.UI.Components.User (shared by
+# ui-web, wallet-pwa and verifier): a fix rebuilt ui-web and shipped a stale wallet-pwa
+# carrying the same bug, which reads as "the fix didn't work" rather than "the image is
+# stale". src/Common/ and src/Core/ already force a rebuild-all, so this covers exactly
+# the remaining gap: cross-references inside src/Apps/.
+#
+# See scripts/check-publish-paths.ps1.
+
+name: publish-paths-gate
+
+on:
+  pull_request:
+    paths:
+      - "src/Apps/**/*.csproj"
+      - "src/Services/**/*.csproj"
+      - ".github/workflows/docker-publish.yml"
+      - "scripts/check-publish-paths.ps1"
+      - ".github/workflows/publish-paths-gate.yml"
+  workflow_dispatch:
+
+jobs:
+  publish-paths:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check publish-path coverage
+        shell: pwsh
+        run: ./scripts/check-publish-paths.ps1

--- a/scripts/check-publish-paths.ps1
+++ b/scripts/check-publish-paths.ps1
@@ -1,0 +1,133 @@
+#!/usr/bin/env pwsh
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Sorcha Contributors
+#
+# Publish-path coverage gate.
+#
+# docker-publish.yml rebuilds an image only when a file under one of that service's
+# SERVICE_PATHS entries changed. A project can ProjectReference a library living under a
+# DIFFERENT app's directory — and when it does, the referencing image is NEVER rebuilt if
+# only that library changed. It publishes a stale bundle, with no error anywhere.
+#
+# That happened: Sorcha.UI.Components.User (the F122 shared user-facing component library)
+# lives under src/Apps/Sorcha.UI/ and is consumed by wallet-pwa and verifier too. A slider
+# render-loop fix (#1319) rebuilt ui-web and shipped a stale wallet-pwa carrying the same
+# frozen form — which reads as "the fix didn't work on the phone", not "the image is stale".
+#
+# Changes under src/Common/ and src/Core/ already force a rebuild-all in docker-publish.yml,
+# so this gate covers exactly the gap: cross-references INSIDE src/Apps/.
+#
+# Exits non-zero listing each (service -> referenced project) pair that is not covered.
+
+$ErrorActionPreference = 'Stop'
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$workflow = Join-Path $repoRoot '.github/workflows/docker-publish.yml'
+
+if (-not (Test-Path $workflow)) {
+    Write-Error "docker-publish.yml not found at $workflow"
+    exit 1
+}
+
+$lines = Get-Content $workflow
+
+# --- Parse SERVICE_PATHS["svc"]="p1 p2 ..." and DOCKERFILES["svc"]="path/to/Dockerfile" ---
+$servicePaths = @{}
+$dockerfiles  = @{}
+foreach ($line in $lines) {
+    if ($line -match 'SERVICE_PATHS\["([^"]+)"\]="([^"]*)"') {
+        $servicePaths[$Matches[1]] = @($Matches[2] -split '\s+' | Where-Object { $_ })
+    }
+    elseif ($line -match 'DOCKERFILES\["([^"]+)"\]="([^"]*)"') {
+        $dockerfiles[$Matches[1]] = $Matches[2]
+    }
+}
+
+if ($servicePaths.Count -eq 0) {
+    Write-Error "Parsed zero SERVICE_PATHS entries — the workflow format changed; update this gate."
+    exit 1
+}
+
+function Normalize([string]$p) { ($p -replace '\\', '/').TrimEnd('/') }
+
+# Resolve a csproj's ProjectReference targets to repo-relative directories.
+function Get-ProjectReferences([string]$csprojPath) {
+    if (-not (Test-Path $csprojPath)) { return @() }
+    $dir = Split-Path -Parent $csprojPath
+    $refs = @()
+    foreach ($m in [regex]::Matches((Get-Content $csprojPath -Raw), 'ProjectReference\s+Include="([^"]+)"')) {
+        $resolved = Join-Path $dir $m.Groups[1].Value
+        try { $full = (Resolve-Path $resolved -ErrorAction Stop).Path } catch { continue }
+        $rel = Normalize ($full.Substring($repoRoot.Length).TrimStart('\', '/'))
+        $refs += (Split-Path -Parent $rel) -replace '\\', '/'
+    }
+    return $refs
+}
+
+# Walk references transitively — a two-hop dependency goes just as stale as a one-hop one.
+function Get-TransitiveAppRefs([string]$csprojPath) {
+    $seen = [System.Collections.Generic.HashSet[string]]::new()
+    $queue = [System.Collections.Generic.Queue[string]]::new()
+    $queue.Enqueue($csprojPath)
+    $result = @()
+    while ($queue.Count -gt 0) {
+        $current = $queue.Dequeue()
+        if (-not $seen.Add((Normalize $current))) { continue }
+        $dir = Split-Path -Parent $current
+        foreach ($m in [regex]::Matches((Get-Content $current -Raw -ErrorAction SilentlyContinue), 'ProjectReference\s+Include="([^"]+)"')) {
+            $resolved = Join-Path $dir $m.Groups[1].Value
+            try { $full = (Resolve-Path $resolved -ErrorAction Stop).Path } catch { continue }
+            $rel = Normalize ($full.Substring($repoRoot.Length).TrimStart('\', '/'))
+            if ($rel -like 'src/Apps/*') { $result += (Split-Path -Parent $rel) -replace '\\', '/' }
+            $queue.Enqueue($full)
+        }
+    }
+    return $result | Sort-Object -Unique
+}
+
+$violations = @()
+
+foreach ($svc in $servicePaths.Keys | Sort-Object) {
+    if (-not $dockerfiles.ContainsKey($svc)) { continue }
+
+    # The service's own project directory is the Dockerfile's directory.
+    $ownDir = Normalize (Split-Path -Parent $dockerfiles[$svc])
+    $csproj = Get-ChildItem -Path (Join-Path $repoRoot $ownDir) -Filter *.csproj -ErrorAction SilentlyContinue |
+              Select-Object -First 1
+    if (-not $csproj) { continue }
+
+    $watched = $servicePaths[$svc] | ForEach-Object { Normalize $_ }
+
+    foreach ($refDir in (Get-TransitiveAppRefs $csproj.FullName)) {
+        # Covered when any watched path is a prefix of the referenced directory.
+        $covered = $false
+        foreach ($w in $watched) {
+            if ($refDir -eq $w -or $refDir.StartsWith("$w/")) { $covered = $true; break }
+        }
+        if (-not $covered) {
+            $violations += [pscustomobject]@{ Service = $svc; Referenced = $refDir; Watched = ($watched -join ', ') }
+        }
+    }
+}
+
+if ($violations.Count -gt 0) {
+    Write-Host ''
+    Write-Host 'publish-paths gate FAILED' -ForegroundColor Red
+    Write-Host ''
+    Write-Host 'These images ProjectReference a project under src/Apps/ that their SERVICE_PATHS'
+    Write-Host 'entry does not watch. A change to that project would rebuild some images but ship'
+    Write-Host 'this one STALE, with no error:'
+    Write-Host ''
+    foreach ($v in $violations) {
+        Write-Host ("  {0}" -f $v.Service) -ForegroundColor Yellow
+        Write-Host ("      references : {0}" -f $v.Referenced)
+        Write-Host ("      watches    : {0}" -f $v.Watched)
+    }
+    Write-Host ''
+    Write-Host 'Fix: add the referenced directory to that service''s SERVICE_PATHS entry in'
+    Write-Host '.github/workflows/docker-publish.yml (entries are space-separated, ANY-match).'
+    Write-Host ''
+    exit 1
+}
+
+Write-Host "publish-paths gate passed — every src/Apps/ cross-reference is watched by its consuming image." -ForegroundColor Green
+exit 0


### PR DESCRIPTION
Change detection watched exactly one directory per image, so an app that
ProjectReferences a library under ANOTHER app's directory was never rebuilt
when that library changed.

Sorcha.UI.Components.User (the Feature 122 shared user-facing component
library) lives under src/Apps/Sorcha.UI/ and is consumed by wallet-pwa and
verifier as well as ui-web. The slider render-loop fix (#1319) therefore
rebuilt ui-web and silently shipped a STALE wallet-pwa bundle carrying the
same frozen form — which presents as "the fix didn't work on the phone"
rather than "the image was never rebuilt". Same latent staleness applied to
the verifier.

src/Common/ and src/Core/ changes already force a rebuild-all, so the gap was
specifically cross-references inside src/Apps/.

SERVICE_PATHS entries are now space-separated path lists, matched with ANY
semantics. Verified by simulation:
  shared component change -> ["wallet-pwa","ui-web","verifier"]
  PWA-only change         -> ["wallet-pwa"]
  unrelated app change    -> ["mcp-server"]   (no UI over-trigger)

The diff is computed once instead of per-service.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RboWP2TKvm1nBG22nqsWek
