### PR TITLE
fix: [F127] - credential-match 400s were reported to citizens as "no matching credential"

### DIFF
--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/Credentials/CredentialApiService.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/Credentials/CredentialApiService.cs
@@ -706,13 +706,25 @@ public class CredentialApiService : ICredentialApiService
                 return results ?? [];
             }
 
-            _logger.LogWarning("Credential match failed: {StatusCode}", response.StatusCode);
-            return [];
+            // Do NOT return an empty list here. "The request failed" and "you hold no matching
+            // credential" are different facts, and CredentialGatePanel renders an empty list as
+            // "No matching credential — check your wallet". A 400 from a serialisation mismatch
+            // therefore accused citizens of not owning credentials they demonstrably held, and
+            // pointed them at their wallet instead of at the bug (n1, 2026-07-28). Throw so the
+            // caller can show its error state.
+            var body = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+            _logger.LogError(
+                "Credential match request failed for wallet {WalletAddress}: {StatusCode} {Body}",
+                walletAddress, response.StatusCode, body);
+            throw new HttpRequestException(
+                $"Credential match failed with {(int)response.StatusCode} {response.StatusCode}.",
+                inner: null,
+                statusCode: response.StatusCode);
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error matching credentials for wallet {WalletAddress}", walletAddress);
-            return [];
+            throw;
         }
     }
 

--- a/src/Services/Sorcha.Wallet.Service/Program.cs
+++ b/src/Services/Sorcha.Wallet.Service/Program.cs
@@ -314,6 +314,29 @@ builder.AddSorchaOpenApi("Sorcha Wallet Service API", "Cryptographic wallet mana
 builder.Services.AddHealthChecks()
     .AddWalletServiceHealthChecks(builder.Configuration);
 
+// Minimal-API JSON: read/write the shared SorchaJson shape (camelCase properties + kebab-case
+// string enums), matching Tenant Service and what every client already sends.
+//
+// Without this, body binding used ASP.NET's DEFAULT options, which know only the PascalCase names
+// from each enum's type-level [JsonConverter(typeof(JsonStringEnumConverter))]. The UI serialises
+// with JsonDefaults.Api (SorchaJson), whose kebab converter in the Converters collection OUTRANKS
+// that attribute — so it sends "fail-closed" / "sorcha-wallet" and the binder threw before the
+// handler ran.
+//
+// Live consequence (n1, 2026-07-28): every POST /credentials/match returned 400 in ~1ms, and the
+// client turns a non-success status into an empty match list — so the AIAS Cyber gate told a
+// citizen holding a valid, Active, correctly-typed Assured Identity credential that they had
+// "No matching credential". The endpoint had never worked from the web UI; it went unnoticed
+// because M1's actions declare no credentialRequirements.
+//
+// Scoped deliberately to this service rather than platform-wide (see the same call in Tenant's
+// Program.cs): services fronting standards surfaces — OAuth/OIDC snake_case, VC token bodies —
+// must NOT get a uniform casing. Wallet's standards output (the status-list JWT, credential
+// export) is written as text/pre-serialised tokens, not through minimal-API JSON serialisation,
+// so it is unaffected.
+builder.Services.ConfigureHttpJsonOptions(
+    options => Sorcha.Serialization.SorchaJson.Configure(options.SerializerOptions));
+
 // Configure CORS - production restriction handled at API Gateway (YARP)
 builder.AddSorchaCors();
 

--- a/tests/Sorcha.UI.ContractTests/CredentialRequirementWireContractTests.cs
+++ b/tests/Sorcha.UI.ContractTests/CredentialRequirementWireContractTests.cs
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Text.Json;
+using FluentAssertions;
+using Sorcha.Blueprint.Models.Credentials;
+using Xunit;
+
+namespace Sorcha.UI.ContractTests;
+
+/// <summary>
+/// The UI POSTs <see cref="CredentialRequirement"/> objects to Wallet Service's
+/// <c>POST /api/v1/wallets/{address}/credentials/match</c>. The client serialises with
+/// <c>JsonDefaults.Api</c> (SorchaJson — camelCase properties + kebab-case string enums).
+///
+/// Wallet Service used to bind the body with ASP.NET's DEFAULT options, which know only the
+/// PascalCase names from each enum's type-level <c>[JsonConverter(typeof(JsonStringEnumConverter))]</c>.
+/// SorchaJson's kebab converter lives in the <c>Converters</c> collection, which OUTRANKS that
+/// attribute — so the client sent <c>"fail-closed"</c> / <c>"sorcha-wallet"</c> and the binder threw.
+///
+/// Live consequence (n1, 2026-07-28): every match request was rejected 400 in ~1ms, before the
+/// handler ran, and the client turned a non-success status into an EMPTY match list. The AIAS Cyber
+/// gate therefore told a citizen holding a valid, Active, correctly-typed Assured Identity
+/// credential that they had "No matching credential — check your wallet". The endpoint had never
+/// worked from the web UI; it went unnoticed because M1's actions declare no credentialRequirements.
+/// </summary>
+public class CredentialRequirementWireContractTests
+{
+    private static readonly JsonSerializerOptions ClientOptions = Sorcha.Serialization.SorchaJson.Options;
+
+    /// <summary>Wallet Service's minimal-API body binder, built exactly as its Program.cs does.</summary>
+    private static readonly JsonSerializerOptions ServerOptions = BuildServerOptions();
+
+    /// <summary>ASP.NET's binder when a service does NOT call ConfigureHttpJsonOptions — the broken state.</summary>
+    private static readonly JsonSerializerOptions UnconfiguredServerOptions = new(JsonSerializerDefaults.Web);
+
+    private static JsonSerializerOptions BuildServerOptions()
+    {
+        var options = new JsonSerializerOptions(JsonSerializerDefaults.Web);
+        Sorcha.Serialization.SorchaJson.Configure(options);
+        return options;
+    }
+
+    private static CredentialRequirement MakeCyberGateRequirement() => new()
+    {
+        Type = "https://sorcha.dev/vc/assured-identity/v1",
+        PresentationSource = PresentationSource.SorchaWallet,
+        RequiredClaims =
+        [
+            new ClaimConstraint { ClaimName = "givenName" },
+            new ClaimConstraint { ClaimName = "familyName" }
+        ]
+    };
+
+    [Fact]
+    public void ClientSerialisedRequirement_IsReadableByTheServersOwnBinder()
+    {
+        var json = JsonSerializer.Serialize(MakeCyberGateRequirement(), ClientOptions);
+
+        var act = () => JsonSerializer.Deserialize<CredentialRequirement>(json, ServerOptions);
+
+        act.Should().NotThrow(
+            "the wallet-service body binder must be able to read what the UI actually sends; "
+            + "a binding failure here is a 400 the client reports as 'no matching credential'");
+
+        var roundTripped = JsonSerializer.Deserialize<CredentialRequirement>(json, ServerOptions);
+        roundTripped!.PresentationSource.Should().Be(PresentationSource.SorchaWallet,
+            "the gate must still route through the SorchaWallet presentation lifecycle");
+        roundTripped.Type.Should().Be("https://sorcha.dev/vc/assured-identity/v1");
+    }
+
+    [Fact]
+    public void AnUnconfiguredBinderCannotReadIt_WhichIsWhyTheServiceMustConfigureJson()
+    {
+        // Characterisation of the live failure. Kept so the REASON for the ConfigureHttpJsonOptions
+        // call is testable, rather than only asserted in a comment someone later tidies away.
+        var json = JsonSerializer.Serialize(MakeCyberGateRequirement(), ClientOptions);
+
+        var act = () => JsonSerializer.Deserialize<CredentialRequirement>(json, UnconfiguredServerOptions);
+
+        act.Should().Throw<JsonException>(
+            "default options know only the PascalCase enum names, so a service that skips "
+            + "ConfigureHttpJsonOptions rejects what every Sorcha client sends");
+    }
+
+    [Fact]
+    public void BlueprintAuthoredPascalCase_StillBinds()
+    {
+        // Blueprints declare "SorchaWallet" (PascalCase) on the wire — the fix for the kebab
+        // direction must NOT break reading authored blueprint JSON.
+        const string authored = """
+            {"type":"https://sorcha.dev/vc/assured-identity/v1","presentationSource":"SorchaWallet"}
+            """;
+
+        var fromClient = JsonSerializer.Deserialize<CredentialRequirement>(authored, ClientOptions);
+        var fromServer = JsonSerializer.Deserialize<CredentialRequirement>(authored, ServerOptions);
+
+        fromClient!.PresentationSource.Should().Be(PresentationSource.SorchaWallet);
+        fromServer!.PresentationSource.Should().Be(PresentationSource.SorchaWallet);
+    }
+
+    [Fact]
+    public void WalletServiceStillConfiguresItsJsonBinder()
+    {
+        // The regression guard that matters. The round-trip tests above build their own options, so
+        // they stay green even if Program.cs stops configuring the binder — which is exactly the
+        // defect that shipped. Assert the call is actually present in the service.
+        var repoRoot = FindRepoRoot();
+        var program = Path.Combine(repoRoot, "src", "Services", "Sorcha.Wallet.Service", "Program.cs");
+
+        File.Exists(program).Should().BeTrue($"expected Wallet Service Program.cs at {program}");
+        File.ReadAllText(program).Should().Contain("ConfigureHttpJsonOptions",
+            "Wallet Service must configure its minimal-API JSON binder with SorchaJson, or every "
+            + "request body carrying a kebab-case enum is rejected 400 before the handler runs");
+    }
+
+    private static string FindRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !Directory.Exists(Path.Combine(dir.FullName, ".git")))
+            dir = dir.Parent;
+        return dir?.FullName ?? throw new InvalidOperationException("repo root not found");
+    }
+}


### PR DESCRIPTION
The AIAS Cyber gate told a citizen holding a valid, Active, correctly-typed
Assured Identity credential that they had none. The credential was never the
problem: POST /api/v1/wallets/{addr}/credentials/match returned 400 in ~1ms,
before the handler ran, and the client turned that into an empty match list.

Root cause: Wallet Service never called ConfigureHttpJsonOptions, so minimal-API
body binding used ASP.NET's DEFAULT options — which know only the PascalCase
names from each enum's type-level [JsonConverter(typeof(JsonStringEnumConverter))].
The UI serialises with JsonDefaults.Api (SorchaJson), whose kebab converter sits
in the Converters collection and OUTRANKS that attribute, so it sends
"fail-closed" / "sorcha-wallet". The binder threw on the first kebab enum it met
($.revocationCheckPolicy), meaning ANY credentialRequirement 400d — this endpoint
has never worked from the web UI. It went unnoticed because M1's actions declare
no credentialRequirements; the cyber gate is the first that does.

Two fixes:

1. Wallet Service configures its binder with SorchaJson, matching Tenant. Scoped
   to this service, not platform-wide, per the rationale on Tenant's own call:
   services fronting standards surfaces (OAuth/OIDC snake_case, VC token bodies)
   must not get uniform casing. Wallet's standards output — the status-list JWT
   and credential export — is pre-serialised text, not minimal-API JSON, so it is
   unaffected. CLI contract tests (60) and wallet tests (963) confirm.

2. The client no longer converts a non-success status into an empty list. "The
   request failed" and "you hold no matching credential" are different facts, and
   collapsing them accused citizens of not owning credentials they demonstrably
   held while pointing them at their wallet instead of the bug. It now throws;
   CredentialGatePanel already catches and renders its "Failed to check
   credentials" state. Same defect class as the ambient-HttpClient 401 that
   surfaced as "No trusted lists imported yet".

Tests watched failing first: the round-trip threw on $.revocationCheckPolicy.
WalletServiceStillConfiguresItsJsonBinder is the guard that matters — the
round-trip tests build their own options and would stay green if Program.cs
stopped configuring the binder, which is exactly how this shipped.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RboWP2TKvm1nBG22nqsWek
