### PR TITLE
fix: [1434] - Generate Seed:AdminPassword for non-Dev installs (unblock Production boot)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -481,6 +481,12 @@ services:
       Seed__ServicePrincipals__tenant-service: ${TENANT_SERVICE_SECRET:?not set — run ./scripts/sorcha-setup.sh to generate .env (see README Quick Start); bare docker compose up is unsupported}
       Seed__ServicePrincipals__service-haip: ${HAIP_SERVICE_SECRET:?not set — run ./scripts/sorcha-setup.sh to generate .env (see README Quick Start); bare docker compose up is unsupported}
       Seed__ServicePrincipals__service-verifier: ${VERIFIER_SERVICE_SECRET:?not set — run ./scripts/sorcha-setup.sh to generate .env (see README Quick Start); bare docker compose up is unsupported}
+      # Seed admin credentials (issues #1409 / #1434). An empty AdminPassword is
+      # allowed in Development (DatabaseInitializer uses its dev default); in
+      # Production/Staging DatabaseInitializer fail-closes at startup unless it is
+      # set, so sorcha-setup.sh generates one for any non-Development install.
+      Seed__AdminEmail: ${SEED_ADMIN_EMAIL:-admin@sorcha.local}
+      Seed__AdminPassword: ${SEED_ADMIN_PASSWORD:-}
       ServiceClients__WalletService__Address: http://wallet-service:8080
       ServiceClients__TenantService__Address: http://tenant-service:8080
       ServiceClients__RegisterService__Address: http://register-service:8080

--- a/scripts/sorcha-setup.sh
+++ b/scripts/sorcha-setup.sh
@@ -419,6 +419,16 @@ write_env_file() {
     : "${HAIP_SERVICE_SECRET:=$(generate_service_secret)}"
     : "${VERIFIER_SERVICE_SECRET:=$(generate_service_secret)}"
 
+    # Seed admin password (issues #1409 / #1434). In Development the Tenant
+    # Service uses its committed dev default when AdminPassword is empty; in
+    # Production/Staging DatabaseInitializer fail-closes at startup unless it is
+    # set, so generate a strong one for any non-Development install. It is shown
+    # once in the final summary and is not recoverable afterwards.
+    SEED_ADMIN_EMAIL="${SEED_ADMIN_EMAIL:-admin@sorcha.local}"
+    if [ "$ASPNETCORE_ENVIRONMENT" != "Development" ]; then
+        : "${SEED_ADMIN_PASSWORD:=$(generate_service_secret)}"
+    fi
+
     if [ -f "$ENV_FILE" ]; then
         local backup="$ENV_FILE.backup.$(date +%Y%m%d-%H%M%S)"
         cp "$ENV_FILE" "$backup"
@@ -485,6 +495,13 @@ VALIDATOR_SERVICE_SECRET=${VALIDATOR_SERVICE_SECRET}
 TENANT_SERVICE_SECRET=${TENANT_SERVICE_SECRET}
 HAIP_SERVICE_SECRET=${HAIP_SERVICE_SECRET}
 VERIFIER_SERVICE_SECRET=${VERIFIER_SERVICE_SECRET}
+
+# Seed admin credentials (issues #1409 / #1434). Development uses the Tenant
+# Service dev default when AdminPassword is empty; Production/Staging fail-closed
+# at startup unless it is set, so setup generates one above for non-Development
+# installs. Read as Seed:AdminEmail / Seed:AdminPassword by DatabaseInitializer.
+SEED_ADMIN_EMAIL=${SEED_ADMIN_EMAIL:-admin@sorcha.local}
+SEED_ADMIN_PASSWORD=${SEED_ADMIN_PASSWORD:-}
 ENVFILE
 
     success ".env file written"
@@ -639,8 +656,15 @@ print_summary() {
     echo -e "  Aspire Dashboard   ${CYAN}http://localhost:18888${NC}"
     echo ""
     echo -e "${BOLD}Default Login:${NC}"
-    echo -e "  Email:     ${CYAN}admin@sorcha.local${NC}"
-    echo -e "  Password:  ${CYAN}Dev_Pass_2025!${NC}"
+    if [ "$ASPNETCORE_ENVIRONMENT" != "Development" ] && [ -n "${SEED_ADMIN_PASSWORD:-}" ]; then
+        echo -e "  Email:     ${CYAN}${SEED_ADMIN_EMAIL:-admin@sorcha.local}${NC}"
+        echo -e "  Password:  ${CYAN}${SEED_ADMIN_PASSWORD}${NC}"
+        echo -e "             (generated for this ${ASPNETCORE_ENVIRONMENT} install — save it now;"
+        echo -e "              it is not recoverable. Change it on first login.)"
+    else
+        echo -e "  Email:     ${CYAN}admin@sorcha.local${NC}"
+        echo -e "  Password:  ${CYAN}Dev_Pass_2025!${NC}  (development default)"
+    fi
     echo ""
     echo -e "${BOLD}Useful Commands:${NC}"
     echo -e "  View logs:         ${CYAN}docker compose logs -f${NC}"


### PR DESCRIPTION
#1409 made DatabaseInitializer fail-closed on the admin password in
Production/Staging, but sorcha-setup.sh never set Seed:AdminPassword and the base
compose had no Seed__AdminPassword env — so a Production install via the
documented one-liner refused to seed the admin and the node was unbootable, found
only at runtime.

- docker-compose.yml: tenant-service now reads Seed__AdminEmail / Seed__AdminPassword
  (empty default → Development uses the dev literal; Production/Staging require it
  non-empty, matching #1409's fail-closed).
- sorcha-setup.sh: generate a strong SEED_ADMIN_PASSWORD for any non-Development
  install, write it to .env, and print it once with a save/change-on-first-login
  note. Development keeps the committed dev default.

Verified: bash -n clean; docker compose config resolves Seed__AdminPassword="" by
default (Dev-safe). Unblocks the fresh-Production-install path and the Public Gates
rate-limit burst-test. Closes #1434.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016GvgN77L1QD85tUES8n4D2
