### PR TITLE
fix: [#1330] - Submitting overlay blocked the credential gate dialog

### DIFF
--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/NewSubmissionWorkspace.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/NewSubmissionWorkspace.razor
@@ -211,6 +211,14 @@
             // and the other four submission paths silently discarded the same warnings.
             result.SurfaceWarnings(Feedback);
 
+            // #1330 — the submission HTTP call is DONE; release the workspace's "Submitting..."
+            // overlay (ZIndex 9999) NOW. This handler doesn't return until any credential
+            // offer/presentation dialog below CLOSES, so leaving the overlay up parks it on top
+            // of the dialog for its entire life — blocking "Share & continue", "Open on this
+            // device" and "Copy link" on both desktop and phone. The cross-device QR only ever
+            // worked because a camera can scan through the dimmed overlay.
+            _workspace?.ClearSubmitting();
+
             // HAIP external wallet interactions — show QR dialog before navigating away
             if (result.CredentialOffer is { } offer)
             {


### PR DESCRIPTION
## Summary
- Live-gate finding round 2 (n1, both phone + desktop): the 'Use this device' panel rendered correctly but was unclickable — `ActionWorkspace`'s ZIndex-9999 'Submitting...' overlay stays up until the page's submit handler returns, and the handler awaits the gate dialog's CLOSE. The overlay therefore covered the dialog for its whole life.
- Pre-existing (also deadened 'Open on this device'/'Copy link' on the QR path and the credential-offer dialog); the cross-device QR only ever worked because a camera can scan through the dimmed overlay. The local route's Share button promoted it to a blocker.
- Fix: call the workspace's designed `ClearSubmitting()` seam the moment the submission result is back, before any dialog opens.

Part of #1330. Verification is the n1 live gate (UI-interplay path; the overlay/dialog stack isn't reachable from bUnit without mocking the whole DialogService interplay — the live click-through is the test, as this whole issue chain demonstrates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RboWP2TKvm1nBG22nqsWek