### PR TITLE
fix: [#1330] - local route died silently on the shipped relative request_uri

### DIFF
--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Presentation/PresentationRequestCard.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Presentation/PresentationRequestCard.razor
@@ -304,10 +304,33 @@
     /// </summary>
     private async Task ProbeLocalRouteAsync(Guid requestId, string requestUri, CancellationToken ct)
     {
-        var presenter = ServiceProvider.GetService<ISorchaWalletLocalPresenter>();
-        if (presenter is null) return;
+        // This method is fired-and-forgotten, so nothing here may throw silently: a DI
+        // construction failure resolving the presenter (or anything else unexpected) must land
+        // in the browser console, not in an unobserved task. The #1330 live gate failed
+        // invisibly precisely because every failure path on this route was quiet.
+        LocalPresentationCandidate? candidate;
+        try
+        {
+            var presenter = ServiceProvider.GetService<ISorchaWalletLocalPresenter>();
+            if (presenter is null)
+            {
+                Logger.LogInformation(
+                    "No ISorchaWalletLocalPresenter registered on this host — SorchaWallet gate is QR-only.");
+                return;
+            }
 
-        var candidate = await presenter.ProbeAsync(requestUri, ct);
+            candidate = await presenter.ProbeAsync(requestUri, ct);
+        }
+        catch (OperationCanceledException)
+        {
+            return;
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Local-presentation probe failed unexpectedly; the gate stays QR-only.");
+            return;
+        }
+
         if (candidate is null) return;
 
         await InvokeAsync(() =>

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/Presentation/SorchaWalletLocalPresenter.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/Presentation/SorchaWalletLocalPresenter.cs
@@ -148,16 +148,60 @@ public sealed class SorchaWalletLocalPresenter : ISorchaWalletLocalPresenter
         };
     }
 
-    /// <summary>Absolute same-origin URLs become relative paths; cross-origin returns null.</summary>
+    /// <summary>
+    /// Maps a server-supplied URI onto a same-origin request path, or null to refuse. This client
+    /// attaches the citizen's bearer to every call, so refusal is the fail-safe.
+    /// <para>
+    /// A rooted path (<c>/api/…</c>) is accepted as same-origin by construction — this is THE
+    /// SHIPPED SHAPE: <c>PresentationLifecycleOptions.PublicBaseUrl</c> is unset on every
+    /// deployment, so the lifecycle emits relative request_uri/response_uri values. The rooted
+    /// check MUST come before <see cref="Uri.TryCreate(string, UriKind, out Uri)"/>: on
+    /// non-Windows runtimes (including browser-wasm) a rooted path parses as an ABSOLUTE
+    /// <c>file://</c> URI with an empty Authority, so the previous "TryCreate(Absolute) failed ⇒
+    /// relative" test silently classified the shipped shape as cross-origin — the local route
+    /// never fetched anything and every gate fell back to the QR (#1330 live-gate finding,
+    /// n1 2026-07-29; invisible to tests, which run on Windows semantics).
+    /// </para>
+    /// Protocol-relative (<c>//host/…</c>) and backslash-carrying values are refused outright —
+    /// resolved against an https base they can escape the origin.
+    /// </summary>
     private string? ToSameOriginRelative(string uri)
     {
-        if (!Uri.TryCreate(uri, UriKind.Absolute, out var abs))
-            return uri; // already relative — same origin by construction
-        var baseAddress = _http.BaseAddress;
-        if (baseAddress is null) return null;
-        return string.Equals(abs.Authority, baseAddress.Authority, StringComparison.OrdinalIgnoreCase)
-            ? abs.PathAndQuery
-            : null;
+        if (string.IsNullOrEmpty(uri))
+            return null;
+
+        if (uri.Contains('\\'))
+        {
+            _logger.LogWarning("Local presentation route refused a backslash-carrying URI.");
+            return null;
+        }
+
+        if (uri.StartsWith("//", StringComparison.Ordinal))
+        {
+            _logger.LogWarning("Local presentation route refused a protocol-relative URI.");
+            return null;
+        }
+
+        if (uri.StartsWith('/'))
+            return uri; // rooted path — same-origin by construction (shipped shape)
+
+        if (Uri.TryCreate(uri, UriKind.Absolute, out var abs)
+            && (abs.Scheme == Uri.UriSchemeHttp || abs.Scheme == Uri.UriSchemeHttps))
+        {
+            var baseAddress = _http.BaseAddress;
+            if (baseAddress is null) return null;
+            if (!string.Equals(abs.Authority, baseAddress.Authority, StringComparison.OrdinalIgnoreCase))
+            {
+                _logger.LogWarning(
+                    "Local presentation route refused a cross-origin URI (authority {Authority}).",
+                    abs.Authority);
+                return null;
+            }
+            return abs.PathAndQuery;
+        }
+
+        _logger.LogWarning("Local presentation route refused an unrecognised URI shape.");
+        return null;
     }
 
     private static string? ReadString(JsonElement root, string name)

--- a/tests/Sorcha.UI.Core.Tests/Services/Presentation/SorchaWalletLocalPresenterProbeTests.cs
+++ b/tests/Sorcha.UI.Core.Tests/Services/Presentation/SorchaWalletLocalPresenterProbeTests.cs
@@ -195,6 +195,62 @@ public class SorchaWalletLocalPresenterProbeTests
         (await presenter.ProbeAsync(DeepLink())).Should().BeNull(
             "multi-credential local consent is out of scope — degrade to the QR route, which fails loudly by design (#1311)");
     }
+
+    /// <summary>
+    /// #1330 live-gate regression (found on n1, 2026-07-29) — THE SHIPPED SHAPE.
+    /// <c>PresentationLifecycleOptions.PublicBaseUrl</c> is unset on every deployment
+    /// (rehearse.ps1:402 documents this), so the lifecycle emits request_uri and response_uri as
+    /// RELATIVE rooted paths. <c>Uri.TryCreate("/api/…", UriKind.Absolute)</c> SUCCEEDS as a
+    /// file:// URI with an empty Authority, so the original guard misclassified the shipped shape
+    /// as cross-origin and silently killed the local route — the QR-only fallback rendered on
+    /// every real gate while all tests (absolute-URL fixtures only) stayed green.
+    /// </summary>
+    [Fact]
+    public async Task ProbeAsync_RelativeRequestAndResponseUris_ReturnsCandidate()
+    {
+        var jwt = BuildRequestObjectJwt(
+            responseUri: "/api/presentations/callbacks/sorcha-wallet/rid-1");
+        var (presenter, http, _, _) = Build(jwt, baseAddress: "https://unit.test/app/");
+
+        var candidate = await presenter.ProbeAsync(
+            DeepLink("/api/presentations/rid1hex/request-object"));
+
+        candidate.Should().NotBeNull("the shipped PublicBaseUrl-unset shape is relative and same-origin by construction");
+        candidate!.ResponseUri.Should().Be("/api/presentations/callbacks/sorcha-wallet/rid-1");
+        // A rooted path must resolve against the ORIGIN, not the /app/ base path.
+        http.Requests[0].RequestUri.Should().Be(new Uri("https://unit.test/api/presentations/rid1hex/request-object"));
+    }
+
+    /// <summary>
+    /// A protocol-relative value ("//host/…") is NOT a rooted same-origin path — resolved against
+    /// an https base it becomes https://host/…, and this client attaches the citizen's bearer to
+    /// every call. Must be refused before any fetch.
+    /// </summary>
+    [Fact]
+    public async Task ProbeAsync_ProtocolRelativeRequestUri_RefusedWithoutFetching()
+    {
+        var (presenter, http, _, _) = Build(BuildRequestObjectJwt());
+        (await presenter.ProbeAsync(DeepLink("//evil.example/api/presentations/x/request-object"))).Should().BeNull();
+        http.Requests.Should().BeEmpty("a protocol-relative request_uri must never be fetched");
+    }
+
+    [Fact]
+    public async Task ProbeAsync_ProtocolRelativeResponseUri_ReturnsNull()
+    {
+        var jwt = BuildRequestObjectJwt(responseUri: "//evil.example/collect");
+        var (presenter, _, _, _) = Build(jwt);
+        (await presenter.ProbeAsync(DeepLink())).Should().BeNull(
+            "a protocol-relative response_uri would direct_post the bearer to a foreign origin");
+    }
+
+    [Fact]
+    public async Task ProbeAsync_BackslashRequestUri_RefusedWithoutFetching()
+    {
+        // Backslashes normalise unpredictably during URI combination — refuse outright.
+        var (presenter, http, _, _) = Build(BuildRequestObjectJwt());
+        (await presenter.ProbeAsync(DeepLink(@"/\evil.example/x"))).Should().BeNull();
+        http.Requests.Should().BeEmpty();
+    }
 }
 
 /// <summary>Records every request and answers via the supplied responder.</summary>


### PR DESCRIPTION
## Summary
- Live-gate finding (n1, 2026-07-29): the #1331 'Use this device' panel never appeared — the probe made zero HTTP calls and logged nothing. Root cause: `ToSameOriginRelative` used `Uri.TryCreate(..., Absolute)` failure as its 'relative' test; on browser-wasm (non-Windows semantics) a rooted path like the SHIPPED `request_uri` (`PublicBaseUrl` unset everywhere → relative paths) parses as an absolute `file://` URI with empty Authority → classified cross-origin → silent null → QR-only fallback on every real gate.
- Windows-hosted tests could not catch it: rooted paths parse as relative there, and every fixture used absolute URLs anyway.
- Fix: rooted-path acceptance precedes Uri parsing (platform-independent); protocol-relative `//host` and backslash values refused explicitly (this client carries the citizen's bearer); every refusal now logs; the card's fire-and-forget probe wraps resolution+probe in try/catch→LogError so no failure on this route can be silent again.
- New tests pin the shipped relative shape end-to-end (incl. rooted-path resolution against a `/app/` base) + the protocol-relative/backslash refusals. Mutation-tested (rooted branch → null → RED → restored). Full suite 1659/1659.

Part of #1330 (follow-up to #1331).

## Test plan
- [x] `SorchaWalletLocalPresenterProbeTests` 12/12 incl. 4 new; full Sorcha.UI.Core.Tests 1659/1659
- [ ] n1 live gate after deploy (with blueprint-service also brought to :latest for the #1329 hub JoinGroup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RboWP2TKvm1nBG22nqsWek