### PR TITLE
fix: [#1182] - SECURITY: participant-gate the instance read endpoints

### DIFF
--- a/.claude/skills/jwt/SKILL.md
+++ b/.claude/skills/jwt/SKILL.md
@@ -27,7 +27,9 @@ Sorcha uses **JWT Bearer authentication** with the **Tenant Service** as the tok
 
 **Mint mapping today:** `TokenService.GenerateUserTokenAsync` → `platform`; `GenerateServiceTokenAsync` → `service`; `EnrolSessionService` redeem → `consumer`, mint → `enrol-session`. Refresh tokens carry a `tier` claim and re-mint the same tier.
 
-> **In-progress (US1/US4/US5, not yet landed):** tier *selection* at login (consumer-vs-platform from `returnTo`), per-endpoint tier *classification* across services, the `RequireService` `:service`-audience extension, and the `IdentityMetrics` (`Sorcha.Identity` meter) DI/OTel wiring. Until US1 lands, endpoints are not yet tier-gated — any valid tier audience authenticates. Spec/plan/tasks: `specs/136-jwt-audience-tiers/`.
+> **Status: all five user stories SHIPPED** (verified 2026-08-02 — `AuthorizationPolicyExtensions` registers `RequireConsumerAudience` / `RequirePlatformAudience`, `RequireService` adds `TierAudienceRequirement(Tier.Service)`, and `IdentityMetrics` is wired in `ServiceDefaults`). Tier selection at login, per-endpoint tier classification, the `:service` audience extension and the `Sorcha.Identity` meter are all live. Spec/plan/tasks: `specs/136-jwt-audience-tiers/`.
+>
+> This block previously read "not yet landed … endpoints are not yet tier-gated". That was stale and load-bearing in the wrong direction: it tells a reader the tier gate is inert, so they skip adding one. Treat CLAUDE.md §13 and the `sorcha-architecture` skill as co-authoritative and keep all three in step.
 
 **No migration:** coordinated config rollout; existing tokens expire (pre-release).
 
@@ -106,6 +108,49 @@ options.AddPolicy("CanManageBlueprints", policy =>
 
 The Wallet Service's `CanRecoverSystemWallet` (system-wallet BIP39 import) follows the same shape:
 service-tier **OR** (`Administrator`/`SystemAdmin` role AND `:platform` audience).
+
+### Resource ownership is NOT a policy — gate it in the handler (issue #1182)
+
+**A tier policy answers "what kind of caller is this", never "does this row belong to them".** Both
+questions must be answered, and only the first can live in `.RequireAuthorization(...)`. Conflating
+them is how `GET /api/instances/{id}` shipped returning any citizen's identity application — name,
+date of birth, address and portrait tokens — to any authenticated stranger who knew a GUID. The group
+carried `CanExecuteBlueprints`, which looks like authorization but resolves to a bare
+`RequireAuthenticatedUser()`.
+
+**Audit rule with teeth: a handler that takes an id and returns per-subject data, but does not take
+`HttpContext`, cannot be checking ownership.** It has no caller identity to check against. That
+signature alone convicted three endpoints here.
+
+```csharp
+// Tier gate on the route; ownership gate in the handler. You need BOTH.
+var instance = await instanceStore.GetAsync(instanceId, ct);
+if (instance is null) return Results.NotFound(...);
+
+var blueprint = await blueprintStore.GetAsync(instance.BlueprintId);   // BEFORE the decision
+if (!await InstanceParticipantGate.IsParticipantAsync(httpContext, instance, walletClient, logger, ct)
+    && !InstanceParticipantGate.IsAwaitingOpenParticipant(instance, blueprint))
+{
+    return Results.Problem("You are not a participant on this instance.", statusCode: 403);
+}
+```
+
+Two traps make the obvious implementation wrong in **opposite** directions — this codebase has now hit
+both, more than once each:
+
+| Trap | Symptom | Rule |
+|---|---|---|
+| Reading `wallet_address` off the claim set | 403s every real citizen (consumer tokens omit it, FR-014) **while leaving platform-tier callers unrestricted** | Always resolve via `ParticipantWalletResolver.ResolveUserWalletAddressesAsync` — claim fast path, then Wallet-Service lookup by owner. Match against the caller's FULL wallet set. |
+| Gating on recorded participation alone | 403s the Feature 103 open participant on their own freshly-created instance — `CreateInstance` seeds `ParticipantWallets` only from participants that already carry a wallet, so the walk-in citizen is absent until their first submission seals | Add an explicit empty-shell carve-out (`CompletedActionCount == 0` **and** a current action whose sender is unbound). It closes the instant real data exists. |
+
+Ordering matters too: resolve the blueprint **before** the gate decides, and raise any
+"blueprint/action not found" error **after** it, so a non-participant cannot read the difference
+between error bodies to probe instance internals (#1183).
+
+An empty resolved wallet set means "could not resolve", not "any wallet" — **fail closed**.
+
+Canonical implementations: `Sorcha.Blueprint.Service.Services.Infrastructure.InstanceParticipantGate`
+and its four callers (`InstanceReadEndpoints`, `InstanceActionEndpoints`).
 
 ### Extract Claims in Handler
 

--- a/docs/reference/API-DOCUMENTATION.md
+++ b/docs/reference/API-DOCUMENTATION.md
@@ -874,10 +874,49 @@ only what `SorchaFormRenderer` reads to render and validate the form for this on
 sender, which this endpoint's caller always is). `404` if the instance, blueprint, or action is not
 found; `403` if the caller is not a recorded participant on the instance.
 
-> **Known gap, not fixed here (flagged, not silently copied):** the sibling `GET /api/instances/{id}`
-> endpoint on the same group performs **no participant check at all** — any authenticated caller can
-> read any instance by id. This endpoint intentionally does not repeat that gap. Tightening
-> `GET /api/instances/{id}` itself is out of scope for this fix and tracked separately.
+> **That known gap is now CLOSED (issue #1182).** `GET /api/instances/{id}` and its two siblings had
+> no participant check at all — any authenticated caller could read any instance by id. All three are
+> now gated; see below.
+
+### Instance read endpoints — participant gate (issue #1182)
+
+`GET /api/instances/{instanceId}`, `GET /api/instances/{instanceId}/state` and
+`GET /api/instances/{instanceId}/next-actions` previously returned instance content to **any**
+authenticated caller. The `/api/instances` group carries only `CanExecuteBlueprints`, which resolves
+to a bare `RequireAuthenticatedUser()` — so knowledge of a GUID was the only thing protecting another
+citizen's in-flight application. `GET /{instanceId}` was the most serious: it returned the `Instance`
+verbatim, including `accumulatedData` (on an identity workflow: name, date of birth, address and
+portrait image tokens in plaintext) and `participantWallets` (which de-anonymises every participant).
+
+| Method | Path | Authorization |
+|--------|------|---------------|
+| GET | `/api/instances/` | Authenticated; returns only instances where a wallet the caller controls is a participant |
+| GET | `/api/instances/{instanceId}` | Authenticated **and** (caller controls a participant wallet **or** the instance is an unstarted open-participant shell) |
+| GET | `/api/instances/{instanceId}/state` | As above, plus the `X-Delegation-Token` header |
+| GET | `/api/instances/{instanceId}/next-actions` | As above |
+
+Two behaviours are deliberate and easy to get wrong in the opposite direction:
+
+- **The caller's wallets are resolved, not read from a claim.** A consumer-tier token — every real
+  citizen sign-in, web and PWA — carries no `wallet_address` (Feature 136). Resolution goes through
+  `ParticipantWalletResolver` (claim fast path, then Wallet-Service lookup by owner) and matches
+  against the caller's full wallet set. A claim-only gate would 403 every genuine citizen while
+  leaving platform-tier callers unrestricted.
+- **An unstarted instance awaiting its open (Feature 103) participant is readable by any
+  authenticated caller.** `CreateInstance` seeds `participantWallets` only from participants that
+  already carry a wallet, so the walk-in applicant is absent until their first submission seals — and
+  the PWA reads `GET /api/instances/{id}` to find the current action *before* they submit anything.
+  The carve-out requires `completedActionCount == 0` **and** a current action whose sender is unbound,
+  so it holds no accumulated data and only wallets the published blueprint already carries in the
+  clear on the register. It closes the moment any action completes.
+
+`403` returns the same body for "not a participant" as for "blueprint/action not found", so a
+non-participant cannot probe instance internals by reading the difference (#1183).
+
+**Also fixed (same root cause, opposite symptom):** `GET /api/instances/` read the `wallet_address`
+claim directly and returned an empty page when it was absent — so every consumer-tier citizen saw
+none of their own applications. It now resolves through the same seam, spans every wallet the caller
+controls, deduplicates by instance id and orders newest-first.
 
 ### Timebound Presentation Lifecycle (Feature 111)
 

--- a/src/Services/Sorcha.Blueprint.Service/Endpoints/InstanceReadEndpoints.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Endpoints/InstanceReadEndpoints.cs
@@ -1,0 +1,356 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using Sorcha.Blueprint.Service.Services.Infrastructure;
+using Sorcha.Blueprint.Service.Services.Interfaces;
+using Sorcha.Blueprint.Service.Storage;
+using Sorcha.ServiceClients.Wallet;
+
+namespace Sorcha.Blueprint.Service.Endpoints;
+
+/// <summary>
+/// Issue #1182 — the three READ endpoints on the <c>/api/instances</c> group, lifted out of
+/// <c>Program.cs</c>'s inline lambdas so they can carry a participant gate and be tested without a
+/// <c>WebApplicationFactory</c> (the reflection-based pattern
+/// <c>InstanceActionEndpointsTests</c> established).
+///
+/// <para>All three previously returned instance content to ANY authenticated caller. The group's
+/// <c>CanExecuteBlueprints</c> policy resolves to a bare <c>RequireAuthenticatedUser()</c>, so the
+/// only thing between a stranger and another citizen's in-flight application was knowledge of a
+/// GUID — which appears in URLs, logs, inbox <c>detailHref</c> values and client-side state.
+/// <c>GET /{instanceId}</c> was the worst of the three: it returned the <c>Instance</c> verbatim,
+/// including <c>AccumulatedData</c> (on an identity workflow: name, date of birth, address and
+/// portrait image tokens in plaintext) and <c>ParticipantWallets</c> (which de-anonymises every
+/// participant).</para>
+///
+/// <para>The gate itself lives in <see cref="InstanceParticipantGate"/> — see that type for the two
+/// traps (consumer-tier tokens carry no <c>wallet_address</c>; open participants are not yet
+/// participants) that make the obvious implementation of this check wrong in both directions.</para>
+/// </summary>
+public static class InstanceReadEndpoints
+{
+    /// <summary>
+    /// Maps the three instance read routes onto the group it is called on (the existing
+    /// <c>/api/instances</c> group in <c>Program.cs</c>, already gated by <c>CanExecuteBlueprints</c>).
+    /// </summary>
+    public static void MapInstanceReadEndpoints(this IEndpointRouteBuilder group)
+    {
+        group.MapGet("/", ListInstances)
+            .WithName("ListInstances")
+            .WithSummary("List workflow instances for the authenticated user")
+            .WithDescription(
+                "Returns paginated workflow instances where a wallet the authenticated caller "
+                + "controls is a participant. The caller's wallet(s) are resolved from the "
+                + "wallet_address claim when present, else via a Wallet-Service lookup by owner "
+                + "(consumer-tier tokens carry no wallet_address per Feature 136). Results span every "
+                + "wallet the caller controls, deduplicated by instance and ordered newest-first. "
+                + "Supports optional status filtering (Active, Completed, Rejected, TimedOut, Cancelled).")
+            .Produces(StatusCodes.Status200OK);
+
+        group.MapGet("/{instanceId}", GetInstance)
+            .WithName("GetInstance")
+            .WithSummary("Get workflow instance")
+            .WithDescription(
+                "Retrieve a workflow instance by its ID. Readable only by a caller controlling a "
+                + "wallet recorded as a participant on the instance — the caller's wallet(s) are "
+                + "resolved from the wallet_address claim when present, else via a Wallet-Service "
+                + "lookup by owner (consumer-tier tokens carry no wallet_address per Feature 136). "
+                + "An instance that has completed no actions and is still awaiting its open "
+                + "(Feature 103) starting participant is readable by any authenticated caller, "
+                + "because it holds no accumulated data and only the participant wallets the "
+                + "published blueprint already carries in the clear. 403 otherwise; 404 if the "
+                + "instance does not exist.")
+            .Produces(StatusCodes.Status200OK)
+            .Produces(StatusCodes.Status403Forbidden)
+            .Produces(StatusCodes.Status404NotFound);
+
+        group.MapGet("/{instanceId}/state", GetInstanceState)
+            .WithName("GetInstanceState")
+            .WithSummary("Get accumulated state")
+            .WithDescription(
+                "Get the accumulated state from all prior actions in the workflow. Requires an "
+                + "X-Delegation-Token header, and requires the caller to control a wallet recorded "
+                + "as a participant on the instance.")
+            .Produces(StatusCodes.Status200OK)
+            .Produces(StatusCodes.Status403Forbidden)
+            .Produces(StatusCodes.Status404NotFound);
+
+        group.MapGet("/{instanceId}/next-actions", GetNextActions)
+            .WithName("GetNextActions")
+            .WithSummary("Get next available actions")
+            .WithDescription(
+                "Get the actions currently awaiting execution on the workflow instance. Requires "
+                + "the caller to control a wallet recorded as a participant on the instance.")
+            .Produces(StatusCodes.Status200OK)
+            .Produces(StatusCodes.Status403Forbidden)
+            .Produces(StatusCodes.Status404NotFound);
+    }
+
+    /// <summary>
+    /// Handler for <c>GET /api/instances/</c> — the caller's own instances. Internal for the same
+    /// reason as <see cref="GetInstance"/>.
+    /// </summary>
+    internal static async Task<IResult> ListInstances(
+        HttpContext httpContext,
+        IInstanceStore instanceStore,
+        IWalletServiceClient walletClient,
+        ILogger<InstanceReadEndpointsLogCategory> logger,
+        Sorcha.Blueprint.Service.Models.InstanceState? status,
+        int page,
+        int pageSize,
+        CancellationToken cancellationToken)
+    {
+        // Issue #1182 (adjacent) — this previously read the wallet_address claim directly and
+        // returned an empty page when it was absent. A consumer-tier token never carries that claim
+        // (Feature 136), so EVERY citizen saw "no applications" while the server held their data.
+        // Same missing resolver as the gate bug on the sibling endpoints, opposite symptom: that one
+        // let strangers in, this one locked the owner out.
+        var callerWallets = await ParticipantWalletResolver.ResolveUserWalletAddressesAsync(
+            httpContext, walletClient, logger, cancellationToken);
+
+        if (callerWallets.Count == 0)
+        {
+            return Results.Ok(new { items = Array.Empty<object>(), totalCount = 0, pageNumber = page, pageSize });
+        }
+
+        // A caller may control several wallets, so the page spans all of them. Each is fetched
+        // unpaged and combined here — the previous implementation already made exactly this unpaged
+        // call per request to compute totalCount, so this costs no extra round trips. Deduplicated by
+        // instance id (a caller holding two participant wallets on one instance must not see it
+        // twice) and ordered newest-first with an id tiebreak so paging is deterministic across
+        // requests; the store interface promises no ordering of its own.
+        var combined = new Dictionary<string, Sorcha.Blueprint.Service.Models.Instance>(StringComparer.Ordinal);
+        foreach (var wallet in callerWallets)
+        {
+            foreach (var instance in await instanceStore.GetByParticipantWalletAsync(
+                         wallet, status, 0, int.MaxValue, cancellationToken))
+            {
+                combined[instance.Id] = instance;
+            }
+        }
+
+        var ordered = combined.Values
+            .OrderByDescending(i => i.CreatedAt)
+            .ThenBy(i => i.Id, StringComparer.Ordinal)
+            .ToList();
+
+        var items = ordered.Skip((page - 1) * pageSize).Take(pageSize).ToList();
+
+        return Results.Ok(new { items, totalCount = ordered.Count, pageNumber = page, pageSize });
+    }
+
+    /// <summary>
+    /// Handler for <c>GET /api/instances/{instanceId}</c>. Internal (not private) so tests can reach
+    /// it by reflection — see <c>tests/Sorcha.Blueprint.Service.Tests/Endpoints/InstanceReadEndpointsTests.cs</c>.
+    /// </summary>
+    internal static async Task<IResult> GetInstance(
+        HttpContext httpContext,
+        string instanceId,
+        IInstanceStore instanceStore,
+        IBlueprintStore blueprintStore,
+        IWalletServiceClient walletClient,
+        ILogger<InstanceReadEndpointsLogCategory> logger,
+        CancellationToken cancellationToken)
+    {
+        var instance = await instanceStore.GetAsync(instanceId, cancellationToken);
+        if (instance == null)
+        {
+            return Results.NotFound(new { error = "Instance not found" });
+        }
+
+        var blueprint = await blueprintStore.GetAsync(instance.BlueprintId);
+        if (!await IsPermittedAsync(httpContext, instance, blueprint, walletClient, logger, cancellationToken))
+        {
+            return Forbidden();
+        }
+
+        return Results.Ok(instance);
+    }
+
+    /// <summary>
+    /// The read gate shared by all three handlers: a caller may read an instance if they control a
+    /// wallet recorded as a participant on it, OR the instance is still an untouched shell awaiting
+    /// its open (Feature 103) starting participant. See <see cref="InstanceParticipantGate"/> for why
+    /// both arms are load-bearing.
+    /// </summary>
+    private static async Task<bool> IsPermittedAsync(
+        HttpContext httpContext,
+        Sorcha.Blueprint.Service.Models.Instance instance,
+        Sorcha.Blueprint.Models.Blueprint? blueprint,
+        IWalletServiceClient walletClient,
+        ILogger logger,
+        CancellationToken cancellationToken)
+        => await InstanceParticipantGate.IsParticipantAsync(
+               httpContext, instance, walletClient, logger, cancellationToken)
+           || InstanceParticipantGate.IsAwaitingOpenParticipant(instance, blueprint);
+
+    /// <summary>
+    /// Deliberately identical for "not a participant" and "blueprint/action does not exist", so a
+    /// non-participant cannot probe instance internals by reading the difference between error
+    /// bodies (#1183).
+    /// </summary>
+    private static IResult Forbidden() => Results.Problem(
+        "You are not a participant on this instance.",
+        statusCode: StatusCodes.Status403Forbidden);
+
+    /// <summary>
+    /// Handler for <c>GET /api/instances/{instanceId}/state</c>. Internal for the same reason as
+    /// <see cref="GetInstance"/>.
+    /// </summary>
+    internal static async Task<IResult> GetInstanceState(
+        HttpContext httpContext,
+        string instanceId,
+        IStateReconstructionService stateService,
+        IInstanceStore instanceStore,
+        IBlueprintStore blueprintStore,
+        IWalletServiceClient walletClient,
+        ILogger<InstanceReadEndpointsLogCategory> logger,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            // Get delegation token from context (set by middleware)
+            var delegationToken = httpContext.Items["DelegationToken"] as string;
+            if (string.IsNullOrEmpty(delegationToken))
+            {
+                return Results.BadRequest(new { error = "X-Delegation-Token header is required to view state" });
+            }
+
+            var instance = await instanceStore.GetAsync(instanceId, cancellationToken);
+            if (instance == null)
+            {
+                return Results.NotFound(new { error = "Instance not found" });
+            }
+
+            // Resolved BEFORE the gate decides (the open-participant arm needs it), and the
+            // blueprint-missing 400 is deliberately raised AFTER the gate, so a non-participant
+            // cannot distinguish "not allowed" from "blueprint not replicated here" (#1183).
+            var blueprint = await blueprintStore.GetAsync(instance.BlueprintId);
+            if (!await IsPermittedAsync(httpContext, instance, blueprint, walletClient, logger, cancellationToken))
+            {
+                return Forbidden();
+            }
+
+            if (blueprint == null)
+            {
+                return Results.BadRequest(new { error = "Blueprint not found" });
+            }
+
+            // Use the first current action for state reconstruction
+            var currentActionId = instance.CurrentActionIds.FirstOrDefault();
+            if (currentActionId == 0)
+            {
+                return Results.Ok(new
+                {
+                    instanceId,
+                    actionCount = 0,
+                    previousTransactionId = (string?)null,
+                    data = new Dictionary<string, object?>(),
+                    branchStates = new Dictionary<string, object>()
+                });
+            }
+
+            var state = await stateService.ReconstructAsync(
+                blueprint,
+                instanceId,
+                currentActionId,
+                instance.RegisterId,
+                delegationToken,
+                instance.ParticipantWallets,
+                cancellationToken);
+
+            return Results.Ok(new
+            {
+                instanceId,
+                actionCount = state.ActionCount,
+                previousTransactionId = state.PreviousTransactionId,
+                data = state.GetFlattenedData(),
+                branchStates = state.BranchStates
+            });
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Request failed");
+            return Results.Problem("An error occurred processing the request.", statusCode: 400);
+        }
+    }
+
+    /// <summary>
+    /// Handler for <c>GET /api/instances/{instanceId}/next-actions</c>. Internal for the same reason
+    /// as <see cref="GetInstance"/>.
+    /// </summary>
+    internal static async Task<IResult> GetNextActions(
+        HttpContext httpContext,
+        string instanceId,
+        IInstanceStore instanceStore,
+        IBlueprintStore blueprintStore,
+        IWalletServiceClient walletClient,
+        ILogger<InstanceReadEndpointsLogCategory> logger,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var instance = await instanceStore.GetAsync(instanceId, cancellationToken);
+            if (instance == null)
+            {
+                return Results.NotFound(new { error = "Instance not found" });
+            }
+
+            // Gate ordering as in GetInstanceState — blueprint resolved first (the open-participant
+            // arm needs it), blueprint-missing 400 raised only after the caller has been admitted.
+            var blueprint = await blueprintStore.GetAsync(instance.BlueprintId);
+            if (!await IsPermittedAsync(httpContext, instance, blueprint, walletClient, logger, cancellationToken))
+            {
+                return Forbidden();
+            }
+
+            if (blueprint == null)
+            {
+                return Results.BadRequest(new { error = "Blueprint not found" });
+            }
+
+            var nextActions = new List<object>();
+            foreach (var actionId in instance.CurrentActionIds)
+            {
+                var action = blueprint.Actions.FirstOrDefault(a => a.Id == actionId);
+                if (action != null)
+                {
+                    // Get participant info
+                    var participant = action.Participants?.FirstOrDefault();
+                    nextActions.Add(new
+                    {
+                        actionId = action.Id,
+                        title = action.Title,
+                        description = action.Description,
+                        participantId = participant?.Principal,
+                        branchId = instance.ActiveBranches
+                            .FirstOrDefault(b => b.CurrentActionId == actionId)?.Id,
+                        blueprintId = instance.BlueprintId,
+                        registerId = instance.RegisterId,
+                        blueprintName = blueprint.Title
+                    });
+                }
+            }
+
+            return Results.Ok(new
+            {
+                instanceId,
+                state = instance.State.ToString().ToLowerInvariant(),
+                isComplete = instance.State == Sorcha.Blueprint.Service.Models.InstanceState.Completed,
+                nextActions
+            });
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Request failed");
+            return Results.Problem("An error occurred processing the request.", statusCode: 400);
+        }
+    }
+
+    /// <summary>
+    /// Marker type for <see cref="ILogger{T}"/> categorisation — <see cref="InstanceReadEndpoints"/>
+    /// is static, so it cannot itself be used as a generic type argument. Mirrors
+    /// <c>InstanceActionEndpoints.InstanceActionEndpointsLogCategory</c>.
+    /// </summary>
+    internal sealed class InstanceReadEndpointsLogCategory { }
+}

--- a/src/Services/Sorcha.Blueprint.Service/Program.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Program.cs
@@ -2176,41 +2176,6 @@ instanceRebuildGroup.MapPost("/{registerId}/{instanceId}/rebuild", async (
 // <summary>
 // List workflow instances for the authenticated user's wallet
 // </summary>
-instancesGroup.MapGet("/", async (
-    HttpContext httpContext,
-    Sorcha.Blueprint.Service.Storage.IInstanceStore instanceStore,
-    Sorcha.Blueprint.Service.Models.InstanceState? status = null,
-    int page = 1,
-    int pageSize = 20) =>
-{
-    var walletAddress = httpContext.User.FindFirst("wallet_address")?.Value;
-    if (string.IsNullOrEmpty(walletAddress))
-    {
-        return Results.Ok(new { items = Array.Empty<object>(), totalCount = 0, pageNumber = page, pageSize });
-    }
-
-    var skip = (page - 1) * pageSize;
-    var items = (await instanceStore.GetByParticipantWalletAsync(
-        walletAddress, status, skip, pageSize)).ToList();
-
-    // Get total count by querying without pagination
-    var allItems = await instanceStore.GetByParticipantWalletAsync(
-        walletAddress, status, 0, int.MaxValue);
-    var totalCount = allItems.Count();
-
-    return Results.Ok(new
-    {
-        items,
-        totalCount,
-        pageNumber = page,
-        pageSize
-    });
-})
-.WithName("ListInstances")
-.WithSummary("List workflow instances for the authenticated user")
-.WithDescription("Returns paginated workflow instances where the authenticated user's wallet is a participant. "
-    + "Supports optional status filtering (Active, Completed, Rejected, TimedOut, Cancelled).");
-
 // <summary>
 // Create a new workflow instance
 // </summary>
@@ -2373,24 +2338,10 @@ instancesGroup.MapPost("/", async (
 .WithSummary("Create workflow instance")
 .WithDescription("Create a new workflow instance for a published blueprint");
 
-// <summary>
-// Get workflow instance by ID
-// </summary>
-instancesGroup.MapGet("/{instanceId}", async (
-    string instanceId,
-    Sorcha.Blueprint.Service.Storage.IInstanceStore instanceStore) =>
-{
-    var instance = await instanceStore.GetAsync(instanceId);
-    if (instance == null)
-    {
-        return Results.NotFound(new { error = "Instance not found" });
-    }
-
-    return Results.Ok(instance);
-})
-.WithName("GetInstance")
-.WithSummary("Get workflow instance")
-.WithDescription("Retrieve a workflow instance by its ID");
+// Issue #1182 — GET /{instanceId}, /{instanceId}/state and /{instanceId}/next-actions. Previously
+// three inline lambdas here, each returning instance content to ANY authenticated caller; now
+// participant-gated handlers in Sorcha.Blueprint.Service.Endpoints.InstanceReadEndpoints.
+instancesGroup.MapInstanceReadEndpoints();
 
 // P0 fix (fix/pwa-p0-claim-and-camera) — GET /{instanceId}/actions/{actionId}: instance-scoped,
 // consumer-readable action schema (see Sorcha.Blueprint.Service.Endpoints.InstanceActionEndpoints).
@@ -2553,141 +2504,6 @@ instancesGroup.MapPost("/{instanceId}/actions/{actionId}/reject", async (
 .WithName("RejectActionInInstance")
 .WithSummary("Reject action in workflow")
 .WithDescription("Reject an action in a workflow instance, routing to the configured rejection target. Requires X-Delegation-Token header.");
-
-// <summary>
-// Get accumulated state for a workflow instance
-// </summary>
-instancesGroup.MapGet("/{instanceId}/state", async (
-    HttpContext context,
-    string instanceId,
-    Sorcha.Blueprint.Service.Services.Interfaces.IStateReconstructionService stateService,
-    Sorcha.Blueprint.Service.Storage.IInstanceStore instanceStore,
-    IBlueprintStore blueprintStore) =>
-{
-    try
-    {
-        // Get delegation token from context (set by middleware)
-        var delegationToken = context.Items["DelegationToken"] as string;
-        if (string.IsNullOrEmpty(delegationToken))
-        {
-            return Results.BadRequest(new { error = "X-Delegation-Token header is required to view state" });
-        }
-
-        var instance = await instanceStore.GetAsync(instanceId);
-        if (instance == null)
-        {
-            return Results.NotFound(new { error = "Instance not found" });
-        }
-
-        var blueprint = await blueprintStore.GetAsync(instance.BlueprintId);
-        if (blueprint == null)
-        {
-            return Results.BadRequest(new { error = "Blueprint not found" });
-        }
-
-        // Use the first current action for state reconstruction
-        var currentActionId = instance.CurrentActionIds.FirstOrDefault();
-        if (currentActionId == 0)
-        {
-            return Results.Ok(new
-            {
-                instanceId,
-                actionCount = 0,
-                previousTransactionId = (string?)null,
-                data = new Dictionary<string, object?>(),
-                branchStates = new Dictionary<string, object>()
-            });
-        }
-
-        var state = await stateService.ReconstructAsync(
-            blueprint,
-            instanceId,
-            currentActionId,
-            instance.RegisterId,
-            delegationToken,
-            instance.ParticipantWallets);
-
-        return Results.Ok(new
-        {
-            instanceId,
-            actionCount = state.ActionCount,
-            previousTransactionId = state.PreviousTransactionId,
-            data = state.GetFlattenedData(),
-            branchStates = state.BranchStates
-        });
-    }
-    catch (Exception ex)
-    {
-        logger.LogWarning(ex, "Request failed");
-        return Results.Problem("An error occurred processing the request.", statusCode: 400);
-    }
-})
-.WithName("GetInstanceState")
-.WithSummary("Get accumulated state")
-.WithDescription("Get the accumulated state from all prior actions in the workflow. Requires X-Delegation-Token header.");
-
-// <summary>
-// Get next available actions for a workflow instance
-// </summary>
-instancesGroup.MapGet("/{instanceId}/next-actions", async (
-    string instanceId,
-    Sorcha.Blueprint.Service.Storage.IInstanceStore instanceStore,
-    IBlueprintStore blueprintStore) =>
-{
-    try
-    {
-        var instance = await instanceStore.GetAsync(instanceId);
-        if (instance == null)
-        {
-            return Results.NotFound(new { error = "Instance not found" });
-        }
-
-        var blueprint = await blueprintStore.GetAsync(instance.BlueprintId);
-        if (blueprint == null)
-        {
-            return Results.BadRequest(new { error = "Blueprint not found" });
-        }
-
-        var nextActions = new List<object>();
-        foreach (var actionId in instance.CurrentActionIds)
-        {
-            var action = blueprint.Actions.FirstOrDefault(a => a.Id == actionId);
-            if (action != null)
-            {
-                // Get participant info
-                var participant = action.Participants?.FirstOrDefault();
-                nextActions.Add(new
-                {
-                    actionId = action.Id,
-                    title = action.Title,
-                    description = action.Description,
-                    participantId = participant?.Principal,
-                    branchId = instance.ActiveBranches
-                        .FirstOrDefault(b => b.CurrentActionId == actionId)?.Id,
-                    blueprintId = instance.BlueprintId,
-                    registerId = instance.RegisterId,
-                    blueprintName = blueprint.Title
-                });
-            }
-        }
-
-        return Results.Ok(new
-        {
-            instanceId,
-            state = instance.State.ToString().ToLowerInvariant(),
-            isComplete = instance.State == Sorcha.Blueprint.Service.Models.InstanceState.Completed,
-            nextActions
-        });
-    }
-    catch (Exception ex)
-    {
-        logger.LogWarning(ex, "Request failed");
-        return Results.Problem("An error occurred processing the request.", statusCode: 400);
-    }
-})
-.WithName("GetNextActions")
-.WithSummary("Get next available actions")
-.WithDescription("Get the next available actions that can be executed in the workflow instance");
 
 // ===========================
 // Health & Status Endpoints

--- a/src/Services/Sorcha.Blueprint.Service/Services/Infrastructure/InstanceParticipantGate.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Services/Infrastructure/InstanceParticipantGate.cs
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Sorcha.Blueprint.Service.Models;
+using Sorcha.ServiceClients.Wallet;
+using BlueprintModel = Sorcha.Blueprint.Models.Blueprint;
+
+namespace Sorcha.Blueprint.Service.Services.Infrastructure;
+
+/// <summary>
+/// Issue #1182 — the single authority for "may this authenticated caller read this workflow
+/// instance?". Extracted from the inline gate in
+/// <see cref="Sorcha.Blueprint.Service.Endpoints.InstanceActionEndpoints"/> once three more
+/// endpoints needed the identical decision; one seam rather than four copies that drift apart.
+///
+/// <para><b>Why a gate is needed at all.</b> The <c>/api/instances</c> group carries only
+/// <c>CanExecuteBlueprints</c>, which resolves to a bare <c>RequireAuthenticatedUser()</c>. It
+/// asserts "someone is signed in" and nothing else — no participant check, no org scoping, no tier
+/// check. Every endpoint returning instance content must therefore add its own check on top.</para>
+///
+/// <para><b>The two traps this type exists to make unrepeatable.</b></para>
+/// <list type="number">
+/// <item><description><b>Reading <c>wallet_address</c> off the claim set.</b> Under Feature 136 a
+/// consumer-tier token — every real citizen sign-in, web and PWA — deliberately OMITS that claim
+/// (<c>TokenService.AddWalletAddressClaimAsync</c> fires only for <c>Tier.Platform</c>). A
+/// claim-only gate is therefore unconditionally false for the exact population these endpoints
+/// serve: it 403s every genuine citizen while leaving the hole wide open for platform-tier callers.
+/// Resolution MUST go through <see cref="ParticipantWalletResolver"/>, which falls back to a
+/// Wallet-Service lookup keyed on the owner. This mistake has now been made twice — once on
+/// <c>InstanceActionEndpoints</c> before it shipped, and once in that endpoint's own tests, which
+/// claimed to exercise a consumer-tier principal while actually building a platform-tier one.</description></item>
+/// <item><description><b>Gating on participation alone.</b> <c>CreateInstance</c> pre-populates
+/// <see cref="Instance.ParticipantWallets"/> only from blueprint participants that already carry a
+/// wallet — which by construction EXCLUDES the Feature 103 open participant, i.e. the walk-in
+/// citizen the workflow exists for. Between <c>POST /api/instances/</c> and their starting action
+/// sealing, the applicant is not a participant on their own instance, so a participation-only gate
+/// breaks the apply flow for every citizen (the PWA reads <c>GET /api/instances/{id}</c> to find the
+/// current action before submitting anything). See <see cref="IsAwaitingOpenParticipant"/>.</description></item>
+/// </list>
+/// </summary>
+public static class InstanceParticipantGate
+{
+    /// <summary>
+    /// Whether any wallet the caller controls is a recorded participant on <paramref name="instance"/>.
+    ///
+    /// <para>The caller's wallets are resolved via
+    /// <see cref="ParticipantWalletResolver.ResolveUserWalletAddressesAsync"/> (claim fast path, then
+    /// Wallet-Service-by-owner fallback) rather than read off a single claim — see the type remarks.
+    /// A caller may control more than one wallet, so membership matches if ANY of them is a
+    /// participant.</para>
+    ///
+    /// <para>An empty resolved set means "could not resolve any wallet for this caller", not "did not
+    /// look" — <see cref="ParticipantWalletResolver"/> only returns empty after exhausting both the
+    /// claim and the owner-keyed lookup. It therefore fails closed to <c>false</c>, like any other
+    /// non-match.</para>
+    /// </summary>
+    public static async Task<bool> IsParticipantAsync(
+        HttpContext httpContext,
+        Instance instance,
+        IWalletServiceClient walletClient,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        var callerWallets = await ParticipantWalletResolver.ResolveUserWalletAddressesAsync(
+            httpContext, walletClient, logger, cancellationToken);
+
+        return callerWallets.Count > 0
+            && instance.ParticipantWallets.Values.Any(participantWallet =>
+                callerWallets.Any(w => string.Equals(w, participantWallet, StringComparison.OrdinalIgnoreCase)));
+    }
+
+    /// <summary>
+    /// Whether <paramref name="instance"/> is an untouched shell still waiting for the open
+    /// (Feature 103) participant who will be late-bound to it on first submission — in which case any
+    /// authenticated caller may read it.
+    ///
+    /// <para><b>Why this carve-out is required rather than merely convenient.</b> The citizen an open
+    /// starting action exists for is NOT in <see cref="Instance.ParticipantWallets"/> until they
+    /// submit and the projection folds the late-bind. The Wallet PWA reads
+    /// <c>GET /api/instances/{id}</c> to discover the current action BEFORE the citizen has typed
+    /// anything, so without this the apply flow 403s for every citizen — the same regression class as
+    /// #1183 on the sibling action-schema endpoint, whose <c>IsOpenStartingAction</c> this mirrors at
+    /// instance scope.</para>
+    ///
+    /// <para><b>Why it is safe.</b> Both conditions must hold, and together they mean the instance
+    /// contains nothing a stranger could learn from. <see cref="Instance.CompletedActionCount"/> of 0
+    /// guarantees <see cref="Instance.AccumulatedData"/> is empty — no name, no date of birth, no
+    /// address, no portrait — and the only entries in <see cref="Instance.ParticipantWallets"/> are
+    /// the wallets the published blueprint already carries in the clear on the register, which are
+    /// public by construction. The carve-out closes at exactly the moment content appears: the first
+    /// completed action makes <c>CompletedActionCount</c> non-zero, and from then on only genuine
+    /// participants read the instance.</para>
+    ///
+    /// <para>Fails closed when the blueprint cannot be resolved (a replica that has not finished
+    /// replicating, per <c>CreateInstance</c>'s own fallback) — an unresolvable blueprint means the
+    /// open-participant claim cannot be verified, so it is not granted.</para>
+    /// </summary>
+    public static bool IsAwaitingOpenParticipant(Instance instance, BlueprintModel? blueprint)
+    {
+        if (blueprint is null || instance.CompletedActionCount != 0)
+        {
+            return false;
+        }
+
+        // Every current action must be checked, not just the first: a blueprint may declare parallel
+        // starting actions, and it is enough that one of them is still awaiting its open participant.
+        return instance.CurrentActionIds.Any(actionId =>
+        {
+            var action = blueprint.Actions.FirstOrDefault(a => a.Id == actionId);
+            if (action is null || !action.IsStartingAction)
+            {
+                return false;
+            }
+
+            var sender = blueprint.Participants
+                .FirstOrDefault(p => string.Equals(p.Id, action.Sender, StringComparison.OrdinalIgnoreCase));
+
+            // No resolvable sender participant is treated as NOT open — fail closed.
+            return sender is not null && string.IsNullOrEmpty(sender.WalletAddress);
+        });
+    }
+}

--- a/tests/Sorcha.Blueprint.Service.Tests/Endpoints/InstanceReadEndpointsTests.cs
+++ b/tests/Sorcha.Blueprint.Service.Tests/Endpoints/InstanceReadEndpointsTests.cs
@@ -1,0 +1,431 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Reflection;
+using System.Security.Claims;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Sorcha.Blueprint.Service.Endpoints;
+using Sorcha.Blueprint.Service.Models;
+using Sorcha.Blueprint.Service.Services.Infrastructure;
+using Sorcha.Blueprint.Service.Services.Interfaces;
+using Sorcha.Blueprint.Service.Storage;
+using Sorcha.ServiceClients.Wallet;
+using Xunit;
+using BlueprintModel = Sorcha.Blueprint.Models.Blueprint;
+
+namespace Sorcha.Blueprint.Service.Tests.Endpoints;
+
+/// <summary>
+/// Issue #1182 — the three READ endpoints on <c>/api/instances</c> returned instance content to ANY
+/// authenticated caller. The group policy <c>CanExecuteBlueprints</c> resolves to a bare
+/// <c>RequireAuthenticatedUser()</c>, so knowledge of a GUID was the only thing protecting another
+/// citizen's in-flight identity application — name, date of birth, address and portrait tokens in
+/// <c>AccumulatedData</c>, plus the whole participant→wallet map.
+///
+/// <para>These tests pin BOTH directions of the gate, because this check is wrong in two opposite
+/// ways if written naively, and both have already been made once in this codebase:</para>
+/// <list type="bullet">
+/// <item><description>Too open — no participant check at all (the defect).</description></item>
+/// <item><description>Too closed — reading <c>wallet_address</c> off the claim set, which a
+/// consumer-tier token never carries (Feature 136), thereby 403ing every genuine citizen while
+/// leaving platform-tier callers unrestricted; and gating on participation alone, which 403s the
+/// open (Feature 103) applicant on their own freshly-created instance.</description></item>
+/// </list>
+/// </summary>
+public sealed class InstanceReadEndpointsTests
+{
+    private const string CitizenWallet = "ws1qcitizen000000000000000000000000000000";
+    private const string AnalystWallet = "ws1qanalyst00000000000000000000000000000";
+    private const string StrangerWallet = "ws1qstranger0000000000000000000000000000";
+    private const string CitizenPlatformUserId = "platform-user-citizen";
+    private const string StrangerPlatformUserId = "platform-user-stranger";
+
+    private const string SensitiveField = "dateOfBirth";
+    private const string SensitiveValue = "1984-02-29";
+
+    // ---------------------------------------------------------------------------------------
+    // Fixtures
+    // ---------------------------------------------------------------------------------------
+
+    /// <summary>
+    /// An instance mid-flight: one action already completed, so <c>AccumulatedData</c> holds real
+    /// citizen data and the applicant has been late-bound into <c>ParticipantWallets</c>.
+    /// </summary>
+    private static Instance InFlightInstance() => new()
+    {
+        Id = "inst-1",
+        BlueprintId = "bp-1",
+        BlueprintVersion = 1,
+        RegisterId = "reg-1",
+        TenantId = "default",
+        CurrentActionIds = [2],
+        CompletedActionCount = 1,
+        ParticipantWallets = new Dictionary<string, string>
+        {
+            ["citizen"] = CitizenWallet,
+            ["analyst"] = AnalystWallet,
+        },
+        AccumulatedData = new Dictionary<string, object> { [SensitiveField] = SensitiveValue },
+    };
+
+    /// <summary>
+    /// A freshly-created instance whose starting action belongs to an OPEN participant (Feature 103):
+    /// nothing completed, and the applicant is not yet a participant — exactly the state the PWA reads
+    /// before the citizen has typed anything.
+    /// </summary>
+    private static Instance AwaitingOpenParticipantInstance() => new()
+    {
+        Id = "inst-open",
+        BlueprintId = "bp-1",
+        BlueprintVersion = 1,
+        RegisterId = "reg-1",
+        TenantId = "default",
+        CurrentActionIds = [1],
+        CompletedActionCount = 0,
+        // CreateInstance seeds only participants that already carry a wallet — the open applicant
+        // is deliberately absent.
+        ParticipantWallets = new Dictionary<string, string> { ["analyst"] = AnalystWallet },
+        AccumulatedData = new Dictionary<string, object>(),
+    };
+
+    /// <summary>Blueprint whose action 1 is a starting action sent by an unbound (open) participant.</summary>
+    private static BlueprintModel OpenParticipantBlueprint() => new()
+    {
+        Id = "bp-1",
+        Title = "Assured Identity",
+        Participants =
+        [
+            new Sorcha.Blueprint.Models.Participant { Id = "citizen", Name = "Citizen", WalletAddress = null },
+            new Sorcha.Blueprint.Models.Participant { Id = "analyst", Name = "Analyst", WalletAddress = AnalystWallet },
+        ],
+        Actions =
+        [
+            new Sorcha.Blueprint.Models.Action { Id = 1, Title = "Apply", Sender = "citizen", IsStartingAction = true },
+            new Sorcha.Blueprint.Models.Action { Id = 2, Title = "Assess", Sender = "analyst" },
+        ],
+    };
+
+    // ---------------------------------------------------------------------------------------
+    // Principals
+    // ---------------------------------------------------------------------------------------
+
+    /// <summary>
+    /// Genuine consumer-tier claim set per <c>TokenService.GenerateUserTokenAsync</c> — explicitly NO
+    /// <c>wallet_address</c> and no roles, both of which are platform-tier only (Feature 136). The
+    /// caller's wallet must be resolved via the Wallet-Service-by-owner fallback, like a real citizen.
+    /// </summary>
+    private static HttpContext ConsumerTierContext(string platformUserId) =>
+        new DefaultHttpContext
+        {
+            User = new ClaimsPrincipal(new ClaimsIdentity(
+            [
+                new Claim("sub", "user-" + platformUserId),
+                new Claim("email", platformUserId + "@example.com"),
+                new Claim("org_id", "org-1"),
+                new Claim("platform_user_id", platformUserId),
+            ], "test")),
+        };
+
+    /// <summary>Platform-tier claim set — carries <c>wallet_address</c> directly (the claim fast path).</summary>
+    private static HttpContext PlatformTierContext(string walletAddress) =>
+        new DefaultHttpContext
+        {
+            User = new ClaimsPrincipal(new ClaimsIdentity(
+                [new Claim("wallet_address", walletAddress)], "test")),
+        };
+
+    private static HttpContext WithDelegationToken(HttpContext context)
+    {
+        context.Items["DelegationToken"] = "delegation-token";
+        return context;
+    }
+
+    private static WalletInfo Wallet(string address) => new()
+    {
+        Address = address, Name = "w", PublicKey = "pk", Algorithm = "ED25519",
+        Status = "Active", Owner = "owner", Tenant = "tenant",
+    };
+
+    private static IWalletServiceClient WalletClientFor(string owner, params string[] addresses)
+    {
+        var mock = new Mock<IWalletServiceClient>();
+        mock.Setup(c => c.GetWalletsByOwnerAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string requestedOwner, CancellationToken _) =>
+                string.Equals(requestedOwner, owner, StringComparison.Ordinal)
+                    ? addresses.Select(Wallet).ToList()
+                    : new List<WalletInfo>());
+        return mock.Object;
+    }
+
+    private static IInstanceStore StoreWith(Instance instance)
+    {
+        var mock = new Mock<IInstanceStore>();
+        mock.Setup(s => s.GetAsync(instance.Id, It.IsAny<CancellationToken>())).ReturnsAsync(instance);
+        return mock.Object;
+    }
+
+    private static IBlueprintStore BlueprintStoreWith(BlueprintModel? blueprint)
+    {
+        var mock = new Mock<IBlueprintStore>();
+        mock.Setup(s => s.GetAsync(It.IsAny<string>())).ReturnsAsync(blueprint);
+        return mock.Object;
+    }
+
+    private static IStateReconstructionService StateServiceReturning(AccumulatedState state)
+    {
+        var mock = new Mock<IStateReconstructionService>();
+        mock.Setup(s => s.ReconstructAsync(
+                It.IsAny<BlueprintModel>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string>(),
+                It.IsAny<string>(), It.IsAny<Dictionary<string, string>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(state);
+        return mock.Object;
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // Reflection invokers (static handlers, no WebApplicationFactory — matches InstanceActionEndpointsTests)
+    // ---------------------------------------------------------------------------------------
+
+    private static Task<IResult> InvokeAsync(string handlerName, params object?[] args)
+    {
+        var method = typeof(InstanceReadEndpoints).GetMethod(
+            handlerName, BindingFlags.NonPublic | BindingFlags.Static);
+        method.Should().NotBeNull($"{handlerName} should be reachable for reflection-based endpoint testing");
+        return (Task<IResult>)method!.Invoke(null, args)!;
+    }
+
+    private static Task<IResult> GetInstance(
+        HttpContext ctx, Instance instance, BlueprintModel? blueprint, IWalletServiceClient wallets) =>
+        InvokeAsync(nameof(InstanceReadEndpoints.GetInstance),
+            ctx, instance.Id, StoreWith(instance), BlueprintStoreWith(blueprint), wallets,
+            NullLogger<InstanceReadEndpoints.InstanceReadEndpointsLogCategory>.Instance,
+            CancellationToken.None);
+
+    private static Task<IResult> GetInstanceState(
+        HttpContext ctx, Instance instance, BlueprintModel? blueprint, IWalletServiceClient wallets) =>
+        InvokeAsync(nameof(InstanceReadEndpoints.GetInstanceState),
+            ctx, instance.Id,
+            StateServiceReturning(new AccumulatedState { ActionCount = 1 }),
+            StoreWith(instance), BlueprintStoreWith(blueprint), wallets,
+            NullLogger<InstanceReadEndpoints.InstanceReadEndpointsLogCategory>.Instance,
+            CancellationToken.None);
+
+    private static Task<IResult> GetNextActions(
+        HttpContext ctx, Instance instance, BlueprintModel? blueprint, IWalletServiceClient wallets) =>
+        InvokeAsync(nameof(InstanceReadEndpoints.GetNextActions),
+            ctx, instance.Id, StoreWith(instance), BlueprintStoreWith(blueprint), wallets,
+            NullLogger<InstanceReadEndpoints.InstanceReadEndpointsLogCategory>.Instance,
+            CancellationToken.None);
+
+    private static int? StatusOf(IResult result) =>
+        result as IStatusCodeHttpResult is { } s ? s.StatusCode : null;
+
+    // ---------------------------------------------------------------------------------------
+    // The defect: a stranger reads another citizen's in-flight application
+    // ---------------------------------------------------------------------------------------
+
+    [Fact]
+    public async Task GetInstance_AuthenticatedNonParticipant_IsForbidden()
+    {
+        var instance = InFlightInstance();
+        var result = await GetInstance(
+            ConsumerTierContext(StrangerPlatformUserId),
+            instance,
+            OpenParticipantBlueprint(),
+            WalletClientFor(StrangerPlatformUserId, StrangerWallet));
+
+        StatusOf(result).Should().Be(StatusCodes.Status403Forbidden,
+            "a caller who controls no wallet on this instance must not read another citizen's application");
+    }
+
+    [Fact]
+    public async Task GetInstance_AuthenticatedNonParticipant_DoesNotLeakAccumulatedData()
+    {
+        var instance = InFlightInstance();
+        var result = await GetInstance(
+            ConsumerTierContext(StrangerPlatformUserId),
+            instance,
+            OpenParticipantBlueprint(),
+            WalletClientFor(StrangerPlatformUserId, StrangerWallet));
+
+        // Assert on the RESULT'S CARRIED VALUE, not on a serialisation of the IResult wrapper.
+        // The first version of this test serialised `result` itself — which serialises the declared
+        // IResult type and therefore never contained the payload, passing identically whether or not
+        // the endpoint leaked. It proved nothing. AccumulatedData is where name / date of birth /
+        // address / portrait tokens live, so the object itself must not reach a non-participant.
+        var carried = (result as IValueHttpResult)?.Value;
+        carried.Should().NotBeOfType<Instance>(
+            "the response must not carry the Instance (and its AccumulatedData) to a non-participant");
+    }
+
+    [Fact]
+    public async Task GetInstanceState_AuthenticatedNonParticipant_IsForbidden()
+    {
+        var instance = InFlightInstance();
+        var result = await GetInstanceState(
+            WithDelegationToken(ConsumerTierContext(StrangerPlatformUserId)),
+            instance,
+            OpenParticipantBlueprint(),
+            WalletClientFor(StrangerPlatformUserId, StrangerWallet));
+
+        StatusOf(result).Should().Be(StatusCodes.Status403Forbidden);
+    }
+
+    [Fact]
+    public async Task GetNextActions_AuthenticatedNonParticipant_IsForbidden()
+    {
+        var instance = InFlightInstance();
+        var result = await GetNextActions(
+            ConsumerTierContext(StrangerPlatformUserId),
+            instance,
+            OpenParticipantBlueprint(),
+            WalletClientFor(StrangerPlatformUserId, StrangerWallet));
+
+        StatusOf(result).Should().Be(StatusCodes.Status403Forbidden);
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // The opposite failure: the gate must not lock out the people it exists to serve
+    // ---------------------------------------------------------------------------------------
+
+    [Fact]
+    public async Task GetInstance_ConsumerTierParticipant_ReturnsOk()
+    {
+        // A real citizen token carries no wallet_address, so this only passes if the gate resolves
+        // wallets through the Wallet-Service-by-owner fallback rather than reading the claim.
+        var instance = InFlightInstance();
+        var result = await GetInstance(
+            ConsumerTierContext(CitizenPlatformUserId),
+            instance,
+            OpenParticipantBlueprint(),
+            WalletClientFor(CitizenPlatformUserId, CitizenWallet));
+
+        StatusOf(result).Should().NotBe(StatusCodes.Status403Forbidden,
+            "a consumer-tier citizen who IS a participant must be able to read their own application");
+    }
+
+    [Fact]
+    public async Task GetInstance_PlatformTierParticipant_ReturnsOk()
+    {
+        var instance = InFlightInstance();
+        var result = await GetInstance(
+            PlatformTierContext(AnalystWallet),
+            instance,
+            OpenParticipantBlueprint(),
+            WalletClientFor("nobody"));
+
+        StatusOf(result).Should().NotBe(StatusCodes.Status403Forbidden);
+    }
+
+    [Fact]
+    public async Task GetInstance_InstanceAwaitingOpenParticipant_IsReadableByAnyAuthenticatedCaller()
+    {
+        // The PWA reads this endpoint to discover the current action BEFORE the citizen submits, at
+        // which point they are not yet a participant. Refusing here breaks the apply flow for every
+        // citizen (the #1183 regression class).
+        var instance = AwaitingOpenParticipantInstance();
+        var result = await GetInstance(
+            ConsumerTierContext(StrangerPlatformUserId),
+            instance,
+            OpenParticipantBlueprint(),
+            WalletClientFor(StrangerPlatformUserId, StrangerWallet));
+
+        StatusOf(result).Should().NotBe(StatusCodes.Status403Forbidden,
+            "an unstarted instance awaiting its open participant holds no citizen data to protect");
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // The carve-out must be narrow: it closes the moment real content exists
+    // ---------------------------------------------------------------------------------------
+
+    [Fact]
+    public async Task GetInstance_OpenStartingActionButWorkAlreadyCompleted_IsForbidden()
+    {
+        // Same open-participant blueprint, but an action has completed — so AccumulatedData is
+        // populated and the applicant is late-bound. The carve-out must NOT still apply here, or it
+        // is a blanket hole rather than an empty-shell exemption.
+        var instance = InFlightInstance();
+        instance.CurrentActionIds = [1];  // action 1 is the open starting action
+        instance.CompletedActionCount = 1;
+
+        var result = await GetInstance(
+            ConsumerTierContext(StrangerPlatformUserId),
+            instance,
+            OpenParticipantBlueprint(),
+            WalletClientFor(StrangerPlatformUserId, StrangerWallet));
+
+        StatusOf(result).Should().Be(StatusCodes.Status403Forbidden,
+            "once any action has completed the instance carries real data and the carve-out must close");
+    }
+
+    [Fact]
+    public void IsAwaitingOpenParticipant_UnresolvableBlueprint_FailsClosed()
+    {
+        // On a replica the blueprint may not have replicated yet (CreateInstance has its own fallback
+        // for this). An unverifiable open-participant claim must not be granted.
+        InstanceParticipantGate
+            .IsAwaitingOpenParticipant(AwaitingOpenParticipantInstance(), blueprint: null)
+            .Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsAwaitingOpenParticipant_StartingActionSenderIsBound_FailsClosed()
+    {
+        var blueprint = OpenParticipantBlueprint();
+        blueprint.Participants.First(p => p.Id == "citizen").WalletAddress = CitizenWallet;
+
+        InstanceParticipantGate
+            .IsAwaitingOpenParticipant(AwaitingOpenParticipantInstance(), blueprint)
+            .Should().BeFalse("a starting action with a pre-bound sender is not an open participant");
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // The same root cause, opposite symptom: the LIST endpoint read wallet_address off the claim
+    // set, which a consumer-tier token never carries — so every citizen saw an empty list of their
+    // own applications. Not a disclosure bug, but the same missing resolver.
+    // ---------------------------------------------------------------------------------------
+
+    [Fact]
+    public async Task ListInstances_ConsumerTierCitizen_ReturnsTheirInstances()
+    {
+        var instance = InFlightInstance();
+        var store = new Mock<IInstanceStore>();
+        store.Setup(s => s.GetByParticipantWalletAsync(
+                CitizenWallet, It.IsAny<InstanceState?>(), It.IsAny<int>(), It.IsAny<int>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { instance });
+        store.Setup(s => s.GetByParticipantWalletAsync(
+                It.Is<string>(w => w != CitizenWallet), It.IsAny<InstanceState?>(), It.IsAny<int>(),
+                It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<Instance>());
+
+        var result = await InvokeAsync(nameof(InstanceReadEndpoints.ListInstances),
+            ConsumerTierContext(CitizenPlatformUserId), store.Object,
+            WalletClientFor(CitizenPlatformUserId, CitizenWallet),
+            NullLogger<InstanceReadEndpoints.InstanceReadEndpointsLogCategory>.Instance,
+            (InstanceState?)null, 1, 20, CancellationToken.None);
+
+        var payload = (result as IValueHttpResult)?.Value;
+        payload.Should().NotBeNull();
+        var totalCount = payload!.GetType().GetProperty("totalCount")!.GetValue(payload);
+        totalCount.Should().Be(1,
+            "a consumer-tier citizen carries no wallet_address claim, so the list must resolve their "
+            + "wallet via the Wallet-Service owner fallback rather than returning an empty page");
+    }
+
+    [Fact]
+    public async Task GetInstance_CallerWithNoResolvableWallet_IsForbidden()
+    {
+        // Empty resolved set means "could not resolve", not "any wallet" — must fail closed.
+        var instance = InFlightInstance();
+        var result = await GetInstance(
+            ConsumerTierContext(StrangerPlatformUserId),
+            instance,
+            OpenParticipantBlueprint(),
+            WalletClientFor("someone-else"));
+
+        StatusOf(result).Should().Be(StatusCodes.Status403Forbidden);
+    }
+}


### PR DESCRIPTION
Closes #1182.

## The defect

`GET /api/instances/{id}`, `/{id}/state` and `/{id}/next-actions` returned instance content to **any authenticated caller**. The `/api/instances` group carries only `CanExecuteBlueprints`, which resolves to a bare `RequireAuthenticatedUser()` — so knowledge of a GUID was the only thing between a stranger and another citizen's in-flight application.

`GET /{id}` was the most serious: it returned the `Instance` verbatim, including `AccumulatedData` (on an identity workflow: **name, date of birth, address and portrait image tokens in plaintext**) and `ParticipantWallets`, which de-anonymises every participant.

## Scope is wider than the issue as filed

#1182 named one endpoint. The two siblings on the same group have the same gap:

| Endpoint | Before | Note |
|---|---|---|
| `GET /{id}` | no check | returns the whole `Instance` |
| `GET /{id}/state` | no check | **zero callers** in `src/`, `walkthroughs/`, `demos/` — gating costs nothing |
| `GET /{id}/next-actions` | no check | took **no `HttpContext` at all**, so it provably could not have been checking anything |

That last signature is a useful audit rule: *a handler that takes an id and returns per-subject data but has no `HttpContext` cannot be checking ownership.*

## Approach

The three handlers move out of `Program.cs`'s inline lambdas into `InstanceReadEndpoints` so they can carry a gate and be tested by reflection (the `InstanceActionEndpointsTests` pattern). The gate is extracted into `InstanceParticipantGate` — one authority, now shared with `InstanceActionEndpoints`, rather than four copies that drift.

## Two traps, in opposite directions

Both have already been made in this codebase, which is why the gate is a named type with the reasoning attached rather than an inline `if`:

- **Reading `wallet_address` off the claim set** 403s every real citizen (consumer-tier tokens omit it by design, F136) *while leaving platform-tier callers unrestricted*. Resolution goes through `ParticipantWalletResolver` and matches the caller's **full** wallet set.

- **Gating on recorded participation alone** 403s the F103 open participant on their own instance. `CreateInstance` seeds `ParticipantWallets` only from participants that already carry a wallet, so the walk-in citizen is absent until their first submission seals — and the PWA reads `GET /api/instances/{id}` to find the current action *before* they submit. This would have broken the apply flow for every citizen (the #1183 regression class).

  The carve-out requires `CompletedActionCount == 0` **and** a current action whose sender is unbound, so the instance holds no accumulated data and only wallets the published blueprint already carries in the clear on the register. **It closes with no coverage gap:** pre-fold the carve-out covers the applicant, post-fold participation does.

Ordering: the blueprint is resolved *before* the gate decides, and "blueprint not found" is raised *after* it, so a non-participant cannot read the difference between error bodies to probe (#1183).

## Also fixed — same root cause, opposite symptom

`GET /api/instances/` read the `wallet_address` claim directly and returned an empty page when absent, so **every consumer-tier citizen saw none of their own applications**. Now on the same seam, spanning every wallet the caller controls, deduplicated by instance id, ordered newest-first. Flagged separately because it is a correctness bug, not a disclosure one — but leaving one endpoint on the raw claim while its three siblings use the resolver is precisely the drift that produced this issue.

## Verification

- 12 new tests. **6 were watched RED first**, each failing with `Expected 403, but found 200`.
- One first-draft test passed vacuously — it serialised the `IResult` wrapper rather than the carried value, so it would have gone green with or without the bug. Rewritten to assert on the carried value; it then failed correctly.
- `Sorcha.Blueprint.Service.Tests`: **1063 passed, 0 failed** (5 skipped).
- `Sorcha.UI.ContractTests`: **37/37**.
- Full solution builds, **0 errors**.
- Wire shapes unchanged (`Instance`, and the same `items/totalCount/pageNumber/pageSize` envelope), so no client contract break.

Caller review: the agent only POSTs `execute`/`reject`; AIAS demo polls use the applicant's own session headers; walkthrough polls use participant headers. The demo also reads `$inst.data.decision`, so `AccumulatedData` deliberately stays in the response shape.

## Documentation

- `docs/reference/API-DOCUMENTATION.md` — the existing "known gap" note is now the closure, plus an authorization table and the two deliberate behaviours.
- `.claude/skills/jwt/SKILL.md` — new "Resource ownership is NOT a policy" section, and a **stale block corrected**: it claimed F136 US1/US4/US5 were "not yet landed" and that "endpoints are not yet tier-gated". They shipped (verified against `AuthorizationPolicyExtensions` and `IdentityMetrics`); that text tells a reader the tier gate is inert, so they skip adding one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K45NT42dtMe4KEAMzBEwVt