### PR TITLE
fix: [1397] - Allow register-service to sign the validator system wallet (genesis)

### DIFF
--- a/src/Services/Sorcha.Wallet.Service/Endpoints/WalletEndpoints.cs
+++ b/src/Services/Sorcha.Wallet.Service/Endpoints/WalletEndpoints.cs
@@ -899,14 +899,21 @@ public static class WalletEndpoints
                 // #1397 — the service-token bypass above is deliberately broad (Blueprint Service
                 // legitimately signs OTHER organisations' wallets during credential issuance), but a
                 // validator:*-owned wallet is the docket-signing / SSR-owner system key. Narrow the
-                // bypass so only the Validator service principal itself may sign with one — any other
-                // service token targeting it is the #1397 oracle.
+                // bypass so only the trusted system principals that operate that key may sign with one:
+                //   validator-service — seals dockets with the docket-signing key
+                //   register-service  — signs register genesis at creation (finalize) and F189 governance
+                // Any OTHER service token targeting it is the #1397 oracle. (Blueprint's sandbox-register
+                // creation delegates finalize to register-service, so it is covered transitively; peer
+                // replicates but never seals; genesis import uses /system/recover, not /sign.)
                 var systemWallet = await walletManager.GetWalletAsync(address, cancellationToken);
                 if (systemWallet is not null && systemWallet.Owner is not null &&
                     systemWallet.Owner.StartsWith("validator:", StringComparison.Ordinal))
                 {
                     var clientId = context.User.Claims.FirstOrDefault(c => c.Type == "client_id")?.Value;
-                    if (!string.Equals(clientId, "validator-service", StringComparison.Ordinal))
+                    var isSystemSigner =
+                        string.Equals(clientId, "validator-service", StringComparison.Ordinal) ||
+                        string.Equals(clientId, "register-service", StringComparison.Ordinal);
+                    if (!isSystemSigner)
                     {
                         logger.LogWarning(
                             "SEC-AUDIT: service principal {ClientId} attempted to sign system wallet {Wallet} owned by {Owner}",

--- a/tests/Sorcha.Wallet.Service.Tests/Endpoints/SystemWalletSigningRestrictionTests.cs
+++ b/tests/Sorcha.Wallet.Service.Tests/Endpoints/SystemWalletSigningRestrictionTests.cs
@@ -30,9 +30,12 @@ namespace Sorcha.Wallet.Service.Tests.Endpoints;
 /// <summary>
 /// #1397 — narrows the service-token ownership bypass in <c>WalletEndpoints.SignTransaction</c>
 /// so that a <c>validator:*</c>-owned system wallet (the docket-signing / SSR-owner key) may only
-/// be signed by the Validator service principal (<c>client_id == "validator-service"</c>, confirmed
-/// against <see cref="Sorcha.Tenant.Service.Data.DatabaseInitializer.ValidatorServicePrincipalId"/>'s
-/// seeded <c>ClientId</c> — NOT "service-validator" as a naive guess would assume).
+/// be signed by the trusted system principals that operate it: <c>validator-service</c> (docket
+/// sealing) and <c>register-service</c> (register genesis at creation + F189 governance). The
+/// register-service arm was added after a live n1 walkthrough caught that register finalize signs
+/// the validator system wallet through register-service — the initial fix allowed only
+/// <c>validator-service</c> and broke all new register creation. Client ids confirmed against the
+/// seeded <c>ClientId</c>s in <see cref="Sorcha.Tenant.Service.Data.DatabaseInitializer"/>.
 ///
 /// Service tokens legitimately bypass wallet ownership for ordinary (non-<c>validator:*</c>) wallets —
 /// e.g. Blueprint Service signs the issuing org's wallet during credential issuance for a different
@@ -181,6 +184,21 @@ public sealed class SystemWalletSigningRestrictionTests
 
         result.Should().NotBeOfType<Microsoft.AspNetCore.Http.HttpResults.ForbidHttpResult>();
         result.GetType().Name.Should().Contain("Ok", "the validator principal must be able to sign its own system wallet");
+    }
+
+    [Fact]
+    public async Task SignTransaction_RegisterServiceToken_SystemWallet_Proceeds()
+    {
+        // Register creation (finalize) signs the register genesis with the validator system wallet
+        // through the register-service principal. A live n1 walkthrough caught that the initial
+        // validator-service-only allowlist 403'd this and broke all new register creation.
+        var (wallet, _) = await _walletManager.CreateWalletAsync("System", "ED25519", ValidatorOwner, "system");
+        var context = BuildServiceHttpContext(clientId: "register-service");
+
+        var result = await InvokeSignTransactionAsync(wallet.Address, ValidSignRequest(), context);
+
+        result.Should().NotBeOfType<Microsoft.AspNetCore.Http.HttpResults.ForbidHttpResult>();
+        result.GetType().Name.Should().Contain("Ok", "register-service signs register genesis with the validator system wallet");
     }
 
     [Fact]


### PR DESCRIPTION
Regression fix for the Task 2 #1397 restriction (#1408). **Caught by a live ConstructionPermit walkthrough on n1** — exactly the ground-truth test the earlier unit + targeted validation missed.

## The regression
Task 2 narrowed signing of a `validator:*` system wallet to `client_id == "validator-service"`. But **register-service also legitimately signs that key** — it signs the register genesis during creation (finalize) and for F189 governance. So the restriction 403'd `POST /api/registers/finalize` and **broke all new register creation** on any node running the WS0 images.

The walkthrough provisioned 6 orgs/wallets/participants fine, then finalize failed:
```
RegisterCreationOrchestrator Finalizing register creation ... with 1 signed attestations
WalletServiceClient Failed to sign transaction with wallet ws11qpdnc9qk... : 403 (Forbidden)
POST /api/registers/finalize responded 500
```

## The fix
Allowlist broadened to `{validator-service, register-service}` — the only two services that operate the validator system key (validator-service seals dockets; register-service creates genesis + governance). Blueprint's sandbox registers delegate finalize to register-service; peer replicates but never seals; genesis import uses `/system/recover`, not `/sign`. **Every other service token is still refused, so #1397's oracle stays closed.**

Added a `register-service`-allowed test beside the blueprint-refused one. Wallet suite 1000/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)