### PR TITLE
fix: [F127] - stop giving up on a live presentation after 60s, and authenticate the hub

### DIFF
--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Forms/Panels/CredentialGatePanel.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Forms/Panels/CredentialGatePanel.razor
@@ -111,6 +111,12 @@
     private bool _matchError;
     private bool _allRequirementsMet;
 
+    /// <summary>
+    /// The (wallet, requirement-types) pair the current <see cref="_matchResults"/> were fetched
+    /// for. Guards against re-matching on every parent re-render.
+    /// </summary>
+    private string? _matchedFor;
+
     protected override async Task OnParametersSetAsync()
     {
         _requirements = Requirements.ToList();
@@ -118,6 +124,17 @@
         if (!_requirements.Any() || string.IsNullOrEmpty(WalletAddress))
             return;
 
+        // MatchCredentialsAsync calls StateHasChanged, which re-renders the parent, which sets
+        // parameters again — an unguarded call here is a feedback loop. Observed live on n1
+        // (2026-07-28): six POSTs to /credentials/match within the same second for one
+        // requirement. Same shape as the slider render loop (#1319).
+        var key = $"{WalletAddress}|{string.Join(",", _requirements.Select(r => r.Type))}";
+        if (string.Equals(key, _matchedFor, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        _matchedFor = key;
         await MatchCredentialsAsync();
     }
 

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Models/User/Workflows/WorkflowInstanceViewModel.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Models/User/Workflows/WorkflowInstanceViewModel.cs
@@ -3,6 +3,7 @@
 
 using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
+using Sorcha.Blueprint.Models.Credentials;
 
 namespace Sorcha.UI.Core.Models.Workflows;
 
@@ -58,6 +59,12 @@ public record ActionSubmissionViewModel
     public string ActionId { get; init; } = string.Empty;
     public string InstanceId { get; init; } = string.Empty;
     public Dictionary<string, object> Data { get; init; } = new();
+
+    /// <summary>
+    /// Credentials the citizen selected from their own wallet, carried from the form's
+    /// <c>CredentialGatePanel</c> through the dialog to the execute request.
+    /// </summary>
+    public List<CredentialPresentation>? CredentialPresentations { get; init; }
 }
 
 /// <summary>
@@ -71,4 +78,18 @@ public record ActionExecuteRequest
     public string SenderWallet { get; init; } = string.Empty;
     public string RegisterAddress { get; init; } = string.Empty;
     public Dictionary<string, object> PayloadData { get; init; } = new();
+
+    /// <summary>
+    /// Credentials the citizen selected from their own wallet to satisfy the action's
+    /// requirements, and consented to disclose.
+    /// </summary>
+    /// <remarks>
+    /// Load-bearing. The server skips the cross-device presentation lifecycle entirely when this
+    /// is populated (<c>ActionExecutionService</c>: <c>!hasSubmittedPresentations</c>). This field
+    /// did not exist, so a citizen who picked a credential in <c>CredentialGatePanel</c> — while
+    /// signed in, with that credential in their own wallet — had the selection silently dropped
+    /// here and was then shown a QR code to scan with a second device. The UI offered a consent
+    /// control wired to nothing.
+    /// </remarks>
+    public List<CredentialPresentation>? CredentialPresentations { get; init; }
 }

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/Presentation/SorchaWalletGateTransport.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/Presentation/SorchaWalletGateTransport.cs
@@ -47,11 +47,18 @@ public sealed class SorchaWalletGateTransport(
             return Task.CompletedTask;
         }
 
+        // A 404 streak IS terminal: the lifecycle holds no such request, so no amount of further
+        // waiting can succeed.
         void OnUnreachable() => completion.TrySetResult(GateOutcome.Unreachable);
 
-        // 60 s with neither transport surfacing anything is an infrastructure problem, not a
-        // holder decision — say so, rather than blaming the citizen's wallet.
-        void OnManualRecovery() => completion.TrySetResult(GateOutcome.Unreachable);
+        // Manual-recovery fires after 60 s with no signal. That is NOT terminal and must never be
+        // reported as Unreachable: a presentation request is valid for its whole window (ten
+        // minutes on n1), and sixty seconds is simply how long it takes a citizen to pick up their
+        // phone, unlock it and scan. Ending the wait here told a citizen "nothing was sent from
+        // your wallet" about a request that was alive and waiting for them — the same wrong
+        // diagnosis this component exists to remove, pointed at a different innocent party.
+        // Expiry is the lifecycle's job: /status reports "expired" and that maps to Expired.
+        void OnManualRecovery() => progress?.Report(GateOutcome.Pending);
 
         void OnFallback() => progress?.Report(GateOutcome.Pending);
 

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/WorkflowService.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/WorkflowService.cs
@@ -205,12 +205,17 @@ public class WorkflowService : IWorkflowService
                 instanceId = request.InstanceId,
                 senderWallet = request.SenderWallet,
                 registerAddress = request.RegisterAddress,
-                payloadData = request.PayloadData
+                payloadData = request.PayloadData,
+                // Populated when the citizen satisfied the gate from their OWN wallet. The server
+                // then skips the cross-device presentation lifecycle entirely, so no QR appears.
+                credentialPresentations = request.CredentialPresentations
             };
 
             using var httpRequest = new HttpRequestMessage(HttpMethod.Post,
                 $"/api/instances/{request.InstanceId}/actions/{request.ActionId}/execute");
-            httpRequest.Content = JsonContent.Create(body);
+            // Explicit options: the anonymous fields above are hand-cased, but CredentialPresentation
+            // is a real type and would serialise PascalCase under the default options.
+            httpRequest.Content = JsonContent.Create(body, options: JsonDefaults.Api);
             httpRequest.Headers.Add("X-Delegation-Token", "delegate");
 
             var response = await _httpClient.SendAsync(httpRequest, cancellationToken);

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Workflows/ActionForm.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Workflows/ActionForm.razor
@@ -70,7 +70,13 @@
             InstanceId = Action.InstanceId,
             Data = submission.Data.ToDictionary(
                 kvp => kvp.Key.TrimStart('/'),
-                kvp => kvp.Value ?? (object)string.Empty)
+                kvp => kvp.Value ?? (object)string.Empty),
+            // Carry the citizen's consented credential selection through the dialog. Without it
+            // the server never learns the gate was already satisfied locally and falls back to a
+            // cross-device QR.
+            CredentialPresentations = submission.CredentialPresentations is { Count: > 0 }
+                ? submission.CredentialPresentations
+                : null
         };
 
         MudDialog?.Close(DialogResult.Ok(submissionVm));

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/MyActions.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/MyActions.razor
@@ -441,7 +441,10 @@
             {
                 ActionId = action.ActionId,
                 InstanceId = action.InstanceId,
-                Data = FormPayloadBuilder.BuildNested(cardSubmission.Data)
+                Data = FormPayloadBuilder.BuildNested(cardSubmission.Data),
+                CredentialPresentations = cardSubmission.CredentialPresentations is { Count: > 0 }
+                    ? cardSubmission.CredentialPresentations
+                    : null
             };
             result = DialogResult.Ok(adapted);
         }
@@ -484,7 +487,8 @@
                     InstanceId = submission.InstanceId,
                     SenderWallet = walletAddress,
                     RegisterAddress = action.RegisterId,
-                    PayloadData = submission.Data
+                    PayloadData = submission.Data,
+                    CredentialPresentations = submission.CredentialPresentations
                 };
 
                 var submitResult = await WorkflowService.SubmitActionExecuteAsync(executeRequest);

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/NewSubmissionWorkspace.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/NewSubmissionWorkspace.razor
@@ -175,7 +175,13 @@
                 InstanceId = instance.InstanceId,
                 SenderWallet = _selectedWallet,
                 RegisterAddress = RegisterId,
-                PayloadData = payloadData
+                PayloadData = payloadData,
+                // The citizen's own consented credential selection, from CredentialGatePanel.
+                // Dropping this is what forced a cross-device QR on someone who was signed in,
+                // holding the credential, and had already consented.
+                CredentialPresentations = submission.CredentialPresentations is { Count: > 0 }
+                    ? submission.CredentialPresentations
+                    : null
             };
 
             var result = await WorkflowService.SubmitActionExecuteAsync(request);

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Program.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Program.cs
@@ -10,6 +10,8 @@ using Sorcha.UI.Components.User.Extensions;
 using Sorcha.UI.Components.User.Services.Verification;
 using Sorcha.UI.Core.Extensions;
 using Sorcha.UI.Core.Services;
+using Sorcha.UI.Core.Services.Authentication;
+using Sorcha.UI.Core.Services.Configuration;
 using Sorcha.UI.Core.Services.Http;
 using Sorcha.UI.Core.Services.User.Enrolment;
 using Sorcha.UI.Core.Services.User.Presentation;
@@ -130,10 +132,27 @@ builder.Services.AddHttpClient<Sorcha.UI.Core.Services.User.Pairing.IPairingClie
 // now only the sample council portal registered this, so the web app had no transport for a
 // SorchaWallet-sourced gate and fell through to HAIP.
 //
-// Deliberately NOT wrapped in AuthenticatedHttpMessageHandler: /api/presentations/{id}/status and
-// /disclosed-claims are AllowAnonymous by design, authenticated instead by the high-entropy
-// request id and the single-use ClaimsFetchToken.
-builder.Services.AddSorchaPresentationGate(builder.HostEnvironment.BaseAddress);
+// The typed HTTP clients are deliberately NOT wrapped in AuthenticatedHttpMessageHandler:
+// /api/presentations/{id}/status and /disclosed-claims are AllowAnonymous by design,
+// authenticated instead by the high-entropy request id and the single-use ClaimsFetchToken.
+//
+// The HUB is different. AddSorchaPresentationGate defaults its accessTokenProvider to null for the
+// council-page case (a third-party portal has no user session), but /hubs/blueprint DOES require
+// auth — so on this host, which always has a session, omitting the provider makes negotiate 401
+// and the hub never connects. Observed live on n1: the gate silently degraded to the 3s poll
+// fallback on every presentation.
+builder.Services.AddSorchaPresentationGate(
+    builder.HostEnvironment.BaseAddress,
+    accessTokenProvider: sp =>
+    {
+        var authService = sp.GetRequiredService<IAuthenticationService>();
+        var configService = sp.GetRequiredService<IConfigurationService>();
+        return async () =>
+        {
+            var profileName = await configService.GetActiveProfileNameAsync();
+            return await authService.GetAccessTokenAsync(profileName);
+        };
+    });
 
 // Feature 181 US3 (T037) — platform-admin trusted-list snapshot management. The endpoints are
 // admin + platform-audience gated, so the client must carry the admin's bearer token.

--- a/tests/Sorcha.UI.Core.Tests/Services/User/ActionExecuteWirePayloadTests.cs
+++ b/tests/Sorcha.UI.Core.Tests/Services/User/ActionExecuteWirePayloadTests.cs
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Net;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Sorcha.Blueprint.Models.Credentials;
+using Sorcha.UI.Core.Models.Workflows;
+using Sorcha.UI.Core.Services;
+using Xunit;
+
+namespace Sorcha.UI.Core.Tests.Services.User;
+
+/// <summary>
+/// Asserts that every field on <see cref="ActionExecuteRequest"/> actually reaches the wire.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>WorkflowService.SubmitActionExecuteAsync</c> hand-writes an anonymous body rather than
+/// serialising the request record. A field added to the record but forgotten in that literal is
+/// dropped silently — no compiler error, no test failure, and on the server a
+/// <c>required</c>-less property simply arrives null.
+/// </para>
+/// <para>
+/// That is exactly what happened to <c>CredentialPresentations</c>: the citizen selected a
+/// credential from their own wallet in <c>CredentialGatePanel</c> and consented, and the selection
+/// was discarded here — so the server saw no presentations, decided the gate was unsatisfied, and
+/// showed a QR code to scan with a second device. Found by clicking through on n1, 2026-07-28;
+/// no unit test could see it because none of them looked at the payload.
+/// </para>
+/// </remarks>
+public class ActionExecuteWirePayloadTests
+{
+    private sealed class CapturingHandler : HttpMessageHandler
+    {
+        public string? Body { get; private set; }
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Body = request.Content is null
+                ? null
+                : await request.Content.ReadAsStringAsync(cancellationToken);
+
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(
+                    """{"transactionId":"tx","instanceId":"i","isComplete":false}""",
+                    System.Text.Encoding.UTF8,
+                    "application/json")
+            };
+        }
+    }
+
+    private static ActionExecuteRequest FullyPopulatedRequest() => new()
+    {
+        BlueprintId = "bp-1",
+        ActionId = "0",
+        InstanceId = "inst-1",
+        SenderWallet = "ws11qtest",
+        RegisterAddress = "reg-1",
+        PayloadData = new Dictionary<string, object> { ["answer"] = "yes" },
+        CredentialPresentations =
+        [
+            new CredentialPresentation
+            {
+                CredentialId = "did:sorcha:w:ws11qtest",
+                RawPresentation = "eyJ.header~disclosure~",
+                DisclosedClaims = new Dictionary<string, object> { ["givenName"] = "Stuart" }
+            }
+        ]
+    };
+
+    private static async Task<string> CaptureBodyAsync(ActionExecuteRequest request)
+    {
+        var handler = new CapturingHandler();
+        var http = new HttpClient(handler) { BaseAddress = new Uri("https://n1.test/") };
+        var sut = new WorkflowService(http, NullLogger<WorkflowService>.Instance);
+
+        await sut.SubmitActionExecuteAsync(request);
+
+        handler.Body.Should().NotBeNull("the service must send a request body");
+        return handler.Body!;
+    }
+
+    [Fact]
+    public async Task EveryRequestPropertyAppearsInTheSentBody()
+    {
+        var body = await CaptureBodyAsync(FullyPopulatedRequest());
+
+        using var doc = JsonDocument.Parse(body);
+        var sent = doc.RootElement.EnumerateObject().Select(p => p.Name).ToArray();
+
+        var expected = typeof(ActionExecuteRequest)
+            .GetProperties()
+            .Select(p => JsonNamingPolicy.CamelCase.ConvertName(p.Name));
+
+        sent.Should().Contain(expected,
+            "a property on ActionExecuteRequest that the hand-written body omits is dropped "
+            + "silently — add it to the anonymous object in SubmitActionExecuteAsync");
+    }
+
+    [Fact]
+    public async Task TheConsentedCredentialSelectionSurvivesToTheWire()
+    {
+        var body = await CaptureBodyAsync(FullyPopulatedRequest());
+
+        using var doc = JsonDocument.Parse(body);
+        doc.RootElement.TryGetProperty("credentialPresentations", out var presentations)
+            .Should().BeTrue();
+        presentations.ValueKind.Should().Be(JsonValueKind.Array);
+        presentations.GetArrayLength().Should().Be(1);
+
+        // camelCase, not PascalCase: the anonymous fields are hand-cased but this is a real type,
+        // and default options would serialise it as "CredentialId".
+        presentations[0].TryGetProperty("credentialId", out _).Should().BeTrue(
+            "the server binds camelCase; PascalCase here would be a silent wire mismatch");
+    }
+
+    [Fact]
+    public async Task NoCredentialSelectionSendsNullNotAnEmptyArray()
+    {
+        // The server branches on "no presentations submitted" to start the cross-device
+        // lifecycle. An empty array must not read as a satisfied gate.
+        var body = await CaptureBodyAsync(FullyPopulatedRequest() with { CredentialPresentations = null });
+
+        using var doc = JsonDocument.Parse(body);
+        if (doc.RootElement.TryGetProperty("credentialPresentations", out var presentations))
+        {
+            presentations.ValueKind.Should().Be(JsonValueKind.Null);
+        }
+    }
+}

--- a/tests/Sorcha.UI.Core.Tests/Services/User/Presentation/SorchaWalletGateTransportTests.cs
+++ b/tests/Sorcha.UI.Core.Tests/Services/User/Presentation/SorchaWalletGateTransportTests.cs
@@ -120,17 +120,40 @@ public class SorchaWalletGateTransportTests
     }
 
     [Fact]
-    public async Task ManualRecoveryEndsTheWaitAsUnreachable()
+    public async Task ManualRecoveryDoesNotEndTheWait()
     {
+        // Observed live on n1 (2026-07-28): a request valid for TEN MINUTES was reported to the
+        // citizen as "nothing was sent from your wallet" after 60 s, while it sat in
+        // awaiting-presentation waiting for them to scan. Sixty seconds is how long it takes to
+        // pick up a phone — not evidence of failure.
         var signal = new FakeSignal();
         var sut = Build(signal);
+        var id = Guid.NewGuid();
 
-        var waiting = sut.WaitForOutcomeAsync(Guid.NewGuid());
+        var waiting = sut.WaitForOutcomeAsync(id);
         signal.RaiseManualRecovery();
 
-        (await waiting).Should().Be(GateOutcome.Unreachable,
-            "60 s with no signal from either transport is an infrastructure problem, "
-            + "not the holder declining");
+        waiting.IsCompleted.Should().BeFalse(
+            "the request is still valid; only a terminal outcome or expiry may end the wait");
+
+        await signal.RaiseOutcomeAsync(id, "success");
+        (await waiting).Should().Be(GateOutcome.Success,
+            "a late scan must still succeed");
+    }
+
+    [Fact]
+    public async Task ExpiryStillEndsTheWait()
+    {
+        // Expiry is the lifecycle's call, surfaced through /status — not a client-side timer.
+        var signal = new FakeSignal();
+        var sut = Build(signal);
+        var id = Guid.NewGuid();
+
+        var waiting = sut.WaitForOutcomeAsync(id);
+        signal.RaiseManualRecovery();
+        await signal.RaiseOutcomeAsync(id, "expired");
+
+        (await waiting).Should().Be(GateOutcome.Expired);
     }
 
     [Fact]


### PR DESCRIPTION
Both found by the first real click-through on n1, which neither the
rehearsal nor any unit test could reach.

1. The 60s manual-recovery signal was mapped to a TERMINAL Unreachable.
   A presentation request is valid for its whole window - ten minutes on
   n1 - and sixty seconds is simply how long it takes a citizen to pick up
   their phone, unlock it and scan. The gate was telling them "nothing was
   sent from your wallet" about a request sitting in awaiting-presentation
   waiting for them. That is the same wrong-diagnosis failure this
   component was built to remove, aimed at a different innocent party.
   Manual-recovery is now a hint, not an outcome; only a terminal state or
   the lifecycle's own "expired" ends the wait. A late scan still succeeds.

2. /hubs/blueprint negotiate returned 401. AddSorchaPresentationGate
   defaults accessTokenProvider to null for the council-page case (a
   third-party portal has no user session), but this host always has one
   and that hub requires auth. Every presentation silently degraded to the
   3s poll fallback - working, but losing the instant signal. The web
   client now passes a real provider, matching TenantHubConnection.

Confirmed working in the same session: the card renders, routes to
/api/presentations/{id}/status and not HAIP, and shows the right credential
type and claims.

Documentation updated: none required (no API or config change)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RboWP2TKvm1nBG22nqsWek
