### PR TITLE
fix: [#1158 #1159] - retire the last bespoke wallet DTOs and register the source-gen JSON context

### DIFF
--- a/.wallet-contracts-allowlist
+++ b/.wallet-contracts-allowlist
@@ -4,7 +4,9 @@
 # the canonical Wallet DTO names outside Sorcha.Wallet.Contracts. See
 # scripts/check-wallet-contracts-clean-break.ps1.
 #
-# Sorcha.Demo is an isolated sample app whose wallet shapes diverge from the canonical
-# contracts (bespoke WalletResponse / SignatureResponse). Its retirement is a documented
-# follow-up; until then its CreateWalletResponse copy is tolerated here.
-src/Apps/Sorcha.Demo/Services/Api/WalletApiClient.cs
+# EMPTY as of issue #1158 — Sorcha.Demo's bespoke wallet DTOs (its own CreateWalletResponse
+# and WalletDetails, plus WalletResponse / SignatureResponse) were retired onto the canonical
+# Sorcha.Wallet.Contracts.Models shapes. That was the last entry, so a new declaration of a
+# canonical Wallet DTO name outside Sorcha.Wallet.Contracts now fails CI outright.
+#
+# Do NOT add an entry to make a build pass — the ratchet may only shrink.

--- a/src/Apps/Sorcha.Demo/Services/Api/WalletApiClient.cs
+++ b/src/Apps/Sorcha.Demo/Services/Api/WalletApiClient.cs
@@ -3,11 +3,23 @@
 
 using Microsoft.Extensions.Logging;
 using System.Text.Json;
+using Sorcha.Wallet.Contracts.Models;
 
 namespace Sorcha.Demo.Services.Api;
 
 /// <summary>
-/// Client for Wallet Service API
+/// Client for Wallet Service API.
+///
+/// <para>Issue #1158 — this client used to declare its own <c>CreateWalletResponse</c>,
+/// <c>WalletDetails</c>, <c>WalletResponse</c> and <c>SignatureResponse</c>, and was the sole entry
+/// in <c>.wallet-contracts-allowlist</c>. It now binds the canonical
+/// <see cref="Sorcha.Wallet.Contracts.Models"/> shapes, so the ratchet is empty.</para>
+///
+/// <para>The bespoke <c>WalletResponse</c> was not merely duplicative, it was wrong on the wire for
+/// two of the four calls it served: <c>GetWalletAsync</c> and <c>ListWalletsAsync</c> deserialised
+/// the server's <see cref="WalletDto"/> into a type carrying <c>Mnemonic</c> and
+/// <c>AccountIndex</c> (which no read endpoint returns, so they were always null) while silently
+/// dropping <c>Status</c>, <c>Owner</c>, <c>Tenant</c> and <c>UpdatedAt</c> (which it does).</para>
 /// </summary>
 public class WalletApiClient : ApiClientBase
 {
@@ -22,7 +34,7 @@ public class WalletApiClient : ApiClientBase
     /// <summary>
     /// Creates a new HD wallet
     /// </summary>
-    public async Task<WalletResponse?> CreateWalletAsync(
+    public async Task<CreateWalletResponse?> CreateWalletAsync(
         string name,
         string algorithm = "ED25519",
         CancellationToken ct = default)
@@ -33,46 +45,32 @@ public class WalletApiClient : ApiClientBase
             algorithm
         };
 
-        // New API returns nested structure with wallet + mnemonic
-        var response = await PostAsync<object, CreateWalletResponse>($"{_baseUrl}/wallets", request, ct);
-
-        if (response == null)
-        {
-            return null;
-        }
-
-        // Convert to flat WalletResponse for backward compatibility
-        return new WalletResponse
-        {
-            Address = response.Wallet.Address,
-            Name = response.Wallet.Name,
-            Algorithm = response.Wallet.Algorithm,
-            PublicKey = response.Wallet.PublicKey,
-            Mnemonic = response.MnemonicWords != null ? string.Join(" ", response.MnemonicWords) : null,
-            CreatedAt = response.Wallet.CreatedAt
-        };
+        // Returns the canonical nested shape: { wallet: WalletDto, mnemonicWords: string[], … }.
+        // Previously flattened into a bespoke WalletResponse "for backward compatibility" with a
+        // caller that no longer exists — the one consumer reads the nested shape directly now.
+        return await PostAsync<object, CreateWalletResponse>($"{_baseUrl}/wallets", request, ct);
     }
 
     /// <summary>
     /// Gets wallet details by address
     /// </summary>
-    public async Task<WalletResponse?> GetWalletAsync(string address, CancellationToken ct = default)
+    public async Task<WalletDto?> GetWalletAsync(string address, CancellationToken ct = default)
     {
-        return await GetAsync<WalletResponse>($"{_baseUrl}/wallets/{address}", ct);
+        return await GetAsync<WalletDto>($"{_baseUrl}/wallets/{address}", ct);
     }
 
     /// <summary>
     /// Lists all wallets
     /// </summary>
-    public async Task<List<WalletResponse>?> ListWalletsAsync(CancellationToken ct = default)
+    public async Task<List<WalletDto>?> ListWalletsAsync(CancellationToken ct = default)
     {
-        return await GetAsync<List<WalletResponse>>($"{_baseUrl}/wallets", ct);
+        return await GetAsync<List<WalletDto>>($"{_baseUrl}/wallets", ct);
     }
 
     /// <summary>
     /// Signs data with a wallet
     /// </summary>
-    public async Task<SignatureResponse?> SignAsync(
+    public async Task<SignTransactionResponse?> SignAsync(
         string walletAddress,
         string dataToSign,
         CancellationToken ct = default)
@@ -82,7 +80,7 @@ public class WalletApiClient : ApiClientBase
             data = dataToSign
         };
 
-        return await PostAsync<object, SignatureResponse>(
+        return await PostAsync<object, SignTransactionResponse>(
             $"{_baseUrl}/wallets/{walletAddress}/sign",
             request,
             ct);
@@ -91,7 +89,7 @@ public class WalletApiClient : ApiClientBase
     /// <summary>
     /// Derives a child wallet (for delegation scenarios)
     /// </summary>
-    public async Task<WalletResponse?> DeriveChildWalletAsync(
+    public async Task<WalletDto?> DeriveChildWalletAsync(
         string parentAddress,
         uint childIndex,
         string? name = null,
@@ -103,7 +101,7 @@ public class WalletApiClient : ApiClientBase
             name = name ?? $"Child-{childIndex}"
         };
 
-        return await PostAsync<object, WalletResponse>(
+        return await PostAsync<object, WalletDto>(
             $"{_baseUrl}/wallets/{parentAddress}/derive",
             request,
             ct);
@@ -116,55 +114,4 @@ public class WalletApiClient : ApiClientBase
     {
         return await base.CheckHealthAsync(_baseUrl, ct);
     }
-}
-
-/// <summary>
-/// Response from wallet creation (new format with nested wallet object)
-/// </summary>
-public class CreateWalletResponse
-{
-    public WalletDetails Wallet { get; set; } = new();
-    public string[]? MnemonicWords { get; set; }
-    public string? Warning { get; set; }
-}
-
-/// <summary>
-/// Wallet details (used in nested responses)
-/// </summary>
-public class WalletDetails
-{
-    public string Address { get; set; } = string.Empty;
-    public string Name { get; set; } = string.Empty;
-    public string Algorithm { get; set; } = string.Empty;
-    public string? PublicKey { get; set; }
-    public string Status { get; set; } = string.Empty;
-    public string Owner { get; set; } = string.Empty;
-    public string Tenant { get; set; } = string.Empty;
-    public DateTime CreatedAt { get; set; }
-    public DateTime UpdatedAt { get; set; }
-    public Dictionary<string, string>? Metadata { get; set; }
-}
-
-/// <summary>
-/// Response from wallet creation/retrieval (legacy flat format for GET requests)
-/// </summary>
-public class WalletResponse
-{
-    public string Address { get; set; } = string.Empty;
-    public string Name { get; set; } = string.Empty;
-    public string Algorithm { get; set; } = string.Empty;
-    public string? PublicKey { get; set; }
-    public string? Mnemonic { get; set; } // Only returned on creation
-    public int? AccountIndex { get; set; }
-    public DateTime CreatedAt { get; set; }
-}
-
-/// <summary>
-/// Response from signing operation
-/// </summary>
-public class SignatureResponse
-{
-    public string Signature { get; set; } = string.Empty;
-    public string PublicKey { get; set; } = string.Empty;
-    public string Algorithm { get; set; } = string.Empty;
 }

--- a/src/Apps/Sorcha.Demo/Services/Execution/ParticipantManager.cs
+++ b/src/Apps/Sorcha.Demo/Services/Execution/ParticipantManager.cs
@@ -96,22 +96,25 @@ public class ParticipantManager
             throw new InvalidOperationException($"Failed to create wallet for participant: {participantId}");
         }
 
+        // Issue #1158 — reads the canonical nested CreateWalletResponse directly. The client used to
+        // flatten it into a bespoke WalletResponse whose single-string Mnemonic was joined from
+        // MnemonicWords here; joining at the point of use keeps one wire shape instead of two.
         var participant = new ParticipantContext
         {
             ParticipantId = participantId,
             Name = participantId,
-            WalletAddress = walletResponse.Address,
-            Algorithm = walletResponse.Algorithm,
-            Mnemonic = walletResponse.Mnemonic, // Store for demo (INSECURE!)
-            CreatedAt = walletResponse.CreatedAt,
+            WalletAddress = walletResponse.Wallet.Address,
+            Algorithm = walletResponse.Wallet.Algorithm,
+            Mnemonic = string.Join(" ", walletResponse.MnemonicWords), // Store for demo (INSECURE!)
+            CreatedAt = walletResponse.Wallet.CreatedAt,
             ActionsExecuted = 0
         };
 
         _logger.LogInformation("Created wallet for {ParticipantId}: {Address}",
             participantId,
-            walletResponse.Address.Length > 16
-                ? walletResponse.Address[..16] + "..."
-                : walletResponse.Address);
+            walletResponse.Wallet.Address.Length > 16
+                ? walletResponse.Wallet.Address[..16] + "..."
+                : walletResponse.Wallet.Address);
 
         return participant;
     }

--- a/src/Apps/Sorcha.Demo/Sorcha.Demo.csproj
+++ b/src/Apps/Sorcha.Demo/Sorcha.Demo.csproj
@@ -35,6 +35,7 @@
     <ProjectReference Include="..\..\Common\Sorcha.Cryptography\Sorcha.Cryptography.csproj" />
     <ProjectReference Include="..\..\Common\Sorcha.TransactionHandler\Sorcha.TransactionHandler.csproj" />
     <ProjectReference Include="..\..\Core\Sorcha.Wallet.Core\Sorcha.Wallet.Core.csproj" />
+    <ProjectReference Include="..\..\Common\Sorcha.Wallet.Contracts\Sorcha.Wallet.Contracts.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Common/Sorcha.Serialization/Sorcha.Serialization.csproj
+++ b/src/Common/Sorcha.Serialization/Sorcha.Serialization.csproj
@@ -7,4 +7,12 @@
     <RootNamespace>Sorcha.Serialization</RootNamespace>
   </PropertyGroup>
 
+  <ItemGroup>
+    <!-- Issue #1159 — for the Wallet contracts' source-generated JSON context, chained into the
+         platform options by SorchaJson.Configure so the WASM client is trim-safe. Sorcha.Wallet.Contracts
+         is a dependency-free leaf by design (CLAUDE.md §15), so this adds no transitive weight and
+         cannot cycle. See the remarks on SorchaJson.Configure for why it lives here. -->
+    <ProjectReference Include="..\Sorcha.Wallet.Contracts\Sorcha.Wallet.Contracts.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/src/Common/Sorcha.Serialization/SorchaJson.cs
+++ b/src/Common/Sorcha.Serialization/SorchaJson.cs
@@ -3,6 +3,7 @@
 
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
 
 namespace Sorcha.Serialization;
 
@@ -43,6 +44,40 @@ public static class SorchaJson
         if (!options.Converters.OfType<JsonStringEnumConverter>().Any())
         {
             options.Converters.Add(new JsonStringEnumConverter(JsonNamingPolicy.KebabCaseLower));
+        }
+
+        // Issue #1159 — source-generated metadata for the Wallet contracts. Chained (Insert at 0)
+        // rather than assigned, so it takes precedence for those types while every other type still
+        // falls through to the default reflection resolver. The naming policy set above governs the
+        // wire names either way, so this changes performance and trim-safety, not the wire format.
+        //
+        // Why here rather than per host, despite the awkwardness of a generic serialisation helper
+        // naming a domain contract: `Options` below is the instance UI clients deserialise with, and
+        // it is MakeReadOnly() — nothing can chain a resolver into it afterwards. Per-host
+        // registration therefore could NOT have covered the WASM client, which is the main
+        // beneficiary (Release publish trims the reflection metadata the fallback needs). Doing it
+        // in Configure reaches that static and every host that calls it, and no host can be missed.
+        // Sorcha.Wallet.Contracts is a dependency-free leaf, so this cannot cycle.
+        if (!options.TypeInfoResolverChain.Any(r => r is Wallet.Contracts.Serialization.WalletContractsJsonContext))
+        {
+            options.TypeInfoResolverChain.Insert(
+                0, Wallet.Contracts.Serialization.WalletContractsJsonContext.Default);
+
+            // MANDATORY, and the reason this is three lines rather than one. A JsonSerializerOptions
+            // carries an IMPLICIT default reflection resolver only while its chain is untouched. The
+            // moment anything is inserted, that implicit default is gone — so adding the Wallet
+            // context alone leaves the chain able to resolve seven types and NOTHING else, and every
+            // other payload in the platform dies with "JsonTypeInfo metadata for type X was not
+            // provided by TypeInfoResolver". MakeReadOnly(populateMissingResolver: true) does not
+            // save you either: a resolver is no longer "missing", so it adds nothing.
+            //
+            // Appending the default restores the previous behaviour exactly — Wallet contracts hit
+            // the source-generated metadata first, everything else falls through to reflection as
+            // before. (Caught by Sorcha.UI.ContractTests, which went 18-red on the one-line version.)
+            if (!options.TypeInfoResolverChain.Any(r => r is DefaultJsonTypeInfoResolver))
+            {
+                options.TypeInfoResolverChain.Add(new DefaultJsonTypeInfoResolver());
+            }
         }
     }
 

--- a/tests/Sorcha.Wallet.Contracts.Tests/Sorcha.Wallet.Contracts.Tests.csproj
+++ b/tests/Sorcha.Wallet.Contracts.Tests/Sorcha.Wallet.Contracts.Tests.csproj
@@ -30,6 +30,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Common\Sorcha.Wallet.Contracts\Sorcha.Wallet.Contracts.csproj" />
+    <ProjectReference Include="..\..\src\Common\Sorcha.Serialization\Sorcha.Serialization.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Sorcha.Wallet.Contracts.Tests/WalletContractsSerializationTests.cs
+++ b/tests/Sorcha.Wallet.Contracts.Tests/WalletContractsSerializationTests.cs
@@ -2,6 +2,7 @@
 // Copyright (c) 2026 Sorcha Contributors
 
 using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
 using FluentAssertions;
 using Sorcha.Wallet.Contracts.Models;
 using Sorcha.Wallet.Contracts.Serialization;
@@ -18,6 +19,71 @@ public class WalletContractsSerializationTests
     // Use the context's own baked options (camelCase + source-gen metadata) — the self-contained usage.
     // Hosts that instead chain the resolver into their existing options inherit those options' camelCase.
     private static readonly JsonSerializerOptions Options = WalletContractsJsonContext.Default.Options;
+
+    /// <summary>
+    /// Issue #1159 — the source-generated context existed and was test-validated, but was registered
+    /// in NO host, so every Wallet contract actually (de)serialised by reflection: correct, but not
+    /// trim-safe. The main casualty is the Blazor WASM client, where a Release publish trims the
+    /// reflection metadata the fallback depends on.
+    ///
+    /// <para>It is registered on <see cref="SorchaJson"/> rather than per host. That is deliberate and
+    /// slightly awkward — a generic serialisation helper naming a domain contract — but per-host
+    /// chaining could not have covered the main beneficiary: <see cref="SorchaJson.Options"/> is the
+    /// instance UI clients deserialise with and it is <c>MakeReadOnly()</c>, so nothing can chain a
+    /// resolver into it after construction. Registering inside <c>Configure</c> reaches both that
+    /// static and every host that calls it, and no host can be forgotten. Cycle-safe: both projects
+    /// are dependency-free leaves.</para>
+    /// </summary>
+    [Fact]
+    public void SorchaJsonOptions_ResolveWalletContractsThroughSourceGeneration()
+    {
+        Sorcha.Serialization.SorchaJson.Options.TypeInfoResolverChain
+            .Should().Contain(r => r is WalletContractsJsonContext,
+                "the platform options must resolve Wallet contracts via source generation, not reflection");
+    }
+
+    /// <summary>
+    /// Issue #1159 — chaining a resolver must not cost every OTHER type its metadata.
+    ///
+    /// <para>A <see cref="JsonSerializerOptions"/> carries an implicit default reflection resolver only
+    /// while its chain is untouched; inserting anything removes it. The first cut of this change
+    /// inserted the Wallet context alone, which left the platform options able to resolve seven types
+    /// and nothing else — <c>Sorcha.UI.ContractTests</c> went 18-red with "JsonTypeInfo metadata for
+    /// type 'InboxSeverity' was not provided". This pins the fallback so the one-line version cannot
+    /// come back.</para>
+    /// </summary>
+    [Fact]
+    public void SorchaJsonOptions_StillResolveTypesOutsideTheWalletContracts()
+    {
+        // A type the Wallet context knows nothing about must still round-trip.
+        var json = JsonSerializer.Serialize(
+            new Dictionary<string, object> { ["kind"] = "unrelated", ["n"] = 42 },
+            Sorcha.Serialization.SorchaJson.Options);
+
+        json.Should().Contain("unrelated");
+
+        Sorcha.Serialization.SorchaJson.Options.TypeInfoResolverChain
+            .Should().Contain(r => r is DefaultJsonTypeInfoResolver,
+                "the default reflection resolver must remain in the chain as the fallback for every "
+                + "type the source-generated context does not cover");
+    }
+
+    /// <summary>
+    /// Issue #1159 — the load-bearing caveat. Chaining the resolver must NOT disturb the wire names:
+    /// the contracts go out camelCase, and a regression here would silently break every Wallet client.
+    /// </summary>
+    [Fact]
+    public void SorchaJsonOptions_StillEmitCamelCaseWireNames()
+    {
+        var json = JsonSerializer.Serialize(SampleWallet(), Sorcha.Serialization.SorchaJson.Options);
+
+        json.Should().Contain("\"address\"").And.Contain("\"publicKey\"").And.Contain("\"createdAt\"");
+        json.Should().NotContain("\"Address\"").And.NotContain("\"PublicKey\"");
+
+        var round = JsonSerializer.Deserialize<WalletDto>(json, Sorcha.Serialization.SorchaJson.Options);
+        round!.Address.Should().Be("ws1qexample");
+        round.Metadata.Should().ContainKey("k");
+    }
 
     private static WalletDto SampleWallet() => new()
     {


### PR DESCRIPTION
Closes #1158. Closes #1159.

Both are wallet-contracts consolidation follow-ups from #1157.

---

## #1158 — Sorcha.Demo wallet DTO copies retired

`Sorcha.Demo/Services/Api/WalletApiClient.cs` declared its own `CreateWalletResponse`, `WalletDetails`, `WalletResponse` and `SignatureResponse`, and was the **sole entry** in `.wallet-contracts-allowlist`. It now binds the canonical `Sorcha.Wallet.Contracts.Models` shapes, so **the ratchet is empty** — a new declaration of a canonical Wallet DTO name outside the contracts assembly now fails CI outright.

```
OK: Wallet-contracts gate passed. 0 file(s) still on the allowlist.
  Allowlist is empty - every Wallet DTO now has a single canonical declaration.
```

**Worth noting the bespoke `WalletResponse` wasn't merely duplicative — it was wrong on the wire** for two of the four calls it served. `GetWalletAsync` and `ListWalletsAsync` deserialised the server's `WalletDto` into a type carrying `Mnemonic` and `AccountIndex` (which no read endpoint returns, so they were always null) while silently dropping `Status`, `Owner`, `Tenant` and `UpdatedAt` (which it does).

The swap is contained: **only `CreateWalletAsync`'s result is consumed anywhere** in the Demo (`ParticipantManager`, reading Address / Algorithm / Mnemonic / CreatedAt). `SignAsync`, `GetWalletAsync`, `ListWalletsAsync` and `DeriveChildWalletAsync` have no consumers at all. The single-string `Mnemonic` is now joined from `MnemonicWords` at the point of use, so there's one wire shape instead of two.

---

## #1159 — `WalletContractsJsonContext` registered

The source-generated context existed and was test-validated but was registered in **no host**, so every Wallet contract (de)serialised by reflection — correct, but not trim-safe. The main casualty is the Blazor WASM client, where a Release publish trims the metadata that fallback depends on.

**Registered on `SorchaJson` rather than per host.** That's deliberate, and worth a moment's scrutiny since it puts a domain contract's name in a generic serialisation helper: per-host chaining **could not have covered the main beneficiary**. `SorchaJson.Options` — the instance UI clients deserialise with — is `MakeReadOnly()`, so nothing can chain a resolver into it after construction. Doing it inside `Configure` reaches that static *and* every host that calls it, and no host can be forgotten. Cycle-safe: `Sorcha.Serialization` and `Sorcha.Wallet.Contracts` are both dependency-free leaves.

### The trap — caught by the test suite, not by review

A `JsonSerializerOptions` carries an implicit default reflection resolver **only while its chain is untouched**. Inserting the Wallet context alone removed it, leaving the platform options able to resolve seven types and **nothing else**:

```
Sorcha.UI.ContractTests: Failed: 18, Passed: 19
System.NotSupportedException : JsonTypeInfo metadata for type
'Sorcha.Tenant.Service.Models.InboxSeverity' was not provided by
TypeInfoResolver of type '[WalletContractsJsonContext]'
```

`MakeReadOnly(populateMissingResolver: true)` does **not** save you — a resolver is no longer "missing", so it adds nothing. The fix appends `DefaultJsonTypeInfoResolver`, so Wallet contracts hit source-generated metadata first and everything else falls through to reflection exactly as before. **Pinned by a regression test** so the one-line version cannot return.

This is the issue's "load-bearing caveat" in a different form than it anticipated, and it's a good argument for the broad sweep below rather than trusting the targeted suites.

Wire format is unchanged — verified by a camelCase round-trip assertion through `SorchaJson.Options` **itself**, not through the context's own baked options (which would have proved nothing about the host path).

---

## Verification

3 new tests. Because `SorchaJson` is platform-wide:

| Suite | Result |
|---|---|
| `Sorcha.Wallet.Contracts.Tests` | 65 / 0 |
| `Sorcha.UI.ContractTests` | 37 / 0 |
| `Sorcha.Cli.ContractTests` | 60 / 0 |
| `Sorcha.Wallet.Service.Tests` | 996 / 0 |
| `Sorcha.Blueprint.Service.Tests` | 1063 / 0 |
| `Sorcha.UI.Core.Tests` | 1665 / 0 |
| `Sorcha.Tenant.Service.Tests` | 1633 / 0 |

Solution builds, 0 errors. Wallet-contracts gate reports the allowlist empty.

**Not covered here:** the issue suggested landing this with the Docker integration test in the loop to confirm wire compatibility end-to-end. The camelCase round-trip through the real host options plus 5,500 passing tests across every wire-contract suite is strong evidence, but it isn't the same as a live round trip — worth a smoke check on the next deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K45NT42dtMe4KEAMzBEwVt