### PR TITLE
chore: [1423] - Variant compose files + Docker tests use per-deploy ServiceAuth secrets

### DIFF
--- a/.secrets-allowlist
+++ b/.secrets-allowlist
@@ -12,16 +12,25 @@
 # DB/cert-store dev passwords in the same file (Postgres, MongoDB, Kestrel
 # dev-cert) — not in scope for #1412.
 #
-# federation/infrastructure/multinode/n1 compose variants (local multi-node
-# testing only, never a bare `docker compose up` path): still carry the same
-# class of hardcoded ServiceAuth__ClientSecret literal. Out of scope for
-# #1412 (no ${VAR:-...} pattern exists there to convert) — remove each line
-# if/when those variants get the same per-deploy treatment.
+# federation/infrastructure/multinode compose variants (local multi-node
+# testing only, never a bare `docker compose up` path): docker-compose.yml,
+# docker-compose.federation.yml, and docker-compose.multinode.yml stay
+# allowlisted for unrelated DB dev-password literals (Postgres/MongoDB
+# `sorcha_dev_password`) — not in scope for #1412/#1423.
+#
+# The ServiceAuth__ClientSecret literals themselves are GONE from
+# docker-compose.yml (#1412) and from federation/multinode/n1 (#1423 — env-
+# indirected to match the base compose's ${VAR:?} guard, same var names).
+# docker-compose.n1.yml came OFF this list entirely — #1423 removed its one
+# hardcoded literal (haip-service ClientSecret) and it has no other
+# secret-shaped lines. docker-compose.federation.yml's one federation-only
+# secret (peer-service-b, a synthetic second identity with no base-compose
+# equivalent) is env-indirected with a soft default (${VAR:-...}), not a hard
+# ${VAR:?} guard — see the inline comment in that file.
 docker-compose.yml
 docker-compose.federation.yml
 docker-compose.infrastructure.yml
 docker-compose.multinode.yml
-docker-compose.n1.yml
 
 # Pre-existing local-dev bootstrap secrets — NOT in scope for #1397 (that
 # issue is specifically about the compose ServiceAuth__ClientSecret literals

--- a/docker-compose.federation.yml
+++ b/docker-compose.federation.yml
@@ -107,7 +107,15 @@ services:
       MongoDB__ConnectionString: mongodb://sorcha:sorcha_dev_password@mongodb-b:27017
       MongoDB__DatabaseName: sorcha_system_register
       ServiceAuth__ClientId: service-peer-b
-      ServiceAuth__ClientSecret: peer-service-b-secret
+      # peer-b is a SYNTHETIC second identity for this local two-peer smoke
+      # test — it is not one of the base compose's 8 guarded ServiceAuth
+      # secrets (no "service-peer-b" principal exists there), and
+      # sorcha-setup.sh does not generate a value for it. Env-indirected
+      # (#1423) with the current literal kept as the default so the existing
+      # `docker compose -f docker-compose.yml -f docker-compose.federation.yml
+      # up -d` flow keeps working without extra setup; override
+      # PEER_SERVICE_B_SECRET if you need a non-default value.
+      ServiceAuth__ClientSecret: ${PEER_SERVICE_B_SECRET:-peer-service-b-secret}
       ServiceAuth__Scopes: "registers:write registers:read"
       ServiceClients__TenantService__Address: http://tenant-service-b:8080
       ServiceClients__RegisterService__Address: http://register-service-b:8080

--- a/docker-compose.multinode.yml
+++ b/docker-compose.multinode.yml
@@ -89,7 +89,11 @@ services:
       JwtSettings__InstallationName: ${INSTALLATION_NAME:-localhost}
       JwtSettings__SigningKey: ${JWT_SIGNING_KEY:-c29yY2hhLWRvY2tlci1kZXYta2V5LTIwMjUtbWluLTI1Ni1iaXRzLXNlY3VyZQ==}
       ServiceAuth__ClientId: tenant-service
-      ServiceAuth__ClientSecret: tenant-service-secret
+      # Same ClientId as the base compose's tenant-service (this is a second
+      # replica of the SAME principal, not a distinct identity), so it MUST
+      # use the same generated secret (#1423) — sorcha-setup.sh writes
+      # TENANT_SERVICE_SECRET into .env; no literal default.
+      ServiceAuth__ClientSecret: ${TENANT_SERVICE_SECRET:?not set — run ./scripts/sorcha-setup.sh to generate .env (see README Quick Start); bare docker compose up is unsupported}
       ServiceAuth__Scopes: "wallets:sign wallets:verify persona:crypto"
       ServiceClients__WalletService__Address: http://wallet-service:8080
     depends_on:

--- a/docker-compose.n1.yml
+++ b/docker-compose.n1.yml
@@ -138,7 +138,12 @@ services:
       ServiceClients__BlueprintService__Address: http://blueprint-service:8080
       ServiceClients__TenantService__Address: http://tenant-service:8080
       ServiceAuth__ClientId: service-haip
-      ServiceAuth__ClientSecret: haip-service-secret
+      # Same var/spelling as the base compose (#1423) — required because this
+      # override REPLACES (not additive-merges) the base haip-service
+      # environment block, so the guard has to be repeated here too. n1's
+      # .env already supplies HAIP_SERVICE_SECRET for the base compose; no
+      # new var introduced.
+      ServiceAuth__ClientSecret: ${HAIP_SERVICE_SECRET:?not set — run ./scripts/sorcha-setup.sh to generate .env (see README Quick Start); bare docker compose up is unsupported}
       ServiceAuth__Scopes: "blueprints:read"
 
   sorcha-ui-web:

--- a/docker/desktop/.env.desktop.example
+++ b/docker/desktop/.env.desktop.example
@@ -22,6 +22,19 @@ POSTGRES_PASSWORD=
 MONGO_USERNAME=sorcha
 MONGO_PASSWORD=
 
+# Per-service ServiceAuth client secrets (#1423) — one per internal service
+# principal, seeded into the Tenant Service DB and presented back by each
+# service's own ServiceAuthClient. Generate distinct random values, e.g.
+# openssl rand -base64 32 (or LC_ALL=C tr -dc 'A-Za-z0-9' </dev/urandom | head -c 32).
+# scripts/deploy-desktop.sh / .ps1 fill these in for you on first run.
+WALLET_SERVICE_SECRET=
+TENANT_SERVICE_SECRET=
+REGISTER_SERVICE_SECRET=
+VALIDATOR_SERVICE_SECRET=
+HAIP_SERVICE_SECRET=
+PEER_SERVICE_SECRET=
+BLUEPRINT_SERVICE_SECRET=
+
 # ---- Image selection --------------------------------------------------------
 # Pull a pinned version instead of :latest for a reproducible node, e.g. 2.412.1
 SORCHA_IMAGE_REPO=sorchadev

--- a/docker/desktop/README.md
+++ b/docker/desktop/README.md
@@ -71,7 +71,8 @@ containers). Data in the named volumes is preserved.
 
 - The gateway is **HTTP-only on :8880**. Front it with a TLS-terminating reverse
   proxy (Caddy / nginx) if reachable off the machine.
-- `.env` holds the JWT signing key and DB passwords — it's generated `chmod 600`
+- `.env` holds the JWT signing key, DB passwords, and the per-service
+  `*_SERVICE_SECRET` ServiceAuth credentials — it's generated `chmod 600`
   and must never be committed.
 - `INSTALLATION_NAME` is fixed at first boot (it's baked into issued tokens).
   Changing it later invalidates existing tokens.

--- a/docker/desktop/docker-compose.desktop.yml
+++ b/docker/desktop/docker-compose.desktop.yml
@@ -151,7 +151,12 @@ services:
       ASPNETCORE_ENVIRONMENT: Docker
       ASPNETCORE_URLS: http://+:8080
       ServiceAuth__ClientId: service-wallet
-      ServiceAuth__ClientSecret: wallet-service-secret
+      # Per-deploy secret (#1423, same treatment as the main docker-compose.yml
+      # per #1412) — deploy-desktop.sh/.ps1 generates WALLET_SERVICE_SECRET
+      # into .env on first run. No literal default: a bare `docker compose up`
+      # without a generated .env must fail loudly, not silently run with a
+      # committed secret.
+      ServiceAuth__ClientSecret: ${WALLET_SERVICE_SECRET:?set WALLET_SERVICE_SECRET in .env — run scripts/deploy-desktop.sh (or .ps1) to generate it, or see .env.desktop.example}
       ServiceAuth__Scopes: "registers:write registers:read"
       ServiceClients__TenantService__Address: http://tenant-service:8080
       ServiceClients__RegisterService__Address: http://register-service:8080
@@ -193,7 +198,8 @@ services:
       # MUST stay false in a true production deployment.
       Platform__AllowAdminVerifiedUserCreation: "true"
       ServiceAuth__ClientId: tenant-service
-      ServiceAuth__ClientSecret: tenant-service-secret
+      # Per-deploy secret (#1423) — see wallet-service's ServiceAuth__ClientSecret above.
+      ServiceAuth__ClientSecret: ${TENANT_SERVICE_SECRET:?set TENANT_SERVICE_SECRET in .env — run scripts/deploy-desktop.sh (or .ps1) to generate it, or see .env.desktop.example}
       ServiceAuth__Scopes: "wallets:sign wallets:verify persona:crypto"
       ServiceClients__WalletService__Address: http://wallet-service:8080
       ServiceClients__TenantService__Address: http://tenant-service:8080
@@ -255,7 +261,8 @@ services:
       # MUST equal validator-service Validator__ValidatorId (shared system wallet).
       SystemWalletSigning__ValidatorId: local-validator
       ServiceAuth__ClientId: register-service
-      ServiceAuth__ClientSecret: register-service-secret
+      # Per-deploy secret (#1423) — see wallet-service's ServiceAuth__ClientSecret above.
+      ServiceAuth__ClientSecret: ${REGISTER_SERVICE_SECRET:?set REGISTER_SERVICE_SECRET in .env — run scripts/deploy-desktop.sh (or .ps1) to generate it, or see .env.desktop.example}
       ServiceAuth__Scopes: "wallets:sign validator:write"
       ServiceClients__TenantService__Address: http://tenant-service:8080
     volumes:
@@ -287,7 +294,8 @@ services:
       ASPNETCORE_HTTP_PORTS: "8080"
       ConnectionStrings__Redis: redis:6379
       ServiceAuth__ClientId: validator-service
-      ServiceAuth__ClientSecret: validator-service-secret
+      # Per-deploy secret (#1423) — see wallet-service's ServiceAuth__ClientSecret above.
+      ServiceAuth__ClientSecret: ${VALIDATOR_SERVICE_SECRET:?set VALIDATOR_SERVICE_SECRET in .env — run scripts/deploy-desktop.sh (or .ps1) to generate it, or see .env.desktop.example}
       ServiceAuth__Scopes: "registers:write registers:read blueprints:read"
       # MUST equal register-service SystemWalletSigning__ValidatorId.
       Validator__ValidatorId: local-validator
@@ -339,7 +347,8 @@ services:
       ServiceClients__BlueprintService__Address: http://blueprint-service:8080
       ServiceClients__TenantService__Address: http://tenant-service:8080
       ServiceAuth__ClientId: service-haip
-      ServiceAuth__ClientSecret: haip-service-secret
+      # Per-deploy secret (#1423) — see wallet-service's ServiceAuth__ClientSecret above.
+      ServiceAuth__ClientSecret: ${HAIP_SERVICE_SECRET:?set HAIP_SERVICE_SECRET in .env — run scripts/deploy-desktop.sh (or .ps1) to generate it, or see .env.desktop.example}
       ServiceAuth__Scopes: "blueprints:read"
     depends_on:
       redis: { condition: service_healthy }
@@ -368,7 +377,8 @@ services:
       ASPNETCORE_HTTP_PORTS: "8080"
       MongoDB__DatabaseName: sorcha_system_register
       ServiceAuth__ClientId: service-peer
-      ServiceAuth__ClientSecret: peer-service-secret
+      # Per-deploy secret (#1423) — see wallet-service's ServiceAuth__ClientSecret above.
+      ServiceAuth__ClientSecret: ${PEER_SERVICE_SECRET:?set PEER_SERVICE_SECRET in .env — run scripts/deploy-desktop.sh (or .ps1) to generate it, or see .env.desktop.example}
       ServiceAuth__Scopes: "registers:write registers:read"
       ServiceClients__TenantService__Address: http://tenant-service:8080
       ServiceClients__RegisterService__Address: http://register-service:8080
@@ -417,7 +427,8 @@ services:
       ServiceClients__PeerService__Address: http://peer-service:5000
       ServiceClients__PeerService__HttpAddress: http://peer-service:8080
       ServiceAuth__ClientId: service-blueprint
-      ServiceAuth__ClientSecret: blueprint-service-secret
+      # Per-deploy secret (#1423) — see wallet-service's ServiceAuth__ClientSecret above.
+      ServiceAuth__ClientSecret: ${BLUEPRINT_SERVICE_SECRET:?set BLUEPRINT_SERVICE_SECRET in .env — run scripts/deploy-desktop.sh (or .ps1) to generate it, or see .env.desktop.example}
       ServiceAuth__Scopes: "wallets:sign registers:write blueprints:manage"
       TransactionConfirmation__TimeoutSeconds: "60"
       TransactionConfirmation__PollIntervalSeconds: "1"

--- a/scripts/deploy-desktop.ps1
+++ b/scripts/deploy-desktop.ps1
@@ -95,10 +95,21 @@ function Initialize-Env {
     Warn "No .env found — generating one with fresh secrets."
     Copy-Item (Join-Path $BundleDir '.env.desktop.example') $EnvFile
     $jwt = New-SecretB64; $pgp = New-SecretAlnum; $mgp = New-SecretAlnum   # alnum: mongo pwd is in a URI
+    # Per-service ServiceAuth client secrets (#1423) — one per internal service principal.
+    $walletS = New-SecretAlnum; $tenantS = New-SecretAlnum; $registerS = New-SecretAlnum
+    $validatorS = New-SecretAlnum; $haipS = New-SecretAlnum; $peerS = New-SecretAlnum
+    $blueprintS = New-SecretAlnum
     (Get-Content $EnvFile) `
-        -replace '^JWT_SIGNING_KEY=.*',   "JWT_SIGNING_KEY=$jwt" `
-        -replace '^POSTGRES_PASSWORD=.*', "POSTGRES_PASSWORD=$pgp" `
-        -replace '^MONGO_PASSWORD=.*',    "MONGO_PASSWORD=$mgp" |
+        -replace '^JWT_SIGNING_KEY=.*',         "JWT_SIGNING_KEY=$jwt" `
+        -replace '^POSTGRES_PASSWORD=.*',       "POSTGRES_PASSWORD=$pgp" `
+        -replace '^MONGO_PASSWORD=.*',          "MONGO_PASSWORD=$mgp" `
+        -replace '^WALLET_SERVICE_SECRET=.*',   "WALLET_SERVICE_SECRET=$walletS" `
+        -replace '^TENANT_SERVICE_SECRET=.*',   "TENANT_SERVICE_SECRET=$tenantS" `
+        -replace '^REGISTER_SERVICE_SECRET=.*', "REGISTER_SERVICE_SECRET=$registerS" `
+        -replace '^VALIDATOR_SERVICE_SECRET=.*',"VALIDATOR_SERVICE_SECRET=$validatorS" `
+        -replace '^HAIP_SERVICE_SECRET=.*',     "HAIP_SERVICE_SECRET=$haipS" `
+        -replace '^PEER_SERVICE_SECRET=.*',     "PEER_SERVICE_SECRET=$peerS" `
+        -replace '^BLUEPRINT_SERVICE_SECRET=.*',"BLUEPRINT_SERVICE_SECRET=$blueprintS" |
         Set-Content $EnvFile
     Ok "Generated $EnvFile (secrets written)."
 }

--- a/scripts/deploy-desktop.sh
+++ b/scripts/deploy-desktop.sh
@@ -94,11 +94,25 @@ ensure_env() {
   cp "$BUNDLE_DIR/.env.desktop.example" "$ENV_FILE"
   local jwt pgp mgp
   jwt="$(gen_secret_b64)"; pgp="$(gen_secret_alnum)"; mgp="$(gen_secret_alnum)"
+  # Per-service ServiceAuth client secrets (#1423) — one per internal service
+  # principal; alphanumeric so they're safe unquoted in .env and in compose
+  # ${VAR:?...} interpolation.
+  local wallet_s tenant_s register_s validator_s haip_s peer_s blueprint_s
+  wallet_s="$(gen_secret_alnum)"; tenant_s="$(gen_secret_alnum)"; register_s="$(gen_secret_alnum)"
+  validator_s="$(gen_secret_alnum)"; haip_s="$(gen_secret_alnum)"; peer_s="$(gen_secret_alnum)"
+  blueprint_s="$(gen_secret_alnum)"
   # Mongo password is embedded in a connection URI, so keep it alphanumeric.
   sed -i.bak \
     -e "s|^JWT_SIGNING_KEY=.*|JWT_SIGNING_KEY=${jwt}|" \
     -e "s|^POSTGRES_PASSWORD=.*|POSTGRES_PASSWORD=${pgp}|" \
     -e "s|^MONGO_PASSWORD=.*|MONGO_PASSWORD=${mgp}|" \
+    -e "s|^WALLET_SERVICE_SECRET=.*|WALLET_SERVICE_SECRET=${wallet_s}|" \
+    -e "s|^TENANT_SERVICE_SECRET=.*|TENANT_SERVICE_SECRET=${tenant_s}|" \
+    -e "s|^REGISTER_SERVICE_SECRET=.*|REGISTER_SERVICE_SECRET=${register_s}|" \
+    -e "s|^VALIDATOR_SERVICE_SECRET=.*|VALIDATOR_SERVICE_SECRET=${validator_s}|" \
+    -e "s|^HAIP_SERVICE_SECRET=.*|HAIP_SERVICE_SECRET=${haip_s}|" \
+    -e "s|^PEER_SERVICE_SECRET=.*|PEER_SERVICE_SECRET=${peer_s}|" \
+    -e "s|^BLUEPRINT_SERVICE_SECRET=.*|BLUEPRINT_SERVICE_SECRET=${blueprint_s}|" \
     "$ENV_FILE" && rm -f "$ENV_FILE.bak"
   chmod 600 "$ENV_FILE"
   ok "Generated $ENV_FILE (secrets written, mode 600)."

--- a/tests/Sorcha.Integration.Tests/MultiNode/HubBackplaneCrossReplicaTests.cs
+++ b/tests/Sorcha.Integration.Tests/MultiNode/HubBackplaneCrossReplicaTests.cs
@@ -37,6 +37,14 @@ public class HubBackplaneCrossReplicaTests
     private static bool MultinodeEnabled =>
         Environment.GetEnvironmentVariable("SORCHA_MULTINODE") == "1";
 
+    // The Blueprint service-principal's ServiceAuth secret is per-deploy since
+    // #1412 — sorcha-setup.sh generates BLUEPRINT_SERVICE_SECRET into .env
+    // instead of the old committed "blueprint-service-secret" literal. Read
+    // the same env var name here so this test authenticates against whatever
+    // secret the running stack was actually provisioned with (#1423).
+    private static string? BlueprintServiceSecret =>
+        Environment.GetEnvironmentVariable("BLUEPRINT_SERVICE_SECRET");
+
     [SkippableFact]
     [Trait("Hub", "Blueprint")]
     public async Task BlueprintHub_EventOnReplicaA_ReachesClientOnReplicaB_WithinBudget()
@@ -86,6 +94,10 @@ public class HubBackplaneCrossReplicaTests
     public async Task TenantHub_EventOnReplicaA_ReachesClientOnReplicaB_WithinBudget()
     {
         Skip.IfNot(MultinodeEnabled, "Multi-node fixture not running. Set SORCHA_MULTINODE=1 and start docker-compose.multinode.yml.");
+        Skip.IfNot(!string.IsNullOrEmpty(BlueprintServiceSecret),
+            "BLUEPRINT_SERVICE_SECRET not set. Export the same value sorcha-setup.sh wrote " +
+            "to .env (the Blueprint service principal's per-deploy secret; #1412) before " +
+            "running with SORCHA_MULTINODE=1.");
 
         // 1. Acquire admin user token. TenantHub auto-joins user:{platform_user_id}
         //    on connect; same JWT on both replicas → both pinned to the same
@@ -155,7 +167,7 @@ public class HubBackplaneCrossReplicaTests
         {
             new KeyValuePair<string, string>("grant_type", "client_credentials"),
             new KeyValuePair<string, string>("client_id", "service-blueprint"),
-            new KeyValuePair<string, string>("client_secret", "blueprint-service-secret"),
+            new KeyValuePair<string, string>("client_secret", BlueprintServiceSecret!),
         });
         var resp = await http.PostAsync("/api/service-auth/token", form);
         resp.EnsureSuccessStatusCode();

--- a/tests/Sorcha.Integration.Tests/Quickstart/InboxRoundTripTests.cs
+++ b/tests/Sorcha.Integration.Tests/Quickstart/InboxRoundTripTests.cs
@@ -23,9 +23,11 @@ namespace Sorcha.Integration.Tests.Quickstart;
 /// <para>
 /// Skipped unless <c>SORCHA_DOCKER=1</c> is set and the standard
 /// <c>docker-compose.yml</c> stack is running. Local dev creds are
-/// <c>admin@sorcha.local / Dev_Pass_2025!</c>; service-principal creds are
-/// <c>service-blueprint / blueprint-service-secret</c>. CI gates the same
-/// test under the Docker-CI workflow.
+/// <c>admin@sorcha.local / Dev_Pass_2025!</c>; the service-principal client
+/// id is <c>service-blueprint</c>, and its secret is per-deploy (#1412) —
+/// export <c>BLUEPRINT_SERVICE_SECRET</c> with the same value
+/// <c>sorcha-setup.sh</c> wrote to <c>.env</c> before running this test. CI
+/// gates the same test under the Docker-CI workflow.
 /// </para>
 /// <para>
 /// This test was first executed manually against the running Docker stack
@@ -44,11 +46,23 @@ public class InboxRoundTripTests
     private static bool DockerEnabled =>
         Environment.GetEnvironmentVariable("SORCHA_DOCKER") == "1";
 
+    // The Blueprint service-principal's ServiceAuth secret is per-deploy since
+    // #1412 — sorcha-setup.sh generates BLUEPRINT_SERVICE_SECRET into .env
+    // instead of the old committed "blueprint-service-secret" literal. Read
+    // the same env var name here so this test authenticates against whatever
+    // secret the running stack was actually provisioned with (#1423).
+    private static string? BlueprintServiceSecret =>
+        Environment.GetEnvironmentVariable("BLUEPRINT_SERVICE_SECRET");
+
     [SkippableFact]
     public async Task InboxRoundTrip_PostEntry_FiresRealtime_AndPersistsToRest()
     {
         Skip.IfNot(DockerEnabled,
             "Docker stack not running. Set SORCHA_DOCKER=1 and start docker-compose.yml.");
+        Skip.IfNot(!string.IsNullOrEmpty(BlueprintServiceSecret),
+            "BLUEPRINT_SERVICE_SECRET not set. Export the same value sorcha-setup.sh wrote " +
+            "to .env (the Blueprint service principal's per-deploy secret; #1412) before " +
+            "running with SORCHA_DOCKER=1.");
 
         // 1. Acquire user JWT (admin) and service-principal JWT (Blueprint Service).
         using var http = new HttpClient { BaseAddress = new Uri(GatewayUrl) };
@@ -160,7 +174,7 @@ public class InboxRoundTripTests
         {
             new KeyValuePair<string, string>("grant_type", "client_credentials"),
             new KeyValuePair<string, string>("client_id", "service-blueprint"),
-            new KeyValuePair<string, string>("client_secret", "blueprint-service-secret"),
+            new KeyValuePair<string, string>("client_secret", BlueprintServiceSecret!),
         });
         var resp = await http.PostAsync("/api/service-auth/token", form);
         resp.EnsureSuccessStatusCode();


### PR DESCRIPTION
## Summary

Closes #1423 — pure hygiene follow-up to #1412 (which guarded the main `docker-compose.yml`'s 8 `ServiceAuth__ClientSecret` / `Seed__ServicePrincipals` literals with `${VAR:?...}` so a bare `docker compose up` fails loudly instead of silently running with a committed secret). Two gaps remained, neither touching the shipped/validated path:

### Part 1 — variant compose files

| File | Literal → guard |
|---|---|
| `docker-compose.multinode.yml` | `tenant-service-2`'s `ServiceAuth__ClientSecret: tenant-service-secret` → `${TENANT_SERVICE_SECRET:?...}` (same var/message as base). **This was a live latent bug**: replica 1 (merged from base) already required the real generated secret while replica 2 hardcoded the old literal — the two replicas of the *same* `tenant-service` principal disagreed on their own secret. |
| `docker-compose.n1.yml` | `haip-service`'s `ServiceAuth__ClientSecret: haip-service-secret` → `${HAIP_SERVICE_SECRET:?...}` (same var/message as base). n1's override *replaces* rather than merges the base `haip-service` environment block (documented inline in the file), so the guard has to be repeated here. |
| `docker-compose.federation.yml` | `peer-service-b`'s `ServiceAuth__ClientSecret: peer-service-b-secret` → `${PEER_SERVICE_B_SECRET:-peer-service-b-secret}` (**soft default**, not a hard fail — see "Deliberate difference" below). |
| `docker/desktop/docker-compose.desktop.yml` | 7 secrets (wallet/tenant/register/validator/haip/peer/blueprint — no verifier principal here) → `${WALLET_SERVICE_SECRET:?...}` etc., same var names as the base compose. This file is standalone (never merged with the base compose), so `deploy-desktop.sh` / `deploy-desktop.ps1` now generate all 7 into `.env` on first run (alongside the existing JWT/Postgres/Mongo generation), and `.env.desktop.example` documents them. |

**Deliberate difference — `docker-compose.federation.yml`:** `peer-service-b` is a *synthetic second-peer identity* for the local two-peer federation smoke test — it has no equivalent among the base compose's 8 (no `service-peer-b` principal exists there), and `sorcha-setup.sh` doesn't generate a value for it. A hard `${VAR:?}` guard would break the documented `docker compose -f docker-compose.yml -f docker-compose.federation.yml up -d` flow for anyone who already has a `.env` from `sorcha-setup.sh` (which doesn't set this var). I env-indirected it with the current literal kept as the `:-` default instead, flagged here per the task brief's request to surface value differences rather than silently unify them. Happy to switch to a hard fail + `sorcha-setup.sh` generation as a follow-up if that's preferred.

**n1.yml deploy-safety note (per the task brief — I have NOT deployed this):** after this change, `docker-compose.n1.yml` on its own introduces **no new required var** — it only re-references `HAIP_SERVICE_SECRET`, one of the base compose's existing 8. The full set n1's `.env` must already contain (unchanged from today) is:
```
BLUEPRINT_SERVICE_SECRET
WALLET_SERVICE_SECRET
REGISTER_SERVICE_SECRET
TENANT_SERVICE_SECRET
PEER_SERVICE_SECRET
VALIDATOR_SERVICE_SECRET
HAIP_SERVICE_SECRET   <- the one this PR's n1.yml change actually touches
VERIFIER_SERVICE_SECRET
```
Verified via `docker compose -f docker-compose.yml -f docker-compose.n1.yml config` with all 8 set (parses clean) and with `HAIP_SERVICE_SECRET` deliberately unset (fails loudly with the guard message) — see Verification below.

**`.secrets-allowlist`:** `docker-compose.n1.yml` had no other secret-shaped line once its one literal was fixed, so it comes **off** the allowlist entirely (ratchet shrunk). `docker-compose.federation.yml` and `docker-compose.multinode.yml` stay allowlisted — for unrelated `Password=sorcha_dev_password` Postgres/MongoDB dev-credential lines, not ServiceAuth secrets. Comment updated to reflect all of this.

### Part 2 — two Docker-gated integration tests

`tests/Sorcha.Integration.Tests/Quickstart/InboxRoundTripTests.cs` (`SORCHA_DOCKER=1`) and `tests/Sorcha.Integration.Tests/MultiNode/HubBackplaneCrossReplicaTests.cs` (`SORCHA_MULTINODE=1`) both hardcoded `client_secret: "blueprint-service-secret"` for the Blueprint service principal. Neither runs in CI, but both would fail against a `sorcha-setup.sh`-provisioned stack (the secret is now random). Both now read `BLUEPRINT_SERVICE_SECRET` from the environment — the same var name `sorcha-setup.sh` writes to `.env` — and `Skip.IfNot` with a clear message if it's unset, instead of authenticating with the wrong secret.

**Found but out of scope:** both tests still POST to the public `/api/service-auth/token` for `client_credentials`, which #1407/#1408 (issue #1397) moved to internal-only `/api/internal/service-auth/token` — so even with the right secret these two tests would currently get a 400 from the wrong endpoint. Pre-existing, unrelated to secret sourcing, and outside this PR's stated scope; flagging for a follow-up issue rather than fixing here (single-purpose PR).

## Verification

- `docker compose -f docker-compose.yml -f docker-compose.{federation,multinode,n1}.yml config --services` parses clean with all vars set; `docker compose -f docker-compose.desktop.yml config` (standalone) parses clean with its own vars set.
- Confirmed the guard actually fires: unsetting `HAIP_SERVICE_SECRET` on the n1 overlay and `WALLET_SERVICE_SECRET` on the desktop compose both fail loudly with the expected message (not silently defaulting).
- `dotnet build tests/Sorcha.Integration.Tests/Sorcha.Integration.Tests.csproj` — 0 errors (pre-existing warnings only).
- `pwsh scripts/check-secrets.ps1` — passes; ratchet shrunk by one entry (`docker-compose.n1.yml`).

## Test plan

- [x] `docker compose config` parse-checked for all four edited compose files (federation/multinode/n1/desktop), including the fail-loudly path
- [x] `dotnet build` on `Sorcha.Integration.Tests` — compiles clean
- [x] `scripts/check-secrets.ps1` passes
- [ ] Maintainer confirms n1's `.env` covers `HAIP_SERVICE_SECRET` (already required by the base compose today) before the next n1 deploy — no new var, just re-confirming coverage per the task brief

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016GvgN77L1QD85tUES8n4D2