### PR TITLE
feat/docs: Issue templates + Discussions routing + agent-friendly issue bar (WS3/WS2)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,100 @@
+name: Bug report
+description: Something in Sorcha isn't working the way it should.
+title: "[Bug]: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug. This form works the same whether you're a human tester or an autonomous agent — fill in every required field precisely, since the fields below are what a maintainer (or another agent) will use to reproduce and fix the issue without further back-and-forth.
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened
+      description: A clear, specific description of the observed behaviour. Include exact error messages, status codes, or log lines if you have them.
+      placeholder: |
+        e.g. POST /api/v1/wallet/create returned 500 Internal Server Error with body {"error":"..."}.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behaviour
+      description: What you expected to happen instead.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: entry-point
+    attributes:
+      label: Entry point used
+      description: Which surface were you using when you hit this?
+      options:
+        - "Self-hosted (one-line installer)"
+        - "Shared demo node (n1.sorcha.dev)"
+        - "MCP / agent"
+        - "Docs only"
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: >
+        The Sorcha version you were running. Find it in the UI footer (bottom of any page),
+        the Settings/Help page's "Version" field, or by calling `GET /.well-known/openapi.json`
+        and reading `info.version` from the response body.
+      placeholder: "e.g. 2.935.1"
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro-steps
+    attributes:
+      label: Steps to reproduce
+      description: Numbered steps from a clean starting point. Include request bodies, CLI commands, or UI clicks — whatever is needed for someone else to hit the same failure.
+      placeholder: |
+        1. ...
+        2. ...
+        3. ...
+      value: |
+        1.
+        2.
+        3.
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: OS, browser (if UI), .NET version (if self-hosted), Docker version, and anything else about how the platform was running.
+      placeholder: |
+        OS: ...
+        Browser: ...
+        Docker: ...
+        .NET SDK: ...
+    validations:
+      required: false
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs or output
+      description: Paste any stack traces, console output, or network responses. This will be rendered as-is, so no need to add backticks.
+      render: shell
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: agent-disclosure
+    attributes:
+      label: Reporter
+      description: Optional — helps maintainers calibrate how to respond.
+      options:
+        - label: This report was filed by an autonomous agent (not a human directly typing it)
+          required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions & open-ended feedback
+    url: https://github.com/Sorcha-Platform/Sorcha/discussions
+    about: For questions and discussion that aren't a specific bug or feature request.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,44 @@
+name: Feature request
+description: Propose a new capability or improvement for Sorcha.
+title: "[Feature]: "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for proposing an improvement. Describe the problem before the solution — it lets a maintainer (or another agent) evaluate whether the proposed approach is actually the best fix.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What's missing, awkward, or broken about the current behaviour? Who runs into it and when?
+      placeholder: |
+        e.g. There's no way to list wallets by org from the CLI, so scripting an org-wide audit requires N manual calls.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed-solution
+    attributes:
+      label: Proposed solution
+      description: What you'd like to see instead. Sketch an API shape, CLI flag, or UI change if you have one in mind — it doesn't need to be final.
+    validations:
+      required: true
+
+  - type: textarea
+    id: who-benefits
+    attributes:
+      label: Who benefits
+      description: Which users, integrators, or workflows this helps (e.g. self-hosters, external testers, agent integrations, a specific service team).
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you considered and why you didn't propose them instead. "None" is a fine answer.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feedback.yml
+++ b/.github/ISSUE_TEMPLATE/feedback.yml
@@ -1,0 +1,57 @@
+name: First-impressions feedback
+description: Not a specific bug or feature request — tell us how your first run of Sorcha went.
+title: "[Feedback]: "
+labels:
+  - feedback
+body:
+  - type: markdown
+    attributes:
+      value: |
+        This form is for general impressions rather than a single reproducible defect — if you hit a concrete error, use the **Bug report** form instead so it carries repro steps. Agents are welcome to file this too: describe what you tried and where the trail went cold.
+
+  - type: dropdown
+    id: entry-point
+    attributes:
+      label: Which entry point did you try?
+      options:
+        - "Self-hosted (one-line installer)"
+        - "Shared demo node (n1.sorcha.dev)"
+        - "MCP / agent"
+        - "Docs only"
+    validations:
+      required: true
+
+  - type: textarea
+    id: what-worked
+    attributes:
+      label: What worked
+      description: What got you further than you expected, or just worked smoothly.
+    validations:
+      required: true
+
+  - type: textarea
+    id: where-stuck
+    attributes:
+      label: Where you got stuck
+      description: The point where you slowed down, backtracked, or gave up. Be as specific as you can — a page URL, a command, an error you didn't file separately.
+    validations:
+      required: true
+
+  - type: textarea
+    id: what-expected
+    attributes:
+      label: What you expected instead
+      description: What would have made the sticking point above a non-issue.
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: >
+        Optional. Find it in the UI footer, the Settings/Help page's "Version" field,
+        or `info.version` from `GET /.well-known/openapi.json`.
+      placeholder: "e.g. 2.935.1"
+    validations:
+      required: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -259,8 +259,20 @@ Include:
 - `bug` - Something isn't working
 - `enhancement` - New feature or request
 - `documentation` - Documentation improvements
-- `good first issue` - Good for newcomers
-- `help wanted` - Extra attention needed
+- `good first issue` - Small, self-contained, and a reasonable way to learn the codebase. Doesn't require deep familiarity with Sorcha's architecture to complete safely.
+- `help wanted` - The maintainers want outside help on this; scope may be larger or less well-defined than `good first issue`.
+- `agent-friendly` - Meets the bar below: a fresh autonomous agent (or a fresh Claude session with no prior context) can pick it up cold and complete it without needing to ask a human a clarifying question first. See "The agent-friendly bar" below before applying or requesting this label.
+
+### The agent-friendly bar
+
+An issue labelled `agent-friendly` is a promise that the issue text itself is a sufficient brief — an agent shouldn't need to guess intent, hunt for the relevant code, or invent its own success criteria. Before applying the label (maintainers) or asking for it (contributors filing an issue meant for agent pickup), the issue must contain:
+
+1. **Affected files/area** — the specific file(s), directory, or service the change lives in (e.g. `src/Services/Sorcha.Tenant.Service/Services/LoginService.cs`, not "the auth system"). If the exact file is unknown, name the narrowest area you can (service + rough responsibility) so the agent's first move is confirmation, not a codebase-wide search.
+2. **Inputs** — what the agent needs to know to start: relevant request/response shapes, an example payload, a reproducing command, a linked PR/commit that shows the pattern to follow, or a pointer to a similar already-solved case elsewhere in the repo.
+3. **Explicit done-criteria** — a concrete, checkable statement of what "finished" looks like. Not "fix the bug" but "calling `POST /api/x` with `{...}` returns `200` instead of `500`" or "`FooTests.Bar_Baz_Should()` passes." If the fix is structural (e.g. a naming/pattern cleanup), name the specific instances or the exact rule to apply everywhere.
+4. **How to verify** — the command(s) to run to confirm the done-criteria are met (a `dotnet test --filter ...` invocation, a specific `curl`/CLI call, a script under `walkthroughs/`). An agent should be able to close the loop itself, not rely on a maintainer to eyeball the result.
+
+An issue missing any of these isn't wrong to file — it's just not `agent-friendly` yet. Add the missing piece (or ask the reporter to) before applying the label.
 
 ## Release Process
 


### PR DESCRIPTION
Public Gates plan Tasks 13 + 12 — the feedback surface for external testers and autonomous agents.

- `.github/ISSUE_TEMPLATE/{bug_report,feature_request,feedback,config}.yml` — GitHub issue-forms. `bug_report` has a required **entry-point** dropdown (self-host / n1 / MCP / docs) and a **version** field hinting at the UI footer / `GET /.well-known/openapi.json`; `config.yml` routes open-ended questions to Discussions (blank issues disabled). Fields shaped so an agent fills them correctly. YAML validated.
- `CONTRIBUTING.md` — an **agent-friendly issue bar** (affected files, inputs, done-criteria, how to verify) + label meanings (`good first issue`, `help wanted`, `agent-friendly`).

Labels created in repo settings. Discussions already enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)