### PR TITLE
fix: [#1333] - expired presentation requests no longer read as 'couldn't reach your wallet'

### DIFF
--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/Presentation/PresentationSignal.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/Presentation/PresentationSignal.cs
@@ -48,6 +48,15 @@ public sealed class PresentationSignal : IPresentationSignal, IAsyncDisposable
     private int _notFoundStreak;
     private bool _unreachableRaised;
 
+    /// <summary>
+    /// The expiry the status endpoint advertised while the request was last seen ALIVE. The
+    /// discriminator for the 404 verdict (#1333, minor half): the Redis pending entry lapses at
+    /// the validity window and /status then 404s — so 404s that begin AFTER an expiry we
+    /// observed are an <c>expired</c> outcome, while 404s with no live sighting (or before the
+    /// expiry) remain genuinely unreachable.
+    /// </summary>
+    private DateTimeOffset? _lastSeenExpiresAt;
+
     public event Func<PresentationSignalOutcome, Task>? OnOutcomeReady;
     public event Action? OnFallbackEngaged;
     public event Action? OnManualRecoveryRequired;
@@ -77,6 +86,7 @@ public sealed class PresentationSignal : IPresentationSignal, IAsyncDisposable
         _signalReceived = false;
         _notFoundStreak = 0;
         _unreachableRaised = false;
+        _lastSeenExpiresAt = null;
 
         _cts?.Cancel();
         _cts?.Dispose();
@@ -236,6 +246,20 @@ public sealed class PresentationSignal : IPresentationSignal, IAsyncDisposable
             {
                 if (++_notFoundStreak >= UnreachableThreshold && !_unreachableRaised && !_signalReceived)
                 {
+                    // A request we WATCHED alive whose 404s begin after its own advertised
+                    // expiry has EXPIRED — the pending entry lapsed at the validity window
+                    // and the read path forgot it. Reporting that as "couldn't reach your
+                    // wallet" sends the citizen to debug the wrong thing (#1333, minor half).
+                    if (_lastSeenExpiresAt is { } expiresAt && _time.GetUtcNow() > expiresAt)
+                    {
+                        _unreachableRaised = true; // terminal either way — suppress the outage path
+                        _logger.LogInformation(
+                            "Presentation request {RequestId} 404s after its observed expiry "
+                            + "{ExpiresAt:O} — reporting expired.",
+                            _presentationRequestId, expiresAt);
+                        return "expired";
+                    }
+
                     _unreachableRaised = true;
                     _logger.LogError(
                         "Presentation lifecycle has no request {RequestId} after {Streak} "
@@ -256,6 +280,10 @@ public sealed class PresentationSignal : IPresentationSignal, IAsyncDisposable
             var payload = await response.Content
                 .ReadFromJsonAsync<StatusProbeShape>(JsonDefaults.Api, ct)
                 .ConfigureAwait(false);
+            if (payload?.ExpiresAt is { } seenExpiry)
+            {
+                _lastSeenExpiresAt = seenExpiry;
+            }
             return payload?.State;
         }
         catch (OperationCanceledException) when (ct.IsCancellationRequested) { return null; }
@@ -281,5 +309,6 @@ public sealed class PresentationSignal : IPresentationSignal, IAsyncDisposable
     private sealed record StatusProbeShape
     {
         [JsonPropertyName("state")] public string? State { get; init; }
+        [JsonPropertyName("expiresAt")] public DateTimeOffset? ExpiresAt { get; init; }
     }
 }

--- a/tests/Sorcha.UI.Core.Tests/Services/User/Presentation/PresentationSignalTests.cs
+++ b/tests/Sorcha.UI.Core.Tests/Services/User/Presentation/PresentationSignalTests.cs
@@ -231,6 +231,80 @@ public sealed class PresentationSignalTests : IAsyncDisposable
         unreachableFired.Should().BeFalse();
     }
 
+    [Fact]
+    public async Task NotFounds_AfterObservedExpiry_RaiseExpiredOutcome_NotUnreachable()
+    {
+        // #1333 (minor half) — the Redis pending entry lapses at the validity window, after
+        // which /status 404s. For a request the signal WATCHED alive, 404s that begin after
+        // its own advertised expiresAt are an EXPIRY: telling the citizen "we couldn't reach
+        // your wallet" sends them to debug the wrong thing.
+        _handler.NextState = "awaiting-presentation";
+        _handler.NextExpiresAt = _time.GetUtcNow().AddSeconds(6);
+
+        var unreachableFired = false;
+        PresentationSignalOutcome? captured = null;
+        var done = new TaskCompletionSource();
+        _sut.OnRequestUnreachable += () => unreachableFired = true;
+        _sut.OnOutcomeReady += outcome =>
+        {
+            captured = outcome;
+            done.TrySetResult();
+            return Task.CompletedTask;
+        };
+
+        await _sut.StartAsync(_requestId, CancellationToken.None);
+
+        // First poll sees the request ALIVE (and learns its expiry).
+        _time.Advance(TimeSpan.FromSeconds(4));
+        await Task.Yield();
+        await Task.Delay(20);
+
+        // The window lapses; the pending entry is gone; every poll now 404s.
+        _handler.NextStatus = HttpStatusCode.NotFound;
+        for (var i = 0; i < 4; i++)
+        {
+            _time.Advance(TimeSpan.FromSeconds(4));
+            await Task.Yield();
+            await Task.Delay(20);
+        }
+
+        await done.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        captured.Should().NotBeNull();
+        captured!.Kind.Should().Be("expired");
+        unreachableFired.Should().BeFalse("an expiry we can prove is not an outage");
+    }
+
+    [Fact]
+    public async Task NotFounds_BeforeObservedExpiry_StillRaiseUnreachable()
+    {
+        // 404s while the request should still be alive ARE our fault — a vanished lifecycle
+        // row, not a lapsed window. The unreachable path must survive the expiry carve-out.
+        _handler.NextState = "awaiting-presentation";
+        _handler.NextExpiresAt = _time.GetUtcNow().AddMinutes(10);
+
+        var unreachableFired = false;
+        PresentationSignalOutcome? captured = null;
+        _sut.OnRequestUnreachable += () => unreachableFired = true;
+        _sut.OnOutcomeReady += outcome => { captured = outcome; return Task.CompletedTask; };
+
+        await _sut.StartAsync(_requestId, CancellationToken.None);
+
+        _time.Advance(TimeSpan.FromSeconds(4));
+        await Task.Yield();
+        await Task.Delay(20);
+
+        _handler.NextStatus = HttpStatusCode.NotFound;
+        for (var i = 0; i < 4; i++)
+        {
+            _time.Advance(TimeSpan.FromSeconds(4));
+            await Task.Yield();
+            await Task.Delay(20);
+        }
+
+        unreachableFired.Should().BeTrue();
+        captured.Should().BeNull("a mid-window vanish must not masquerade as an expiry");
+    }
+
     public async ValueTask DisposeAsync()
     {
         await _sut.DisposeAsync();
@@ -245,9 +319,13 @@ public sealed class PresentationSignalTests : IAsyncDisposable
         /// <summary>Status the status endpoint answers with. 404 means "no such request".</summary>
         public HttpStatusCode NextStatus { get; set; } = HttpStatusCode.OK;
 
+        /// <summary>Optional expiresAt carried on 200 bodies — the real endpoint always sends it.</summary>
+        public DateTimeOffset? NextExpiresAt { get; set; }
+
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
-            var body = $"{{\"presentationRequestId\":\"00000000-0000-0000-0000-000000000000\",\"state\":\"{NextState}\"}}";
+            var expires = NextExpiresAt is { } e ? $",\"expiresAt\":\"{e:O}\"" : string.Empty;
+            var body = $"{{\"presentationRequestId\":\"00000000-0000-0000-0000-000000000000\",\"state\":\"{NextState}\"{expires}}}";
             return Task.FromResult(new HttpResponseMessage(NextStatus)
             {
                 Content = new StringContent(body, System.Text.Encoding.UTF8, "application/json")


### PR DESCRIPTION
## Summary
- Closes the minor half of #1333: once the Redis pending entry lapses, `/status` 404s and `PresentationSignal` declared the request *Unreachable* — telling a citizen whose window simply ran out that "we couldn't reach your wallet".
- The signal now remembers the `expiresAt` it saw on live 200s. Post-threshold 404s that begin **after** that observed expiry surface as the existing terminal `expired` outcome (card already renders "This request has expired. A new presentation request is needed."). Requests never seen alive — or 404ing mid-window — remain genuinely Unreachable (that distinction is #1327's and stays).
- Client-only (`Sorcha.UI.Components.User`); no server change. Mutation-tested; full Sorcha.UI.Core.Tests 1661/1661.

## Test plan
- [x] PresentationSignalTests 11/11: after-observed-expiry 404s → `expired` outcome + no Unreachable; before-expiry 404s → still Unreachable; never-seen-alive unchanged
- [x] Mutation: carve-out disabled → after-expiry test RED → restored

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RboWP2TKvm1nBG22nqsWek