### PR TITLE
fix: postcode and country rendered as bare labels with no input

### DIFF
--- a/.github/workflows/razor-comment-placement-gate.yml
+++ b/.github/workflows/razor-comment-placement-gate.yml
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Sorcha Contributors
+#
+# Razor comment placement gate. Fails when a @* ... *@ comment sits inside an element's
+# attribute list, where the compiler emits it as an ATTRIBUTE NAME rather than stripping it.
+# The browser then throws InvalidCharacterError at render time and aborts the render batch,
+# so the control — and whatever would have rendered after it — silently disappears.
+#
+# This needs a static gate because nothing else catches it: the C# compiler accepts it with no
+# warning, and bUnit's AngleSharp DOM tolerates an attribute name a real browser rejects, so
+# component tests pass against the broken markup.
+#
+# See scripts/check-razor-comment-placement.ps1.
+
+name: razor-comment-placement-gate
+
+on:
+  pull_request:
+    paths:
+      - "src/**/*.razor"
+      - "scripts/check-razor-comment-placement.ps1"
+      - ".github/workflows/razor-comment-placement-gate.yml"
+  workflow_dispatch:
+
+jobs:
+  razor-comment-placement:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run Razor comment placement gate
+        shell: pwsh
+        run: ./scripts/check-razor-comment-placement.ps1

--- a/scripts/check-razor-comment-placement.ps1
+++ b/scripts/check-razor-comment-placement.ps1
@@ -1,0 +1,109 @@
+#!/usr/bin/env pwsh
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Sorcha Contributors
+#
+# Razor comment placement CI gate.
+#
+# A Razor comment (@* ... *@) is stripped at compile time ONLY when it sits where markup is
+# expected. Inside an element's attribute list it is not a comment at all — the compiler emits it
+# as an attribute NAME, and the browser then throws at render time:
+#
+#   InvalidCharacterError: Failed to execute 'setAttribute' on 'Element':
+#   '@* Issue #1278: a postcode is the canonical machine-checked value ... *@'
+#   is not a valid attribute name
+#
+# That exception aborts the whole render batch, so the offending control AND whatever the renderer
+# was going to emit next simply do not appear. On the AIAS "Your address" page this left Postcode
+# and Country as bare labels with no input while the four fields above them rendered normally
+# (issue: PostalAddressRenderRepro).
+#
+# Why a static gate rather than a test:
+#   - The C# compiler accepts it. There is no build warning.
+#   - bUnit does NOT catch it. PostcodeLookupRendererTests passed against the broken file, because
+#     bUnit's AngleSharp DOM tolerates an attribute name a real browser rejects. Only a browser
+#     reproduces this, and only at the moment the component renders.
+#
+# Detection: walk each .razor file tracking whether the cursor is inside an element tag (between
+# `<tag` and its closing `>`). A `@*` encountered in that state is a violation. Comments in markup
+# position, in @code blocks, and at file scope are all unaffected.
+#
+# Usage:
+#   pwsh scripts/check-razor-comment-placement.ps1
+#
+# Exit codes:
+#   0 — no violations
+#   1 — a Razor comment sits inside an element's attribute list
+
+[CmdletBinding()]
+param(
+    [string]$Root = (Join-Path $PSScriptRoot '..')
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Test-RazorFile {
+    param([string]$Path)
+
+    $text = Get-Content -Raw -LiteralPath $Path
+    if ([string]::IsNullOrEmpty($text)) { return @() }
+
+    $violations = @()
+    $inTag = $false
+    $line = 1
+    $i = 0
+
+    while ($i -lt $text.Length) {
+        $c = $text[$i]
+
+        if ($c -eq "`n") { $line++ }
+
+        if (-not $inTag -and $c -eq '<' -and ($i + 1) -lt $text.Length -and
+            ([char]::IsLetter($text[$i + 1]) -or $text[$i + 1] -eq '/')) {
+            $inTag = $true
+        }
+        elseif ($inTag -and $c -eq '>') {
+            $inTag = $false
+        }
+        elseif ($inTag -and $c -eq '@' -and ($i + 1) -lt $text.Length -and $text[$i + 1] -eq '*') {
+            $violations += [pscustomobject]@{ Path = $Path; Line = $line }
+
+            # Skip past the comment so one violation is reported per comment, not per character.
+            $close = $text.IndexOf('*@', $i)
+            if ($close -lt 0) { break }
+            for ($k = $i; $k -lt $close; $k++) { if ($text[$k] -eq "`n") { $line++ } }
+            $i = $close + 2
+            continue
+        }
+
+        $i++
+    }
+
+    return $violations
+}
+
+$srcRoot = Join-Path $Root 'src'
+$files = Get-ChildItem -Path $srcRoot -Recurse -Filter '*.razor' -File |
+    Where-Object { $_.FullName -notmatch '[\\/](obj|bin)[\\/]' }
+
+$all = @()
+foreach ($file in $files) {
+    $all += Test-RazorFile -Path $file.FullName
+}
+
+if ($all.Count -gt 0) {
+    Write-Host "FAIL: Razor comment inside an element's attribute list." -ForegroundColor Red
+    Write-Host ""
+    Write-Host "In that position the compiler emits the comment as an ATTRIBUTE NAME. The browser" -ForegroundColor Red
+    Write-Host "throws InvalidCharacterError at render time and the render batch aborts, so the" -ForegroundColor Red
+    Write-Host "control and whatever renders after it silently disappear. Move the comment ABOVE" -ForegroundColor Red
+    Write-Host "the element." -ForegroundColor Red
+    Write-Host ""
+    foreach ($v in $all) {
+        $relative = [IO.Path]::GetRelativePath($Root, $v.Path)
+        Write-Host "  $relative`:$($v.Line)" -ForegroundColor Yellow
+    }
+    exit 1
+}
+
+Write-Host "OK: no Razor comments inside attribute lists ($($files.Count) .razor files scanned)." -ForegroundColor Green
+exit 0

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Forms/Controls/PostcodeLookupRenderer.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Forms/Controls/PostcodeLookupRenderer.razor
@@ -32,6 +32,16 @@
     writing to /address/line1, /address/town, etc via FormContext.SetValue.
 *@
 
+@* Issue #1278: a postcode is the canonical machine-checked value — this field is literally checked
+   against a gazetteer, and "Eh91ja" is not a postcode. The ExactValueHints applied below are
+   unconditional rather than schema-derived: a field dispatched to THIS renderer is a postcode by
+   definition.
+
+   This comment lives ABOVE the element on purpose. Inside an attribute list a Razor comment is not
+   stripped — it is emitted as an attribute NAME, so the browser threw
+   `InvalidCharacterError: Failed to execute 'setAttribute'` and aborted the render batch. The
+   postcode input never appeared, and the exception took the next field (country) with it, leaving
+   both as bare labels. *@
 <div @onfocusin="OnFocusIn" @onfocusout="OnFocusOut" class="postcode-lookup">
     <MudTextField T="string"
                   data-testid="postcode-input"
@@ -50,10 +60,6 @@
                   Margin="Margin.Dense"
                   DebounceInterval="300"
                   OnBlur="OnBlurAsync"
-                  @* Issue #1278: a postcode is the canonical machine-checked value — this field is
-                     literally checked against a gazetteer, and "Eh91ja" is not a postcode. Hints are
-                     unconditional here rather than schema-derived: a field dispatched to THIS
-                     renderer is a postcode by definition. *@
                   @attributes="ExactValueHints" />
 
     @if (_mode == LookupMode.FullAddress)


### PR DESCRIPTION
The AIAS **"Your address"** page rendered **Postcode** and **Country** as bare labels with no input box, while the four fields above them were fine. Reproduced live in the running app.

## Cause

A Razor comment sat **inside `MudTextField`'s attribute list** in `PostcodeLookupRenderer.razor`, between `OnBlur=` and `@attributes=`.

In that position `@* … *@` is **not stripped** — the compiler emits it as an attribute **name**:

```
InvalidCharacterError: Failed to execute 'setAttribute' on 'Element':
'@* Issue #1278: a postcode is the canonical machine-checked value — this field is
   literally checked against a gazetteer …*@' is not a valid attribute name
```

That exception aborts the render batch, which is why **exactly two** fields broke: it killed the postcode input and took the next field with it (`Cannot set attribute on non-element child`). Country was collateral, not a second bug.

Live DOM confirms:

| | before | after |
|---|---|---|
| labels | 6 | 6 |
| `<input>` elements | **4** | **6** |
| postcode `.mud-input` | present but **empty** | contains its input |
| country `.mud-input` | **absent** | present |

The comment now sits above the element, where it is a comment.

## Why a CI gate and not a test

Nothing else can catch this class:

- **The C# compiler accepts it.** No error, no warning.
- **bUnit does not catch it.** `PostcodeLookupRendererTests` passes against the broken file — I verified by stashing the fix and re-running — because bUnit's AngleSharp DOM tolerates an attribute name a real browser rejects. Only a browser reproduces it, and only at render time.

`scripts/check-razor-comment-placement.ps1` walks each `.razor` tracking whether the cursor is inside an element tag, and fails on a `@*` found there. Comments in markup position, in `@code` blocks, and at file scope are unaffected.

**Mutation-tested both ways** rather than trusted because it went green:

```
pre-fix file  -> exit 1, flags PostcodeLookupRenderer.razor:53
post-fix file -> exit 0
whole repo    -> 0 hits across 358 .razor files
```

## Note on the repro file

`tests/.../PostalAddressRenderRepro.cs` — the diagnostic that documented this — passes both before and after, because it only exercises schema→control generation. That was never where the defect was: `AutoGenerateForm` produced controls for all six fields correctly. The failure was purely in rendering. Left as-is; it is still a useful record of the schema shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K45NT42dtMe4KEAMzBEwVt