### PR TITLE
fix: [#1437] Deliver production rate limits to the gateway container

### DIFF
--- a/docker-compose.n1.yml
+++ b/docker-compose.n1.yml
@@ -158,3 +158,9 @@ services:
       Dashboard__AspireDashboardUrl: https://n1.sorcha.dev:18888
       # Disable HTTPS on gateway - Caddy handles TLS
       ASPNETCORE_URLS: http://+:8080
+      # Rate limits (#1437): this override MERGES with the base api-gateway environment
+      # (compose unions environment maps across -f files), so n1's gateway inherits the base
+      # RateLimiting__* production limits (api 600/min, auth 60/min, strict 60 tokens, all
+      # QueueLimit=0). n1 is the public edge this fix targets, so it is deliberately NOT loosened
+      # here. Only tenant-service's PlatformAuth is loosened above, for walkthrough user-creation
+      # bursts. To relax a gateway limit for a demo, set the RATELIMIT_* vars in the host .env.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -842,6 +842,25 @@ services:
       ConnectionStrings__Redis: redis:6379
       OpenApi__RequireAuth: ${OPENAPI_REQUIRE_AUTH:-true}
       Dashboard__AspireDashboardUrl: http://localhost:18888
+      # Production rate limits, delivered via env vars (issue #1437). appsettings.Production.json
+      # is stripped from every image by .dockerignore ("**/appsettings.*.json"), and deployments
+      # (incl. n1) do not run ASPNETCORE_ENVIRONMENT=Production on the gateway — so the coded
+      # RateLimitSettings defaults (ApiPermitLimit 100000, ApiQueueLimit 1000) were the effective
+      # limits on the public edge, leaving the gateway ~100k API req/min/IP unthrottled. Env vars
+      # are the real config channel for a deployed container and apply regardless of environment.
+      # Values mirror src/Services/Sorcha.ApiGateway/appsettings.Production.json.
+      # The QueueLimit=0 entries are load-bearing: a FixedWindow limiter QUEUES overflow up to
+      # QueueLimit rather than rejecting, so any non-zero queue (the coded default is 1000) never
+      # emits a 429 until a burst exceeds PermitLimit+QueueLimit in one window. QueueLimit=0 =
+      # immediate clean 429 at the limit. Overridable per-deploy via the RATELIMIT_* vars.
+      RateLimiting__ApiPermitLimit: ${RATELIMIT_API_PERMIT:-600}
+      RateLimiting__ApiQueueLimit: ${RATELIMIT_API_QUEUE:-0}
+      RateLimiting__AuthenticationPermitLimit: ${RATELIMIT_AUTH_PERMIT:-60}
+      RateLimiting__AuthenticationQueueLimit: ${RATELIMIT_AUTH_QUEUE:-0}
+      RateLimiting__StrictTokenLimit: ${RATELIMIT_STRICT_TOKENS:-60}
+      RateLimiting__StrictTokensPerPeriod: ${RATELIMIT_STRICT_PER_PERIOD:-10}
+      RateLimiting__StrictReplenishmentPeriodSeconds: ${RATELIMIT_STRICT_PERIOD_SECS:-1}
+      RateLimiting__StrictQueueLimit: ${RATELIMIT_STRICT_QUEUE:-0}
     volumes:
       - dataprotection-keys:/home/app/.aspnet/DataProtection-Keys
       - ./docker/certs:/https:ro

--- a/tests/Sorcha.ApiGateway.Tests/Routing/ProductionRateLimitDeliveryTests.cs
+++ b/tests/Sorcha.ApiGateway.Tests/Routing/ProductionRateLimitDeliveryTests.cs
@@ -1,0 +1,198 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Text.Json;
+using System.Text.RegularExpressions;
+
+using FluentAssertions;
+
+using Xunit;
+
+namespace Sorcha.ApiGateway.Tests.Routing;
+
+/// <summary>
+/// Regression guard for issue #1437 — the production rate limits must be DELIVERED to the deployed
+/// gateway container, not merely present in a config file the image discards.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Why a green "values-when-loaded" test is not enough.</b> <c>appsettings.Production.json</c> is
+/// stripped from every image by <c>.dockerignore</c> ("**/appsettings.*.json"), and deployments do
+/// not run <c>ASPNETCORE_ENVIRONMENT=Production</c> on the gateway — so a unit test that binds the
+/// <c>RateLimiting</c> section and sees 600/60/60 proves nothing about the running edge, which fell
+/// back to the coded <see cref="Sorcha.ServiceDefaults.RateLimitSettings"/> defaults (ApiPermitLimit
+/// 100000). The public gateway answered ~100k API req/min/IP unthrottled. The actual config channel
+/// for a container is environment variables, so this test asserts <c>docker-compose.yml</c> DELIVERS
+/// the limits to the api-gateway service via <c>RateLimiting__*</c> env vars.
+/// </para>
+/// <para>
+/// <b>QueueLimit=0 is load-bearing.</b> A FixedWindow limiter QUEUES overflow up to QueueLimit rather
+/// than rejecting; with the coded default queue of 1000 a burst never emits a 429 until it exceeds
+/// PermitLimit+QueueLimit in one window. The delivered queue limits must therefore be 0 for a clean
+/// 429 at the limit — a permit-limit-only delivery looks fixed but silently still absorbs bursts.
+/// </para>
+/// <para>
+/// The compose defaults are also cross-checked against <c>appsettings.Production.json</c> so the two
+/// cannot drift: the file remains the documented source of the intended production posture, and the
+/// env-var delivery must match it.
+/// </para>
+/// </remarks>
+public class ProductionRateLimitDeliveryTests
+{
+    // Keys that MUST be delivered to the gateway container, mapped to their appsettings.Production.json
+    // property name so the compose default and the file value are asserted equal.
+    private static readonly (string EnvKey, string JsonProperty)[] RequiredLimits =
+    [
+        ("RateLimiting__ApiPermitLimit", "ApiPermitLimit"),
+        ("RateLimiting__ApiQueueLimit", "ApiQueueLimit"),
+        ("RateLimiting__AuthenticationPermitLimit", "AuthenticationPermitLimit"),
+        ("RateLimiting__AuthenticationQueueLimit", "AuthenticationQueueLimit"),
+        ("RateLimiting__StrictTokenLimit", "StrictTokenLimit"),
+        ("RateLimiting__StrictQueueLimit", "StrictQueueLimit"),
+    ];
+
+    [Fact]
+    public void DockerCompose_DeliversProductionRateLimits_ToGateway()
+    {
+        var env = GatewayEnvironment();
+
+        foreach (var (envKey, _) in RequiredLimits)
+        {
+            env.Should().ContainKey(envKey,
+                $"docker-compose.yml must deliver {envKey} to the api-gateway container — " +
+                "appsettings.Production.json is stripped from the image, so env vars are the only " +
+                "channel that reaches the deployed edge (issue #1437).");
+        }
+    }
+
+    [Fact]
+    public void DeliveredQueueLimits_AreZero_SoOverflowIsRejectedNotQueued()
+    {
+        var env = GatewayEnvironment();
+
+        foreach (var queueKey in new[]
+                 {
+                     "RateLimiting__ApiQueueLimit",
+                     "RateLimiting__AuthenticationQueueLimit",
+                     "RateLimiting__StrictQueueLimit",
+                 })
+        {
+            ResolveDefault(env[queueKey]).Should().Be("0",
+                $"{queueKey} must be 0 so the limiter emits a clean 429 at the permit limit; a " +
+                "non-zero queue (the coded default is 1000) absorbs bursts and never rejects.");
+        }
+    }
+
+    [Fact]
+    public void DeliveredLimits_MatchAppsettingsProduction_SoTheyCannotDrift()
+    {
+        var env = GatewayEnvironment();
+        using var doc = JsonDocument.Parse(File.ReadAllText(
+            Path.Combine(RepoRoot(), "src", "Services", "Sorcha.ApiGateway", "appsettings.Production.json")));
+        var rl = doc.RootElement.GetProperty("RateLimiting");
+
+        foreach (var (envKey, jsonProperty) in RequiredLimits)
+        {
+            var composeValue = ResolveDefault(env[envKey]);
+            var fileValue = rl.GetProperty(jsonProperty).GetRawText();
+            composeValue.Should().Be(fileValue,
+                $"the docker-compose default for {envKey} must match appsettings.Production.json " +
+                $"{jsonProperty} — the file documents the intended production posture and the env-var " +
+                "delivery is what actually reaches the container.");
+        }
+    }
+
+    /// <summary>
+    /// Parses the <c>environment:</c> block of the <c>api-gateway</c> service from docker-compose.yml
+    /// into a key→raw-value map. A focused indentation-aware scan avoids adding a YAML dependency.
+    /// </summary>
+    private static IReadOnlyDictionary<string, string> GatewayEnvironment()
+    {
+        var lines = File.ReadAllLines(Path.Combine(RepoRoot(), "docker-compose.yml"));
+        var result = new Dictionary<string, string>(StringComparer.Ordinal);
+
+        var inGateway = false;
+        var inEnv = false;
+        for (var i = 0; i < lines.Length; i++)
+        {
+            var line = lines[i];
+            if (line.TrimEnd().Length == 0 || line.TrimStart().StartsWith('#'))
+            {
+                continue;
+            }
+
+            var indent = line.Length - line.TrimStart().Length;
+
+            if (indent == 2 && line.TrimStart().StartsWith("api-gateway:", StringComparison.Ordinal))
+            {
+                inGateway = true;
+                inEnv = false;
+                continue;
+            }
+
+            // A new 2-space service key ends the api-gateway block.
+            if (inGateway && indent == 2 && line.TrimStart().EndsWith(':') && !line.TrimStart().StartsWith("api-gateway:"))
+            {
+                break;
+            }
+
+            if (inGateway && indent == 4 && line.TrimStart().StartsWith("environment:", StringComparison.Ordinal))
+            {
+                inEnv = true;
+                continue;
+            }
+
+            // A new 4-space key (volumes:, depends_on:, …) ends the environment block.
+            if (inGateway && inEnv && indent <= 4)
+            {
+                inEnv = false;
+            }
+
+            if (inGateway && inEnv && indent >= 6)
+            {
+                var trimmed = line.TrimStart();
+                var colon = trimmed.IndexOf(':');
+                if (colon <= 0)
+                {
+                    continue;
+                }
+
+                var key = trimmed[..colon].Trim();
+                var value = trimmed[(colon + 1)..].Trim();
+                result[key] = value;
+            }
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Resolves a compose value that may be a <c>${VAR:-default}</c> interpolation to its default,
+    /// stripping any wrapping quotes. A plain value is returned unquoted as-is.
+    /// </summary>
+    private static string ResolveDefault(string raw)
+    {
+        var m = Regex.Match(raw, @"^\$\{[A-Za-z0-9_]+:-(?<def>[^}]*)\}$");
+        var value = m.Success ? m.Groups["def"].Value : raw;
+        return value.Trim().Trim('"');
+    }
+
+    private static string RepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            if (File.Exists(Path.Combine(dir.FullName, "docker-compose.yml"))
+                && Directory.Exists(Path.Combine(dir.FullName, "src")))
+            {
+                return dir.FullName;
+            }
+
+            dir = dir.Parent;
+        }
+
+        throw new DirectoryNotFoundException(
+            "Could not locate the repository root (a directory containing both docker-compose.yml and " +
+            $"src/) by walking up from {AppContext.BaseDirectory}.");
+    }
+}


### PR DESCRIPTION
## Problem (#1437 — CRITICAL, Public Gates)

A public node answered ~**100,000 API req/min/IP unthrottled**. The production rate limits never took effect in a deployed gateway container.

## Root cause (two silent seams)

1. **Config never reaches the container.** `appsettings.Production.json` (Api 600 / Auth 60 / Strict 60) is stripped from every image by `.dockerignore` (`**/appsettings.*.json`), and no deployment runs `ASPNETCORE_ENVIRONMENT=Production` on the gateway (n1 runs it Development). So the coded `RateLimitSettings` defaults — `ApiPermitLimit=100000`, `ApiQueueLimit=1000` — were the effective edge limits. Environment variables are the real config channel for a container.
2. **QueueLimit masks rejection.** Even with a permit limit delivered, the coded `ApiQueueLimit=1000` makes the FixedWindow limiter **queue** overflow instead of rejecting — no 429 until a burst exceeds `PermitLimit + QueueLimit` in one window. This is exactly why setting only `ApiPermitLimit=600` produced zero 429s in earlier testing. `QueueLimit=0` is required for a clean 429 at the limit.

**The gateway's per-route YARP `RateLimiterPolicy` enforcement was verified WORKING — it was never the fault.** Proof: `ApiPermitLimit=5, ApiQueueLimit=0`, burst 50 → exactly **5×200 + 45×429**.

## Live BEFORE/AFTER (forced-Production local stack, single IP partition via fixed `X-Forwarded-For`, `api`-policy route `/api/registers/{id}/advertise`)

| Scenario | Burst | Result |
|---|---|---|
| BEFORE — coded defaults (100000) — the deployed bug | 800 | **800×200, 0×429** (unthrottled) |
| BEFORE — user's case: `ApiPermitLimit=600` only, queue=1000 default | 800 | **800×200, 0×429** (queue absorbs) |
| discriminator — `permit=5, queue=0` | 50 | **5×200, 45×429** (enforcement works) |
| AFTER — fix delivered by base `docker-compose.yml`, `600/0` | 800 | **600×200, 200×429** clean 429 |

429s carry `Retry-After: 60`, `X-RateLimit-Policy`, and the JSON error body.

## The fix

- **`docker-compose.yml`** — deliver the production limits to the `api-gateway` service via `RateLimiting__*` env vars (Api 600/queue 0, Auth 60/queue 0, Strict 60/10/1s/queue 0), each overridable per-deploy via a `RATELIMIT_*` var. Env vars apply **regardless of `ASPNETCORE_ENVIRONMENT`**, which is the robustness win over relying on the stripped file.
- **`docker-compose.n1.yml`** — documented reconciliation: the n1 gateway override merges with the base env (compose unions environment maps), so n1 inherits the limits. n1 is the public edge this targets and is deliberately **not** loosened; only tenant `PlatformAuth` stays loosened for walkthrough bursts. Verified via `docker compose config`.
- **Regression guard** `ProductionRateLimitDeliveryTests` (runs under `build-and-test`) — asserts the compose delivers the `RateLimiting__*` env vars, that the queue limits are `0`, and that values match `appsettings.Production.json`. Mutation-checked (set queue default back to 1000 → 2 tests red). Closes the gap where a green "values-when-loaded" test coexists with an inert deploy.

## Config-channel decision

Kept the **env-var channel** (not un-dockerignoring the file). It is the real channel for a container, matches the existing `docker-compose.n1.yml` pattern, and — critically — works even though the gateway runs Development on n1, whereas the file would require flipping the environment. No limit was weakened.

## Not regressed
Forced-Production stack boots healthy (confirms #1409/#1412/#1434 fail-closed config still works). No production C# changed.