### PR TITLE
fix: [F092] - persona autofill was unreadable in dark mode (the dark rules never applied)

### DIFF
--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Forms/PersonaFillSummary.razor.css
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Forms/PersonaFillSummary.razor.css
@@ -14,15 +14,20 @@
     gap: 8px;
     padding: 8px 12px;
     margin: 0 0 12px 0;
+    /* Theme-derived (see the note at the foot of this file) — fallbacks first. */
     background-color: #fff8e1;
+    background-color: color-mix(in srgb, var(--mud-palette-warning) 14%, var(--mud-palette-surface));
     border: 1px solid #ffcc80;
+    border: 1px solid color-mix(in srgb, var(--mud-palette-warning) 55%, var(--mud-palette-surface));
     border-radius: 6px;
     color: #4e342e;
+    color: var(--mud-palette-text-primary);
     font-size: 0.875rem;
 }
 
 .persona-fill-summary-icon {
     color: #ef6c00;
+    color: var(--mud-palette-warning);
     flex-shrink: 0;
 }
 
@@ -54,10 +59,13 @@
     margin: -6px 0 12px 0;
     padding: 8px 12px 12px 12px;
     background-color: #fffdf7;
+    background-color: color-mix(in srgb, var(--mud-palette-warning) 6%, var(--mud-palette-surface));
     border: 1px solid #ffe0b2;
+    border: 1px solid color-mix(in srgb, var(--mud-palette-warning) 35%, var(--mud-palette-surface));
     border-top: none;
     border-radius: 0 0 6px 6px;
-    box-shadow: 0 2px 4px rgba(78, 52, 46, 0.06);
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.12);
+    color: var(--mud-palette-text-primary);
 }
 
 .persona-fill-review-header {
@@ -89,20 +97,15 @@
     font-weight: 500;
 }
 
-/* --- Dark mode --- */
-
-:global([data-mud-theme="dark"]) .persona-fill-summary {
-    background-color: #3f3622;
-    border-color: #ffb74d;
-    color: #fff3e0;
-}
-
-:global([data-mud-theme="dark"]) .persona-fill-summary-icon {
-    color: #ffb74d;
-}
-
-:global([data-mud-theme="dark"]) .persona-fill-review {
-    background-color: #2a241a;
-    border-color: #5d4037;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.4);
-}
+/* --- Dark mode: nothing to do here, deliberately ---
+ *
+ * This file previously carried three `:global([data-mud-theme="dark"])` overrides. They
+ * NEVER APPLIED. MudBlazor 9.5's MudThemeProvider signals the active theme purely by
+ * swapping `--mud-palette-*` custom properties on :root — it adds no class or attribute to
+ * the DOM for theme state and emits no `data-mud-theme` at all. The banner therefore kept
+ * its light cream in dark mode while MudBlazor switched the surrounding text to light.
+ *
+ * The rules above now mix against `--mud-palette-surface` / `--mud-palette-text-primary`,
+ * so they track the active palette with no theme detection. Do NOT reintroduce a
+ * `[data-mud-theme]` selector — it is not a real hook.
+ */

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Forms/SorchaFormRenderer.razor.css
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Forms/SorchaFormRenderer.razor.css
@@ -148,9 +148,34 @@
  * changes). See research.md Decision 6.
  */
 
+/* THEME-DERIVED, NOT THEME-DETECTED.
+ *
+ * These colours are mixed from the live MudBlazor palette variables, so they follow
+ * whichever theme is active with no dark-mode selector at all.
+ *
+ * The previous version hardcoded a light cream here and corrected it under
+ * `:global([data-mud-theme="dark"])`. That override NEVER APPLIED: MudBlazor 9.5's
+ * MudThemeProvider signals the theme purely by swapping `--mud-palette-*` custom
+ * properties on :root — it puts no class or attribute in the DOM for theme state, and
+ * emits no `data-mud-theme` anywhere. So dark mode kept the light cream while MudBlazor
+ * switched its text to light, giving light-on-cream: unreadable.
+ *
+ * Mixing against `--mud-palette-surface` means the tint is pale on a light surface and
+ * muted-warm on a dark one automatically, and `--mud-palette-text-primary` is by
+ * definition the readable foreground for the active theme.
+ *
+ * NOTE: the sibling PersonaFillSummary.razor.css carried the same dead selectors and is
+ * fixed the same way. Those two files were the only source occurrences in the repo (an
+ * earlier count of ~35 was inflated by build-artifact copies under obj/ and bin/).
+ */
+
 .sorcha-field.autofilled {
-    background-color: #fff8e1; /* cream — WCAG AA against dark text */
-    border-left: 3px solid #ffcc80; /* warm amber accent */
+    /* Fallback for engines without color-mix (pre-Chrome 111 / Safari 16.2 / FF 113);
+     * the mixed values below win everywhere else. */
+    background-color: #fff8e1;
+    background-color: color-mix(in srgb, var(--mud-palette-warning) 14%, var(--mud-palette-surface));
+    border-left: 3px solid var(--mud-palette-warning);
+    color: var(--mud-palette-text-primary);
     padding: 6px 8px 6px 10px;
     border-radius: 4px;
     transition: background-color 160ms ease-out, border-color 160ms ease-out;
@@ -167,28 +192,15 @@
     line-height: 1.4;
     text-transform: uppercase;
     letter-spacing: 0.03em;
-    color: #4e342e; /* deep warm brown — ≥4.5:1 on #fff8e1 */
+    color: var(--mud-palette-text-primary);
     background-color: #ffe0b2;
+    background-color: color-mix(in srgb, var(--mud-palette-warning) 30%, var(--mud-palette-surface));
     border: 1px solid #ffcc80;
+    border: 1px solid color-mix(in srgb, var(--mud-palette-warning) 55%, var(--mud-palette-surface));
     border-radius: 999px;
 }
 
 .sorcha-field.autofilled .persona-tick::before {
     content: "\2713"; /* check mark */
     font-weight: 700;
-}
-
-/* Dark-mode palette. MudBlazor sets `data-mud-theme="dark"` on <html> when
- * dark mode is active. The darker cream + brighter accent keeps the tinted
- * state visible without blowing out contrast. */
-
-:global([data-mud-theme="dark"]) .sorcha-field.autofilled {
-    background-color: #3f3622; /* muted dark cream */
-    border-left-color: #ffb74d;
-}
-
-:global([data-mud-theme="dark"]) .sorcha-field.autofilled .persona-tick {
-    color: #fff3e0;
-    background-color: #5d4037;
-    border-color: #ffb74d;
 }


### PR DESCRIPTION
Dark mode kept the light cream tint on persona-filled fields while MudBlazor
switched the surrounding text to light, giving light-on-cream.

The dark-mode CSS existed and was well chosen. It simply never matched. Every
override was written as :global([data-mud-theme="dark"]), and MudBlazor 9.5
emits no such attribute: MudThemeProvider signals the active theme purely by
swapping --mud-palette-* custom properties on :root, adding no class or
attribute to the DOM for theme state. Confirmed against the package (only
mud-dark / mud-theme-dark appear in its own CSS) and against the MudBlazor
docs for MudThemeProvider.

Fixed by deriving instead of detecting: the tint mixes against
--mud-palette-surface and the foreground is --mud-palette-text-primary, so
both follow the active palette with no theme selector at all. Hardcoded
fallbacks are declared first for engines without color-mix (pre-Chrome 111 /
Safari 16.2 / FF 113).

Scope correction, recorded because it changed the plan: an initial count of
"~35 dead rules across the UI" was wrong — it included build-artifact copies
under obj/ and bin/. The real figure was 5 dead selectors in 2 adjacent files
(SorchaFormRenderer + PersonaFillSummary), so both are fixed here rather than
deferred to an audit. Source now contains zero [data-mud-theme] selectors, and
both files carry a note not to reintroduce one — it is not a real hook.

Contrast is not unit-testable here; verification is visual on n1. UI.Core
tests 1577/1577 unaffected.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RboWP2TKvm1nBG22nqsWek
