### PR TITLE
fix: [WALLET-STARTUP] - Wallet Service could not start at all without a Postgres connection string

### DIFF
--- a/src/Services/Sorcha.Wallet.Service/Endpoints/WalletEndpoints.cs
+++ b/src/Services/Sorcha.Wallet.Service/Endpoints/WalletEndpoints.cs
@@ -843,7 +843,13 @@ public static class WalletEndpoints
         string address,
         [FromBody] SignTransactionRequest request,
         WalletManager walletManager,
-        Sorcha.Wallet.Core.Data.WalletDbContext dbContext,
+        // Nullable + explicit [FromServices]: WalletDbContext is registered ONLY when a Postgres
+        // connection string is present (WalletServiceExtensions.AddWalletDatabase). Declared
+        // non-nullable and un-attributed, minimal APIs could not infer it at endpoint-build time
+        // and the whole host failed to start with "Failure to infer one or more parameters" —
+        // so the Wallet Service could not run on the in-memory storage path at all, which
+        // Pattern #13 explicitly supports outside Production. Nullable resolves via GetService.
+        [FromServices] Sorcha.Wallet.Core.Data.WalletDbContext? dbContext,
         HttpContext context,
         ILogger<Program> logger,
         CancellationToken cancellationToken = default)
@@ -881,12 +887,16 @@ public static class WalletEndpoints
 
             // Only check derived key status if this is an org-derived wallet.
             // Use DerivedKeyRecordId FK to avoid a full table scan for standalone wallets.
-            var derivedKeyRecordId = await dbContext.Wallets
-                .Where(w => w.Address == address)
-                .Select(w => w.DerivedKeyRecordId)
-                .FirstOrDefaultAsync(cancellationToken);
+            // Skipped entirely without a relational store: org key derivation is Postgres-backed,
+            // so on the in-memory path there are no DerivedKeyRecords to rotate or revoke.
+            var derivedKeyRecordId = dbContext is null
+                ? null
+                : await dbContext.Wallets
+                    .Where(w => w.Address == address)
+                    .Select(w => w.DerivedKeyRecordId)
+                    .FirstOrDefaultAsync(cancellationToken);
 
-            if (derivedKeyRecordId is not null)
+            if (derivedKeyRecordId is not null && dbContext is not null)
             {
                 var derivedKeyRecord = await dbContext.DerivedKeyRecords
                     .FirstOrDefaultAsync(d => d.Id == derivedKeyRecordId, cancellationToken);
@@ -2169,11 +2179,31 @@ public static class WalletEndpoints
     }
 
     /// <summary>
+    /// Uniform answer for endpoints whose feature genuinely requires the relational store, when
+    /// the host is running on the in-memory storage path (no Postgres connection string). Returns
+    /// 503 rather than throwing: the capability is unavailable in this configuration, which is a
+    /// deployment fact, not a request error. Production/Staging already fail fast on an in-memory
+    /// <c>IWalletRepository</c> (Pattern #13), so this is only reachable in dev/test.
+    /// </summary>
+    private static IResult RelationalStoreRequired(string capability) =>
+        Results.Json(
+            new ProblemDetails
+            {
+                Title = "Relational store required",
+                Detail = $"{capability} requires the Postgres-backed wallet store, but this host is "
+                       + "running on the in-memory storage path. Configure "
+                       + "ConnectionStrings:Wallet:Postgres (or ConnectionStrings:Sorcha:Postgres).",
+                Status = StatusCodes.Status503ServiceUnavailable
+            },
+            statusCode: StatusCodes.Status503ServiceUnavailable);
+
+    /// <summary>
     /// POST /api/v1/wallets/recover/delegations/preserve — selective delegation preservation.
     /// </summary>
     private static async Task<IResult> PreserveDelegations(
         PreserveDelegationsRequest request,
-        Sorcha.Wallet.Core.Data.WalletDbContext dbContext,
+        // See SignTransaction: nullable so the host still starts without Postgres.
+        [FromServices] Sorcha.Wallet.Core.Data.WalletDbContext? dbContext,
         Sorcha.Wallet.Core.Services.Interfaces.IDelegationService delegationService,
         HttpContext context,
         CancellationToken cancellationToken)
@@ -2181,6 +2211,9 @@ public static class WalletEndpoints
         var userId = context.User.FindFirstValue(ClaimTypes.NameIdentifier);
         if (string.IsNullOrEmpty(userId))
             return TypedResults.Unauthorized();
+
+        if (dbContext is null)
+            return RelationalStoreRequired("Selective delegation preservation");
 
         var preserved = 0;
         foreach (var delegationId in request.DelegationIds)
@@ -2211,13 +2244,17 @@ public static class WalletEndpoints
     /// GET /api/v1/wallets/recovery-status — check recovery capabilities.
     /// </summary>
     private static async Task<IResult> GetRecoveryStatus(
-        Sorcha.Wallet.Core.Data.WalletDbContext dbContext,
+        // See SignTransaction: nullable so the host still starts without Postgres.
+        [FromServices] Sorcha.Wallet.Core.Data.WalletDbContext? dbContext,
         HttpContext context,
         CancellationToken cancellationToken)
     {
         var userId = context.User.FindFirstValue(ClaimTypes.NameIdentifier);
         if (string.IsNullOrEmpty(userId))
             return TypedResults.Unauthorized();
+
+        if (dbContext is null)
+            return RelationalStoreRequired("Recovery status");
 
         var wallets = await Microsoft.EntityFrameworkCore.EntityFrameworkQueryableExtensions
             .ToListAsync(dbContext.Wallets.Where(w => w.Owner == userId), cancellationToken);


### PR DESCRIPTION
## The defect

`WalletDbContext` is registered **only** when a Postgres connection string is present (`WalletServiceExtensions.AddWalletDatabase`). Three endpoint handlers declared it as a plain, non-nullable, un-attributed parameter:

| Handler | Line |
|---|---|
| `SignTransaction` | `WalletEndpoints.cs:846` |
| `PreserveDelegations` | `WalletEndpoints.cs:2176` |
| `GetRecoveryStatus` | `WalletEndpoints.cs:2214` |

Minimal APIs bind handler parameters when endpoints are **built**, not when they're called. With no DbContext registered, inference failed and the host threw during startup:

```
System.InvalidOperationException: Failure to infer one or more parameters.
Parameter           | Source
request             | Body (Inferred)
dbContext           | UNKNOWN
```

So **the Wallet Service could not boot at all without Postgres** — even though Pattern #13 explicitly supports the in-memory storage path outside Production.

### Why this matters beyond startup

This is why `Sorcha.Wallet.Service.IntegrationTests` was **entirely dead**: all 33 tests failed inside `CreateClient()` before reaching a single assertion. That, in turn, is why this service has **no HTTP-level authorization coverage at all** — the suite that would carry it never ran. That absence is how the wallet-ownership gaps found in the 2026-07-29 catch-up security review went unnoticed.

I found this while trying to write an HTTP-level test proving one citizen could read another's credentials.

## The fix

Mark the three parameters `[FromServices]` **and nullable**, so they resolve via `GetService` and the host builds endpoints regardless. Then handle absence honestly rather than throwing:

- **`SignTransaction`** skips the org-derived-key rotation/revocation check. This is *correct*, not just convenient: org key derivation is Postgres-backed, so on the in-memory path there are no `DerivedKeyRecords` to rotate or revoke.
- **`PreserveDelegations`** and **`GetRecoveryStatus`** genuinely need the relational store, so they return a named **503** via a new `RelationalStoreRequired` helper that names the config key to set.

## This is partial — deliberately

Integration suite goes **0/33 → 5/33 passing**. The host starts.

The remaining **28 fail on the same class of defect one level deeper**: `IHolderAddressLookup` is registered unconditionally (`Program.cs:198-199`) with only an EF Core implementation, so `POST /api/v1/wallets` returns 500 without Postgres. Closing that needs an in-memory implementation — genuine scope, tracked separately rather than smuggled in here.

**No regression:** every one of those 28 tests already failed before this change (all 33 did).

## Production impact

Limited. Production/Staging already fail fast on an in-memory `IWalletRepository` (Pattern #13), so this bit **dev, CI and test hosts** — which is bad enough, since it silently removed a whole suite's worth of coverage.

## Verification

- `Sorcha.Wallet.Service` builds clean
- Integration suite: 0 → 5 passing, host boots, no test regressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012FGDTjzfzkecNr1rPZfatL