### PR TITLE
fix: [UT-016] - the postcode CAPS fix targeted the wrapper, not the input

### DIFF
--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Forms/Controls/PostcodeLookupRenderer.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Forms/Controls/PostcodeLookupRenderer.razor
@@ -58,7 +58,6 @@
                   Immediate="false"
                   Variant="Variant.Outlined"
                   Margin="Margin.Dense"
-                  Style="text-transform: uppercase;"
                   DebounceInterval="300"
                   OnBlur="OnBlurAsync"
                   @attributes="ExactValueHints" />

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Forms/Controls/PostcodeLookupRenderer.razor.css
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Forms/Controls/PostcodeLookupRenderer.razor.css
@@ -1,0 +1,25 @@
+/* SPDX-License-Identifier: MIT */
+/* Copyright (c) 2026 Sorcha Contributors */
+
+/*
+   A postcode is displayed uppercase because that is its canonical written form, and because this
+   field is checked against a real gazetteer — "eh1 1yz" and "EH1 1YZ" are the same postcode and
+   should not look like two different answers.
+
+   This has to target the <input> itself. Putting `text-transform: uppercase` on MudTextField's
+   `Style` parameter lands it on MudBlazor's wrapper div, where it computes correctly and then does
+   nothing: browsers' UA stylesheet sets `text-transform: none` on form controls, so the property is
+   NOT inherited into the input the way it is into ordinary text. The wrapper reads "uppercase" in
+   DevTools while the input reads "none", which is exactly why the first attempt looked right in the
+   markup and wrong on screen.
+
+   ::deep is required because the input is rendered by MudTextField, a child component, so the
+   scope attribute is not on it — only on this component's own .postcode-lookup wrapper.
+
+   Display only. The value is normalised on the write path (PostalValueNormaliser) before validation,
+   and that is what governs what gets signed; this makes the field LOOK like what will be stored
+   rather than pretending to change it.
+*/
+.postcode-lookup ::deep input {
+    text-transform: uppercase;
+}

--- a/tests/Sorcha.UI.Components.User.Tests/Forms/PostcodeLookupRendererTests.cs
+++ b/tests/Sorcha.UI.Components.User.Tests/Forms/PostcodeLookupRendererTests.cs
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Bunit;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using MudBlazor.Services;
+using Sorcha.Blueprint.Models;
+using Sorcha.UI.Core.Components.Forms.Controls;
+using Sorcha.UI.Core.Models.Forms;
+using Sorcha.UI.Core.Services.AddressLookup;
+using Sorcha.UI.Core.Services.Forms;
+using Xunit;
+
+namespace Sorcha.UI.Components.User.Tests.Forms;
+
+/// <summary>
+/// Render-level tests for the postcode field.
+/// </summary>
+/// <remarks>
+/// The uppercase display lives in <c>PostcodeLookupRenderer.razor.css</c> as
+/// <c>.postcode-lookup ::deep input</c>. Whether the browser actually applies it is not something a
+/// test can answer — bUnit has no style engine — so that half is verified live. What IS testable, and
+/// what silently broke this control once already, is the JOIN: the stylesheet addresses the markup by
+/// a class name, and nothing else relates the two. Rename or drop the wrapper and the selector matches
+/// nothing, with no build error, no warning, and no failing test — the postcode simply renders
+/// lowercase again.
+/// </remarks>
+public sealed class PostcodeLookupRendererTests : BunitContext
+{
+    public PostcodeLookupRendererTests()
+    {
+        Services.AddMudServices(o => o.PopoverOptions.CheckForPopoverProvider = false);
+        Services.AddSingleton<IFormSchemaService, FormSchemaService>();
+
+        // No provider available: discovery returns null, the renderer degrades to a plain text input
+        // and still renders. That is the path with the fewest moving parts for a markup assertion.
+        var lookup = new Mock<IAddressLookupClient>();
+        lookup.Setup(l => l.GetProvidersAsync(It.IsAny<CancellationToken>()))
+              .Returns(Task.FromResult<IReadOnlyList<ProviderInfo>?>(null));
+        Services.AddSingleton(lookup.Object);
+
+        JSInterop.Mode = JSRuntimeMode.Loose;
+    }
+
+    private const string Schema = """
+        {
+          "type": "object",
+          "properties": {
+            "postcode": { "type": "string", "x-address-lookup": true }
+          }
+        }
+        """;
+
+    private IRenderedComponent<PostcodeLookupRenderer> RenderPostcode()
+    {
+        var context = new FormContext { DataSchema = JsonDocument.Parse(Schema) };
+        return Render<PostcodeLookupRenderer>(p => p
+            .AddCascadingValue(context)
+            .Add(c => c.Control, new Control { Scope = "/postcode", Title = "Postcode" }));
+    }
+
+    [Fact]
+    public void Renders_TheWrapperClassTheStylesheetTargets()
+    {
+        // `.postcode-lookup ::deep input` in PostcodeLookupRenderer.razor.css binds to this class.
+        var cut = RenderPostcode();
+
+        cut.Find(".postcode-lookup").Should().NotBeNull(
+            "the uppercase stylesheet selects on this class and fails silently if it is renamed");
+    }
+
+    [Fact]
+    public void TheInputIsInsideThatWrapper()
+    {
+        // ::deep matches DESCENDANTS of the scoped element. An input moved out of the wrapper would
+        // leave the selector valid and matching nothing.
+        var cut = RenderPostcode();
+
+        cut.FindAll(".postcode-lookup input").Should().NotBeEmpty(
+            "::deep only reaches inputs nested inside the scoped wrapper");
+    }
+
+    [Fact]
+    public void DoesNotReintroduceTheInlineStyleThatSilentlyDidNothing()
+    {
+        // The first attempt at this put `text-transform: uppercase` on MudTextField's Style parameter.
+        // It landed on MudBlazor's wrapper div, where it computes as "uppercase" and achieves nothing:
+        // the UA stylesheet sets `text-transform: none` on form controls, so it is not inherited into
+        // the input. It looked correct in the markup and in DevTools on the wrapper, and was wrong on
+        // screen — which is why it shipped.
+        var cut = RenderPostcode();
+
+        cut.Markup.Should().NotContain("text-transform",
+            "an inline text-transform here targets the wrapper, not the input, and does nothing");
+    }
+}


### PR DESCRIPTION
Caught on the deployed build, not in review. `Style="text-transform: uppercase;"`
on MudTextField lands on MudBlazor's wrapper div. Live on n1 that div computed
`text-transform: uppercase` — correctly — and the <input> inside it computed `none`,
because the UA stylesheet sets `text-transform: none` on form controls, so the
property is not inherited into them the way it is into ordinary text.

So the fix was visible in the markup, visible in DevTools on the element it was
written to, and did nothing at all on screen. "eh1 1yz" stayed lowercase.

Moved to PostcodeLookupRenderer.razor.css as `.postcode-lookup ::deep input`, which
targets the input itself. ::deep is required because the input is rendered by
MudTextField, a child component, so the CSS-isolation scope attribute is on this
component's wrapper and not on the input — the same pattern already used by
PresentationRequestCard and IdCardLayout for MudBlazor internals.

The no-op Style attribute is removed rather than left beside the working rule.

Whether a browser applies the rule is not testable here — bUnit has no style engine,
and that half was verified live. What IS testable is the JOIN, which is where this
class of bug lives: the stylesheet addresses the markup by a class name and nothing
relates the two, so renaming the wrapper breaks it with no build error, no warning and
no failing test. Three tests pin it, mutation-verified: renaming the wrapper class
turns exactly the two selector guards RED and leaves the third — which guards against
reintroducing the inline style — green.

Display only. PostalValueNormaliser still governs what is stored and signed.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013FAcr5HQSGN69eMT4Apm2b
