### PR TITLE
fix: enrolment confirmation rendered completely unstyled on a phone

### DIFF
--- a/src/Apps/Sorcha.Wallet.Pwa/Components/EnrolmentRedeemConfirmDialog.razor.css
+++ b/src/Apps/Sorcha.Wallet.Pwa/Components/EnrolmentRedeemConfirmDialog.razor.css
@@ -1,0 +1,111 @@
+/* SPDX-License-Identifier: MIT */
+/* Copyright (c) 2026 Sorcha Contributors */
+
+/*
+    Feature 126 — styles for the friend-scans-by-mistake confirmation.
+
+    The component is deliberately plain HTML rather than MudBlazor components (it is a recognition
+    gate shown before any device is registered, so it stays independent of the dialog service). That
+    means it depends ENTIRELY on these rules — and they did not exist. Every `enrol-confirm*` class
+    in the markup was undefined anywhere in the repo, so the surface rendered as a bare <h2>, two
+    bare <p>s and two unstyled <button>s running together as one line of text: "Yes, that's me —
+    continue This isn't me". On a phone, straight after scanning the pairing QR, that is the first
+    thing a citizen sees.
+
+    Colours come from the MudBlazor palette variables so the card follows the wallet's light/dark
+    theme rather than pinning its own, with literal fallbacks for any context that renders this
+    outside a MudThemeProvider.
+*/
+
+.enrol-confirm {
+    max-width: 30rem;
+    margin: 0 auto;
+    padding: 1.5rem;
+
+    background-color: var(--mud-palette-surface, #ffffff);
+    color: var(--mud-palette-text-primary, rgba(0, 0, 0, 0.87));
+    border: 1px solid var(--mud-palette-lines-default, rgba(0, 0, 0, 0.12));
+    border-radius: var(--mud-default-borderradius, 8px);
+    box-shadow: var(--mud-elevation-4, 0 2px 8px rgba(0, 0, 0, 0.16));
+}
+
+.enrol-confirm__heading {
+    margin: 0 0 0.75rem;
+    font-size: 1.375rem;
+    font-weight: 600;
+    line-height: 1.3;
+}
+
+.enrol-confirm__body {
+    margin: 0 0 0.75rem;
+    font-size: 1rem;
+    line-height: 1.5;
+}
+
+/* The consequence line. This is the whole point of the screen — an unintended recipient must be
+   able to see, at a glance, that continuing would bind THEIR device to someone else's account. */
+.enrol-confirm__warning {
+    margin: 0 0 1.25rem;
+    padding: 0.625rem 0.75rem;
+    font-size: 0.9375rem;
+    line-height: 1.4;
+
+    color: var(--mud-palette-warning-text, #ffffff);
+    background-color: var(--mud-palette-warning, #ff9800);
+    border-radius: var(--mud-default-borderradius, 8px);
+}
+
+.enrol-confirm__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    align-items: center;
+}
+
+/* Both actions are real targets on a phone held one-handed — 44px is the iOS minimum. */
+.enrol-confirm__confirm,
+.enrol-confirm__cancel {
+    min-height: 44px;
+    padding: 0.625rem 1.25rem;
+    font: inherit;
+    font-weight: 600;
+    border-radius: var(--mud-default-borderradius, 8px);
+    cursor: pointer;
+}
+
+.enrol-confirm__confirm {
+    flex: 1 1 auto;
+    color: var(--mud-palette-primary-text, #ffffff);
+    background-color: var(--mud-palette-primary, #594ae2);
+    border: 1px solid transparent;
+}
+
+.enrol-confirm__confirm:hover {
+    background-color: var(--mud-palette-primary-darken, #4b3fd0);
+}
+
+/* Deliberately quieter than Confirm, but NOT hidden — cancelling is the safe action for the
+   person this screen is protecting, so it stays a visible, full-size target. */
+.enrol-confirm__cancel {
+    color: var(--mud-palette-text-primary, rgba(0, 0, 0, 0.87));
+    background-color: transparent;
+    border: 1px solid var(--mud-palette-lines-default, rgba(0, 0, 0, 0.23));
+}
+
+.enrol-confirm__cancel:hover {
+    background-color: var(--mud-palette-action-default-hover, rgba(0, 0, 0, 0.06));
+}
+
+.enrol-confirm__confirm:focus-visible,
+.enrol-confirm__cancel:focus-visible {
+    outline: 2px solid var(--mud-palette-primary, #594ae2);
+    outline-offset: 2px;
+}
+
+/* Narrow phones: stack so neither action is cramped or accidentally adjacent to the other. */
+@media (max-width: 26rem) {
+    .enrol-confirm__actions {
+        flex-direction: column;
+        align-items: stretch;
+    }
+}

--- a/tests/Sorcha.Wallet.Pwa.Tests/Components/EnrolmentRedeemConfirmDialogTests.cs
+++ b/tests/Sorcha.Wallet.Pwa.Tests/Components/EnrolmentRedeemConfirmDialogTests.cs
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+
+using Bunit;
+
+using FluentAssertions;
+
+using Sorcha.Wallet.Pwa.Components;
+
+using Xunit;
+
+namespace Sorcha.Wallet.Pwa.Tests.Components;
+
+/// <summary>
+/// Feature 126 — the friend-scans-by-mistake confirmation shown after a pairing QR is scanned.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This component is deliberately plain HTML rather than MudBlazor components, so it depends
+/// entirely on its own scoped stylesheet. That stylesheet <b>did not exist</b>: every
+/// <c>enrol-confirm*</c> class in the markup was undefined anywhere in the repository, so on a real
+/// phone the screen rendered as a bare heading, two bare paragraphs, and two unstyled buttons
+/// running together as one line — "Yes, that's me — continue This isn't me".
+/// </para>
+/// <para>
+/// The rendering tests below cannot catch that on their own: bUnit asserts the DOM, and the DOM was
+/// always correct. <see cref="EveryBespokeClassInTheMarkupIsDefinedInTheScopedStylesheet"/> is the
+/// test that would have caught it, and it is the reason this file exists.
+/// </para>
+/// </remarks>
+public sealed class EnrolmentRedeemConfirmDialogTests : BunitContext
+{
+    private const string Email = "citizen@example.test";
+
+    private IRenderedComponent<EnrolmentRedeemConfirmDialog> RenderDialog(
+        string? displayName = "Test Citizen") =>
+        Render<EnrolmentRedeemConfirmDialog>(p => p
+            .Add(c => c.Email, Email)
+            .Add(c => c.DisplayName, displayName));
+
+    // ---------------------------------------------------------------------------------------
+    // The guard that matters
+    // ---------------------------------------------------------------------------------------
+
+    [Fact]
+    public void EveryBespokeClassInTheMarkupIsDefinedInTheScopedStylesheet()
+    {
+        var componentDir = LocateComponentDirectory();
+        var markup = File.ReadAllText(Path.Combine(componentDir, "EnrolmentRedeemConfirmDialog.razor"));
+        var stylesheetPath = Path.Combine(componentDir, "EnrolmentRedeemConfirmDialog.razor.css");
+
+        File.Exists(stylesheetPath).Should().BeTrue(
+            "the component styles itself with bespoke classes rather than MudBlazor components, so " +
+            "without this stylesheet it renders completely unstyled on a real device");
+
+        var stylesheet = File.ReadAllText(stylesheetPath);
+
+        var used = Regex.Matches(markup, @"class=""(?<classes>[^""]+)""")
+            .SelectMany(m => m.Groups["classes"].Value.Split(' ', StringSplitOptions.RemoveEmptyEntries))
+            .Where(c => c.StartsWith("enrol-confirm", StringComparison.Ordinal))
+            .Distinct(StringComparer.Ordinal)
+            .ToList();
+
+        used.Should().NotBeEmpty("the markup should carry the bespoke classes this test guards");
+
+        var undefined = used.Where(c => !stylesheet.Contains($".{c}", StringComparison.Ordinal)).ToList();
+
+        undefined.Should().BeEmpty(
+            "a class used in the markup but defined in no stylesheet renders as nothing at all — " +
+            "which is exactly how this screen shipped unstyled");
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // Recognition content — the point of the screen
+    // ---------------------------------------------------------------------------------------
+
+    [Fact]
+    public void ShowsTheBoundAccountSoAnUnintendedRecipientCanRecogniseItIsNotTheirs()
+    {
+        var dialog = RenderDialog();
+
+        dialog.Markup.Should().Contain(Email);
+        dialog.Markup.Should().Contain("Test Citizen");
+    }
+
+    [Fact]
+    public void WithNoDisplayName_StillShowsTheEmail()
+    {
+        var dialog = RenderDialog(displayName: null);
+
+        dialog.Markup.Should().Contain(Email);
+    }
+
+    [Fact]
+    public void OffersBothAConfirmAndACancel()
+    {
+        // Cancel is the safe action for the person this screen protects, so it must always be
+        // present — not merely a way to dismiss.
+        var dialog = RenderDialog();
+
+        dialog.FindAll("[data-testid='enrol-confirm-yes']").Should().HaveCount(1);
+        dialog.FindAll("[data-testid='enrol-confirm-no']").Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task ConfirmAndCancelRaiseTheirCallbacks()
+    {
+        var confirmed = false;
+        var cancelled = false;
+
+        var dialog = Render<EnrolmentRedeemConfirmDialog>(p => p
+            .Add(c => c.Email, Email)
+            .Add(c => c.OnConfirm, () => confirmed = true)
+            .Add(c => c.OnCancel, () => cancelled = true));
+
+        await dialog.Find("[data-testid='enrol-confirm-yes']").ClickAsync(new());
+        confirmed.Should().BeTrue();
+
+        await dialog.Find("[data-testid='enrol-confirm-no']").ClickAsync(new());
+        cancelled.Should().BeTrue();
+    }
+
+    /// <summary>
+    /// Walks up from the test binaries to the repository root and returns the component's source
+    /// directory. Keeps the guard working regardless of the build output layout.
+    /// </summary>
+    private static string LocateComponentDirectory()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "Sorcha.sln")))
+        {
+            dir = dir.Parent;
+        }
+
+        dir.Should().NotBeNull("the test must be able to find the repository root to read component source");
+
+        return Path.Combine(dir!.FullName, "src", "Apps", "Sorcha.Wallet.Pwa", "Components");
+    }
+}


### PR DESCRIPTION
Reported from a real device: scanning the wallet pairing QR landed on an **unstyled screen**.

The "Is this you?" recognition step rendered as a bare `<h2>`, two bare `<p>`s, and two unstyled `<button>`s running together as one line of text:

```
Yes, that's me — continue This isn't me
```

## Cause

`EnrolmentRedeemConfirmDialog` is deliberately plain HTML rather than MudBlazor components — it is a recognition gate shown before any device is registered, so it stays independent of the dialog service. That means it depends **entirely** on its own scoped stylesheet.

That stylesheet never existed. Every `enrol-confirm*` class in the markup was defined **nowhere in the repository** — no `.razor.css`, no rule in any stylesheet:

```
$ grep -rn "enrol-confirm" --include=*.css src/
(no matches)
```

Ruled out first: the PWA's CSS pipeline is fine. `MudBlazor.min.css`, `css/app.css` and `Sorcha.Wallet.Pwa.styles.css` all return `200 text/css` on n1, `<base href="/wallet/">` is correct, and the component renders inside `MudContainer` within `MainLayout`, so the theme is in scope.

## Why this one matters more than it looks

This is the first thing a citizen sees on their phone after scanning, and its entire purpose is **recognition** — an unintended recipient must be able to tell at a glance that continuing would bind *their* device to someone else's account. Rendered as a single run-together line, Confirm and Cancel were not distinguishable as separate actions.

## Fix

Adds the scoped stylesheet:

- Themed from `--mud-palette-*` variables so it follows the wallet's light/dark theme instead of pinning its own, with literal fallbacks.
- The warning line is given real visual weight — it is the consequence the screen exists to convey.
- **44px minimum touch targets** on both actions (iOS minimum), and they **stack below 26rem** so they are never accidentally adjacent on a narrow phone.
- Cancel is quieter than Confirm but stays a visible, full-size target — cancelling is the safe action for the person this screen protects.

## Guard

`EveryBespokeClassInTheMarkupIsDefinedInTheScopedStylesheet` extracts the bespoke classes from the component's markup and asserts each is defined in its stylesheet.

**Mutation-tested**, because a guard that goes green immediately proves nothing:

```
stylesheet deleted (the shipped state) -> Failed: 1, Passed: 4
stylesheet restored                    -> Failed: 0, Passed: 5
```

The four rendering tests stay green either way — which is precisely why bUnit could not catch this. The DOM was always correct; only the styles were missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K45NT42dtMe4KEAMzBEwVt