### PR TITLE
fix: [CI] - pin claude-code-action; the floating @v1 tag broke code review on 2026-07-21

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -33,7 +33,22 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@v1
+        # PINNED, deliberately. `@v1` is a FLOATING tag: it moves with every
+        # claude-code-action release, so an upstream change silently breaks this job
+        # with no commit on our side. That happened — 105 consecutive failures with
+        # zero successes beginning 2026-07-21, the exact day v1.0.180 shipped
+        # (v1.0.179, 2026-07-20, was the last green run). Our OAuth token secret had
+        # been unchanged since 2026-04-26 and this workflow since 2026-06-04, so
+        # nothing here changed when it broke.
+        #
+        # The failure mode is nasty: the action reports subtype "success" with
+        # is_error:true, num_turns 1, $0 cost and NO error text, so the log gives you
+        # nothing to diagnose from and it reads as an infra blip rather than a
+        # regression. Reviews stopped happening on every PR, including ones touching
+        # fail-closed security paths, and were merged past as "flaky".
+        #
+        # Bump this pin deliberately after checking a run goes green — do NOT restore @v1.
+        uses: anthropics/claude-code-action@v1.0.179
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'


### PR DESCRIPTION
claude-review has failed 105 consecutive times with ZERO successes since
2026-07-21. It is not the credentials.

Evidence:
- CLAUDE_CODE_OAUTH_TOKEN secret last updated 2026-04-26 (unchanged).
- This workflow last changed 2026-06-04 (unchanged).
- GitHub-side auth succeeds every run: OIDC token obtained, app token
  obtained, Claude Code initializes and reports its model.
- Failures begin exactly on 2026-07-21 — the day claude-code-action v1.0.180
  shipped. v1.0.179 (2026-07-20) covers the last green runs.
- The workflow pinned @v1, a floating tag, so upstream releases land here with
  no commit on our side.

Pinning to v1.0.179 both tests and fixes that. If this PR's own claude-review
goes green, the regression is confirmed and the credentials are exonerated.

Why this mattered more than a red tick: the action reports subtype "success"
with is_error:true, num_turns 1, $0 cost and no error text at all, so the log
offers nothing to diagnose and it reads as an infra blip. Code review silently
stopped running on every PR for a week — including several touching
fail-closed security paths, which were merged past on the assumption of flake.

Bump the pin deliberately after verifying green. Do not restore @v1.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RboWP2TKvm1nBG22nqsWek
