### PR TITLE
fix: [#1333] - BlueprintHub JoinGroup: make the F127 hub signal actually deliver

### DIFF
--- a/src/Services/Sorcha.Blueprint.Service/Hubs/BlueprintHub.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Hubs/BlueprintHub.cs
@@ -26,6 +26,7 @@ namespace Sorcha.Blueprint.Service.Hubs;
 /// Server Methods (called by clients):
 /// - <see cref="SubscribeToWallet"/>: Subscribe to notifications for a wallet
 /// - <see cref="UnsubscribeFromWallet"/>: Unsubscribe from wallet notifications
+/// - <see cref="JoinGroup"/> / <see cref="LeaveGroup"/>: F127 presentation-outcome groups ONLY (#1333)
 /// </remarks>
 [Authorize]
 public class BlueprintHub : Hub<IBlueprintHubClient>
@@ -146,6 +147,92 @@ public class BlueprintHub : Hub<IBlueprintHubClient>
             "Client unsubscribed from wallet notifications. ConnectionId: {ConnectionId}, Wallet: {Wallet}",
             Context.ConnectionId,
             walletAddress);
+    }
+
+    /// <summary>
+    /// Join an F127 presentation-outcome group (#1333). This is the server half of
+    /// <c>PresentationHubConnection.JoinGroupAsync</c> — the client half shipped with F127,
+    /// the publisher (<c>PresentationLifecycleService.HandleOutcomeAsync</c>) has always sent
+    /// <see cref="IBlueprintHubClient.PresentationOutcomeReady"/> to
+    /// <see cref="BlueprintHubGroups.PresentationNonce"/>, and until this method existed the
+    /// group had no possible members — every gate silently rode the 3-second status poll.
+    /// </summary>
+    /// <remarks>
+    /// The ONLY groups joinable here are presentation groups
+    /// (<c>presentation:{32 lowercase hex}</c> — the exact shape
+    /// <see cref="BlueprintHubGroups.PresentationNonce"/> emits). Wallet groups have their own
+    /// ownership-validated <see cref="SubscribeToWallet"/> path and MUST NOT be reachable via
+    /// this RPC. Authorization model for presentation groups: the name embeds the high-entropy
+    /// request id known only to the submitter that received the 202, and the only event the
+    /// group ever carries is the thin opaque-id <c>PresentationOutcomeReady</c> signal — the
+    /// same information the anonymous <c>/api/presentations/{id}/status</c> endpoint serves.
+    /// </remarks>
+    /// <param name="groupName">Presentation group name, e.g. <c>presentation:4f7ef492…</c>.</param>
+    public async Task JoinGroup(string groupName)
+    {
+        if (!IsPresentationGroup(groupName))
+        {
+            _logger.LogWarning(
+                "JoinGroup refused for non-presentation group. ConnectionId: {ConnectionId}",
+                Context.ConnectionId);
+            throw new HubException("Only presentation groups can be joined via JoinGroup.");
+        }
+
+        await Groups.AddToGroupAsync(Context.ConnectionId, groupName);
+
+        _logger.LogInformation(
+            "Client joined presentation group {Group}. ConnectionId: {ConnectionId}",
+            groupName, Context.ConnectionId);
+    }
+
+    /// <summary>
+    /// Leave an F127 presentation-outcome group previously joined via <see cref="JoinGroup"/>.
+    /// Idempotent — leaving a group the connection never joined is a no-op.
+    /// </summary>
+    /// <param name="groupName">Presentation group name.</param>
+    public async Task LeaveGroup(string groupName)
+    {
+        if (!IsPresentationGroup(groupName))
+        {
+            throw new HubException("Only presentation groups can be left via LeaveGroup.");
+        }
+
+        await Groups.RemoveFromGroupAsync(Context.ConnectionId, groupName);
+
+        _logger.LogInformation(
+            "Client left presentation group {Group}. ConnectionId: {ConnectionId}",
+            groupName, Context.ConnectionId);
+    }
+
+    /// <summary>
+    /// True iff <paramref name="groupName"/> is exactly <c>presentation:</c> followed by 32
+    /// lowercase hex characters — the shape <see cref="BlueprintHubGroups.PresentationNonce"/>
+    /// (<c>{guid:N}</c>) emits. Anything else (wallet groups, uppercase, hyphenated GUIDs,
+    /// wrong length) is refused so this RPC cannot be used as a generic group-join oracle.
+    /// </summary>
+    internal static bool IsPresentationGroup(string? groupName)
+    {
+        const string Prefix = "presentation:";
+        if (groupName is null || groupName.Length != Prefix.Length + 32)
+        {
+            return false;
+        }
+
+        if (!groupName.StartsWith(Prefix, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        for (var i = Prefix.Length; i < groupName.Length; i++)
+        {
+            var c = groupName[i];
+            if (c is (< '0' or > '9') and (< 'a' or > 'f'))
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /// <summary>

--- a/tests/Sorcha.Blueprint.Service.Tests/Integration/SignalRIntegrationTests.cs
+++ b/tests/Sorcha.Blueprint.Service.Tests/Integration/SignalRIntegrationTests.cs
@@ -488,6 +488,87 @@ public class SignalRIntegrationTests : IClassFixture<BlueprintServiceWebApplicat
 
     #endregion
 
+    #region Presentation Group Tests (#1333)
+
+    [Fact]
+    public async Task JoinGroup_PresentationGroup_ReceivesPublishedOutcomeReady()
+    {
+        // #1333 — the client has always invoked JoinGroup, the publisher has always sent
+        // PresentationOutcomeReady to the group, and no server method ever existed between
+        // them. This test IS the join: a real hub client must receive the published event.
+        var connection = CreateHubConnection();
+        var received = Channel.CreateUnbounded<string>();
+        connection.On<string>("PresentationOutcomeReady", id => received.Writer.TryWrite(id));
+
+        await connection.StartAsync();
+        var requestId = Guid.NewGuid();
+        await connection.InvokeAsync("JoinGroup", BlueprintHubGroups.PresentationNonce(requestId));
+
+        var hub = _factory.Services.GetRequiredService<IHubContext<BlueprintHub, IBlueprintHubClient>>();
+        await hub.Clients.Group(BlueprintHubGroups.PresentationNonce(requestId))
+            .PresentationOutcomeReady(requestId.ToString("N"));
+
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        var deliveredId = await received.Reader.ReadAsync(cts.Token);
+        deliveredId.Should().Be(requestId.ToString("N"));
+    }
+
+    [Fact]
+    public async Task JoinGroup_WalletGroup_ThrowsHubException()
+    {
+        // JoinGroup must not become a generic group-join oracle: wallet groups have their
+        // own ownership-validated SubscribeToWallet path and must not be reachable here.
+        var connection = CreateHubConnection();
+        await connection.StartAsync();
+
+        var act = async () => await connection.InvokeAsync(
+            "JoinGroup", BlueprintHubGroups.Wallet("ws1qvictim"));
+        await act.Should().ThrowAsync<HubException>().WithMessage("*presentation*");
+    }
+
+    [Fact]
+    public async Task JoinGroup_MalformedPresentationGroup_ThrowsHubException()
+    {
+        var connection = CreateHubConnection();
+        await connection.StartAsync();
+
+        var act = async () => await connection.InvokeAsync("JoinGroup", "presentation:not-a-hex-guid");
+        await act.Should().ThrowAsync<HubException>();
+    }
+
+    [Fact]
+    public async Task LeaveGroup_AfterJoin_StopsReceiving()
+    {
+        var connection = CreateHubConnection();
+        var received = Channel.CreateUnbounded<string>();
+        connection.On<string>("PresentationOutcomeReady", id => received.Writer.TryWrite(id));
+
+        await connection.StartAsync();
+        var requestId = Guid.NewGuid();
+        var group = BlueprintHubGroups.PresentationNonce(requestId);
+        await connection.InvokeAsync("JoinGroup", group);
+        await connection.InvokeAsync("LeaveGroup", group);
+
+        var hub = _factory.Services.GetRequiredService<IHubContext<BlueprintHub, IBlueprintHubClient>>();
+        await hub.Clients.Group(group).PresentationOutcomeReady(requestId.ToString("N"));
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(750));
+        var receivedAfterLeave = false;
+        try
+        {
+            await received.Reader.ReadAsync(cts.Token);
+            receivedAfterLeave = true;
+        }
+        catch (OperationCanceledException)
+        {
+            // Expected — the connection left the group before the publish.
+        }
+
+        receivedAfterLeave.Should().BeFalse("the connection left the group before the publish");
+    }
+
+    #endregion
+
     #region Helper Methods
 
     /// <summary>


### PR DESCRIPTION
## Summary
- Adds the `JoinGroup`/`LeaveGroup` RPCs that `PresentationHubConnection` has invoked since F127 shipped. Until now no server method existed: the publisher sent `PresentationOutcomeReady` to a group nobody could join, the client logged `Method does not exist` on every gate, and the 3s poll fallback silently carried everything (which is exactly why it went unnoticed — instance #9 in the seam-bug memory).
- Only presentation groups (`presentation:{32 lowercase hex}` — the exact `BlueprintHubGroups.PresentationNonce` shape) are joinable; wallet groups keep their ownership-validated `SubscribeToWallet` path. Mutation-tested: accept-all validation → 2 tests RED.
- Deployed v2.903.1 clients start receiving the hub signal with **no client change** — the method name matches what they already invoke.

Closes #1333 (the expired→404→"Unreachable" wording item noted there is minor and tracked separately in the F127 memory).

## Test plan
- [x] Real hub-client integration tests (SignalRIntegrationTests 18/18): join → receive published `PresentationOutcomeReady`; wallet-group + malformed names refused; leave stops delivery
- [ ] n1 after deploy: gate console shows no `JoinGroup … Method does not exist`; outcome arrives ahead of the poll

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RboWP2TKvm1nBG22nqsWek