### PR TITLE
fix: [B2+ wave 2 follow-up] - bind the second participants group, and make the non-change test actually detectable

### DIFF
--- a/src/Services/Sorcha.Tenant.Service/Endpoints/ParticipantEndpoints.cs
+++ b/src/Services/Sorcha.Tenant.Service/Endpoints/ParticipantEndpoints.cs
@@ -224,9 +224,21 @@ public static class ParticipantEndpoints
             .Produces(StatusCodes.Status409Conflict);
 
         // Service-internal endpoints (used by Blueprint Service for wallet ownership validation)
+        //
+        // B2+ wave 2 follow-up: this is a SECOND group on the SAME route prefix as orgGroup above,
+        // and gating only that one left this one open — plain .RequireAuthorization(), no role check
+        // and no caller-org bind, while GET /by-user/{userId} resolves the participant straight from
+        // route values. Any authenticated principal, including a citizen, could read a participant
+        // record for any user in any organisation. Two groups sharing a prefix is exactly how a
+        // route-family sweep misses one; the wiring guard below now enumerates by prefix rather than
+        // by group variable.
+        //
+        // Blueprint Service (the intended caller) is unaffected: CallerOrganizationGate exempts
+        // token_type=service.
         var serviceGroup = app.MapGroup("/api/organizations/{organizationId:guid}/participants")
             .WithTags("Participants (Service)")
-            .RequireAuthorization();
+            .RequireAuthorization()
+            .RequireCallerOrganization();
 
         serviceGroup.MapGet("/by-user/{userId:guid}", GetParticipantByUser)
             .WithName("GetParticipantByUser")

--- a/src/Services/Sorcha.Tenant.Service/README.md
+++ b/src/Services/Sorcha.Tenant.Service/README.md
@@ -592,7 +592,15 @@ its absence here was a gap, not a decision.
 `CustomDomainEndpoints`, `DomainRestrictionEndpoints`, `DashboardEndpoints` (both `/dashboard` and
 `/dashboard-summary`), the 13 per-organisation routes in `OrganizationEndpoints` (user management +
 recovery-config), and — wave 2 — `IdpConfigurationEndpoints`, `OrgSettingsEndpoints`,
-`ParticipantEndpoints`, `RegisterInvitationEndpoints`, `RegisterSubscriptionEndpoints`.
+`ParticipantEndpoints` (**both** of its groups — see below), `RegisterInvitationEndpoints`,
+`RegisterSubscriptionEndpoints`.
+
+> **`ParticipantEndpoints` maps TWO groups on the SAME prefix** (`orgGroup` and `serviceGroup`).
+> Wave 2 gated only the first, leaving `GET .../participants/by-user/{userId}` on plain
+> `.RequireAuthorization()` — no role check, no caller-org bind — so any signed-in principal,
+> including a citizen, could read a participant record for any user in any organisation. Caught in
+> review of #1346 and fixed. The wiring guard now enumerates **by route prefix**, not by group
+> variable, because a per-group review cannot see a second group sharing a prefix.
 
 Two wave-2 cases are worth calling out:
 
@@ -606,10 +614,19 @@ Two wave-2 cases are worth calling out:
 **Deliberately NOT gated — `PlatformOrgEndpoints`.** `/api/platform/organizations` is cross-org **by
 design** (platform topology administration) and is *already* correctly scoped: both
 `RequireSystemAdmin` and `RequirePlatformAuditor` assert membership of the system-admin org, not
-merely a role. Adding a caller-org bind keyed on the route's `{orgId}` would refuse the platform
-admin for every organisation but their own — breaking a real capability while appearing to harden it.
-`OrgScopedCallerBindingTests` pins this as a deliberate non-change so nobody "completes the sweep"
-later. `InternalEndpoints` and the DID-document regenerate route are `RequireService`, out of scope.
+merely a role.
+
+The principal a caller-org bind would actually break is **not** the SystemAdmin — the gate exempts
+SystemAdmin-in-system-admin-org unconditionally. It is a **platform auditor**:
+`RequirePlatformAuditor` admits an `Auditor` (or `Administrator`) role in the system-admin org, and
+that principal has **no exemption arm**, so a route-org comparison would refuse them for every
+organisation except `…0001`. (An earlier version of this note gave the SystemAdmin as the affected
+principal, which was wrong — corrected in review of #1346.)
+
+`OrgScopedCallerBindingTests` pins this as a deliberate non-change **via route metadata**, not by
+driving a request: a behavioural test using a SystemAdmin client passes whether or not the gate is
+applied, because that caller is exempt either way — so it could never detect the regression it
+claimed to pin. `InternalEndpoints` and the DID-document regenerate route are `RequireService`, out of scope.
 
 **One legitimate cross-org flow depends on the SystemAdmin exemption:** cross-node public-org
 subscription (`Add-SorchaPublicOrgSubscription` → `POST /organizations/{publicOrgId}/register-subscriptions`)

--- a/tests/Sorcha.Tenant.Service.Tests/Endpoints/EndpointAuthorizationMetadata.cs
+++ b/tests/Sorcha.Tenant.Service.Tests/Endpoints/EndpointAuthorizationMetadata.cs
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Sorcha.Tenant.Service.Tests.Endpoints;
+
+/// <summary>
+/// Test harness for inspecting endpoint metadata without issuing a request and without standing up
+/// the full tenant service graph. Maps the real <c>Map*Endpoints</c> extension onto a builder whose
+/// service provider answers <see cref="IServiceProviderIsService"/> permissively, so
+/// RequestDelegateFactory treats every complex handler parameter as a DI service at delegate-build
+/// time (services are only <em>resolved</em> when an endpoint is invoked — never here).
+///
+/// <para>Mirrors <c>Sorcha.Wallet.Service.Tests.Endpoints.EndpointAuthorizationMetadata</c>. Needed
+/// here because a behavioural HTTP test cannot prove the ABSENCE of a gate: the review of #1346
+/// showed a "deliberate non-change" test driving a SystemAdmin client passed whether or not the gate
+/// was applied, because that principal is exempt from the gate either way. Metadata assertions can
+/// express "this route must NOT be bound" and "this route MUST be bound" without that ambiguity.</para>
+/// </summary>
+internal static class EndpointAuthorizationMetadata
+{
+    /// <summary>Maps endpoints via <paramref name="map"/> and returns the resulting route endpoints.</summary>
+    public static IReadOnlyList<RouteEndpoint> Collect(Action<IEndpointRouteBuilder> map)
+    {
+        var builder = WebApplication.CreateBuilder();
+        var app = builder.Build();
+
+        var routeBuilder = new TestEndpointRouteBuilder(new PermissiveServiceProvider(app.Services));
+        map(routeBuilder);
+
+        return routeBuilder.DataSources
+            .SelectMany(ds => ds.Endpoints)
+            .OfType<RouteEndpoint>()
+            .ToList();
+    }
+
+    /// <summary>Minimal <see cref="IEndpointRouteBuilder"/> whose service provider we control.</summary>
+    private sealed class TestEndpointRouteBuilder : IEndpointRouteBuilder
+    {
+        public TestEndpointRouteBuilder(IServiceProvider serviceProvider) => ServiceProvider = serviceProvider;
+
+        public IServiceProvider ServiceProvider { get; }
+
+        public ICollection<EndpointDataSource> DataSources { get; } = new List<EndpointDataSource>();
+
+        public IApplicationBuilder CreateApplicationBuilder() => new ApplicationBuilder(ServiceProvider);
+    }
+
+    /// <summary>
+    /// Wraps a real provider but answers <see cref="IServiceProviderIsService"/> /
+    /// <see cref="IServiceProviderIsKeyedService"/> with "yes" for every type, so
+    /// RequestDelegateFactory treats all complex handler parameters as services at build time.
+    /// </summary>
+    private sealed class PermissiveServiceProvider
+        : IServiceProvider, IServiceProviderIsService, IServiceProviderIsKeyedService
+    {
+        private readonly IServiceProvider _inner;
+
+        public PermissiveServiceProvider(IServiceProvider inner) => _inner = inner;
+
+        public object? GetService(Type serviceType)
+        {
+            if (serviceType == typeof(IServiceProviderIsService) ||
+                serviceType == typeof(IServiceProviderIsKeyedService))
+            {
+                return this;
+            }
+
+            return _inner.GetService(serviceType);
+        }
+
+        public bool IsService(Type serviceType) => true;
+
+        public bool IsKeyedService(Type serviceType, object? serviceKey) => true;
+    }
+}

--- a/tests/Sorcha.Tenant.Service.Tests/Endpoints/OrgScopedCallerBindingTests.cs
+++ b/tests/Sorcha.Tenant.Service.Tests/Endpoints/OrgScopedCallerBindingTests.cs
@@ -6,6 +6,10 @@ using System.Net.Http.Json;
 
 using FluentAssertions;
 
+using Microsoft.AspNetCore.Routing;
+
+using Sorcha.Tenant.Service.Authorization;
+using Sorcha.Tenant.Service.Endpoints;
 using Sorcha.Tenant.Service.Tests.Infrastructure;
 
 namespace Sorcha.Tenant.Service.Tests.Endpoints;
@@ -270,18 +274,94 @@ public class OrgScopedCallerBindingTests : IClassFixture<TenantServiceWebApplica
     public async Task PlatformOrgEndpoints_AreNotGated_TheyAreSystemAdminOrgScopedByPolicy()
     {
         // Deliberate NON-change, pinned so nobody "completes the sweep" by gating it later.
+        //
         // /api/platform/organizations is cross-org BY DESIGN (platform topology administration) and
         // is already correctly scoped: RequireSystemAdmin AND RequirePlatformAuditor both assert
-        // membership of the system-admin org, not merely a role. Adding a caller-org bind keyed on
-        // the ROUTE's {orgId} would refuse the platform admin for every organisation but their own —
-        // breaking a real capability while appearing to harden it.
-        var client = CreateSystemAdminClient();
+        // membership of the system-admin org, not merely a role.
+        //
+        // The principal that WOULD be broken by adding the bind is NOT the SystemAdmin — the gate
+        // exempts SystemAdmin-in-system-admin-org unconditionally. It is a **platform auditor**:
+        // RequirePlatformAuditor admits an `Auditor` (or `Administrator`) role in the system-admin
+        // org, and that principal has NO exemption arm in the gate, so a route-org comparison would
+        // refuse them for every organisation except `…0001`.
+        //
+        // This is asserted against ROUTE METADATA, not by driving a request. An earlier version of
+        // this test drove the route with a SystemAdmin client and asserted "not Forbidden" — which
+        // the gate's SystemAdmin exemption satisfies whether or not the gate is applied, so it could
+        // never have detected the regression it claimed to pin. (Caught in review of #1346.)
+        var endpoints = EndpointAuthorizationMetadata.Collect(rb => rb.MapPlatformOrgEndpoints());
+
+        var orgScoped = endpoints
+            .Where(e => e.RoutePattern.RawText!.Contains("{orgId", StringComparison.OrdinalIgnoreCase))
+            .ToList();
+
+        orgScoped.Should().NotBeEmpty("PlatformOrgEndpoints must expose per-organisation routes");
+
+        foreach (var endpoint in orgScoped)
+        {
+            endpoint.Metadata.GetMetadata<CallerOrganizationRequiredMetadata>().Should().BeNull(
+                $"'{endpoint.RoutePattern.RawText}' is intentionally cross-organisation — it is scoped "
+                + "by system-admin-org membership in RequireSystemAdmin / RequirePlatformAuditor. "
+                + "Binding it to the route's organisation would refuse a platform AUDITOR for every "
+                + "organisation but the system-admin org, breaking a real capability.");
+        }
+    }
+
+    [Fact]
+    public async Task AnyAuthenticatedNonAdmin_ReadingAnotherOrgsParticipantByUser_IsForbidden()
+    {
+        // ParticipantEndpoints maps TWO groups on the SAME prefix. Wave 2 gated `orgGroup` but not
+        // `serviceGroup`, whose GET /by-user/{userId} carried plain .RequireAuthorization() — no role
+        // check, no caller-org bind — and resolves the participant straight from route values. So any
+        // authenticated principal, including a citizen, could read a participant record for any user
+        // in any organisation. (Caught in review of #1346.)
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Add("X-Test-Role", "Consumer");
+        client.DefaultRequestHeaders.Add("X-Test-User-Id", Guid.NewGuid().ToString());
+        client.DefaultRequestHeaders.Add("X-Test-Organization-Id", CallerOwnOrgId.ToString());
 
         var response = await client.GetAsync(
-            $"/api/platform/organizations/{ForeignOrgId}/users");
+            $"/api/organizations/{ForeignOrgId}/participants/by-user/{Guid.NewGuid()}");
 
-        response.StatusCode.Should().NotBe(HttpStatusCode.Forbidden,
-            "platform topology administration is intentionally cross-organisation");
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden,
+            "a second group sharing a route prefix must be bound too — participant records in another "
+            + "organisation are not readable by any signed-in principal");
+    }
+
+    [Fact]
+    public void EveryOrgScopedRouteInTheGatedFiles_CarriesTheBind()
+    {
+        // Enumerates BY ROUTE PREFIX rather than by group variable. The wave-2 miss happened because
+        // ParticipantEndpoints declares two groups on one prefix and only one was gated — a
+        // per-group review cannot see that, but a per-route sweep can.
+        var maps = new (string Name, Action<IEndpointRouteBuilder> Map)[]
+        {
+            ("Invitation", rb => rb.MapInvitationEndpoints()),
+            ("Audit", rb => rb.MapAuditEndpoints()),
+            ("CustomDomain", rb => rb.MapCustomDomainEndpoints()),
+            ("DomainRestriction", rb => rb.MapDomainRestrictionEndpoints()),
+            ("IdpConfiguration", rb => rb.MapIdpConfigurationEndpoints()),
+            ("OrgSettings", rb => rb.MapOrgSettingsEndpoints()),
+            ("Participant", rb => rb.MapParticipantEndpoints()),
+            ("RegisterInvitation", rb => rb.MapRegisterInvitationEndpoints()),
+            ("RegisterSubscription", rb => rb.MapRegisterSubscriptionEndpoints()),
+        };
+
+        foreach (var (name, map) in maps)
+        {
+            var endpoints = EndpointAuthorizationMetadata.Collect(map);
+
+            var orgScoped = endpoints.Where(e =>
+                e.RoutePattern.RawText!.Contains("/api/organizations/{organizationId", StringComparison.OrdinalIgnoreCase)
+                || e.RoutePattern.RawText!.Contains("/api/organizations/{orgId", StringComparison.OrdinalIgnoreCase));
+
+            foreach (var endpoint in orgScoped)
+            {
+                endpoint.Metadata.GetMetadata<CallerOrganizationRequiredMetadata>().Should().NotBeNull(
+                    $"[{name}] '{endpoint.RoutePattern.RawText}' names an organisation in its route, so "
+                    + "the caller must be bound to it — RequireAdministrator is a role check only");
+            }
+        }
     }
 
     [Theory]


### PR DESCRIPTION
Both findings from `claude-review` on #1346. Both real. The second one catches an error in **my reasoning**, not in the code.

## 1. `ParticipantEndpoints` maps two groups on the same prefix — I gated one

`orgGroup` and `serviceGroup` are both mapped on `/api/organizations/{organizationId:guid}/participants`. Wave 2 gated only the first.

`serviceGroup` kept plain `.RequireAuthorization()` — **no role check and no caller-org bind** — while its `GET /by-user/{userId:guid}` resolves the participant straight from route values. So **any authenticated principal, including a citizen, could read a participant record for any user in any organisation.**

Same class as the `RegisterSubscription` read routes wave 2 fixed — and it made the PR's and README's "every org-scoped group is now bound" claim **untrue**. Now gated. Blueprint Service (the intended caller) is unaffected: the gate exempts `token_type=service`.

**The guard now enumerates by route prefix, not by group variable.** That's the actual lesson — a per-group review structurally cannot see a second group sharing a prefix, which is exactly how this was missed.

## 2. My "deliberate non-change" test couldn't detect its own regression, and its rationale was wrong

The test drove `/api/platform/organizations/{orgId}/users` with a **SystemAdmin** client and asserted "not Forbidden". But the gate exempts SystemAdmin-in-system-admin-org **unconditionally** — so that assertion holds whether or not the gate is applied. It would have kept passing straight through the regression it existed to catch.

The stated rationale was also wrong. I wrote that binding would refuse *"the platform admin for every organisation but their own"*. It wouldn't — the SystemAdmin is exempt. The principal actually affected is a **platform auditor**: `RequirePlatformAuditor` admits an `Auditor`/`Administrator` role in the system-admin org, and that principal has **no exemption arm**, so a route-org comparison would refuse them for every org except `…0001`.

**The conclusion still stands — don't gate `PlatformOrgEndpoints` — but for that reason, not the one I gave.**

Rewritten to assert the **absence** of `CallerOrganizationRequiredMetadata` on the route, which a behavioural test cannot express. That needed a metadata harness in this test project, so `EndpointAuthorizationMetadata` is mirrored from the Wallet test project.

## Verification — and a third mistake caught in the process

I tried to prove the rewritten test works by temporarily gating `PlatformOrgEndpoints`. My first attempt injected against `.WithTags("Platform Organizations")` — but the real string is the **British spelling** `"Platform Organisations"`, so nothing was gated and the test passed trivially. I'd have recorded a green "proof" of nothing.

Re-run with the correct anchor:

| Check | Result |
|---|---|
| revert the `serviceGroup` gate | **2 fail** (participant read + prefix sweep) |
| actually gate `PlatformOrgEndpoints` | **exactly 1 fails** (the non-change test) |
| both restored | 32/32 pass |

`Sorcha.Tenant.Service.Tests`: **1633 passed**, 8 skipped. Full solution builds clean.

README corrected on both points.

## Provenance

Follow-up to #1346, from the catch-up security review of the 51 PRs merged unreviewed 2026-07-21..29.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012FGDTjzfzkecNr1rPZfatL