### PR TITLE
chore: add a gitignored /temp for runtime scratch, and glob the secret ignore rules

### DIFF
--- a/.claude/skills/network-bootstrap/SKILL.md
+++ b/.claude/skills/network-bootstrap/SKILL.md
@@ -30,9 +30,14 @@ dotnet run --project src/Apps/Sorcha.Cli -- system-register create --network-id 
 
 **Outputs:**
 - `src/Common/Sorcha.Register.Models/Resources/system-register-genesis.json` (embedded in assembly)
-- `genesis-validator-key.json` (root of repo, DO NOT commit — gitignored)
+- `temp/genesis-validator-key.json` (the gitignored `/temp` dir — DO NOT commit)
 
-**CRITICAL:** Store `genesis-validator-key.json` securely. The mnemonic controls all keys derived from this wallet.
+**CRITICAL:** Store `temp/genesis-validator-key.json` securely, then destroy it after import. The mnemonic controls all keys derived from this wallet — not just the genesis signing key.
+
+> The ceremony writes it into the gitignored `/temp` rather than the repo root. The root default left
+> a `genesis-validator-key.json.bak-pre471` sitting untracked for weeks, and `.gitignore` matched only
+> the exact filename — which a `.bak-*` suffix defeats. `.gitignore` now globs
+> `genesis-validator-key*` as well, so the family is excluded wherever it lands.
 
 > **Genesis freshness window — RESOLVED (2026-06-01, F145 session; static trace).** The 1h window is the intended, enforced, unit-tested behaviour. Genesis is **NOT exempt** — by design it gets a *separate, short* freshness window:
 > - **`ValidateTiming` applies `GenesisMaxAge` (default 1h) to genesis** (vs `MaxTransactionAge`/1h for live txs), rejecting with `VAL_TIME_002` when `CreatedAt` is older. This is a deliberate **replay guard**: a stale-but-accepted genesis lets an attacker seed/hijack a bootstrapping node (rationale in `ValidationEngineConfiguration.GenesisMaxAge` + `ValidateTiming`). Unit-tested: `ValidationEngineTests` VAL_TIME_002 genesis cases (too-old → reject; within-window → pass).
@@ -184,7 +189,7 @@ validator-service finds it.
 .\scripts\n1-reset.ps1 `
   -ResourceGroup sorcha-n1-uk `
   -UpdateCompose `
-  -ImportValidatorKeyPath .\genesis-validator-key.json `
+  -ImportValidatorKeyPath .\temp\genesis-validator-key.json `
   -Yes
 ```
 
@@ -211,7 +216,7 @@ until ssh sorcha@<n1-ip> "docker ps --filter name=sorcha-wallet-service --format
 # Step 5d: import via curl on the sorcha network. The wallet-service
 # container has no shell, so docker exec sh won't work — use a one-shot
 # curl container on the same compose network.
-MNEMONIC=$(python3 -c "import json; print(json.load(open('genesis-validator-key.json'))['mnemonic'])")
+MNEMONIC=$(python3 -c "import json; print(json.load(open('temp/genesis-validator-key.json'))['mnemonic'])")
 ssh sorcha@<n1-ip> "docker run --rm --network=sorcha_sorcha-network curlimages/curl:latest \
   -sk -X POST http://wallet-service:8080/api/v1/wallets/system/recover \
   -H 'Content-Type: application/json' \
@@ -227,7 +232,7 @@ ssh sorcha@<n1-ip> 'cd /opt/sorcha && docker compose \
 **`HTTP 000` from the import almost always means it SUCCEEDED (verified 2026-06-02).** The one-shot curl can exit non-zero (lost response / blip) even though wallet-service processed the POST and logged `system/recover responded 201`. The automated `n1-setup-remote.sh` treats `000` as fatal (`set -euo pipefail`) and **aborts before bringing up the rest of the stack**. Do NOT `down -v` and retry — wallet-service-alone can't auto-generate a `validator:` wallet, so the recovered wallet is real. Verify with `docker exec sorcha-postgres psql -U sorcha -d sorcha_wallet -tc 'select "Owner" from wallet."Wallets" where "Owner" like '"'"'validator:%'"'"';'` (or grep the wallet-service log for `responded 201`), then just run Step 5e (`up -d`) to finish.
 
 **Note on wallet address:** the address returned by `/system/recover`
-will NOT match the `walletAddress` in `genesis-validator-key.json`.
+will NOT match the `walletAddress` in `temp/genesis-validator-key.json`.
 That's expected — the address is derived from a different BIP path than
 the docket-signing key. The roster check uses the
 `m/44'/0'/0'/0/102` (`sorcha:docket-signing`) pubkey, which IS the same

--- a/.claude/skills/sorcha-architecture/SKILL.md
+++ b/.claude/skills/sorcha-architecture/SKILL.md
@@ -346,13 +346,14 @@ sorcha system-register create --network-id sorcha-dev
 
 # Outputs:
 #   system-register-genesis.json  → embed in source tree or deploy as config
-#   genesis-validator-key.json    → import into first validator, then destroy
+#   temp/genesis-validator-key.json → import into first validator, then destroy
+#                                     (the gitignored /temp — it is private key material)
 
 # Verify a genesis file
 sorcha system-register verify path/to/system-register-genesis.json
 
 # Import validator key into running Wallet Service (first validator only)
-sorcha system-register import-validator-key --key genesis-validator-key.json
+sorcha system-register import-validator-key --key temp/genesis-validator-key.json
 ```
 
 ### Bootstrap Flow (Register Service)

--- a/.gitignore
+++ b/.gitignore
@@ -9,8 +9,21 @@
 # GSD local planning/workflow state (roadmaps, phase plans, debug traces) — local only
 .planning/
 
-# Genesis ceremony private key material (never commit)
-genesis-validator-key.json
+# Runtime scratch. /temp carries its own .gitignore so the folder is tracked while its contents
+# never are; this entry is belt-and-braces for anything that resolves the path differently.
+/temp/*
+!/temp/.gitignore
+!/temp/README.md
+
+# Genesis ceremony private key material (never commit).
+#
+# GLOB, not the exact filename — that is the whole point. This rule used to read
+# `genesis-validator-key.json`, which does NOT match `genesis-validator-key.json.bak-pre471`; such a
+# file sat untracked in the repo root for weeks, and its mnemonic controls every key derived from the
+# genesis wallet. One `git add -A` would have published it. Match the family, wherever it lands and
+# whatever suffix a backup or re-ceremony gives it.
+genesis-validator-key*
+**/genesis-validator-key*
 
 # .NET
 bin/

--- a/src/Apps/Sorcha.Cli/Commands/SystemRegisterCommands.cs
+++ b/src/Apps/Sorcha.Cli/Commands/SystemRegisterCommands.cs
@@ -266,11 +266,11 @@ public class SystemRegisterCreateCommand : Command
 
         await File.WriteAllTextAsync(genesisPath, genesisJson, ct);
 
-        // Write key file adjacent to genesis when output path is specified (for test isolation),
-        // otherwise to current working directory
-        var keyFilePath = outputPath is not null
-            ? Path.Combine(Path.GetDirectoryName(Path.GetFullPath(outputPath)) ?? Directory.GetCurrentDirectory(), "genesis-validator-key.json")
-            : Path.Combine(Directory.GetCurrentDirectory(), "genesis-validator-key.json");
+        var keyFilePath = ResolveValidatorKeyPath(outputPath, Directory.GetCurrentDirectory());
+        var keyFileDir = Path.GetDirectoryName(keyFilePath);
+        if (!string.IsNullOrEmpty(keyFileDir))
+            Directory.CreateDirectory(keyFileDir);
+
         var keyFileJson = JsonSerializer.Serialize(validatorKeyFile, PrettyJsonOptions);
         await File.WriteAllTextAsync(keyFilePath, keyFileJson, ct);
 
@@ -362,6 +362,65 @@ public class SystemRegisterCreateCommand : Command
             _ => "s0"
         };
         return $"{prefix}{Convert.ToHexString(hash)[..40].ToLowerInvariant()}";
+    }
+
+    /// <summary>
+    /// Where the genesis ceremony's validator key file goes.
+    ///
+    /// <para>This is private key material: its mnemonic controls EVERY key derived from the genesis
+    /// wallet, not just the genesis signing key. With no explicit <c>--output</c> it used to land in
+    /// the process's current directory — which, for the documented ceremony workflow, is the repo
+    /// root. A <c>genesis-validator-key.json.bak-pre471</c> duly sat there untracked for weeks, one
+    /// <c>git add -A</c> from being published (<c>.gitignore</c> matched the exact filename, which a
+    /// <c>.bak-*</c> suffix defeats; it now globs the family).</para>
+    ///
+    /// <para>The default is now the repo's gitignored <c>/temp</c>, located by walking up for the
+    /// same marker <see cref="FindDefaultGenesisPath"/> uses — so it does not matter where inside the
+    /// checkout the CLI was invoked from. Outside a checkout (the CLI ships as a global tool and can
+    /// run anywhere) it falls back to the working directory rather than inventing a location.</para>
+    ///
+    /// <para>An explicit <c>--output</c> still keeps the key adjacent to the genesis file. Scripted
+    /// ceremonies pass one and depend on that; only the default moved.</para>
+    ///
+    /// <para>Internal rather than private so it can be tested directly — the alternative is asserting
+    /// on a path the test would have to reproduce by copying this logic, which proves nothing.</para>
+    /// </summary>
+    internal static string ResolveValidatorKeyPath(string? outputPath, string workingDirectory)
+    {
+        const string KeyFileName = "genesis-validator-key.json";
+
+        if (outputPath is not null)
+        {
+            return Path.Combine(
+                Path.GetDirectoryName(Path.GetFullPath(outputPath)) ?? workingDirectory,
+                KeyFileName);
+        }
+
+        var repoRoot = FindRepoRoot(workingDirectory);
+        return repoRoot is not null
+            ? Path.Combine(repoRoot, "temp", KeyFileName)
+            : Path.Combine(workingDirectory, KeyFileName);
+    }
+
+    /// <summary>
+    /// Walks up from <paramref name="startDirectory"/> looking for the Sorcha checkout marker,
+    /// returning the repo root or null when not inside one. Shared by the genesis-file and
+    /// validator-key path defaults so the two cannot disagree about where the repo is.
+    /// </summary>
+    private static string? FindRepoRoot(string startDirectory)
+    {
+        var dir = startDirectory;
+        for (var i = 0; i < 10; i++)
+        {
+            if (Directory.Exists(Path.Combine(dir, "src", "Common", "Sorcha.Register.Models")))
+                return dir;
+
+            var parent = Directory.GetParent(dir);
+            if (parent is null) break;
+            dir = parent.FullName;
+        }
+
+        return null;
     }
 
     private static string FindDefaultGenesisPath()

--- a/temp/.gitignore
+++ b/temp/.gitignore
@@ -1,0 +1,8 @@
+# Everything written into /temp is runtime scratch — ignore it all, keep the folder.
+#
+# Self-contained on purpose: because this file lives INSIDE the directory it ignores, the folder
+# exists on every clone (git tracks this file and the README) while its contents never can be
+# committed. That holds even if someone edits or reorders the root .gitignore.
+*
+!.gitignore
+!README.md

--- a/temp/README.md
+++ b/temp/README.md
@@ -1,0 +1,48 @@
+# `/temp` — runtime scratch, never committed
+
+Everything written here is ignored by git. The folder itself is tracked (via its own `.gitignore`
+and this file) so it exists on a fresh clone and tooling can rely on it without a `mkdir` dance.
+
+## What belongs here
+
+Anything a script, ceremony, walkthrough or demo produces **at runtime**:
+
+- generated key material and mnemonics (e.g. `genesis-validator-key.json`)
+- state files, deploy outputs, scratch configs
+- logs, dumps, one-off exports
+
+## What does NOT belong here
+
+Artefacts that are **inputs** to the build or are meant to be committed. The genesis ceremony is the
+clearest illustration of the split — one command writes both:
+
+| Output | Goes to | Why |
+|---|---|---|
+| `system-register-genesis.json` | `src/Common/Sorcha.Register.Models/Resources/` | A committed artefact — the embedded dev trust anchor. |
+| `genesis-validator-key.json` | **`/temp/`** | Private key material. Import it into the first validator, then destroy it. |
+
+## Why this exists
+
+A `genesis-validator-key.json.bak-pre471` — a file whose mnemonic controls **every key derived from
+the genesis wallet** — sat untracked in the repo root for weeks. `.gitignore` carried the exact
+string `genesis-validator-key.json`, which does not match a `.bak-pre471` suffix, so one `git add -A`
+would have published it.
+
+Two independent things now prevent a repeat, and both matter:
+
+1. **This directory.** Producers write scratch here rather than to the repo root, so there is nothing
+   at root to catch in the first place.
+2. **Pattern-based ignores at the root.** `.gitignore` matches `genesis-validator-key*` — the whole
+   family, not one exact filename — so a key that lands somewhere unexpected, or picks up a suffix,
+   is still excluded. Belt and braces: the convention can be forgotten, the pattern cannot.
+
+## If you are writing tooling
+
+Write runtime output here, not to the repo root and not next to source. Resolve the path by walking
+up for the repo marker rather than assuming the current working directory — a CLI installed as a
+global tool can be invoked from anywhere, and should fall back to the working directory when it is
+not running inside a checkout.
+
+See also: the per-tool convention for walkthroughs and demos, which keeps their own state inside
+`walkthroughs/<name>/` and `demos/<name>/`. That convention still applies; `/temp` is the default for
+anything without a natural home of its own.

--- a/tests/Sorcha.Cli.Tests/Commands/SystemRegisterCreateCommandTests.cs
+++ b/tests/Sorcha.Cli.Tests/Commands/SystemRegisterCreateCommandTests.cs
@@ -28,6 +28,65 @@ public class SystemRegisterCreateCommandTests : IDisposable
         catch { /* best effort cleanup */ }
     }
 
+    /// <summary>
+    /// The genesis ceremony's validator key is private material whose mnemonic controls EVERY key
+    /// derived from the genesis wallet. With no explicit --output it used to land in the process's
+    /// current directory, which for the documented workflow is the repo root — and a
+    /// <c>genesis-validator-key.json.bak-pre471</c> duly sat there untracked for weeks, one
+    /// <c>git add -A</c> away from being published.
+    ///
+    /// <para>It now resolves into the repo's gitignored <c>/temp</c>. The repo is located by walking
+    /// up for the same marker the genesis-file default uses, so it does not depend on where the CLI
+    /// was invoked from within the checkout.</para>
+    /// </summary>
+    [Fact]
+    public void ResolveValidatorKeyPath_InsideARepo_WritesIntoGitignoredTemp()
+    {
+        // A checkout is identified by this marker directory, mirroring FindDefaultGenesisPath.
+        var repoRoot = Path.Combine(_tempDir, "checkout");
+        var invokedFrom = Path.Combine(repoRoot, "some", "nested", "dir");
+        Directory.CreateDirectory(Path.Combine(repoRoot, "src", "Common", "Sorcha.Register.Models"));
+        Directory.CreateDirectory(invokedFrom);
+
+        var resolved = SystemRegisterCreateCommand.ResolveValidatorKeyPath(
+            outputPath: null, workingDirectory: invokedFrom);
+
+        resolved.Should().Be(
+            Path.Combine(repoRoot, "temp", "genesis-validator-key.json"),
+            "private key material belongs in the gitignored /temp, not the repo root");
+    }
+
+    /// <summary>
+    /// The CLI ships as a global tool and can be run from anywhere. Outside a checkout there is no
+    /// /temp to write to, so it must fall back to the working directory rather than inventing one.
+    /// </summary>
+    [Fact]
+    public void ResolveValidatorKeyPath_OutsideARepo_FallsBackToWorkingDirectory()
+    {
+        var elsewhere = Path.Combine(_tempDir, "not-a-checkout");
+        Directory.CreateDirectory(elsewhere);
+
+        var resolved = SystemRegisterCreateCommand.ResolveValidatorKeyPath(
+            outputPath: null, workingDirectory: elsewhere);
+
+        resolved.Should().Be(Path.Combine(elsewhere, "genesis-validator-key.json"));
+    }
+
+    /// <summary>
+    /// An explicit --output keeps the key adjacent to the genesis file — the behaviour the existing
+    /// tests and any scripted ceremony depend on. Only the DEFAULT moved.
+    /// </summary>
+    [Fact]
+    public void ResolveValidatorKeyPath_WithExplicitOutput_StaysAdjacentToGenesis()
+    {
+        var outputPath = Path.Combine(_tempDir, "custom", "genesis.json");
+
+        var resolved = SystemRegisterCreateCommand.ResolveValidatorKeyPath(
+            outputPath, workingDirectory: _tempDir);
+
+        resolved.Should().Be(Path.Combine(_tempDir, "custom", "genesis-validator-key.json"));
+    }
+
     [Fact]
     public async Task ExecuteCreate_ProducesValidGenesisFile()
     {

--- a/tests/Sorcha.Wallet.Core.Tests/GenesisDerivationProofTests.cs
+++ b/tests/Sorcha.Wallet.Core.Tests/GenesisDerivationProofTests.cs
@@ -25,24 +25,40 @@ namespace Sorcha.Wallet.Core.Tests;
 /// </remarks>
 public class GenesisDerivationProofTests
 {
-    private static string? FindGenesisKeyFile()
+    /// <summary>
+    /// Locates the genesis validator key, returning it with the repo root it was found under.
+    ///
+    /// <para>Checks <c>temp/</c> at each ancestor as well as the ancestor itself. The ceremony now
+    /// writes the key into the gitignored <c>/temp</c> rather than the repo root (it is private key
+    /// material; the old default left it one <c>git add -A</c> from being published). The repo-root
+    /// location is still accepted so a pre-existing key from an earlier ceremony keeps working.</para>
+    ///
+    /// <para>Returning the repo root explicitly matters: this used to derive it as the key file's own
+    /// directory, which was right only while the key sat AT the root. With the key in <c>temp/</c>
+    /// that would resolve the genesis file under <c>temp/src/…</c>, find nothing, and return null —
+    /// and because this whole suite skips silently when either file is missing, the tests would have
+    /// quietly stopped running rather than failing.</para>
+    /// </summary>
+    private static (string KeyPath, string RepoRoot)? FindGenesisKeyFile()
     {
         var dir = new DirectoryInfo(AppContext.BaseDirectory);
         for (int i = 0; i < 8 && dir is not null; i++, dir = dir.Parent)
         {
-            var candidate = Path.Combine(dir.FullName, "genesis-validator-key.json");
-            if (File.Exists(candidate)) return candidate;
+            var inTemp = Path.Combine(dir.FullName, "temp", "genesis-validator-key.json");
+            if (File.Exists(inTemp)) return (inTemp, dir.FullName);
+
+            var atRoot = Path.Combine(dir.FullName, "genesis-validator-key.json");
+            if (File.Exists(atRoot)) return (atRoot, dir.FullName);
         }
         return null;
     }
 
     private static (string Mnemonic, string RosterPubKey)? Load()
     {
-        var keyPath = FindGenesisKeyFile();
-        if (keyPath is null) return null;
+        var found = FindGenesisKeyFile();
+        if (found is null) return null;
+        var (keyPath, repoRoot) = found.Value;
 
-        // Resolve genesis file relative to the key file (repo root sibling)
-        var repoRoot = new FileInfo(keyPath).Directory!.FullName;
         var genesisPath = Path.Combine(repoRoot,
             "src", "Common", "Sorcha.Register.Models", "Resources", "system-register-genesis.json");
         if (!File.Exists(genesisPath)) return null;


### PR DESCRIPTION
## Why

A **`genesis-validator-key.json.bak-pre471`** has been sitting untracked in the repo root for weeks. `.gitignore` carried the exact string `genesis-validator-key.json`, which **does not match a `.bak-pre471` suffix** — so one `git add -A` would have published a mnemonic that controls *every key derived from the genesis wallet*, not just the genesis signing key.

The CLI put it there: with no `--output`, the ceremony defaulted the key to `Directory.GetCurrentDirectory()` — the repo root, when following the documented workflow.

A convention already existed (2026-06-04) that runtime working files belong in a gitignored folder, but it was **per-tool** — "use the tool's own folder or `/deploy/`" — so anything without a natural home still landed at the root. Hence a single default.

## Two independent fixes

The convention can be forgotten; the pattern cannot. Both are needed.

**1. `/temp/`** — tracked (its own `.gitignore` + `README.md`) so it exists on a fresh clone, with the `.gitignore` **inside** it so contents can't be committed even if the root `.gitignore` is later edited or reordered.

**2. Glob ignores** — `genesis-validator-key*` and `**/genesis-validator-key*`: the whole family, not one exact filename, so a backup or re-ceremony variant is excluded wherever it lands.

```
$ git check-ignore -v genesis-validator-key.json.bak-pre471
.gitignore:26:**/genesis-validator-key*   genesis-validator-key.json.bak-pre471
```

## The producer

`SystemRegisterCreateCommand.ResolveValidatorKeyPath` — extracted, `internal`, directly tested — defaults the key into `<repo>/temp`, locating the repo by walking up for the same marker `FindDefaultGenesisPath` uses, so it doesn't matter where in the checkout the CLI ran. **Outside** a checkout it falls back to the working directory: the CLI ships as a global tool and can be invoked anywhere. An explicit `--output` still keeps the key adjacent to the genesis file — scripted ceremonies depend on that; only the default moved.

**The genesis file itself is deliberately not moved.** It's a committed artefact (the embedded dev trust anchor). One command, two outputs, two destinations — the `/temp` README states the split so the next person doesn't "tidy" them together.

## A silent consumer nearly broke

`GenesisDerivationProofTests` locates the key by walking ancestors and **skips silently** when it's absent — so moving the file would have quietly stopped those tests running rather than failing. It also derived the repo root as *the key file's own directory*, which is only correct while the key sits at the root; with the key in `temp/` it would have looked for the genesis under `temp/src/…`, found nothing, and returned null.

Now checks `temp/` as well and returns the repo root explicitly. Worth grepping for readers before relocating anything discovered by convention.

## Also updated

`network-bootstrap` and `sorcha-architecture` skills both referenced `./genesis-validator-key.json` in **runnable commands** — those would have silently stopped working.

## Verification

3 new tests, watched RED first (the method didn't exist). `Sorcha.Cli.Tests` **417/0**, `Sorcha.Wallet.Core.Tests` **106/0**, solution builds **0 errors**. Ignore rules verified with `git check-ignore` rather than assumed.

## One thing left for you

The existing `genesis-validator-key.json.bak-pre471` is **left on disk** — it's yours, and it's now ignored rather than deleted. It still holds live key material and should be destroyed once you no longer need it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K45NT42dtMe4KEAMzBEwVt