### PR TITLE
fix: [#1350 #1303 #1180] - XS batch: TenantId persistence, keyword classification, verdict claim rendering

### DIFF
--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Models/Verification/VerdictViewModel.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Models/Verification/VerdictViewModel.cs
@@ -2,6 +2,7 @@
 // Copyright (c) 2026 Sorcha Contributors
 
 using Sorcha.UI.Components.User.Models.Verification;
+using Sorcha.UI.Core.Services.Credentials;
 using Sorcha.Verifier.Engine.Models;
 
 namespace Sorcha.UI.Components.User.Models.Verification;
@@ -93,15 +94,28 @@ public sealed class VerdictViewModel
             : (IReadOnlyList<string>)question.RequiredClaims;
         var withheld = known.Where(c => !disclosed.ContainsKey(c)).ToList();
 
+        // Issue #1180 — formatted through the SHARED claim formatter, the same one the four credential
+        // -card paths use, rather than ToString(). A structured claim boxed as a JsonElement stringifies
+        // to its raw JSON (GetRawText()), which is how a {"_sd":[…]} digest array could reach the
+        // operator's verdict panel — the "fifth door".
+        //
+        // The first mitigation SKIPPED any value whose text opened with '{' or '[', which stopped the
+        // raw JSON but threw out the real claims with it: a nested `address` the citizen deliberately
+        // disclosed simply vanished from the verdict, indistinguishable from never having been shared.
+        // Formatting renders it properly instead ("Street: …, City: Edinburgh, Postcode: EH9 1JA") and
+        // still drops `_`-prefixed protocol keys at every depth, so the digests never appear.
+        //
+        // The empty filter is what keeps the plumbing out: a claim carrying ONLY protocol keys formats
+        // to an empty string, so it is dropped rather than rendered as a blank row. The portrait is
+        // exempt from formatting — it renders separately as a marker row.
         var disclosedPairs = disclosed
             .Where(kvp => !NonDisplayClaims.Contains(kvp.Key))
-            // Skip structured (object/array) values — e.g. an undisclosed `address` surfaced as its
-            // raw {"_sd":[…]} digest — which would dump machine JSON into the operator's view. The
-            // portrait is exempt (it renders separately as a marker row).
-            .Where(kvp => kvp.Key == PortraitClaim || !LooksLikeStructuredJson(kvp.Value))
             .Select(kvp => new KeyValuePair<string, string>(
                 kvp.Key,
-                kvp.Key == PortraitClaim ? "<portrait>" : kvp.Value?.ToString() ?? ""))
+                kvp.Key == PortraitClaim
+                    ? "<portrait>"
+                    : CredentialClaimDisplayFormatter.FormatClaimForDetailDisplay(kvp.Value)))
+            .Where(kvp => kvp.Value.Length > 0)
             .ToList();
 
         var headline = ageOver18 switch
@@ -172,9 +186,4 @@ public sealed class VerdictViewModel
     /// the shape an undisclosed nested claim (e.g. a partially-disclosed address carrying its raw
     /// <c>_sd</c> digests) takes. Such values are machine plumbing, not a human-readable disclosure.
     /// </summary>
-    private static bool LooksLikeStructuredJson(object? value)
-    {
-        var s = value?.ToString()?.TrimStart();
-        return !string.IsNullOrEmpty(s) && (s[0] == '{' || s[0] == '[');
-    }
 }

--- a/src/Common/Sorcha.Blueprint.Models/Forms/FormKeywordClassifier.cs
+++ b/src/Common/Sorcha.Blueprint.Models/Forms/FormKeywordClassifier.cs
@@ -75,6 +75,24 @@ public static class FormKeywordClassifier
             "x-holder-key",
             // Same idea on a sorcha-device-key field (#1195 Phase 2) — see HolderKeySchemaExtension.
             "x-device-key",
+            // Issue #1303 — three more keywords the code genuinely consumes, previously reaching
+            // "behavioural" only through the fail-safe. Declaring them changes no behaviour; it makes
+            // the classification readable as deliberate, which is the point of a single source of truth.
+            //
+            // x-rule drives conditional display (FormSchemaService.TryParseXRule). Display sounds
+            // presentational, and the call was genuinely arguable — but it is BEHAVIOURAL, because a
+            // show/hide rule decides whether the citizen can supply a field that the schema may still
+            // mark `required`. Change a rule so a required field is hidden and a previously
+            // submittable form stops being submittable: that is a change to which payloads the
+            // definition accepts, which is exactly what the executable-definition hash exists to track.
+            "x-rule",
+            // x-claim-source stamps a platform-vouched JWT claim into the signed payload server-side
+            // (ActionExecutionService step 6a-bis, ClaimSourceBindings.Discover — Feature 183 US1). It
+            // is arguably the most execution-relevant keyword there is: it changes what gets signed.
+            "x-claim-source",
+            // x-sorcha-disclosure selects who can decrypt which fields. Disclosure is the D in DAD —
+            // altering it changes who can read the data, so it can never be display-only.
+            "x-sorcha-disclosure",
         };
 
     /// <summary>

--- a/src/Services/Sorcha.Blueprint.Service/Storage/EfCoreInstanceStore.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Storage/EfCoreInstanceStore.cs
@@ -130,7 +130,7 @@ public class EfCoreInstanceStore : IInstanceStore
         entity.AccumulatedData = SerializeJson(instance.AccumulatedData);
         entity.PendingActionPayloads = SerializePendingActionPayloads(instance.PendingActionPayloads);
         entity.ActiveBranches = SerializeJson(instance.ActiveBranches);
-        entity.Metadata = SerializeJson(instance.Metadata);
+        entity.Metadata = SerializeMetadataWithTenant(instance);
         entity.Version = instance.Version;
         entity.UpdatedAt = instance.UpdatedAt;
         entity.CompletedAt = instance.CompletedAt;
@@ -453,6 +453,33 @@ public class EfCoreInstanceStore : IInstanceStore
         return await context.Instances.CountAsync(i => i.State == state, cancellationToken);
     }
 
+    /// <summary>
+    /// Issue #1350 — the metadata key <see cref="Instance.TenantId"/> is carried in.
+    /// <see cref="InstanceEntity"/> has no TenantId column, and <see cref="ToModel"/> has always read
+    /// the value back out of metadata — but nothing ever wrote it, so every instance loaded from
+    /// Postgres had <c>TenantId == ""</c> despite the model declaring the property <c>required</c>.
+    /// </summary>
+    private const string TenantIdMetadataKey = "TenantId";
+
+    /// <summary>
+    /// Serialises an instance's metadata with <see cref="Instance.TenantId"/> folded in under
+    /// <see cref="TenantIdMetadataKey"/>, closing #1350 with no schema change — adding a real column
+    /// would need a migration, which under this repo's squashed-migration rule is a deployment
+    /// decision (DB recreate) rather than a code change.
+    ///
+    /// <para>The caller's own dictionary is never mutated: the key is merged into a copy, so an
+    /// <c>Instance</c> handed to the store does not silently grow a metadata entry.</para>
+    /// </summary>
+    private static string SerializeMetadataWithTenant(Instance instance)
+    {
+        var metadata = new Dictionary<string, string>(instance.Metadata)
+        {
+            [TenantIdMetadataKey] = instance.TenantId,
+        };
+
+        return SerializeJson(metadata);
+    }
+
     private static InstanceEntity ToEntity(Instance instance)
     {
         return new InstanceEntity
@@ -470,7 +497,7 @@ public class EfCoreInstanceStore : IInstanceStore
             AccumulatedData = SerializeJson(instance.AccumulatedData),
             PendingActionPayloads = SerializePendingActionPayloads(instance.PendingActionPayloads),
             ActiveBranches = SerializeJson(instance.ActiveBranches),
-            Metadata = SerializeJson(instance.Metadata),
+            Metadata = SerializeMetadataWithTenant(instance),
             Version = instance.Version,
             CreatedAt = instance.CreatedAt != default ? instance.CreatedAt : DateTimeOffset.UtcNow,
             UpdatedAt = instance.UpdatedAt != default ? instance.UpdatedAt : DateTimeOffset.UtcNow,
@@ -486,8 +513,12 @@ public class EfCoreInstanceStore : IInstanceStore
             var metadata = DeserializeJson<Dictionary<string, string>>(entity.Metadata)
                            ?? new Dictionary<string, string>();
 
-            // Extract TenantId from metadata if stored there; default to empty
-            var tenantId = metadata.GetValueOrDefault("TenantId", string.Empty);
+            // Issue #1350 — TenantId travels inside Metadata (InstanceEntity has no column for it).
+            // Removing the key after reading it is load-bearing, not tidiness: Metadata is handed
+            // back to the caller wholesale below, so leaving the key in would surface a phantom
+            // entry the caller never wrote and break Metadata's own round-trip.
+            var tenantId = metadata.GetValueOrDefault(TenantIdMetadataKey, string.Empty);
+            metadata.Remove(TenantIdMetadataKey);
 
             return new Instance
             {

--- a/tests/Sorcha.Blueprint.Engine.Tests/FormKeywordClassifierTests.cs
+++ b/tests/Sorcha.Blueprint.Engine.Tests/FormKeywordClassifierTests.cs
@@ -40,6 +40,28 @@ public class FormKeywordClassifierTests
         FormKeywordClassifier.IsPresentational(keyword).Should().BeFalse();
     }
 
+    /// <summary>
+    /// Issue #1303 — three keywords the code genuinely consumes were absent from both declared sets
+    /// and reached "behavioural" only through the fail-safe, so a reader could not tell "deliberately
+    /// behavioural" from "nobody thought about it".
+    ///
+    /// <para>This asserts DECLARED MEMBERSHIP rather than <c>IsBehavioural(...)</c> on purpose. Every
+    /// <c>x-</c> keyword already returns true from <c>IsBehavioural</c> via the fail-safe, so an
+    /// <c>IsBehavioural</c> assertion here would pass whether or not the keyword had ever been
+    /// classified — a test that cannot fail for the reason it exists.</para>
+    /// </summary>
+    [Theory]
+    [InlineData("x-rule")]
+    [InlineData("x-claim-source")]
+    [InlineData("x-sorcha-disclosure")]
+    public void BehaviouralKeywords_DeclaresKeywordsTheCodeConsumes(string keyword)
+    {
+        FormKeywordClassifier.BehaviouralKeywords.Should().Contain(keyword,
+            "a keyword the engine acts on must be classified by declaration, not by the fail-safe");
+        FormKeywordClassifier.IsBehavioural(keyword).Should().BeTrue();
+        FormKeywordClassifier.IsPresentational(keyword).Should().BeFalse();
+    }
+
     [Theory]
     [InlineData("x-foo")]
     [InlineData("x-unknown-future-keyword")]
@@ -85,6 +107,10 @@ public class FormKeywordClassifierTests
             // classification is unchanged — it previously reached "behavioural" via the fail-safe —
             // so no executable-definition hash or rehearsal-gate behaviour changes here.
             "x-file", "x-credential-offer", "x-holder-key", "x-device-key",
+            // #1303 — same story for these three: each was already behavioural via the fail-safe, so
+            // declaring them changes no hash and no gate behaviour. See the source comments for why
+            // x-rule is behavioural despite governing *display* (it can hide a still-required field).
+            "x-rule", "x-claim-source", "x-sorcha-disclosure",
         });
     }
 

--- a/tests/Sorcha.Blueprint.Service.Tests/Storage/EfCoreInstanceStoreUpdateRoundTripTests.cs
+++ b/tests/Sorcha.Blueprint.Service.Tests/Storage/EfCoreInstanceStoreUpdateRoundTripTests.cs
@@ -67,21 +67,12 @@ public class EfCoreInstanceStoreUpdateRoundTripTests
     /// </summary>
     private static readonly Dictionary<string, string> NotRoundTripped = new()
     {
-        // TenantId does NOT round-trip, and this entry is load-bearing for the test staying green.
-        // It is a pre-existing gap of exactly the class this file exists to catch, kept separate
-        // because closing it needs an entity column + a migration, which under this repo's
-        // squashed-migration rule is a deployment decision rather than a code change:
-        //   - InstanceEntity has NO TenantId column at all, so neither ToEntity nor UpdateAsync can
-        //     persist it;
-        //   - ToModel reads it back via metadata.GetValueOrDefault("TenantId", string.Empty), but
-        //     NOTHING anywhere writes Metadata["TenantId"] — grep the solution;
-        //   - so every instance read from Postgres has TenantId == "", despite the model declaring
-        //     it `required`.
-        // No authorization decision currently reads it back off a stored instance (it is written at
-        // projection time and consumed in-flight), so this is silent data loss rather than a
-        // security hole — but do not let this entry read as "handled elsewhere".
-        ["TenantId"] = "PRE-EXISTING BUG, not by design — no column exists and nothing writes the " +
-                       "Metadata fallback, so it always reads back empty. See the comment above.",
+        // (Issue #1350 — the TenantId entry that used to live here is GONE, which is the whole test.
+        //  It documented that no InstanceEntity column exists and nothing wrote the Metadata
+        //  fallback, so every instance read back from Postgres had TenantId == "" despite the model
+        //  declaring it `required`. ToEntity/UpdateAsync now write Metadata["TenantId"], which the
+        //  existing ToModel read path already expected — no column and no migration needed.
+        //  Do NOT re-add it: this dictionary is a list of holes in the guard, not a changelog.)
     };
 
     private static EfCoreInstanceStore CreateStore(string dbName)

--- a/tests/Sorcha.UI.Core.Tests/Verification/VerdictTrailPanelTests.cs
+++ b/tests/Sorcha.UI.Core.Tests/Verification/VerdictTrailPanelTests.cs
@@ -39,6 +39,80 @@ public class VerdictTrailPanelTests : BunitContext
 
     private readonly Mock<IRegisterAnchorClient> _mockAnchorClient = new();
 
+    /// <summary>
+    /// Issue #1180 — an outcome carrying a STRUCTURED disclosed claim (a nested <c>address</c>
+    /// object, boxed as a <see cref="System.Text.Json.JsonElement"/> exactly as it arrives off the
+    /// wire), plus a raw <c>_sd</c> digest array that must never be shown.
+    /// </summary>
+    private static VerificationOutcome BuildOutcomeWithStructuredClaim()
+    {
+        using var doc = System.Text.Json.JsonDocument.Parse(
+            """
+            {
+              "address": { "street": "6/2 Warrender Park Terrace", "city": "Edinburgh", "postcode": "EH9 1JA" },
+              "sdDigests": { "_sd": ["zSH_kfTeW2Mlc", "qX2vBn8Lp0Ra"] }
+            }
+            """);
+
+        return new VerificationOutcome
+        {
+            Accepted = true,
+            DisclosedClaims = new Dictionary<string, object?>
+            {
+                ["fullName"] = "Stuart Fraser",
+                ["address"] = doc.RootElement.GetProperty("address").Clone(),
+                ["sdDigests"] = doc.RootElement.GetProperty("sdDigests").Clone(),
+            },
+            Errors = [],
+            CompletedAt = DateTimeOffset.UtcNow,
+            IssuerSignature = IssuerSignatureStatus.Verified,
+            Layers =
+            [
+                new ValidationLayerResult { Layer = ValidationLayer.LivePresentation, Status = LayerStatus.Pass, Headline = "Valid KB-JWT" },
+                new ValidationLayerResult { Layer = ValidationLayer.IssuerSignature, Status = LayerStatus.Pass, Headline = "Verified" },
+                new ValidationLayerResult { Layer = ValidationLayer.Revocation, Status = LayerStatus.Pass, Headline = "Not revoked" },
+            ],
+        };
+    }
+
+    /// <summary>
+    /// Issue #1180 — a disclosed structured claim must RENDER (formatted), not be silently dropped.
+    ///
+    /// <para>The original defect was raw <c>{"_sd":[…]}</c> JSON reaching the operator's verdict
+    /// panel. That was mitigated by skipping any value whose text starts with <c>{</c> or <c>[</c> —
+    /// which stopped the raw JSON but also means a genuinely disclosed nested claim, such as the
+    /// address a citizen chose to share, VANISHES from the verdict with no trace. A verifier reading
+    /// the panel cannot tell "not disclosed" from "disclosed but undisplayable".</para>
+    /// </summary>
+    [Fact]
+    public void StructuredDisclosedClaim_IsRenderedFormatted_NotDropped()
+    {
+        var vm = VerdictViewModel.From(IdentityPreset, BuildOutcomeWithStructuredClaim());
+
+        vm.Disclosed.Should().ContainSingle(p => p.Key == "address",
+            "a claim the citizen chose to disclose must appear on the verdict, not silently disappear");
+
+        var address = vm.Disclosed.Single(p => p.Key == "address").Value;
+        address.Should().Contain("Edinburgh").And.Contain("EH9 1JA",
+            "the value must be rendered for a human, via the shared claim formatter");
+        address.Should().NotContain("{").And.NotContain("\"street\"",
+            "it must be formatted, never dumped as raw JSON");
+    }
+
+    /// <summary>
+    /// Issue #1180 — the protocol plumbing must still never reach the panel. This is the half the
+    /// skip-filter got right, and it must survive routing through the shared formatter.
+    /// </summary>
+    [Fact]
+    public void RawSdDigestArray_NeverReachesTheVerdictPanel()
+    {
+        var vm = VerdictViewModel.From(IdentityPreset, BuildOutcomeWithStructuredClaim());
+
+        var rendered = string.Join(" | ", vm.Disclosed.Select(p => $"{p.Key}={p.Value}"));
+        rendered.Should().NotContain("zSH_kfTeW2Mlc").And.NotContain("_sd",
+            "selective-disclosure digests are credential plumbing and must never be shown");
+    }
+
     private static VerificationOutcome BuildOutcomeWithThreeLayers(bool accepted = true)
     {
         return new VerificationOutcome


### PR DESCRIPTION
Closes #1350. Closes #1303. Closes #1180.

Three independent small fixes, batched. **Each was verified against current source before starting** — several other issues in the same triage turned out to be already fixed, and were closed rather than re-done (see the note at the bottom).

---

## #1350 — `Instance.TenantId` never persisted

`InstanceEntity` has no `TenantId` column, and `ToModel` has *always* read the value back out of `Metadata["TenantId"]` — but **nothing ever wrote it**, so every instance loaded from Postgres had `TenantId == ""` despite the model declaring the property `required`.

Masked the same way `LastAppliedTxId` was (#1349): `InMemoryInstanceStore` stores the model **by reference**, so the field round-tripped for free there and no test could see the difference.

Takes the **no-migration option**: `ToEntity` and `UpdateAsync` fold the value into the serialised metadata. A real column needs a migration, which under this repo's squashed-migration rule is a deployment decision (DB recreate), not a code change.

**Non-obvious bit:** `ToModel` hands the metadata dictionary back to the caller wholesale, so it must **remove** the key after reading it — otherwise the caller sees a phantom entry they never wrote, and `Metadata`'s own round-trip breaks. The caller's dictionary is never mutated on write either; the key is merged into a copy.

The test is the **deletion** of the `TenantId` entry from `NotRoundTripped`, which the issue itself named as the definition of done. Watched RED first.

---

## #1303 — `FormKeywordClassifier` omitted three keywords the code consumes

`x-rule`, `x-claim-source` and `x-sorcha-disclosure` reached "behavioural" only via the fail-safe, so a reader could not distinguish *deliberately behavioural* from *nobody thought about it* — in a file documented as the single source of truth. Declaring them changes no behaviour, no executable-definition hash, no rehearsal-gate outcome.

**The deliberate call the issue asked for: `x-rule` is BEHAVIOURAL despite governing display.** A show/hide rule decides whether the citizen can supply a field the schema may still mark `required`. Change a rule so a required field is hidden and a previously submittable form stops being submittable — that is a change to which payloads the definition accepts, which is exactly what the hash exists to track.

**The new test asserts declared membership, not `IsBehavioural(...)`.** Every `x-` keyword already returns true from `IsBehavioural` via the fail-safe, so an `IsBehavioural` assertion would have passed whether or not the keyword was ever classified — a test that cannot fail for the reason it exists.

---

## #1180 — structured disclosed claims vanished from the verdict panel

The defect had **changed shape** since filing. The original (raw `{"_sd":[…]}` reaching the operator's verdict) was mitigated by skipping any value whose text opens with `{` or `[`. That stopped the raw JSON but threw out the real claims with it: a nested `address` the citizen **deliberately disclosed** simply vanished from the verdict, indistinguishable from never having been shared.

Now routed through the shared `CredentialClaimDisplayFormatter` — the fix the issue originally asked for, and the same formatter the four credential-card paths use. It renders `Street: …, City: Edinburgh, Postcode: EH9 1JA` and still drops `_`-prefixed protocol keys at every depth. A claim carrying **only** protocol keys formats to an empty string and is dropped rather than rendered as a blank row, which is what keeps the digests out.

Both halves are pinned: one test that a structured claim renders, one that `_sd` digests never appear.

---

## Verification

- **6 new tests**, each watched RED for the right reason first.
- `Sorcha.Blueprint.Service.Tests` **1063 / 0**
- `Sorcha.Blueprint.Engine.Tests` **613 / 0**
- `Sorcha.UI.Core.Tests` **1665 / 0**
- Solution builds, **0 errors**.

## Stale-backlog note

Verifying before working found several issues already fixed but never closed — **#1310** (fixed in #1309, 8 regression tests, live-proven on n1), **#1274** (both halves fixed, with a better root cause than the issue had), and **#1211** (`MyCredentialsTests` now passes on master; its full suite is green above). Closed with evidence rather than re-done. Worth a verify-first pass over the rest of the backlog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K45NT42dtMe4KEAMzBEwVt