### PR TITLE
docs: README external-reader pass + MCP agent quickstart + Discussions welcome (WS1/WS2/WS3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,15 @@ A decentralised register platform for secure, multi-participant data flow orches
 
 Sorcha lets organizations define structured workflows — called **blueprints** — where multiple parties exchange, validate, and record data with cryptographic guarantees. Every transaction is signed, every change is immutable, and every participant sees only what they're authorized to access.
 
+## Four ways in
+
+| Path | Best if you want to... |
+|------|-------------------------|
+| **[Self-host in one line](#try-it-in-one-line)** | run the full stack locally in Docker right now |
+| **[Try the shared sandbox](https://n1.sorcha.dev)** | poke at a live, publicly-reachable instance without installing anything. `n1.sorcha.dev` is a shared demo node, not a production deployment — no real data, periodically wiped. See [`SECURITY.md`](SECURITY.md) |
+| **[Read first](docs/quickstart.md)** | understand setup and architecture before running anything — written to be followed by a human or an AI agent |
+| **[Connect an AI agent](#for-ai-agents-and-integrators)** | point an MCP (Model Context Protocol) client or coding agent at a node and have it drive a workflow |
+
 ## Try it in one line
 
 With **Docker** and **git** installed, this downloads Sorcha, asks a few setup questions, generates your config, and brings the whole stack up:
@@ -40,8 +49,8 @@ It clones this repo into `./sorcha` and hands off to [`scripts/sorcha-setup.sh`]
 | Capability | Description |
 |------------|-------------|
 | **Blueprint Workflows** | Define multi-step, multi-party data flows as declarative JSON with conditional routing, schema validation, and business logic evaluation |
-| **Distributed Ledger** | Immutable, append-only transaction registers with chain validation, Merkle-tree dockets, and DID URI addressing |
-| **Cryptographic Wallets** | HD wallet management (BIP32/39/44) with ED25519, P-256, RSA-4096, and post-quantum algorithms (ML-DSA, ML-KEM, SLH-DSA) |
+| **Distributed Ledger** | Immutable, append-only transaction registers with chain validation, Merkle-tree **dockets** (batches of transactions sealed together), and **DID** (Decentralized Identifier) URI addressing |
+| **Cryptographic Wallets** | HD wallet management (BIP32/39/44) with ED25519, P-256, RSA-4096, and post-quantum algorithms ML-DSA and ML-KEM (SLH-DSA is planned, not yet implemented — see [`STANDARDS.md`](STANDARDS.md)) |
 | **Field-Level Encryption** | Envelope encryption with per-recipient key wrapping — participants see only the fields they're authorized to access |
 | **Multi-Tenant Identity** | JWT authentication with OAuth2 client credentials, participant identity registry, and wallet address linking |
 | **Peer Network** | gRPC-based P2P topology for register replication across nodes |
@@ -196,7 +205,7 @@ See the [CLI documentation](src/Apps/Sorcha.Cli/README.md) for the full command 
 ```mermaid
 graph TD
     UI["Sorcha UI<br/><small>Blazor WASM</small>"]
-    GW["API Gateway<br/><small>YARP Reverse Proxy</small>"]
+    GW["API Gateway<br/><small>Reverse Proxy</small>"]
 
     BP["Blueprint Service<br/><small>Workflows + SignalR</small>"]
     REG["Register Service<br/><small>Distributed Ledger</small>"]
@@ -229,14 +238,14 @@ graph TD
 
 | Service | Purpose |
 |---------|---------|
-| **API Gateway** | YARP reverse proxy — single entry point for all API traffic |
+| **API Gateway** | Reverse proxy built on YARP (Microsoft's .NET reverse-proxy toolkit) — single entry point for all API traffic |
 | **Blueprint Service** | Workflow management, execution engine, SignalR notifications |
-| **Register Service** | Distributed ledger, transaction storage, OData queries |
+| **Register Service** | Distributed ledger, transaction storage, OData (Open Data Protocol) query support |
 | **Wallet Service** | Cryptographic key management, signing, encryption |
 | **Tenant Service** | Multi-tenant auth, JWT issuer, participant identity |
 | **Validator Service** | Transaction validation, consensus, docket building |
-| **Peer Service** | P2P network topology, gRPC replication |
-| **HAIP Service** | OpenID4VCI/VP external-wallet surface (credential issue + verify), reached via the gateway |
+| **Peer Service** | Peer-to-peer network topology, gRPC replication |
+| **HAIP Service** | OpenID4VCI/VP external-wallet surface (HAIP = OpenID4VC High-Assurance Interoperability Profile) — credential issue + verify, reached via the gateway |
 
 ## Configuration
 
@@ -253,10 +262,11 @@ Key settings:
 
 ## For AI Agents and Integrators
 
-Sorcha publishes a machine-readable surface so AI agents, AI coding assistants, and integrators picking up the platform can find, parse, and reason over it without out-of-band documentation. The four published documents are the canonical agent-facing reference and live alongside the standards file and the well-known endpoints:
+Sorcha publishes a machine-readable surface so AI agents, AI coding assistants, and integrators picking up the platform can find, parse, and reason over it without out-of-band documentation. These published documents are the canonical agent-facing reference and live alongside the standards file and the well-known endpoints:
 
 | Surface | Purpose |
 |---------|---------|
+| [`AGENTS.md`](AGENTS.md) | Entry point for an autonomous coding agent working in this repository — read this first |
 | [`llms.txt`](llms.txt) | One-screen factual summary, llmstxt.org-conforming |
 | [`STANDARDS.md`](STANDARDS.md) | Single source of truth for every standard the platform implements |
 | [`docs/quickstart.md`](docs/quickstart.md) | Agent-runnable setup against a clean Docker host |
@@ -264,7 +274,8 @@ Sorcha publishes a machine-readable surface so AI agents, AI coding assistants, 
 | [`docs/openid4vc-haip-integration.md`](docs/openid4vc-haip-integration.md) | Wallet ecosystem boundary (OpenID4VCI / OpenID4VP / HAIP 1.0) |
 | [`docs/applicability.md`](docs/applicability.md) | Regulatory-pull domains (DPP, trade finance, IPC-1782, municipal) |
 | [`docs/security-model.md`](docs/security-model.md) | Selective disclosure, post-quantum posture, honest gaps |
-| [`docs/mcp-server.md`](docs/mcp-server.md) | Connecting an AI agent via the Model Context Protocol |
+| [`docs/reference/maturity-and-limitations.md`](docs/reference/maturity-and-limitations.md) | What's production-shaped versus demo-grade before you test |
+| [`docs/mcp-server.md`](docs/mcp-server.md) | Connecting an AI agent via the Model Context Protocol — transports, auth, role slices |
 | [`docs/llms-full.txt`](docs/llms-full.txt) | Long-form machine-readable narrative |
 | `GET /.well-known/openapi.json` *(running gateway)* | Aggregated OpenAPI 3.1 surface with `info.x-mcp-server` and `info.x-standards` |
 | `GET /.well-known/openapi.yaml` *(running gateway)* | YAML form of the same document |

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ It clones this repo into `./sorcha` and hands off to [`scripts/sorcha-setup.sh`]
 |------------|-------------|
 | **Blueprint Workflows** | Define multi-step, multi-party data flows as declarative JSON with conditional routing, schema validation, and business logic evaluation |
 | **Distributed Ledger** | Immutable, append-only transaction registers with chain validation, Merkle-tree **dockets** (batches of transactions sealed together), and **DID** (Decentralized Identifier) URI addressing |
-| **Cryptographic Wallets** | HD wallet management (BIP32/39/44) with ED25519, P-256, RSA-4096, and post-quantum algorithms ML-DSA and ML-KEM (SLH-DSA is planned, not yet implemented — see [`STANDARDS.md`](STANDARDS.md)) |
+| **Cryptographic Wallets** | HD wallet management (BIP32/39/44) with ED25519, P-256, RSA-4096, and post-quantum algorithms — ML-DSA (FIPS 204) and ML-KEM (FIPS 203) are the core, default path; FIPS-205 (SLH-DSA) primitives are also present in the cryptography library, see [`STANDARDS.md`](STANDARDS.md) |
 | **Field-Level Encryption** | Envelope encryption with per-recipient key wrapping — participants see only the fields they're authorized to access |
 | **Multi-Tenant Identity** | JWT authentication with OAuth2 client credentials, participant identity registry, and wallet address linking |
 | **Peer Network** | gRPC-based P2P topology for register replication across nodes |

--- a/README.md
+++ b/README.md
@@ -276,6 +276,7 @@ Sorcha publishes a machine-readable surface so AI agents, AI coding assistants, 
 | [`docs/security-model.md`](docs/security-model.md) | Selective disclosure, post-quantum posture, honest gaps |
 | [`docs/reference/maturity-and-limitations.md`](docs/reference/maturity-and-limitations.md) | What's production-shaped versus demo-grade before you test |
 | [`docs/mcp-server.md`](docs/mcp-server.md) | Connecting an AI agent via the Model Context Protocol — transports, auth, role slices |
+| [`docs/guides/mcp-agent-quickstart.md`](docs/guides/mcp-agent-quickstart.md) | Copy-pasteable path for an **external** autonomous agent: point MCP at a node, authenticate, and drive one workflow action to a sealed transaction |
 | [`docs/llms-full.txt`](docs/llms-full.txt) | Long-form machine-readable narrative |
 | `GET /.well-known/openapi.json` *(running gateway)* | Aggregated OpenAPI 3.1 surface with `info.x-mcp-server` and `info.x-standards` |
 | `GET /.well-known/openapi.yaml` *(running gateway)* | YAML form of the same document |

--- a/docs/community/discussions-welcome.md
+++ b/docs/community/discussions-welcome.md
@@ -1,0 +1,82 @@
+<!--
+  This file is the version-controlled SOURCE for a pinned GitHub Discussions post.
+  It is not itself rendered anywhere — a maintainer with repo admin access copies the body
+  below into a new Discussion (category: General or Q&A) and pins it, after confirming the
+  four categories referenced below (Q&A, Ideas, Show-and-tell, Feedback) exist under the
+  repository's Discussions settings.
+
+  Keep this file in sync if the pinned post is edited in place on GitHub — it should always
+  be possible to reconstruct the live post from this file.
+-->
+
+# Welcome — how to give feedback, what we're looking for, what's demo-grade
+
+Thanks for trying Sorcha. This post explains where to put feedback, what kind of feedback is
+most useful right now, and what to expect from the platform's current state before you start
+poking at it.
+
+## Where things go
+
+- **Bugs and feature requests → [Issues](https://github.com/Sorcha-Platform/Sorcha/issues).**
+  Something didn't work the way the docs said it would, a workflow broke, an endpoint returned
+  the wrong thing — file it as an issue. See [`CONTRIBUTING.md`](../../CONTRIBUTING.md) → "Issue
+  Reporting" for what makes a bug report or feature request actionable.
+- **Open-ended stuff → Discussions**, in one of four categories:
+  - **Q&A** — "how do I…", "why does X work this way", "is Y supported". If your question turns
+    out to reveal a real bug or gap, we'll spin it out into an issue from there.
+  - **Ideas** — feature proposals, architecture suggestions, "what if Sorcha did…". Doesn't need
+    to be fully worked out — half-formed ideas are welcome.
+  - **Show-and-tell** — built something with Sorcha? A blueprint, an integration, a demo? Post it
+    here. This is genuinely one of the most useful categories for a pre-release project — seeing
+    what real usage looks like tells us more than almost anything else.
+  - **Feedback** — general impressions, rough edges, "this confused me," naming/terminology
+    critique, anything that doesn't fit a bug report but is still worth us hearing.
+- **Security vulnerabilities → do NOT use Issues or Discussions.** Use GitHub's private
+  vulnerability reporting (Security tab → "Report a vulnerability"). See
+  [`SECURITY.md`](../../SECURITY.md) for what's in scope and what to expect.
+
+## What we're looking for
+
+Sorcha is pre-release, hardening toward production. The single most valuable kind of feedback
+right now is **"I ran X and it didn't do what the docs said"** — a live-execution defect, not a
+theoretical one. This project's own experience has repeatedly found real bugs that a fully green
+test suite missed, because the defect lived at a seam between two individually-correct pieces
+(a mapping, a serialisation shape, a timing assumption) that no single test exercised end to end.
+If you hit one of those, that report is gold — please include exactly what you ran and what
+happened, not just what you expected.
+
+Also genuinely useful, roughly in order of how much we can act on it fast:
+
+1. A setup step that didn't work as documented (see [`docs/quickstart.md`](../quickstart.md) —
+   if something there is wrong, that's a fast, high-value fix).
+2. An AI agent (yours, via MCP) that got confused or blocked — see the
+   [external-agent MCP quickstart](../guides/mcp-agent-quickstart.md). Agent-usability feedback
+   is a first-class use case for this project, not an afterthought.
+3. Terminology or documentation that reads as internal-only or unexplained to someone with zero
+   context on the codebase.
+4. Anything that looks like a security or trust-model gap — see the "in scope" list in
+   [`SECURITY.md`](../../SECURITY.md) before deciding whether it's a public Discussion/Issue or a
+   private security report.
+
+## What's demo-grade right now
+
+Before you conclude something is broken, it's worth knowing what's genuinely still rough versus
+what's an intentional current limitation. **Read
+[`docs/reference/maturity-and-limitations.md`](../reference/maturity-and-limitations.md) first** —
+it lays out, in plain language, what's production-shaped (the cryptography, the ledger model,
+fail-fast storage durability) versus what's an open, named gap (governance-key custody, relaxed
+default rate limits, replication requiring an explicit subscription, no in-place schema upgrade
+path yet). If your finding is already named there, it's not a surprise to us — but a Discussion
+or Issue with a concrete repro is still useful, because "confirmed independently, here's exactly
+how" is worth more than the abstract description on that page.
+
+If you're testing against the shared public sandbox at `n1.sorcha.dev`: it's genuinely public,
+shared with other testers, and periodically wiped. Don't put real data or secrets through it —
+see [`SECURITY.md`](../../SECURITY.md) for the full scope statement.
+
+## Thanks
+
+However small — a typo report, a confused "why does this work this way," a fully-reproduced
+live bug — it's useful. Pre-release software gets better from exactly this kind of feedback loop,
+and we'd rather hear about a rough edge from you now than have it be someone's first bad
+impression later.

--- a/docs/guides/mcp-agent-quickstart.md
+++ b/docs/guides/mcp-agent-quickstart.md
@@ -1,0 +1,215 @@
+# External-Agent MCP Quickstart
+
+This is the runnable companion to [`docs/mcp-server.md`](../mcp-server.md) — read that first for the
+full transport / authentication / role-slice reference. This page is one concrete, copy-pasteable path
+an **external** autonomous agent (not a Sorcha internal service, not a human clicking through the UI)
+can follow from "I have a node address" to "I drove a workflow action to a sealed transaction."
+
+Everything below is grounded in the current MCP server source
+(`src/Apps/Sorcha.McpServer/Tools/`) and the discoverability endpoints it serves — not aspirational.
+Where the source and an older doc disagreed, this page follows the source (see "Known doc drift" at
+the bottom).
+
+## Before you start — pick a node
+
+| Option | Command |
+|---|---|
+| Self-hosted (your own Docker stack) | Follow the [one-line installer](../../README.md#try-it-in-one-line) or [`docs/quickstart.md`](../quickstart.md) first — you need a running gateway at `http://localhost` before anything below works. |
+| Shared sandbox | `https://n1.sorcha.dev` — a live, public, periodically-wiped demo node. No setup required, but see [`SECURITY.md`](../../SECURITY.md) before you put anything sensitive through it. |
+
+The examples below use `http://localhost` for a self-hosted stack. Swap in `https://n1.sorcha.dev` (or
+your own node's origin) throughout.
+
+## Step 1 — Read the manifest
+
+`GET /.well-known/mcp.json` is a live, per-installation description of how to connect — it is the
+authoritative source for the exact token issuer/audience and the deployed transport URL, so prefer it
+over hardcoding values from this doc:
+
+```bash
+curl -s http://localhost/.well-known/mcp.json | jq
+```
+
+```jsonc
+{
+  "name": "Sorcha MCP Server",
+  "transports": [
+    { "type": "stdio", "command": "dotnet", "args": ["run", "--project", "src/Apps/Sorcha.McpServer"] },
+    { "type": "http+sse", "url": "http://localhost/mcp" }
+  ],
+  "authentication": {
+    "type": "jwt-bearer",
+    "issuer": "urn:sorcha:sorcha",
+    "audience": "sorcha:platform",
+    "acquisitionUrl": "http://localhost/api/tenant/auth/login"
+  },
+  "toolCatalogueUrl": "http://localhost/api/mcp/tools"
+}
+```
+
+(`http+sse` is the wire name kept for backward compatibility — the endpoint actually speaks
+Streamable HTTP. See `docs/mcp-server.md` for the transport-selection rationale.)
+
+## Step 2 — Get a JWT
+
+Every tool call needs a bearer JWT from the Tenant Service — the same token you'd use for a direct
+REST call.
+
+**Use the `password` grant, not `client_credentials`.** The public gateway's
+`POST /api/service-auth/token` endpoint only accepts the `password` and `refresh_token` grant types.
+`client_credentials` service-token minting is deliberately **not** reachable from outside the
+platform — it moved to an internal-only route after a real external-facing signing-oracle finding
+(issue #1397, see [`SECURITY.md`](../../SECURITY.md)). If your agent needs to act as a specific
+workflow participant, it authenticates as that participant's human-owned (or agent-operated) account
+with a password, exactly like a person would.
+
+```bash
+curl -s -X POST http://localhost/api/tenant/auth/login \
+  -H "Content-Type: application/json" \
+  -d '{"email":"admin@sorcha.local","password":"Dev_Pass_2025!"}' \
+  | jq -r '.accessToken'
+```
+
+On a fresh self-hosted stack, the setup script prints an admin account you can use immediately (see
+README → [Default Credentials](../../README.md#default-credentials) — **change it before exposing the
+node**). On `n1.sorcha.dev`, sign up for your own account rather than trying to reuse someone else's.
+
+A helper script wraps the same call:
+
+```bash
+./scripts/get-jwt-token.sh -e admin@sorcha.local -p 'Dev_Pass_2025!'
+```
+
+Which tools your token can call depends on its claims (role for admin/designer, participant binding
+for participant tools, consumer-tier for citizen tools) — see the token-scoping table in
+[`docs/mcp-server.md`](../mcp-server.md#authentication).
+
+## Step 3 — Point the MCP server at the node
+
+**Local stdio (the `docker-compose run` path from `CLAUDE.md`):**
+
+```bash
+docker-compose run --rm mcp-server --jwt-token <your-jwt-token>
+```
+
+This is the right shape when your agent host controls the local process (a CLI agent, an
+IDE-embedded assistant, Claude Desktop on the same machine as the Docker stack). It talks stdio —
+one connection at a time.
+
+**Remote HTTP (the shape for a hosted/cloud agent, e.g. talking to `n1.sorcha.dev`):**
+
+```bash
+curl -N \
+  -H "Authorization: Bearer <your-jwt-token>" \
+  -H "Accept: text/event-stream" \
+  http://localhost/mcp
+```
+
+Use the exact URL from the manifest's `transports[].url` (Step 1) rather than assuming `/mcp` —
+it's derived per-deployment.
+
+## Step 4 — Discover the tools
+
+```bash
+curl -s http://localhost/api/mcp/tools | jq
+```
+
+Returns one entry per tool: name, category, and short description. The live count and exact roster
+change over time (new tools land regularly) — **don't hand-count from any document, including this
+one**; the catalogue endpoint and a live `tools/list` MCP request are the only two sources that can't
+drift. Every tool name is prefixed `sorcha_` (e.g. `sorcha_inbox_list`, `sorcha_action_submit`) — this
+guide uses the real prefixed names throughout.
+
+`tools/list` on a live session is tier-filtered: a platform-tier token sees the admin + designer +
+participant tools it has role claims for; a consumer-tier token sees only the citizen slice.
+
+## Step 5 — Drive one workflow to completion
+
+This assumes a workflow **instance already exists** and has an action waiting on the participant your
+agent's token represents — for example, one started via the Blueprint Designer UI, the CLI, or a
+prior designer-slice MCP session (`sorcha_blueprint_create` + publishing to a register — see
+[Blueprint Quick Start](../getting-started/blueprint-quick-start.md) if you need to create the
+workflow too). The [README's Invoice Approval example](../../README.md#1-define-a-blueprint) is a
+minimal two-participant blueprint you can use as the target.
+
+```
+1. sorcha_inbox_list                        → list actions assigned to this participant.
+                                               Returns actionInstanceId, workflowInstanceId,
+                                               actionId (numeric), actionTitle, status.
+
+2. sorcha_action_details(actionInstanceId)  → the action's JSON input schema, prompt copy, and
+                                               any upstream data disclosed to this participant.
+
+3. sorcha_action_submit(workflowInstanceId, actionId, dataJson)
+                                             → submits the payload, completes the action, and
+                                               advances the workflow. Signing happens implicitly
+                                               inside this call — there is no separate "sign, then
+                                               submit" step for an agent to orchestrate. (Direct
+                                               signing exists in source as sorcha_wallet_sign but is
+                                               deliberately unregistered — spec 139 T029 — so it is
+                                               not part of the served tool surface.)
+
+4. sorcha_workflow_status(workflowInstanceId)
+                                             → confirms the instance advanced: which actions
+                                               completed, which are now pending, and for whom.
+
+5. sorcha_transaction_history(...)          → the signed, chained record of what was just
+                                               submitted — the audit trail, not the live view.
+```
+
+For a two-participant blueprint (like the README example), a second agent session — authenticated as
+the approver — repeats steps 1-3 against the action that `sorcha_action_submit` in step 3 triggered,
+then step 4 shows the instance in its terminal state.
+
+## What success looks like
+
+- `sorcha_action_submit`'s response includes a `transactionId` and, if the workflow continues, a
+  `nextActions` list naming the action(s) it triggered.
+- `sorcha_workflow_status` on the same `workflowInstanceId` shows the action you just completed is no
+  longer pending, and (once every action in the blueprint has completed) the instance in its terminal
+  state.
+- `sorcha_transaction_history` shows the new transaction, sealed and chained — the cryptographic,
+  immutable evidence that the action happened. That sealed transaction, not the HTTP 200 from the
+  submit call, is what "the action really committed" means on Sorcha (see the DAD model in the
+  [README](../../README.md#the-dad-security-model): *Alteration* is exactly this — every data change
+  is a signed transaction on an immutable ledger).
+
+## Verify
+
+**This sequence has not been executed end to end as part of writing this doc** — there is no live
+stack available in the environment that produced it. It is derived directly from the registered MCP
+tool source (`src/Apps/Sorcha.McpServer/Tools/Participant/*.cs`), cross-checked against
+`docs/mcp-server.md` and the tool table in `src/Apps/Sorcha.McpServer/README.md`. Running this guide
+against a fresh Docker stack — confirming each curl/tool call returns what's shown above, and that a
+real transaction seals — is the acceptance step for this doc. If a step doesn't match reality when you
+run it, fix this page (see the Documentation Sync Policy in `CLAUDE.md`) rather than working around it
+silently.
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+|---|---|
+| `401`/`403` from a tool call | Your token's tier or role doesn't cover that tool — see the scoping table in `docs/mcp-server.md`. |
+| "JWT token is required" from the MCP server process | Token wasn't passed via `--jwt-token` or `SORCHA_JWT_TOKEN`. |
+| Connection refused | Services aren't up yet — `docker-compose ps`, then `docker-compose logs -f <service>`. See [`docs/quickstart.md`](../quickstart.md) for the full failure-mode list. |
+| `sorcha_action_submit` succeeds but the workflow doesn't advance | Check the response's `nextActions` — an empty list on a non-terminal action usually means a routing condition wasn't met, not that the submission failed. |
+
+## Known doc drift found while writing this guide
+
+Two things this guide deliberately does **not** repeat from `docs/mcp-server.md`, because the current
+tool source disagrees with it:
+
+- Tool names there are shown unprefixed (`inbox_list`, `action_submit`); the actual registered names
+  all carry a `sorcha_` prefix (`sorcha_inbox_list`, `sorcha_action_submit`).
+- Its worked example shows an explicit `wallet_sign` step before submitting an action. That tool
+  (`sorcha_wallet_sign`) exists in source but is intentionally unregistered (spec 139 T029) and is not
+  part of the served surface — `sorcha_action_submit` signs implicitly.
+
+## Where to read more
+
+- [`docs/mcp-server.md`](../mcp-server.md) — full transport, authentication, and role-slice reference.
+- [`docs/quickstart.md`](../quickstart.md) — agent-runnable setup against a clean Docker host.
+- [`walkthroughs/McpServerBasics/`](../../walkthroughs/McpServerBasics/) — a scripted stdio smoke test
+  (auth + connect + a health-check tool call) this guide's Steps 2-4 are grounded in.
+- [`src/Apps/Sorcha.McpServer/README.md`](../../src/Apps/Sorcha.McpServer/README.md) — the source-level
+  reference, including the current tool count by slice (don't hand-count; it says the same).


### PR DESCRIPTION
Final documentation batch of the Public Gates plan (Tasks 15, 11, 14).

- **README external-reader pass** — a "Four ways in" table up top (self-host / n1 sandbox / docs-first / MCP-agent), acronyms expanded on first use (docket, DID, YARP, OData, HAIP, MCP), stale doc-count fixed.
- **docs/guides/mcp-agent-quickstart.md** — how an external autonomous agent points the MCP server at a node, authenticates, and drives one workflow; grounded in the real tool source (not the drifted `docs/mcp-server.md`). The worked example's live-stack run is flagged as its own acceptance step (no stack here).
- **docs/community/discussions-welcome.md** — version-controlled source for the pinned Discussions post (how to give feedback, what's demo-grade), linking SECURITY.md, the maturity page, the quickstart.

Discoverability gate passes; `llms.txt`/`STANDARDS.md` untouched. Follow-ups filed for two accuracy drifts found along the way: #1417 (mcp-server.md) and #1418 (STANDARDS.md SLH-DSA).

🤖 Generated with [Claude Code](https://claude.com/claude-code)