### PR TITLE
docs: SECURITY.md, maturity/limitations page, llms.txt refresh + AGENTS.md (WS1/WS2/WS4)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,55 @@
+# AGENTS.md
+
+Entry point for an autonomous coding agent or AI assistant working in this repository. Read
+this first, in order.
+
+## 1. Know what you're working with
+
+- [`llms.txt`](llms.txt) — one-screen factual summary of what Sorcha is and what it implements.
+- [`docs/reference/maturity-and-limitations.md`](docs/reference/maturity-and-limitations.md) —
+  what's production-shaped versus demo-grade, and named limitations you need to know before you
+  test anything (governance-key custody, rate limiting, replication requiring an explicit
+  subscription, the shared/wipe-able `n1.sorcha.dev` sandbox). Read this before you draw
+  conclusions from a live node's behaviour.
+- [`STANDARDS.md`](STANDARDS.md) — the standards this platform implements, with a `full` /
+  `partial` / `planned` status per row and a code path for every `full`/`partial` claim.
+
+## 2. Set up and run it
+
+- [`docs/quickstart.md`](docs/quickstart.md) — agent-runnable setup against a clean Docker host.
+  Every prerequisite, every documented failure mode with its fix, and a verify-installation
+  `curl`. Prefer this over improvising a setup sequence.
+- [`README.md`](README.md) — capability overview, blueprint example, architecture diagram, and
+  the one-line installer if you're not driving setup yourself.
+
+## 3. Act on a running instance via MCP
+
+- [`docs/mcp-server.md`](docs/mcp-server.md) — connect via the Model Context Protocol (stdio or
+  Streamable HTTP), how to obtain a JWT, and the three role-scoped tool slices (admin / designer
+  / participant). This is the preferred way for an agent to drive the platform rather than
+  hand-rolling REST calls.
+- `GET /.well-known/mcp.json` on a running gateway — the live manifest (transports,
+  authentication, tool catalogue link).
+- `GET /.well-known/openapi.json` on a running gateway — the full aggregated REST/gRPC surface,
+  if you need to call an endpoint no MCP tool wraps yet.
+
+## 4. If you're changing code, not just using the platform
+
+- [`CLAUDE.md`](CLAUDE.md) — architectural conventions, critical patterns, and the DO / DON'T
+  list. Read this before editing service code, even if you were spawned by a different tool.
+- [`CONTRIBUTING.md`](CONTRIBUTING.md) — branch/PR workflow, commit conventions, and how changes
+  land.
+- [`SECURITY.md`](SECURITY.md) — if you find something that looks like a vulnerability, report it
+  through GitHub private vulnerability reporting, not a public issue.
+
+## Ground rules
+
+- Treat `n1.sorcha.dev` as a shared public sandbox: no real secrets, no expectation of privacy or
+  durability, and it is reset periodically. See the maturity page above before relying on
+  anything you observe there.
+- A green test suite is not the same as live-verified behaviour on this platform — several
+  documented defects were only found by executing a flow end-to-end against a real deployment,
+  not by unit tests. Prefer verifying a claim by running it over trusting a comment or a doc that
+  hasn't been re-checked recently.
+- Don't invent standards compliance. If you're describing what Sorcha implements, cite a row in
+  `STANDARDS.md` with status `full` or `partial` — a `planned` row is not yet true.

--- a/README.md
+++ b/README.md
@@ -305,6 +305,7 @@ A map of the top-level directories — enough to orient a newcomer. For a full s
 | [Architecture](docs/architecture.md) | System design and data flows |
 | [Deployment Guide](docs/guides/DEPLOYMENT.md) | Production deployment |
 | [Troubleshooting](docs/guides/TROUBLESHOOTING.md) | Common issues and solutions |
+| [What's Real vs Demo](docs/reference/maturity-and-limitations.md) | Maturity posture and known limitations before you test |
 
 ## Walkthroughs
 

--- a/README.md
+++ b/README.md
@@ -344,6 +344,7 @@ MIT License — see [LICENSE](LICENSE) for details.
 - [GitHub Issues](https://github.com/Sorcha-Platform/Sorcha/issues)
 - [GitHub Discussions](https://github.com/Sorcha-Platform/Sorcha/discussions)
 - [Contributing Guide](CONTRIBUTING.md)
+- [Security Policy](SECURITY.md)
 - [Changelog](CHANGELOG.md)
 
 ---

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,77 @@
+# Security Policy
+
+Sorcha is pre-release software. This document explains what's in scope for a security report, how to
+report a vulnerability responsibly, and what to expect once you do.
+
+## Supported scope
+
+Sorcha is **pre-release demo software** — hardening toward production, not yet production-hardened.
+There is no supported release branch with a backport policy; `master` is the only line that receives
+fixes.
+
+**`n1.sorcha.dev` is a shared public sandbox, not a production deployment.** It exists so anyone can
+try the platform without standing up their own stack. Specifically:
+
+- **Do not run production secrets, real personal data, or anything sensitive against n1.** Treat every
+  credential, wallet, and register you create there as disposable.
+- **Do not treat data on n1 as private.** Other testers — and the maintainer, for operational reasons —
+  can see it. n1 is periodically wiped and re-genesised; nothing there is durable.
+- Findings that only affect n1's *operational* state (e.g. "the demo data looks stale") are not security
+  reports — open a regular issue instead.
+
+Findings that **are** in scope: anything that lets one participant read, alter, or destroy data they are
+not authorised to; anything that breaks the DAD guarantees (Disclosure / Alteration / Destruction)
+described in [`docs/security-model.md`](docs/security-model.md); authentication or authorization
+bypasses; signing-key or secret exposure; and supply-chain issues in the platform's own code or
+dependencies.
+
+## Reporting a vulnerability
+
+**Preferred channel: GitHub private vulnerability reporting.**
+
+Go to the repository's **Security** tab → **Report a vulnerability**
+(<https://github.com/Sorcha-Platform/Sorcha/security/advisories/new>). This opens a private draft
+security advisory visible only to you and the maintainer — nothing is public until a fix is ready and
+you and the maintainer agree to disclose.
+
+Please do **not** open a public GitHub issue for a suspected vulnerability. Use the private advisory
+flow above so the report isn't visible to other users before there's a fix.
+
+<!-- MAINTAINER: confirm/enable private vulnerability reporting in repo settings, or add a disclosure email here -->
+
+### What to include
+
+- What you found and why it matters (which DAD guarantee it breaks, what an attacker gains).
+- Steps to reproduce — ideally against a throwaway register/org on n1 or a local Docker stack, not
+  against real data.
+- Any relevant logs, request/response payloads, or a minimal script.
+
+A strong example of the kind of report that's valuable here is issue **#1397** — an external,
+internet-reachable signing oracle found via live probing rather than unit tests. Reports that show the
+issue actually being exploitable (not just theoretically possible) are the most useful.
+
+## Response expectations
+
+This is a small, mostly solo-maintained project. Response is **best-effort**, not SLA-backed:
+
+- Acknowledgement: typically within a few days.
+- Triage and a rough sense of severity/timeline: typically within a week or two, depending on
+  complexity.
+- Fix timeline depends on severity and what else is in flight — a critical, actively-exploitable issue
+  gets prioritised over everything else; a lower-severity design gap may be tracked as an issue and
+  fixed on the normal development cadence.
+
+If you haven't heard back in two weeks, it's fine to follow up on the same advisory thread.
+
+## Disclosure
+
+Coordinated disclosure is the default: please give the maintainer a reasonable window to ship a fix
+before any public write-up. Once a fix is released, the advisory is published (with credit, if you want
+it) so other users understand what changed and why.
+
+## See also
+
+- [`docs/security-model.md`](docs/security-model.md) — the platform's cryptographic evidence model and
+  its honestly-named gaps (including known ones like [#1380](https://github.com/Sorcha-Platform/Sorcha/issues/1380)).
+- [`docs/reference/maturity-and-limitations.md`](docs/reference/maturity-and-limitations.md) — what's
+  production-shaped versus demo-grade right now.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -47,7 +47,9 @@ Seven services, each with a single responsibility:
 - **Tenant** — multi-tenant authentication, JWT issuance, OAuth 2.0, role-based access
   control, platform-org topology, Participant Identity, register invitations.
 - **HAIP Service** — the wire boundary to the OpenID4VC wallet ecosystem (EUDIW,
-  GOV.UK Wallet). OpenID4VCI issuer, OpenID4VP verifier, IETF Token Status List 2024
+  GOV.UK Wallet). OpenID4VCI issuer, OpenID4VP verifier on the final 1.0 dialect
+  (DCQL query, multi-credential presentation), SD-JWT VC and ISO 18013-5 mdoc
+  credential formats, IETF Token Status List 2024 + W3C Bitstring Status List
   publishing.
 
 The **API Gateway** (YARP-based) is the single external surface. It aggregates the
@@ -58,7 +60,7 @@ The **MCP Server** exposes 36 tools across three role slices (admin, designer,
 participant) so AI agents can drive the platform end-to-end.
 
 Full architecture diagrams: `docs/architecture.md`.
-Service-to-service reference: `docs/reference/architecture.md`. Port assignments:
+Service-to-service reference: `docs/reference/API-DOCUMENTATION.md`. Port assignments:
 `docs/getting-started/PORT-CONFIGURATION.md`.
 
 ---
@@ -144,6 +146,12 @@ Honest gaps named explicitly:
   proofs.
 - **mTLS on inter-service hops** is not yet enforced outside the gateway. Hops between
   internal services rely on JWT and network isolation today.
+- **A register's governance approvals prove key custody, not organisational consent.**
+  An organisation's governance key is a wallet held in the platform's own custody, so
+  a sufficiently-privileged principal can produce a valid-looking approval from that
+  organisation without its people deciding anything. Worst under a `Unanimous` quorum
+  policy. Not yet closed; tracked as issue #1380 and detailed in
+  `docs/security-model.md` and `docs/reference/maturity-and-limitations.md`.
 
 The full standards posture is in `STANDARDS.md` at the repo root. Every claim above
 is backed by a row in that file with a status of `full` or `partial`; a `planned`
@@ -209,8 +217,13 @@ Be precise about scope. Sorcha is not:
 - `docs/applicability.md` — domain coverage: DPP, trade finance, IPC-1782, municipal
   governance.
 - `docs/security-model.md` — selective disclosure, aggregate inference threat model,
-  PQC posture, mTLS gap, trust anchor model.
+  PQC posture, mTLS gap, governance key-custody gap, trust anchor model.
+- `docs/reference/maturity-and-limitations.md` — what's production-shaped versus
+  demo-grade, and the specific limitations to know before testing (governance key
+  custody, rate-limit posture, replication subscription model, the shared n1 sandbox).
 - `docs/mcp-server.md` — MCP connection guide and worked example.
 - `docs/quickstart.md` — agent-runnable setup.
+- `AGENTS.md` (repo root) — the entry point for an autonomous agent working in this
+  repository.
 - `walkthroughs/TradeFinance/` and `walkthroughs/AssuredIdentity/` — runnable
   end-to-end demonstrations.

--- a/docs/reference/maturity-and-limitations.md
+++ b/docs/reference/maturity-and-limitations.md
@@ -1,0 +1,137 @@
+# What's Real vs Demo — Maturity and Known Limitations
+
+Sorcha is pre-release software: MVD (Minimum Viable Demonstration) complete, hardening toward
+production. This page is the plain-language companion for anyone about to test the platform — human
+or agent — who needs to know what to trust, what to treat as illustrative, and what is a genuinely
+open gap rather than an oversight.
+
+It complements two other documents rather than repeating them:
+
+- [`docs/reference/development-status.md`](development-status.md) — the feature-by-feature completion
+  record (per-service percentages, what shipped when, live-validation notes).
+- [`docs/security-model.md`](../security-model.md) — the cryptographic evidence model and its "Honest
+  Gaps" section, which this page draws several limitations from directly.
+
+## What's production-shaped
+
+These are architectural properties that hold regardless of deployment polish — the cryptography and
+the ledger model are not demo shortcuts:
+
+- **Every action is signed, every disclosure is cryptographically bounded.** Selective disclosure is
+  enforced by per-recipient key wrapping, not a policy check — the platform genuinely cannot read a
+  field it wasn't given the key for. See `docs/security-model.md` § "Selective Disclosure —
+  Architectural, Not Policy".
+- **Post-quantum signing (ML-DSA) and key encapsulation (ML-KEM) are the internal default**, not a
+  feature flag. The only classical fallback is at the HAIP wallet-ecosystem wire boundary, where the
+  standard itself mandates classical suites.
+- **The ledger model — Merkle-chained dockets, validator quorum consensus, peer replication — is the
+  real mechanism**, not a mock. Governance changes to a register (adding/removing a validator,
+  transferring ownership) are themselves ledger transactions, re-verified independently on every node
+  rather than trusted from whichever node first admitted them (Feature 189).
+- **Storage durability is fail-fast, not silent.** Production and Staging deployments refuse to start
+  if a durability-critical interface (wallet repository, register repository, instance/action stores,
+  the validator mempool queue) is wired to an in-memory fallback instead of a real backing store — see
+  CLAUDE.md pattern #10 (Storage Registration Log).
+
+## Known limitations a tester should know
+
+These are not bugs waiting to be filed — they are open, named gaps. Treat each as "true today,"
+not "will never be true":
+
+### An organisation's governance approval proves key custody, not organisational consent (#1380)
+
+A register's governance roster (who can add/remove validators, transfer ownership, change quorum
+rules) is built from organisation-level signatures. But an organisation's governance key is a wallet
+held in **the platform's own custody** — so any principal authorised to call the Wallet Service's
+signing endpoint for that wallet can produce a valid-looking approval from that organisation. A sealed
+approval on the ledger proves *the node was asked to use the organisation's key*; it does not prove the
+organisation's people actually decided anything. This is worst under a `Unanimous` quorum policy,
+where a single sufficiently-privileged principal can satisfy an entire consortium's vote.
+
+Feature 189 narrowed this without closing it: approvals are produced outside the platform's automatic
+signing path, every counted approval must name a responsible individual, and both signatures are
+re-verified independently on every node. But the named individual's key is custodied the same way, so
+the accountability record shows *who was named*, not *who consented*. Closing this requires the
+organisation's governance key to live outside platform custody entirely — tracked as
+[issue #1380](https://github.com/Sorcha-Platform/Sorcha/issues/1380) and detailed in
+`docs/security-model.md` → "Honest Gaps".
+
+**What this means for testing:** treat a register's governance trail as an audit record of key use,
+not as non-repudiable proof that named organisations consented to a change.
+
+### Rate limiting: relaxed by default, production posture is a live-deploy question
+
+`CLAUDE.md` pattern #8 documents the model — every service goes through one centralised rate-limiting
+extension (`builder.AddRateLimiting()`), driven by `RateLimitSettings` bound from configuration. The
+**default values ship very relaxed** (around 100k requests/minute) because they're tuned for
+pre-release development, not public exposure. Tightened limits for public-facing services (Tenant
+auth, Wallet signing, the API Gateway) are layered in via environment-specific configuration.
+
+**What this means for testing:** whether a specific public deployment (including n1.sorcha.dev) is
+currently running the relaxed dev defaults or a tightened production profile depends on what has been
+deployed to it at the time you're testing — it is a property of the *deployment*, not a property of
+the codebase you're reading. Don't assume either direction; if you're probing rate-limit behaviour
+specifically, verify what's actually configured on the node you're hitting rather than inferring it
+from this document.
+
+### Replication follows an explicit subscription, not advertisement
+
+A register created on one node does **not** automatically appear on another node in the network, even
+if both nodes are otherwise healthy and peered. A subscribing node's Peer service has to explicitly
+request `full-replica` sync for that specific register (`POST /api/registers/{id}/subscribe`) before
+any docket data crosses. Until that subscription exists, the register's absence on the second node is
+expected behaviour, not a replication defect.
+
+This was confirmed the hard way during live testing: a walkthrough that checked for a register on a
+second node before subscribing it there reported a false replication failure — the register genuinely
+hadn't replicated yet, because nothing had asked it to.
+
+**What this means for testing:** if you create a register on one node and don't see it on another, check
+whether a `full-replica` subscription was ever requested before concluding replication is broken.
+
+### n1.sorcha.dev is a shared, wipe-able public sandbox
+
+n1 is the platform's shared public demo node. It is periodically reset — genesis re-ceremony, full data
+wipe — as part of normal operation, and it is shared with other testers. See
+[`SECURITY.md`](../../SECURITY.md) for the full scope statement: no production secrets, no expectation
+of data privacy or durability on n1.
+
+### Pre-release schema policy: no upgrade path yet
+
+Per CLAUDE.md §19, every service's EF Core migration set is currently squashed into a single
+`InitialCreate` migration, amended in place as the schema evolves. This is deliberate while there are no
+real installations to preserve — but it means there is currently **no supported in-place upgrade path**
+between schema versions; the remedy today is to recreate the database (`docker compose down -v` +
+re-genesis), which is fine for a demo node and would not be acceptable for a production installation.
+The switch to additive, non-destructive migrations is a deliberate future cutover, tracked as
+[issue #1365](https://github.com/Sorcha-Platform/Sorcha/issues/1365).
+
+### Other named gaps (see `docs/security-model.md` → "Honest Gaps" for full detail)
+
+- **mTLS is not yet enforced on inter-service hops.** Internal service-to-service calls are
+  JWT-authenticated but not mutually-TLS-authenticated. A defence-in-depth gap, not a
+  cryptographic-evidence gap — signatures on wallet actions and dockets remain independently verifiable
+  regardless of transport.
+- **SLH-DSA (FIPS 205)** and **BBS+ selective-disclosure signatures** are not yet implemented; both are
+  named `planned` in [`STANDARDS.md`](../../STANDARDS.md), not silently absent.
+- **DID method registration** — `did:sorcha:org:` and `did:sorcha:holder:` are implemented and used
+  internally but are not registered with the W3C DID method registry, so cross-platform DID resolution
+  outside Sorcha's own network requires bilateral agreement.
+
+## How to read the completion numbers
+
+`docs/reference/development-status.md` reports per-service completion percentages and a "100% MVD"
+overall figure. Read "100% MVD" as *"every planned demonstration-scope feature is implemented and has
+a passing test suite,"* not as *"production-ready."* Multiple live-execution passes across recent
+features (Feature 145, 176, 183, 184, 188, 189 — see that document's "Recent Completions" section) found
+real defects that a fully green unit-test suite had missed, because the defect lived at a seam between
+two individually-correct components (a mapping, a serialisation shape, a timing assumption) that no
+single test exercised end to end. The project's practice in response is to require **live re-execution**
+as evidence for anything security- or correctness-critical, not just a green build — but that also means
+"green tests" alone should not be read as "verified in production conditions."
+
+## If you find something this page doesn't mention
+
+That's useful information on its own — either the gap wasn't known, or it's known but not documented
+here yet. See [`SECURITY.md`](../../SECURITY.md) for anything security-relevant, or open a regular
+GitHub issue otherwise.

--- a/llms.txt
+++ b/llms.txt
@@ -2,14 +2,15 @@
 > Cryptographic proof infrastructure for multi-party workflows. Every action is wallet-signed, every record is Merkle-chained, every disclosure is cryptographically bounded. Built for AI systems that need verified data inputs to make automated decisions.
 
 ## Capabilities
-- Verifiable credentials: SD-JWT VC issuance, presentation, and revocation per W3C Verifiable Credentials Data Model 2.0
-- HAIP-aligned exchange: OpenID4VCI issuer, OpenID4VP verifier, IETF Token Status List 2024 publishing
-- Distributed registers: append-only transaction logs with Merkle-chained dockets, peer replication, validator consensus
+- Verifiable credentials: SD-JWT VC (`dc+sd-jwt`) and ISO 18013-5 mdoc issuance, presentation, and revocation, per W3C Verifiable Credentials Data Model 2.0
+- HAIP-aligned exchange: OpenID4VCI issuer, OpenID4VP verifier with the DCQL query dialect and multi-credential presentation, IETF Token Status List 2024 + W3C Bitstring Status List publishing
+- Distributed registers: append-only transaction logs with Merkle-chained dockets, opt-in peer replication, validator consensus, and register governance changes signed by participating organisations
 - HD wallets: BIP32 / BIP39 / BIP44 with Sorcha-specific purpose derivation paths and per-slot key isolation
 - Post-quantum cryptography: ML-DSA (FIPS 204) signatures and ML-KEM (FIPS 203) key encapsulation as core; classical co-key at the HAIP wire boundary per HAIP 1.0
 - Selective disclosure: JSON Pointer paths with per-recipient symmetric key wrapping; the platform cannot read data it was not given the key for (architectural, not policy)
+- DID resolution: did:sorcha (org/holder), did:key, did:jwk, plus offline resolution for did:ethr / did:pkh
 - MCP server: 36 tools across admin, designer, and participant slices for AI-driven workflow automation
-- Multi-tenant authentication: OAuth 2.0 / JWT Bearer with role-based access control and platform-org topology
+- Multi-tenant authentication: OAuth 2.0 / JWT Bearer with tiered token audiences (consumer / platform / service), role-based access control, and platform-org topology
 
 ## Standards
 - BIP32: https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki
@@ -23,14 +24,19 @@
 - W3C Verifiable Credentials Data Model 2.0: https://www.w3.org/TR/vc-data-model-2.0/
 - IETF Token Status List 2024 (RFC 9972): https://datatracker.ietf.org/doc/html/rfc9972
 - W3C Bitstring Status List: https://www.w3.org/TR/vc-bitstring-status-list/
+- ISO 18013-5 (mdoc): https://www.iso.org/standard/69084.html
 - DID (W3C): https://www.w3.org/TR/did-core/
+- ETSI TS 119 612 (Trusted Lists): https://www.etsi.org/deliver/etsi_ts/119600_119699/119612/02.02.01_60/ts_119612v020201p.pdf
 - OAuth 2.0: https://datatracker.ietf.org/doc/html/rfc6749
 
 ## Links
 - OpenAPI: /.well-known/openapi.json
 - OpenAPI (YAML): /.well-known/openapi.yaml
 - MCP manifest: /.well-known/mcp.json
+- Agent entry point: https://github.com/Sorcha-Platform/Sorcha/blob/master/AGENTS.md
 - Quickstart: https://github.com/Sorcha-Platform/Sorcha/blob/master/docs/quickstart.md
 - Architecture: https://github.com/Sorcha-Platform/Sorcha/blob/master/docs/architecture.md
+- Security model: https://github.com/Sorcha-Platform/Sorcha/blob/master/docs/security-model.md
+- Maturity and known limitations: https://github.com/Sorcha-Platform/Sorcha/blob/master/docs/reference/maturity-and-limitations.md
 - STANDARDS.md: https://github.com/Sorcha-Platform/Sorcha/blob/master/STANDARDS.md
 - llms-full.txt: https://github.com/Sorcha-Platform/Sorcha/blob/master/docs/llms-full.txt


### PR DESCRIPTION
First batch of the public-facing docs for opening Sorcha to external testers and AI agents (Public Gates plan Tasks 7, 16, 10).

- **SECURITY.md** — coordinated disclosure via GitHub private vulnerability reporting; n1 scoped as a shared, wipe-able public sandbox (don't run production secrets against it); references #1397. README gets a Security link. *(Maintainer: enable private vulnerability reporting in repo settings — marked inline.)*
- **docs/reference/maturity-and-limitations.md** — what's real vs demo, stated plainly: #1380 (governance approvals prove key custody, not organisational consent), the rate-limit posture, replication requires an explicit `full-replica` subscription (not automatic), n1-as-sandbox, the pre-release migration policy (#1365).
- **llms.txt / docs/llms-full.txt refresh + AGENTS.md** — current features (mdoc, DCQL/OpenID4VP 1.0, tiered JWT audiences); `check-discoverability.sh` passes; AGENTS.md is an agent's first read, linking only to files that exist today.

Doc-only. All internal links verified; discoverability gate green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)