### PR TITLE
fix: credential-issuing walkthroughs provision the issuer master key (3 walkthroughs)

### DIFF
--- a/walkthroughs/CyberEssentialsUac/setup.ps1
+++ b/walkthroughs/CyberEssentialsUac/setup.ps1
@@ -374,6 +374,30 @@ foreach ($p in $participantDefs) {
 }
 
 # ============================================================================
+# Step 6c: Provision the Feature-083 org master key for the credential ISSUER org.
+# ============================================================================
+# Blueprint A's action 1 (assessor) issues a CyberEssentialsUacPosture credential
+# (targetAudience: SorchaLocalWallet) signed by the assessor org. Without a master
+# key, IssuanceKeyService.GetActiveSigningMaterialAsync returns null and the mint
+# FAILS (400 "Failed to issue credential"). Re-login first so the session JWT
+# carries wallet_address (the master-key endpoint is wallet-authorized); the
+# assessor's wallet was created above. Idempotent (409 on re-run is fine).
+# See the walkthrough-builder skill.
+
+Write-WtStep "Step 6c: Provision credential-issuer org master key"
+
+$assessorIssuerSession = Connect-SorchaUser `
+    -TenantUrl      $sorchaEnv.TenantUrl `
+    -Email          $assessorAdminEmail `
+    -Password       $secrets.DefaultPassword `
+    -OrganizationId $assessorOrgId
+
+Set-SorchaOrgMasterKey `
+    -WalletUrl      $sorchaEnv.WalletUrl `
+    -OrganizationId $assessorOrgId `
+    -Headers        $assessorIssuerSession.Headers
+
+# ============================================================================
 # Step 7: Substitute Assessor Issuer DID into Blueprint B
 # ============================================================================
 # Blueprint B's credentialRequirements.trustPolicy.allowedIssuers contains the

--- a/walkthroughs/PropertyInspection/setup.ps1
+++ b/walkthroughs/PropertyInspection/setup.ps1
@@ -150,6 +150,34 @@ foreach ($p in $participantPublishDefs) {
     Write-WtInfo "  Published $($p.role)"
 }
 
+# ── Provision the Feature-083 org master key for the credential ISSUER org ─
+# Action 1 (housing-officer, sender) issues a JobAssignmentCredential to the
+# contractor. credentialIssuanceConfig omits targetAudience, which defaults to
+# SorchaLocalWallet (see CredentialIssuanceConfig.TargetAudience) — so this is
+# the same native-wallet issuance path as ConstructionPermit / CyberEssentialsUac
+# / Strathcarron, not the HAIP OpenID4VCI path. Without a master key,
+# IssuanceKeyService.GetActiveSigningMaterialAsync returns null and the mint
+# FAILS (400 "Failed to issue credential"). $housingSession was obtained above
+# (line ~84) via Connect-SorchaUser AFTER the housing-officer's wallet was
+# already created during the shared council setup, so its JWT already carries
+# wallet_address — no extra re-login needed here. Idempotent (409 on re-run
+# is fine). See the walkthrough-builder skill.
+#
+# NB: action 6 (sender "tenant") also carries a credentialIssuanceConfig
+# (ServiceCompletionCredential, also defaulting to SorchaLocalWallet) but is
+# NOT provisioned here — the tenant is a Public-org citizen/consumer, and
+# POST /api/wallets/org/{orgId}/master-key requires RequireAdministrator +
+# RequirePlatformAudience, which a consumer-tier token can never satisfy.
+# Provisioning a master key for the shared Public org (if that's even the
+# right fix) is a platform-wide decision, not a per-walkthrough setup step.
+# Flagged for follow-up; left unedited.
+Write-WtStep "Provisioning credential-issuer org master key (housing-officer / Strathcarron Council)"
+
+Set-SorchaOrgMasterKey `
+    -WalletUrl $sorchaEnv.WalletUrl `
+    -OrganizationId $housingRole.organizationId `
+    -Headers $housingSession.Headers
+
 # ── Publish blueprint ─────────────────────────────────────────────
 Write-WtStep "Publishing blueprint"
 

--- a/walkthroughs/Strathcarron/setup-cold-start-demo.ps1
+++ b/walkthroughs/Strathcarron/setup-cold-start-demo.ps1
@@ -127,6 +127,34 @@ $councilWallet = New-SorchaWallet `
 Write-WtSuccess "Council wallet: $($councilWallet.Address)"
 
 # ============================================================================
+# Step 4b: Provision the Feature-083 org master key for the credential ISSUER org.
+# ============================================================================
+# The council org's "licensing-officer" participant issues both the
+# AssuredIdentityCredential (strathcarron-driving-licence.json, action 2) and
+# the BlueBadgeCredential (strathcarron-blue-badge.json, action 3 — published
+# later by setup-blue-badge-demo.ps1 against this same council org/wallet).
+# Both are SorchaLocalWallet issuances. Without a master key,
+# IssuanceKeyService.GetActiveSigningMaterialAsync returns null and the mint
+# FAILS (400 "Failed to issue credential"). Re-login first so the session JWT
+# carries wallet_address (the master-key endpoint is wallet-authorized); the
+# council wallet was just created above. Idempotent (409 on re-run is fine).
+# One org issues both blueprints, so a single provisioning call here covers
+# strathcarron-blue-badge.json as well. See the walkthrough-builder skill.
+
+Write-WtStep "Step 4b: Provision credential-issuer org master key"
+
+$councilIssuerSession = Connect-SorchaUser `
+    -TenantUrl $sorchaEnv.TenantUrl `
+    -Email $councilAdminEmail `
+    -Password $councilAdminPassword `
+    -OrganizationId $councilOrgId
+
+Set-SorchaOrgMasterKey `
+    -WalletUrl $sorchaEnv.WalletUrl `
+    -OrganizationId $councilOrgId `
+    -Headers $councilIssuerSession.Headers
+
+# ============================================================================
 # Step 5: Register + Blueprint
 # ============================================================================
 Write-WtStep "Step 5: Driving Licence register + blueprint"


### PR DESCRIPTION
Applies the same fix as #1425 (ConstructionPermit) to the other walkthroughs the audit flagged: they issue `SorchaLocalWallet` credentials but never provisioned the Feature-083 issuer master key, so credential issuance fails `400 "Failed to issue credential"`.

- **CyberEssentialsUac** — issuer `assessor` org; added the re-login + `Set-SorchaOrgMasterKey` step.
- **Strathcarron** — issuer `licensing-officer` → Strathcarron Council (one org for both issuing blueprints); step added in `setup-cold-start-demo.ps1`.
- **PropertyInspection** — action 1 (`housing-officer`) fixed. **Action 6 deliberately NOT touched** — a citizen self-issuing under the Public org can't satisfy the master-key endpoint's admin/platform gate; that's a separate design issue (see the tracking issue).

## ⚠ Verification status — honest
Only **ConstructionPermit (#1425) is live-verified green on n1.** These three could NOT be cleanly live-verified end-to-end because each carries *additional* drift beyond the master key: CyberEssentialsUac has no `passwords.json` secrets entry; Strathcarron is a UI cold-start demo with no headless run + a pre-existing session re-login gap; PropertyInspection's action 6 is architecturally distinct. The master-key additions are correct (matching the verified ConstructionPermit pattern) and additive/idempotent, so they reduce drift and don't regress anything — but full green-on-n1 for these is deferred to the walkthrough-currency maintenance tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)