### PR TITLE
fix: ConstructionPermit setup provisions the credential-issuer master key

### DIFF
--- a/walkthroughs/ConstructionPermit/setup.ps1
+++ b/walkthroughs/ConstructionPermit/setup.ps1
@@ -387,6 +387,29 @@ $null = Add-SorchaPublicOrgSubscription `
     -SysAdminEmail $secrets.meridianAdminEmail
 
 # ============================================================================
+# Provision the Feature-083 org master key for the credential ISSUER org.
+# Action 6 (planning-officer) issues a BuildingPermitCredential signed by the planning
+# authority's org. Without a master key, IssuanceKeyService.GetActiveSigningMaterialAsync
+# returns null and the mint FAILS (400 "Failed to issue credential") — this walkthrough
+# predated the requirement and lacked the step that TradeFinance / ForestryCertification /
+# SelfBuildHouse have. Re-login first so the session JWT carries wallet_address (the master-key
+# endpoint is wallet-authorized); the planning-officer's wallet was created above. Idempotent
+# (409 on re-run is fine). See the walkthrough-builder skill.
+# ============================================================================
+Write-WtStep "Step 9b: Provision credential-issuer org master key"
+
+$planningIssuerSession = Connect-SorchaUser `
+    -TenantUrl $env.TenantUrl `
+    -Email $secrets.planningEmail `
+    -Password $secrets.planningPassword `
+    -OrganizationId $orgs.strathcarron
+
+Set-SorchaOrgMasterKey `
+    -WalletUrl $env.WalletUrl `
+    -OrganizationId $orgs.strathcarron `
+    -Headers $planningIssuerSession.Headers
+
+# ============================================================================
 # Step 9: Publish Participant Records to Register
 # ============================================================================
 Write-WtStep "Step 10: Publish Participant Records to Register"


### PR DESCRIPTION
Walkthrough hygiene — surfaced while confirming the platform on n1 after the WS0/#1397 work.

ConstructionPermit issues a `BuildingPermitCredential` (action 6) but its `setup.ps1` never provisioned the Feature-083 org master key for the issuer org — a step the current credential-issuing walkthroughs (TradeFinance, ForestryCertification, SelfBuildHouse) all have. Without it the mint fails 400 "Failed to issue credential" and Scenario B never completes.

Added a Step 9b that re-logs the planning-officer (JWT then carries `wallet_address`, which the master-key endpoint needs) and provisions the org master key. Idempotent.

**Live-verified on n1: ConstructionPermit now PASSES all three scenarios** — A 5/5, B 6/6 (credential issued), C rejection 3/3. Full golden path incl. register creation, publish, action sealing, conditional routing, credential issuance.

A broader walkthrough-currency audit follows (this same gap likely exists elsewhere).

🤖 Generated with [Claude Code](https://claude.com/claude-code)