### PR TITLE
fix+test: [189 US4/T058] - IOptions<> handed back a default-constructed options with no validator id

### DIFF
--- a/src/Services/Sorcha.Register.Service/Services/GovernanceSigningService.cs
+++ b/src/Services/Sorcha.Register.Service/Services/GovernanceSigningService.cs
@@ -6,7 +6,6 @@ using System.Text;
 using Sorcha.Register.Core.Services;
 using Sorcha.Register.Models;
 using Sorcha.Register.Models.Enums;
-using Microsoft.Extensions.Options;
 using Sorcha.ServiceClients.SystemWallet;
 using Sorcha.ServiceClients.Wallet;
 using Sorcha.Wallet.Contracts.Constants;
@@ -123,12 +122,17 @@ public class GovernanceSigningService : IGovernanceSigningService
     public GovernanceSigningService(
         IGovernanceRosterService rosterService,
         IWalletServiceClient walletClient,
-        IOptions<SystemWalletSigningOptions> systemWallet,
+        SystemWalletSigningOptions systemWallet,
         ILogger<GovernanceSigningService> logger)
     {
         _rosterService = rosterService ?? throw new ArgumentNullException(nameof(rosterService));
         _walletClient = walletClient ?? throw new ArgumentNullException(nameof(walletClient));
-        _systemWallet = (systemWallet ?? throw new ArgumentNullException(nameof(systemWallet))).Value;
+        // The CONCRETE options, not IOptions<>. AddSystemWalletSigning registers this type as a bare
+        // singleton instance (services.AddSingleton(options)), so IOptions<SystemWalletSigningOptions>
+        // silently resolves a DEFAULT-constructed one whose ValidatorId is null — and a null validator
+        // id makes the Wallet Service hand back the 'default-validator' wallet, which is a real,
+        // healthy, entirely wrong wallet. Caught live by the roster-key guard below.
+        _systemWallet = systemWallet ?? throw new ArgumentNullException(nameof(systemWallet));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 

--- a/tests/Sorcha.Register.Service.Tests/Unit/GovernanceSigningServiceTests.cs
+++ b/tests/Sorcha.Register.Service.Tests/Unit/GovernanceSigningServiceTests.cs
@@ -3,7 +3,6 @@
 
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 using Moq;
 using Sorcha.ServiceClients.SystemWallet;
 using Sorcha.Register.Core.Services;
@@ -69,7 +68,7 @@ public class GovernanceSigningServiceTests
         _sut = new GovernanceSigningService(
             _rosterMock.Object,
             _walletMock.Object,
-            Options.Create(new SystemWalletSigningOptions { ValidatorId = ValidatorId }),
+            new SystemWalletSigningOptions { ValidatorId = ValidatorId },
             Mock.Of<ILogger<GovernanceSigningService>>());
     }
 
@@ -99,6 +98,41 @@ public class GovernanceSigningServiceTests
     }
 
     // ---- US4: the system register's ceremony-minted Owner ---------------------------------------
+
+    /// <summary>
+    /// The options must be taken as the CONCRETE type, because that is the only registration that
+    /// actually carries a validator id.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>This is a live defect, caught on n1, written down so it cannot come back.</b>
+    /// <c>AddSystemWalletSigning</c> registers a bare instance —
+    /// <c>services.AddSingleton(options)</c> — not <c>Configure&lt;T&gt;</c>. Asking for
+    /// <c>IOptions&lt;SystemWalletSigningOptions&gt;</c> therefore resolves a <b>default-constructed</b>
+    /// one whose <c>ValidatorId</c> is null. <c>required</c> is a compile-time promise about object
+    /// initialisers; it does not make the options system produce a configured instance.
+    /// </para>
+    /// <para>
+    /// The consequence was invisible rather than loud: a null validator id makes the Wallet Service
+    /// hand back the <c>default-validator</c> wallet, which exists, is healthy, and is entirely the
+    /// wrong key. Only the roster-key guard turned it into a diagnosable failure instead of a
+    /// signature the Validator would refuse for reasons naming neither cause.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public void TheServiceTakesTheConcreteOptions_NotIOptions()
+    {
+        var parameter = typeof(GovernanceSigningService)
+            .GetConstructors()
+            .Single()
+            .GetParameters()
+            .Single(p => p.ParameterType.Name.Contains("SystemWalletSigningOptions"));
+
+        parameter.ParameterType.Should().Be<SystemWalletSigningOptions>(
+            "AddSystemWalletSigning registers a bare singleton, so IOptions<> resolves a "
+            + "default-constructed instance with a null ValidatorId — and a null validator id "
+            + "silently selects the wrong system wallet");
+    }
 
     /// <summary>
     /// Sets a roster whose attestation public key is the one the wallet mock actually returns, so a
@@ -212,6 +246,39 @@ public class GovernanceSigningServiceTests
         (await act.Should().ThrowAsync<InvalidOperationException>())
             .WithMessage("*SystemWalletSigning:ValidatorId*",
                 "the message must name the configuration that is actually wrong");
+    }
+
+    /// <summary>
+    /// T058 — once ownership transfers away, the ceremony subject cannot sign again.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The genesis branch is reached only for an attestation the roster actually carries, because
+    /// <c>SelectSigner</c> runs first. That ordering is the whole safety of it: a subject removed by
+    /// a transfer simply stops being selectable, and the branch never fires.
+    /// </para>
+    /// <para>
+    /// Worth pinning rather than assuming. Had the implementation matched on the subject before
+    /// consulting the roster — the obvious shortcut, since the subject is a constant — a former owner
+    /// would go on signing with the node's system wallet forever, and the transfer that US4 exists to
+    /// perform would change nothing.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public async Task SignAsync_AfterTransfer_TheFormerGenesisOwnerCanNoLongerSign()
+    {
+        // The roster as it stands after the transfer: a real organisation, no ceremony subject.
+        SetRoster(($"did:sorcha:w:{OwnerWallet}", RegisterRole.Owner));
+
+        var act = () => _sut.SignDigestAsync(RegisterId, [1, 2, 3], preferredSubject: GenesisSubject);
+
+        (await act.Should().ThrowAsync<InvalidOperationException>())
+            .WithMessage("*governance role*",
+                "the former owner is not on the roster, so there is no authority to sign as");
+
+        _walletMock.Verify(x => x.CreateOrRetrieveSystemWalletAsync(
+            It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never,
+            "a subject that is off the roster must never reach the system wallet");
     }
 
     [Fact]

--- a/tests/Sorcha.Validator.Service.Tests/Services/RightsEnforcementServiceTests.cs
+++ b/tests/Sorcha.Validator.Service.Tests/Services/RightsEnforcementServiceTests.cs
@@ -1020,6 +1020,66 @@ public class RightsEnforcementServiceTests
         result.Errors.Should().NotContain(e => e.Message.Contains("expired"));
     }
 
+    /// <summary>
+    /// T058 / US4 — after the system register's ownership transfers, the ceremony key is refused.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This is the acceptance property of US4 stated at the enforcement gate rather than at the
+    /// signing one. The signing side can only decline to *produce* a signature; the Validator is what
+    /// decides whether one already produced is authorised — and it is the side that runs on every
+    /// node, including nodes that never saw the transfer submitted.
+    /// </para>
+    /// <para>
+    /// It is deliberately the same shape as
+    /// <see cref="ValidateGovernanceRightsAsync_RemovedAdminResubmits_Rejected"/>, and that is the
+    /// point: once the transfer seals, the ceremony subject is an ordinary ex-member with no standing
+    /// left. Nothing about its origin as the genesis key survives the roster change.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public async Task AfterOwnershipTransfers_TheCeremonyKeyIsNoLongerAuthorised()
+    {
+        // The system register after the transfer: a real organisation holds it.
+        var roster = RosterWithControlTx("control-tx-after-transfer",
+            (AdminPublicKey, RegisterRole.Owner, "did:sorcha:w:owner1"));
+        _rosterServiceMock.Setup(r => r.GetCurrentRosterAsync("test-register", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(roster);
+
+        // The former owner — the ceremony's slot-102 key — tries to govern anyway.
+        var result = await _service.ValidateGovernanceRightsAsync(
+            CreateGovernanceTransaction(OwnerPublicKey));
+
+        result.IsValid.Should().BeFalse(
+            "the ceremony key governed the system register only until it handed it over");
+        result.Errors.Should().Contain(e => e.Code == "VAL_PERM_002");
+    }
+
+    /// <summary>
+    /// The counterfactual: the SAME key IS authorised while it is still the owner.
+    /// </summary>
+    /// <remarks>
+    /// Without this the test above would pass just as well if the key had never been able to govern
+    /// at all — which was in fact the state before US4, and is exactly the confusion to avoid.
+    /// </remarks>
+    [Fact]
+    public async Task BeforeOwnershipTransfers_TheCeremonyKeyIsAuthorised()
+    {
+        var roster = RosterWithControlTx("control-tx-genesis",
+            (OwnerPublicKey, RegisterRole.Owner, "did:sorcha:genesis:a3dd941ff5c9cd5a7c0fe16d9b5e08ca"));
+        _rosterServiceMock.Setup(r => r.GetCurrentRosterAsync("test-register", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(roster);
+        _rosterServiceMock.Setup(r => r.ValidateProposal(roster, It.IsAny<GovernanceOperation>()))
+            .Returns(GovernanceValidationResult.Success());
+
+        var result = await _service.ValidateGovernanceRightsAsync(
+            CreateGovernanceTransaction(OwnerPublicKey));
+
+        result.Errors.Should().NotContain(e => e.Code == "VAL_PERM_002",
+            "the ceremony subject is a roster member like any other while it holds the register — "
+            + "the Validator never cared about the subject's DID method, only about the key");
+    }
+
     [Fact] // FR-024
     public async Task RemovingTheLastGoverningMember_IsRefused()
     {


### PR DESCRIPTION
## Summary
- T058 (US4 unit half): after an SSR ownership transfer, the former owner's governance attempt is refused — plus the fix the test surfaced.
- `AddSystemWalletSigning` registered a bare `services.AddSingleton(options)` instance, not `Configure<T>`, so injecting `IOptions<SystemWalletSigningOptions>` resolved a **default-constructed** instance with `ValidatorId == null`. The Wallet Service then silently handed back the `default-validator` wallet — healthy, valid, and the wrong key.
- The roster-match guard added with US4 (#1396) is what made this surface as a diagnosable error instead of a far-away signature refusal.

## Test plan
- Unit tests in the commit (former-owner refusal + options resolution)
- CI full build-and-test

Part of Feature 189 (`specs/189-org-signed-governance/`). Remaining live gates T062/T063 tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)