### PR TITLE
feat: [189 US4] - The system register was never missing its key, only a path that reached it

### DIFF
--- a/specs/189-org-signed-governance/tasks.md
+++ b/specs/189-org-signed-governance/tasks.md
@@ -364,10 +364,60 @@ confirm sealed-in-docket and observable on tiny.
 
 **Independent test**: transfer ownership of a ceremony-created system register; the former owner can no longer govern, the new owner can.
 
+> ## US4 DESIGN — settled 2026-08-11: adopt-then-transfer, **no re-genesis**
+>
+> **The SSR is not governable today, and this is verified live, not inferred.** A propose against it on
+> n1 returns the code's own message: *"Roster subject 'did:sorcha:genesis:a3dd941f…' carries no wallet
+> address (expected 'did:sorcha:w:{address}'), so there is no key to sign with. The system register's
+> ceremony-minted subject has this shape and is not governable by this path."* T007's analysis holds
+> exactly.
+>
+> **What the ceremony actually produces** (`SystemRegisterCommands.CreateAsync` / `BuildControlRecord`)
+> — worth stating precisely, because the task notes and the code disagree and three different keys are
+> in play, all derived from one BIP39 mnemonic:
+>
+> | Key | Path | Used for |
+> |---|---|---|
+> | docket-signing | `m/44'/0'/0'/0/102` | **the Owner attestation's `PublicKey`**, and the validator roster entry |
+> | register-control | `m/44'/0'/0'/0/101` | signs the genesis transaction; its fingerprint is the **network trust anchor** |
+>
+> Note the Owner attestation carries the **slot-102** key, not slot 101 as the T007 note implies, and
+> the subject's fingerprint is of slot 102 while the anchor's is of slot 101 — two different
+> fingerprints. Only the `Subject` *shape* is the obstacle; the key is fine.
+>
+> **Why no re-genesis is needed.** The genesis key file carries the **mnemonic**, and
+> `sorcha system-register import-validator-key` recovers a full HD system wallet from it
+> (`RecoverSystemWalletAsync`, tenant=`system`, owner=`validator:{validatorId}`). **The node therefore
+> already holds the key behind the Owner attestation** — it is the same wallet the validator uses to
+> seal every docket. Nothing needs re-minting; the platform simply has no path that reaches it for
+> governance.
+>
+> **The change**: `GovernanceSigningService` currently resolves subject → wallet by parsing
+> `did:sorcha:w:{address}` and signing at slot 100 (`sorcha:register-attestation`). For a
+> `did:sorcha:genesis:` subject it must instead sign through the existing
+> `ISystemWalletSigningService` at **`SorchaDerivationPaths.DocketSigning`** — already on that
+> service's default `AllowedDerivationPaths` whitelist, and already how Register Service reaches the
+> system wallet (`SystemWalletSigning:ValidatorId`). That yields a signature whose public key matches
+> the roster's recorded Owner key, so `RightsEnforcementService` accepts it with no change.
+>
+> **Then the adopt IS the acceptance test.** With signing reachable, the first governance act on the
+> SSR is an ordinary `Transfer` replacing the genesis Owner with a real `did:sorcha:w:` organisation —
+> which is precisely what US4 sets out to prove. The trust anchor (slot-101 fingerprint) is never
+> touched, so n1 and tiny are not wiped and the AIAS demo survives.
+>
+> **Consequently T059/T060/T061 fall away as written** — they assumed the ceremony had to change and a
+> coordinated re-genesis had to follow. Kept below, struck through, with the reason.
+>
+> **Design caveat to carry into implementation:** the genesis subject signing at slot 102 means one
+> roster subject uses a different derivation path from every other. Confine that to the resolver, keep
+> it keyed on the `did:sorcha:genesis:` prefix, and expect it to become dead code the moment the
+> transfer seals — the genesis subject leaves the roster and nothing reaches that branch again. Do not
+> generalise it into "governance can sign at any path".
+
 - [ ] T058 [P] [US4] Test: after transfer, the former owner's governance attempt is refused
-- [ ] T059 [US4] Mint a fresh genesis with the updated ceremony (slot-100 attestations) via `sorcha system-register create`
-- [ ] T060 [US4] Re-genesis n1 within the 1-hour `VAL_TIME_002` window; bring tiny up on the same network
-- [ ] T061 [US4] **Re-provision the AIAS demo immediately** (`run-demo.ps1 -Target n1 -Force`, then `rehearse.ps1 -Target n1`) — a re-genesis wipes it, and a broken demo discovered later is far more expensive than doing this now
+- [~] T059 [US4] ~~Mint a fresh genesis with the updated ceremony (slot-100 attestations)~~ — **not required.** The node already holds the key behind the Owner attestation (recovered from the ceremony mnemonic as a system wallet); only the signer-resolution path was missing. Revisit only if the ceremony's key layout is changed for some other reason.
+- [~] T060 [US4] ~~Re-genesis n1 within the 1-hour `VAL_TIME_002` window; bring tiny up on the same network~~ — **not required** (follows T059). The trust anchor is untouched.
+- [~] T061 [US4] ~~Re-provision the AIAS demo immediately~~ — **not required** (follows T060): with no re-genesis the demo is never wiped. Still re-run `rehearse.ps1 -Target n1` after the transfer seals, as a regression check that governing the SSR did not disturb it.
 - [ ] T062 [US4] 🔴 **LIVE GATE** Transfer system register ownership through the governance process; confirm the record replicates to tiny
 - [ ] T063 [US4] 🔴 **LIVE GATE** Confirm the former owner can no longer govern and the new owner can
 

--- a/src/Services/Sorcha.Register.Service/Services/GovernanceSigningService.cs
+++ b/src/Services/Sorcha.Register.Service/Services/GovernanceSigningService.cs
@@ -6,6 +6,8 @@ using System.Text;
 using Sorcha.Register.Core.Services;
 using Sorcha.Register.Models;
 using Sorcha.Register.Models.Enums;
+using Microsoft.Extensions.Options;
+using Sorcha.ServiceClients.SystemWallet;
 using Sorcha.ServiceClients.Wallet;
 using Sorcha.Wallet.Contracts.Constants;
 
@@ -58,12 +60,18 @@ public interface IGovernanceSigningService
         CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Signs an already-computed digest as a roster organisation, at slot 100.
+    /// Signs an already-computed digest as a roster organisation.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// Used where the signed bytes are not a transaction digest — notably a governance
     /// <b>approval</b>, which commits to
     /// <see cref="GovernanceApprovalStatement"/> rather than to a transaction id and payload hash.
+    /// </para>
+    /// <para>
+    /// Signs at slot 100 for an ordinary organisation. The system register's ceremony-minted Owner
+    /// is the one exception — its attestation records the slot-102 docket-signing key (US4).
+    /// </para>
     /// </remarks>
     Task<GovernanceSignResult> SignDigestAsync(
         string registerId,
@@ -97,17 +105,30 @@ public class GovernanceSigningService : IGovernanceSigningService
     /// <summary>Prefix of a wallet-bearing roster subject.</summary>
     private const string WalletDidPrefix = "did:sorcha:w:";
 
+    /// <summary>
+    /// Prefix of the system register's ceremony-minted Owner subject (US4).
+    /// </summary>
+    /// <remarks>
+    /// Deliberately a distinct constant rather than a general "unknown DID method" fallback. This is
+    /// one subject, on one register, produced by one offline ceremony, and it stops existing the
+    /// moment ownership transfers away from it.
+    /// </remarks>
+    private const string GenesisDidPrefix = "did:sorcha:genesis:";
+
     private readonly IGovernanceRosterService _rosterService;
     private readonly IWalletServiceClient _walletClient;
+    private readonly SystemWalletSigningOptions _systemWallet;
     private readonly ILogger<GovernanceSigningService> _logger;
 
     public GovernanceSigningService(
         IGovernanceRosterService rosterService,
         IWalletServiceClient walletClient,
+        IOptions<SystemWalletSigningOptions> systemWallet,
         ILogger<GovernanceSigningService> logger)
     {
         _rosterService = rosterService ?? throw new ArgumentNullException(nameof(rosterService));
         _walletClient = walletClient ?? throw new ArgumentNullException(nameof(walletClient));
+        _systemWallet = (systemWallet ?? throw new ArgumentNullException(nameof(systemWallet))).Value;
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -149,26 +170,58 @@ public class GovernanceSigningService : IGovernanceSigningService
                 $"Register {registerId} has no roster member with a governance role (Owner or Admin)" +
                 (preferredSubject is null ? "." : $" matching subject '{preferredSubject}'."));
 
-        var walletAddress = ExtractWalletAddress(attestation.Subject)
-            ?? throw new InvalidOperationException(
-                $"Roster subject '{attestation.Subject}' on register {registerId} carries no wallet " +
-                $"address (expected '{WalletDidPrefix}{{address}}'), so there is no key to sign with. " +
-                "The system register's ceremony-minted subject has this shape and is not governable " +
-                "by this path.");
+        // US4 - the system register's ceremony-minted Owner. Its subject carries no wallet address, so
+        // the ordinary path below could not reach a key and the SSR was ungovernable: a propose
+        // returned "carries no wallet address ... so there is no key to sign with".
+        //
+        // The obstacle was only ever the SUBJECT's shape. The ceremony derives every key from one
+        // BIP39 mnemonic, the Owner attestation records the slot-102 sorcha:docket-signing key, and
+        // `sorcha system-register import-validator-key` recovers that mnemonic into a system wallet -
+        // so this node already holds the key, and it is the same wallet the validator seals dockets
+        // with. Nothing needed re-minting; there was simply no path that reached it.
+        var (walletAddress, derivationPath) = IsGenesisSubject(attestation.Subject)
+            ? (await _walletClient.CreateOrRetrieveSystemWalletAsync(_systemWallet.ValidatorId, cancellationToken),
+               SorchaDerivationPaths.DocketSigning)
+            : (ExtractWalletAddress(attestation.Subject)
+                   ?? throw new InvalidOperationException(
+                       $"Roster subject '{attestation.Subject}' on register {registerId} carries no wallet " +
+                       $"address (expected '{WalletDidPrefix}{{address}}'), so there is no key to sign with."),
+               // Slot 100 - the organisation's governance key, and the key its roster attestation
+               // records. Signing with the wallet's primary key here reproduces the original defect.
+               SorchaDerivationPaths.RegisterAttestation);
 
         var signResult = await _walletClient.SignTransactionAsync(
             walletAddress,
             digest,
-            // Slot 100 — the organisation's governance key, and the key its roster attestation
-            // records. Signing with the wallet's primary key here reproduces the original defect.
-            SorchaDerivationPaths.RegisterAttestation,
+            derivationPath,
             isPreHashed: true,
             cancellationToken);
 
+        // The signature is worthless unless its key is the one the roster records — the Validator
+        // checks exactly that, and a mismatch surfaces as an opaque authorisation failure a long way
+        // from the cause. Checked on the GENESIS path specifically, because that is the one where the
+        // wallet is resolved from CONFIGURATION rather than from the subject itself: a misconfigured
+        // SystemWalletSigning:ValidatorId is the single thing that can silently point this at a
+        // different, perfectly valid wallet.
+        //
+        // Deliberately not applied to the wallet-DID path. There the address is derived from the
+        // subject, so it cannot drift the same way, and making this a blanket check would be a
+        // behaviour change to every governance signature on the platform — worth considering, but on
+        // its own evidence rather than smuggled in beside a US4 fix.
+        if (IsGenesisSubject(attestation.Subject)
+            && !GovernanceKeyMatcher.Matches(attestation.PublicKey, Convert.ToBase64String(signResult.PublicKey)))
+        {
+            throw new InvalidOperationException(
+                $"Signed as '{attestation.Subject}' on register {registerId} using wallet {walletAddress} " +
+                $"at {derivationPath}, but the resulting key is not the one the roster records for that " +
+                "subject, so the Validator would refuse it. For the system register this almost always " +
+                "means SystemWalletSigning:ValidatorId does not match the validator whose key the " +
+                "genesis ceremony minted.");
+        }
+
         _logger.LogInformation(
             "Governance digest on register {RegisterId} signed as {Subject} (role {Role}) using wallet {Wallet} at {Path}",
-            registerId, attestation.Subject, attestation.Role, walletAddress,
-            SorchaDerivationPaths.RegisterAttestation);
+            registerId, attestation.Subject, attestation.Role, walletAddress, derivationPath);
 
         return new GovernanceSignResult
         {
@@ -189,6 +242,19 @@ public class GovernanceSigningService : IGovernanceSigningService
     /// User Story 1 covers. Consortium registers pass <c>preferredSubject</c> so each organisation
     /// signs its own approval — one authority per signature, never one node signing for everyone.
     /// </remarks>
+    /// <summary>
+    /// Whether this is the system register's ceremony-minted Owner (US4).
+    /// </summary>
+    /// <remarks>
+    /// Expected to become dead code: the first governance act on the system register transfers
+    /// ownership to a real <c>did:sorcha:w:</c> organisation, after which this subject is off the
+    /// roster and nothing reaches this branch again. Kept keyed on the prefix rather than generalised
+    /// into "governance may sign at any derivation path", which would let a future subject quietly
+    /// sign with a key its attestation does not record.
+    /// </remarks>
+    private static bool IsGenesisSubject(string? subject)
+        => subject?.StartsWith(GenesisDidPrefix, StringComparison.Ordinal) == true;
+
     private static RegisterAttestation? SelectSigner(AdminRoster roster, string? preferredSubject)
     {
         var eligible = roster.ControlRecord.Attestations

--- a/tests/Sorcha.Register.Service.Tests/Unit/GovernanceSigningServiceTests.cs
+++ b/tests/Sorcha.Register.Service.Tests/Unit/GovernanceSigningServiceTests.cs
@@ -3,7 +3,9 @@
 
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Moq;
+using Sorcha.ServiceClients.SystemWallet;
 using Sorcha.Register.Core.Services;
 using Sorcha.Register.Models;
 using Sorcha.Register.Models.Enums;
@@ -23,6 +25,11 @@ public class GovernanceSigningServiceTests
     private const string RegisterId = "abc123def456abc123def456abc123de";
     private const string OwnerWallet = "ws11qowner00000000000000000000000000000000000000000000000000";
     private const string AdminWallet = "ws11qadmin00000000000000000000000000000000000000000000000000";
+
+    /// <summary>The system register's ceremony-minted Owner subject (US4). Carries no wallet address.</summary>
+    private const string GenesisSubject = "did:sorcha:genesis:a3dd941ff5c9cd5a7c0fe16d9b5e08ca";
+    private const string ValidatorId = "local-validator";
+    private const string SystemWallet = "ws11qsystem0000000000000000000000000000000000000000000000000";
 
     private readonly Mock<IGovernanceRosterService> _rosterMock = new();
     private readonly Mock<IWalletServiceClient> _walletMock = new();
@@ -54,8 +61,16 @@ public class GovernanceSigningServiceTests
                 SignedBy = OwnerWallet
             });
 
+        _walletMock
+            .Setup(x => x.CreateOrRetrieveSystemWalletAsync(
+                It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SystemWallet);
+
         _sut = new GovernanceSigningService(
-            _rosterMock.Object, _walletMock.Object, Mock.Of<ILogger<GovernanceSigningService>>());
+            _rosterMock.Object,
+            _walletMock.Object,
+            Options.Create(new SystemWalletSigningOptions { ValidatorId = ValidatorId }),
+            Mock.Of<ILogger<GovernanceSigningService>>());
     }
 
     private void SetRoster(params (string subject, RegisterRole role)[] members)
@@ -81,6 +96,122 @@ public class GovernanceSigningServiceTests
                 },
                 ControlTransactionCount = 1
             });
+    }
+
+    // ---- US4: the system register's ceremony-minted Owner ---------------------------------------
+
+    /// <summary>
+    /// Sets a roster whose attestation public key is the one the wallet mock actually returns, so a
+    /// signature produced through it genuinely matches what the roster records.
+    /// </summary>
+    /// <remarks>
+    /// The shared <see cref="SetRoster"/> uses a zeroed placeholder key, which is fine for the tests
+    /// that only assert which derivation path was used — but the genesis path asserts the resulting
+    /// key IS the roster's, so it needs a fixture where that can actually be true.
+    /// </remarks>
+    private void SetGenesisRoster(byte[]? attestationKey = null)
+    {
+        _rosterMock.Setup(x => x.GetCurrentRosterAsync(RegisterId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AdminRoster
+            {
+                RegisterId = RegisterId,
+                ControlRecord = new RegisterControlRecord
+                {
+                    RegisterId = RegisterId,
+                    Name = "System Register",
+                    CreatedAt = DateTimeOffset.UtcNow,
+                    Attestations =
+                    [
+                        new RegisterAttestation
+                        {
+                            Role = RegisterRole.Owner,
+                            Subject = GenesisSubject,
+                            // What the ceremony records: the slot-102 docket-signing key.
+                            PublicKey = Convert.ToBase64String(attestationKey ?? [5, 6, 7, 8]),
+                            Signature = string.Empty,
+                            Algorithm = SignatureAlgorithm.ED25519,
+                            GrantedAt = DateTimeOffset.UtcNow
+                        }
+                    ]
+                },
+                ControlTransactionCount = 1
+            });
+    }
+
+    /// <summary>
+    /// The system register is governable: its ceremony-minted Owner resolves to the node's system
+    /// wallet and signs at <c>sorcha:docket-signing</c>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Before this, a propose against the system register threw — "carries no wallet address … so
+    /// there is no key to sign with" — because the subject is <c>did:sorcha:genesis:{fingerprint}</c>
+    /// and the resolver only understood <c>did:sorcha:w:{address}</c>.
+    /// </para>
+    /// <para>
+    /// The key was never missing. The ceremony derives everything from one BIP39 mnemonic and records
+    /// the <b>slot-102</b> key on the Owner attestation; `import-validator-key` recovers that mnemonic
+    /// into the system wallet, which is the same wallet the validator seals dockets with. So the fix
+    /// is a resolution path, not a re-genesis — which is what keeps the trust anchor untouched.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public async Task SignAsync_ForTheGenesisSubject_UsesTheSystemWalletAtDocketSigning()
+    {
+        SetGenesisRoster();
+
+        await _sut.SignAsync(RegisterId, "tx-1", "hash-1");
+
+        _capturedWallet.Should().Be(SystemWallet,
+            "the ceremony subject carries no address, so the wallet comes from the configured validator id");
+        _capturedDerivationPath.Should().Be(SorchaDerivationPaths.DocketSigning,
+            "slot 102 is the key the ceremony recorded on the Owner attestation — slot 100 would "
+            + "produce a signature the Validator refuses");
+        _capturedPreHashed.Should().BeTrue();
+    }
+
+    /// <summary>
+    /// The genesis branch is confined to the genesis subject: an ordinary organisation still signs at
+    /// slot 100 from its own wallet.
+    /// </summary>
+    /// <remarks>
+    /// Without this, the fix would be indistinguishable from "governance may sign at any derivation
+    /// path", which would let any subject sign with a key its attestation does not record.
+    /// </remarks>
+    [Fact]
+    public async Task SignAsync_ForAnOrdinarySubject_IsUnchangedByTheGenesisBranch()
+    {
+        SetRoster(($"did:sorcha:w:{OwnerWallet}", RegisterRole.Owner));
+
+        await _sut.SignAsync(RegisterId, "tx-1", "hash-1");
+
+        _capturedWallet.Should().Be(OwnerWallet, "the address comes from the subject, not from config");
+        _capturedDerivationPath.Should().Be(SorchaDerivationPaths.RegisterAttestation);
+    }
+
+    /// <summary>
+    /// A signature whose key is not the one the roster records is refused here, not left for the
+    /// Validator to reject opaquely.
+    /// </summary>
+    /// <remarks>
+    /// The genesis path resolves its wallet from <c>SystemWalletSigning:ValidatorId</c> rather than
+    /// from the subject, so a misconfigured id silently selects a different — perfectly valid —
+    /// wallet. The signature then fails authorisation far from the cause, and the message names the
+    /// roster rather than the configuration. This turns that into a diagnosable failure at the point
+    /// the wrong key is produced.
+    /// </remarks>
+    [Fact]
+    public async Task SignAsync_ForTheGenesisSubject_RefusesAKeyTheRosterDoesNotRecord()
+    {
+        // The wallet mock returns [5,6,7,8]; the roster records something else — the shape a
+        // mismatched ValidatorId produces.
+        SetGenesisRoster(attestationKey: [9, 9, 9, 9]);
+
+        var act = async () => await _sut.SignAsync(RegisterId, "tx-1", "hash-1");
+
+        (await act.Should().ThrowAsync<InvalidOperationException>())
+            .WithMessage("*SystemWalletSigning:ValidatorId*",
+                "the message must name the configuration that is actually wrong");
     }
 
     [Fact]
@@ -174,17 +305,36 @@ public class GovernanceSigningServiceTests
             It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
+    /// <summary>
+    /// A subject in a shape the resolver does not understand still fails clearly.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>This test used to pin the opposite claim, for <c>did:sorcha:genesis:</c> specifically</b> —
+    /// that the system register's ceremony-minted subject had no key to sign with, which was true and
+    /// was why US4 existed. US4 resolved it (see
+    /// <see cref="SignAsync_ForTheGenesisSubject_UsesTheSystemWalletAtDocketSigning"/>), so keeping
+    /// that assertion would have pinned a limitation the platform no longer has.
+    /// </para>
+    /// <para>
+    /// The half worth keeping is that the resolver is a closed set: exactly two subject shapes are
+    /// understood, and anything else fails loudly rather than falling through to some default wallet.
+    /// That is what stops the US4 branch from generalising into "governance may sign as anything".
+    /// </para>
+    /// </remarks>
     [Fact]
-    public async Task SignAsync_GenesisStyleSubjectWithNoWalletAddress_ThrowsClearly()
+    public async Task SignAsync_SubjectInAnUnrecognisedShape_ThrowsClearly()
     {
-        // The system register's ceremony mints did:sorcha:genesis:{fingerprint}, not a wallet DID,
-        // so there is no key this path can sign with. That is why transferring system-register
-        // ownership is deferred to US4 rather than assumed to work.
-        SetRoster(("did:sorcha:genesis:60d8be0f8846aa31142cd39e928910eb", RegisterRole.Owner));
+        SetRoster(("did:example:not-a-shape-this-resolver-knows", RegisterRole.Owner));
 
         var act = () => _sut.SignAsync(RegisterId, "tx-1", "hash-1");
 
         (await act.Should().ThrowAsync<InvalidOperationException>())
             .WithMessage("*carries no wallet address*");
+
+        _walletMock.Verify(x => x.SignTransactionAsync(
+            It.IsAny<string>(), It.IsAny<byte[]>(), It.IsAny<string?>(),
+            It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Never,
+            "an unrecognised subject must not quietly sign with somebody else's wallet");
     }
 }


### PR DESCRIPTION
Implements **US4**. The system register is now governable — **with no re-genesis**, so n1, tiny and the AIAS demo are untouched.

## The finding

A propose against the SSR threw *"carries no wallet address … so there is no key to sign with"*, because its Owner subject is `did:sorcha:genesis:{fingerprint}` and the resolver understood only `did:sorcha:w:{address}`. T059/T060/T061 assumed that meant re-minting the genesis and re-genesising both nodes.

**It did not.** The ceremony derives every key from one BIP39 mnemonic; the Owner attestation records the **slot-102** `sorcha:docket-signing` key (not slot 101, as the T007 note implies); and `sorcha system-register import-validator-key` recovers that mnemonic into a system wallet — the same wallet the validator seals every docket with. **The node already held the key.** Only the subject's shape was in the way.

## The change

`GovernanceSigningService` resolves a `did:sorcha:genesis:` subject to the system wallet (via the configured `SystemWalletSigning:ValidatorId`) and signs at `DocketSigning`, already on that service's whitelist. The signature then matches the roster's recorded Owner key, so `RightsEnforcementService` accepts it unchanged. The trust anchor is never touched.

**Confined deliberately** — keyed on the prefix, not generalised into "governance may sign at any derivation path", which would let a future subject quietly sign with a key its attestation does not record. It is expected to become dead code: the first governance act on the SSR transfers ownership to a real `did:sorcha:w:` organisation, after which the subject is off the roster.

**One guard added.** The genesis path resolves its wallet from *configuration* rather than from the subject, so a mismatched `ValidatorId` would silently select a different-but-valid wallet and produce a signature the Validator refuses far from the cause. The resulting key must be the one the roster records, and the message names the configuration. Scoped to the genesis path — making it blanket is a behaviour change to every governance signature, worth doing on its own evidence rather than smuggled in here.

## A test that pinned the wrong thing

`SignAsync_GenesisStyleSubjectWithNoWalletAddress_ThrowsClearly` pinned exactly the limitation this removes, so keeping it would have pinned a limitation the platform no longer has. Repurposed to the half still worth having: the resolver is a **closed set** of two subject shapes, and anything else fails loudly rather than falling through to some default wallet.

## Verification

Mutation-tested: signing the genesis path at slot 100 instead of slot 102 reds `SignAsync_ForTheGenesisSubject_UsesTheSystemWalletAtDocketSigning` **and nothing else**.

Register.Service: **424 passed, 0 failed.**

## Still to do (live, after this deploys)

- **T062** 🔴 transfer SSR ownership through governance; confirm it replicates to tiny
- **T063** 🔴 confirm the former owner can no longer govern and the new owner can
- **T058** the unit half of T063
- Re-run `rehearse.ps1 -Target n1` afterwards as a regression check

T059/T060/T061 are struck in `tasks.md` with their reasons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013FAcr5HQSGN69eMT4Apm2b