### PR TITLE
fix: [F127] - a verifier 404 now stops the QR poll and says so, instead of masquerading as Expired

### DIFF
--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/Credentials/HaipOfferService.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/Credentials/HaipOfferService.cs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Sorcha Contributors
 
+using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
 using Microsoft.Extensions.Logging;
@@ -49,25 +50,43 @@ public class HaipOfferService : IHaipOfferService
 
     public async Task<HaipVerificationResult?> GetVerificationResultAsync(
         Guid requestId, CancellationToken ct = default)
+        => (await PollVerificationResultAsync(requestId, ct)).Result;
+
+    /// <inheritdoc />
+    public async Task<HaipPollOutcome> PollVerificationResultAsync(
+        Guid requestId, CancellationToken ct = default)
     {
         try
         {
             var response = await _httpClient.GetAsync(
                 $"/api/v1/verifier/requests/{requestId}/result", ct);
 
+            // 404 is a PERMANENT fact — this verifier has no such request, so retrying cannot
+            // help. Every other failure (500, network) may genuinely succeed on the next tick.
+            // Collapsing the two into one null is what let the card poll a doomed request 150
+            // times and then misreport it as Expired.
+            if (response.StatusCode == HttpStatusCode.NotFound)
+            {
+                _logger.LogDebug(
+                    "Verifier has no request {RequestId} (404) — not retryable", requestId);
+                return HaipPollOutcome.NotFound;
+            }
+
             if (!response.IsSuccessStatusCode)
             {
                 _logger.LogWarning("Failed to get verification result for {RequestId}: {StatusCode}",
                     requestId, response.StatusCode);
-                return null;
+                return HaipPollOutcome.Transient;
             }
 
-            return await response.Content.ReadFromJsonAsync<HaipVerificationResult>(JsonOptions, ct);
+            var result = await response.Content
+                .ReadFromJsonAsync<HaipVerificationResult>(JsonOptions, ct);
+            return new HaipPollOutcome(result, RequestNotFound: false);
         }
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "Error polling verification result for {RequestId}", requestId);
-            return null;
+            return HaipPollOutcome.Transient;
         }
     }
 }

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/Credentials/HaipStates.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/Credentials/HaipStates.cs
@@ -38,6 +38,17 @@ public static class HaipPollingDefaults
 
     /// <summary>Delay (ms) before auto-closing a dialog after reaching an error state.</summary>
     public const int ErrorCloseDelayMs = 3000;
+
+    /// <summary>
+    /// Consecutive "request not found" polls tolerated before the card gives up and reports
+    /// <see cref="HaipVerificationStates.Unreachable"/>.
+    /// </summary>
+    /// <remarks>
+    /// Non-zero because a freshly-created request can 404 for a moment; failing on the very first
+    /// miss would be flaky. Small because the defect being fixed is polling a doomed request for
+    /// the whole <see cref="MaxPollTicks"/> window (5 minutes) while telling the citizen nothing.
+    /// </remarks>
+    public const int MaxConsecutiveNotFound = 3;
 }
 
 /// <summary>
@@ -53,7 +64,20 @@ public static class HaipVerificationStates
     public const string Expired = "Expired";
     public const string Cancelled = "Cancelled";
 
+    /// <summary>
+    /// CLIENT-SIDE ONLY — the verifier has no such request, so polling can never succeed.
+    /// Not a HAIP server state; it has no counterpart in PresentationRequestState.
+    /// </summary>
+    /// <remarks>
+    /// Exists because a 404 used to be collapsed into the same null as a transient failure, so the
+    /// card polled a doomed request for the full five-minute window, showed the citizen only
+    /// "Waiting for wallet to scan…", and finally reported <see cref="Expired"/> — a wrong
+    /// diagnosis. Found live on n1 (2026-07-28), where a SorchaWallet-sourced gate's request lives
+    /// in Blueprint's F127 lifecycle and HAIP has never heard of it.
+    /// </remarks>
+    public const string Unreachable = "Unreachable";
+
     /// <summary>Whether the state is terminal (no further transitions expected).</summary>
     public static bool IsTerminal(string state) =>
-        state is Verified or Denied or Expired or Cancelled;
+        state is Verified or Denied or Expired or Cancelled or Unreachable;
 }

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/Credentials/IHaipOfferService.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/Credentials/IHaipOfferService.cs
@@ -20,6 +20,17 @@ public interface IHaipOfferService
     /// Gets the verification result for a presentation request.
     /// </summary>
     Task<HaipVerificationResult?> GetVerificationResultAsync(Guid requestId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Polls the verification result, distinguishing "this verifier has no such request" (a 404 —
+    /// permanent, retrying cannot help) from a transient failure that may succeed next tick.
+    /// </summary>
+    /// <remarks>
+    /// Prefer this over <see cref="GetVerificationResultAsync"/> in polling loops. The older
+    /// method returns null for BOTH cases, which is what let the QR card poll a non-existent
+    /// request for its full five-minute window and then report it as Expired.
+    /// </remarks>
+    Task<HaipPollOutcome> PollVerificationResultAsync(Guid requestId, CancellationToken ct = default);
 }
 
 /// <summary>Status of a HAIP credential offer.</summary>
@@ -37,3 +48,21 @@ public record HaipVerificationResult(
     bool? IsValid,
     Dictionary<string, JsonElement>? VerifiedClaims,
     IReadOnlyList<string>? Errors);
+
+/// <summary>
+/// One poll of a verification result: the payload when the verifier answered, plus whether the
+/// verifier reported that it holds no such request at all.
+/// </summary>
+/// <param name="Result">The verification result, or null when the poll did not yield one.</param>
+/// <param name="RequestNotFound">
+/// True only for a 404 — the verifier has no such request, so further polling is pointless.
+/// False for transient failures, which are worth retrying.
+/// </param>
+public sealed record HaipPollOutcome(HaipVerificationResult? Result, bool RequestNotFound)
+{
+    /// <summary>The verifier has no such request (404).</summary>
+    public static readonly HaipPollOutcome NotFound = new(null, RequestNotFound: true);
+
+    /// <summary>A retryable failure — no result this tick, but the request may still exist.</summary>
+    public static readonly HaipPollOutcome Transient = new(null, RequestNotFound: false);
+}

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Components/Credentials/PresentationRequestQrCard.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Components/Credentials/PresentationRequestQrCard.razor
@@ -98,6 +98,13 @@
                 This request has expired. A new presentation request is needed.
             </MudAlert>
         }
+        else if (_state == HaipVerificationStates.Unreachable)
+        {
+            <MudAlert Severity="Severity.Error" Dense="true" Class="mt-2">
+                We couldn't reach this verification request. Nothing was sent from your wallet —
+                please close this and try again, and tell us if it keeps happening.
+            </MudAlert>
+        }
         else if (_state == HaipVerificationStates.Cancelled)
         {
             <MudAlert Severity="Severity.Error" Class="mb-4">
@@ -205,6 +212,7 @@
     {
         using var timer = new PeriodicTimer(HaipPollingDefaults.PollInterval);
         var ticks = 0;
+        var notFoundStreak = 0;
         try
         {
             while (await timer.WaitForNextTickAsync(ct))
@@ -221,7 +229,36 @@
                     break;
                 }
 
-                var result = await HaipService.GetVerificationResultAsync(requestId, ct);
+                var outcome = await HaipService.PollVerificationResultAsync(requestId, ct);
+
+                // A 404 means this verifier holds no such request, so no number of further polls
+                // can succeed. Tolerate a couple (a just-created request can 404 briefly), then
+                // stop and SAY SO. Previously this was indistinguishable from "not scanned yet",
+                // so a doomed request was polled for the full 5-minute window and then reported
+                // as Expired — which sent the citizen looking at their wallet instead of at us.
+                if (outcome.RequestNotFound)
+                {
+                    if (++notFoundStreak < HaipPollingDefaults.MaxConsecutiveNotFound) continue;
+
+                    Logger.LogError(
+                        "Verification request {RequestId} does not exist on the verifier after "
+                        + "{Streak} consecutive 404s — giving up. If this gate is presentationSource "
+                        + "'SorchaWallet', its request lives in the Blueprint presentation lifecycle, "
+                        + "not HAIP.", requestId, notFoundStreak);
+
+                    await InvokeAsync(async () =>
+                    {
+                        if (_disposed || HaipVerificationStates.IsTerminal(_state)) return;
+                        _state = HaipVerificationStates.Unreachable;
+                        StateHasChanged();
+                        if (OnStateChanged.HasDelegate) await OnStateChanged.InvokeAsync(_state);
+                    });
+                    break;
+                }
+
+                notFoundStreak = 0;
+
+                var result = outcome.Result;
                 if (result is null) continue;
 
                 var newState = result.State;

--- a/tests/Sorcha.UI.Core.Tests/Services/Credentials/HaipOfferServicePollTests.cs
+++ b/tests/Sorcha.UI.Core.Tests/Services/Credentials/HaipOfferServicePollTests.cs
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Net;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Sorcha.UI.Core.Services.Credentials;
+using Xunit;
+
+namespace Sorcha.UI.Core.Tests.Services.Credentials;
+
+/// <summary>
+/// A 404 from the verifier means "this request does not exist here" — a permanent fact, not a
+/// transient "the wallet hasn't scanned yet". Collapsing both into null (the previous behaviour)
+/// made the QR card poll a doomed request 150 times over five minutes, show the citizen nothing
+/// but "Waiting for wallet to scan…", and finally misreport it as Expired.
+///
+/// Observed live on n1 (2026-07-28): the AIAS Cyber gate is presentationSource "SorchaWallet", so
+/// its request lives in Blueprint's F127 lifecycle and HAIP has never heard of it.
+/// </summary>
+public class HaipOfferServicePollTests
+{
+    private sealed class StubHandler(HttpStatusCode status, string? body = null) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+            => Task.FromResult(new HttpResponseMessage(status)
+            {
+                Content = new StringContent(body ?? string.Empty, System.Text.Encoding.UTF8, "application/json")
+            });
+    }
+
+    private static HaipOfferService Build(HttpStatusCode status, string? body = null) =>
+        new(new HttpClient(new StubHandler(status, body)) { BaseAddress = new Uri("https://n1.test/") },
+            NullLogger<HaipOfferService>.Instance);
+
+    [Fact]
+    public async Task NotFound_IsReportedAsRequestNotFound_NotAsATransientMiss()
+    {
+        var sut = Build(HttpStatusCode.NotFound);
+
+        var outcome = await sut.PollVerificationResultAsync(Guid.NewGuid());
+
+        outcome.RequestNotFound.Should().BeTrue(
+            "a 404 means the verifier has no such request — polling it again cannot succeed");
+        outcome.Result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ServerError_IsTransient_NotRequestNotFound()
+    {
+        // A 500 or a network blip genuinely may succeed on the next tick; it must NOT be
+        // mistaken for "this request will never exist".
+        var sut = Build(HttpStatusCode.InternalServerError);
+
+        var outcome = await sut.PollVerificationResultAsync(Guid.NewGuid());
+
+        outcome.RequestNotFound.Should().BeFalse();
+        outcome.Result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task SuccessfulPoll_ReturnsTheResult()
+    {
+        var sut = Build(HttpStatusCode.OK, """{"state":"Verified"}""");
+
+        var outcome = await sut.PollVerificationResultAsync(Guid.NewGuid());
+
+        outcome.RequestNotFound.Should().BeFalse();
+        outcome.Result.Should().NotBeNull();
+        outcome.Result!.State.Should().Be(HaipVerificationStates.Verified);
+    }
+
+    [Fact]
+    public void UnreachableIsTerminal_SoThePollingLoopStopsAndTheCardCanSayWhy()
+    {
+        HaipVerificationStates.IsTerminal(HaipVerificationStates.Unreachable).Should().BeTrue();
+    }
+
+    [Fact]
+    public void NotFoundToleranceIsSmallButNonZero()
+    {
+        // Non-zero: a request can 404 for a moment immediately after creation, so failing on the
+        // very first miss would be flaky. Small: five minutes of doomed polling is the bug.
+        HaipPollingDefaults.MaxConsecutiveNotFound.Should().BeInRange(2, 5);
+    }
+}


### PR DESCRIPTION
Submitting the AIAS Cyber questionnaire left the page polling
GET /api/v1/verifier/requests/{id}/result 404 over and over while showing
only "Waiting for wallet to scan...".

Correcting the first read of this: the loop is NOT unbounded. MaxPollTicks
(150) x PollInterval (2s) caps it at five minutes, and OnParametersSet is
already guarded against spawning duplicate loops. The actual defect is that
HaipOfferService collapsed a 404 into the same null as a transient failure, so
the card could not tell "this verifier has no such request" (permanent) from
"the wallet hasn't scanned yet" (normal). Every one of the 150 polls was
doomed, the citizen got no signal for five minutes, and it finally reported
Expired - a wrong diagnosis that sends them to look at their wallet.

- PollVerificationResultAsync returns HaipPollOutcome, distinguishing a 404
  from a retryable failure. GetVerificationResultAsync remains, delegating.
- The card tolerates MaxConsecutiveNotFound (3) 404s - a freshly-created
  request can 404 briefly, so failing on the first would be flaky - then stops
  with the new client-side terminal state Unreachable and an honest message
  saying nothing was sent from their wallet.
- The give-up logs the likely cause: a presentationSource "SorchaWallet" gate's
  request lives in Blueprint's F127 lifecycle, not HAIP.

This does NOT fix the underlying mis-routing (PresentationRequestQrCard is
HAIP-only and never branches on PresentationSource) - that is the next piece.
It makes the failure honest and bounded rather than silent and misattributed.

Tests watched failing first (API absent). Sorcha.UI.Core.Tests 1583/1583.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RboWP2TKvm1nBG22nqsWek
