### PR TITLE
fix: [#1433] - Sanitize unhandled-exception responses; fix required page param

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -473,6 +473,38 @@ Do not flip half of this: add-only migrations without an upgrade process is wors
 
 ---
 
+### 20. Global sanitized exception handling (issue #1433)
+
+Every service registers `Sorcha.ServiceDefaults.SanitizedExceptionHandler` via `AddServiceDefaults()`
+(`AddProblemDetails()` + `AddExceptionHandler<SanitizedExceptionHandler>()`) and applies it via
+`app.UseSanitizedExceptionHandling()` — called as the **very first** line after `var app =
+builder.Build();`, before any other `app.Use*`, so it wraps every other middleware's unhandled
+exceptions too.
+
+```csharp
+var app = builder.Build();
+
+// FIRST in the pipeline — wraps every other middleware's unhandled exceptions.
+app.UseSanitizedExceptionHandling();
+```
+
+- **Deliberately environment-UNGATED.** ASP.NET Core auto-adds the DeveloperExceptionPage (full
+  stack trace in the response body) whenever no exception-handling middleware is registered and
+  `ASPNETCORE_ENVIRONMENT=Development` — and before this handler existed, Sorcha had none anywhere.
+  At least one internet-facing node ran with `Development` set, so that page was the live behaviour
+  in production (issue #1433). The sanitized problem+json response is the only possible unhandled-
+  exception response in every environment — a misconfigured node can no longer leak a stack trace,
+  exception type, or exception message.
+- **Only catches UNHANDLED exceptions.** Endpoints that already return their own typed/problem+json
+  errors via `IResult` (the overwhelming majority in Sorcha) are untouched. `AddProblemDetails()`
+  does change the *default* shape ASP.NET Core generates for framework-level 400/415/etc. responses
+  (e.g. minimal-API binding failures) — if you add a test asserting that shape, assert the new one.
+- Full exception detail (type, message, stack trace) is still logged server-side via `ILogger` —
+  only the HTTP response body is sanitized. Every response carries a `traceId` extension an operator
+  can correlate against that log line.
+
+---
+
 ## Key Documentation
 
 | Document | Purpose |

--- a/src/Common/Sorcha.ServiceDefaults/Extensions.cs
+++ b/src/Common/Sorcha.ServiceDefaults/Extensions.cs
@@ -52,6 +52,12 @@ public static class Extensions
 
         builder.Services.AddStorageRegistration();
 
+        // Issue #1433 — global sanitized unhandled-exception posture. Registered here so every
+        // service gets it automatically via AddServiceDefaults; the corresponding app-pipeline call
+        // is UseSanitizedExceptionHandling (each Program.cs calls it as the FIRST middleware).
+        builder.Services.AddProblemDetails();
+        builder.Services.AddExceptionHandler<Sorcha.ServiceDefaults.SanitizedExceptionHandler>();
+
         return builder;
     }
 
@@ -198,6 +204,29 @@ public static class Extensions
             Predicate = r => r.Tags.Contains("live")
         });
 
+        return app;
+    }
+
+    /// <summary>
+    /// Applies the global sanitized unhandled-exception handler (issue #1433). Returns RFC 7807
+    /// problem+json with a generic title, the HTTP status, and a trace id — never the exception's
+    /// type, message, or stack trace. Backed by the <see cref="Sorcha.ServiceDefaults.SanitizedExceptionHandler"/>
+    /// registered by <see cref="AddServiceDefaults{TBuilder}"/>.
+    /// </summary>
+    /// <remarks>
+    /// Call this FIRST in the pipeline — before <c>UseForwardedHeaders</c>, <c>UseSerilogLogging</c>,
+    /// security headers, input validation, CORS, auth, and rate limiting — so it wraps every other
+    /// middleware's unhandled exceptions too. Deliberately not gated to Production/Staging: ASP.NET
+    /// Core auto-adds the DeveloperExceptionPage (full stack trace in the response body) whenever
+    /// <c>ASPNETCORE_ENVIRONMENT=Development</c> and no exception-handling middleware is registered, and
+    /// at least one Sorcha node has run Development while internet-facing. Applying this unconditionally
+    /// means that misconfiguration can no longer leak a stack trace, regardless of environment.
+    /// </remarks>
+    /// <param name="app">The web application</param>
+    /// <returns>The web application for chaining</returns>
+    public static WebApplication UseSanitizedExceptionHandling(this WebApplication app)
+    {
+        app.UseExceptionHandler();
         return app;
     }
 

--- a/src/Common/Sorcha.ServiceDefaults/SanitizedExceptionHandler.cs
+++ b/src/Common/Sorcha.ServiceDefaults/SanitizedExceptionHandler.cs
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using Microsoft.AspNetCore.Diagnostics;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Sorcha.ServiceDefaults;
+
+/// <summary>
+/// Global unhandled-exception handler (issue #1433). Every service registers this via
+/// <see cref="Microsoft.Extensions.Hosting.Extensions.AddServiceDefaults{TBuilder}"/> and applies it
+/// via <see cref="Microsoft.Extensions.Hosting.Extensions.UseSanitizedExceptionHandling"/>, called as
+/// the FIRST middleware in the pipeline so it wraps every other middleware's unhandled exceptions too.
+/// </summary>
+/// <remarks>
+/// Deliberately environment-UNGATED. ASP.NET Core auto-adds the DeveloperExceptionPage — a response
+/// body containing the full exception type, message, and stack trace — whenever no exception-handling
+/// middleware is registered and <c>ASPNETCORE_ENVIRONMENT=Development</c>. Before this handler existed,
+/// Sorcha had no exception-handling middleware at all, so that auto-added page was the live behaviour
+/// wherever a node happened to run with <c>Development</c> set — including at least one internet-facing
+/// node (issue #1433). A "safe in Development, sanitized elsewhere" posture is not good enough for that
+/// failure mode: the sanitized response below must be the ONLY possible unhandled-exception response,
+/// in every environment, so a misconfigured node can never leak implementation detail to a caller.
+/// Local debugging is unaffected — the exception, full type, message, and stack trace are still logged
+/// server-side via <see cref="ILogger"/>; only the HTTP response body is sanitized.
+/// </remarks>
+public sealed class SanitizedExceptionHandler(ILogger<SanitizedExceptionHandler> logger) : IExceptionHandler
+{
+    /// <inheritdoc />
+    public async ValueTask<bool> TryHandleAsync(
+        HttpContext httpContext,
+        Exception exception,
+        CancellationToken cancellationToken)
+    {
+        // Full detail (exception type, message, stack trace) is for the operator's log only — a caller
+        // must never see any of it in the HTTP response.
+        logger.LogError(
+            exception,
+            "Unhandled exception processing {Method} {Path} (TraceId: {TraceId})",
+            httpContext.Request.Method,
+            httpContext.Request.Path,
+            httpContext.TraceIdentifier);
+
+        httpContext.Response.StatusCode = StatusCodes.Status500InternalServerError;
+
+        var problemDetails = new ProblemDetails
+        {
+            Status = StatusCodes.Status500InternalServerError,
+            Title = "An error occurred while processing your request.",
+            Type = "https://tools.ietf.org/html/rfc7231#section-6.6.1",
+        };
+        problemDetails.Extensions["traceId"] = httpContext.TraceIdentifier;
+
+        var problemDetailsService = httpContext.RequestServices.GetService<IProblemDetailsService>();
+        if (problemDetailsService is not null)
+        {
+            return await problemDetailsService.TryWriteAsync(new ProblemDetailsContext
+            {
+                HttpContext = httpContext,
+                ProblemDetails = problemDetails
+            });
+        }
+
+        // IProblemDetailsService is registered by AddServiceDefaults -> AddProblemDetails() on every
+        // service, so this branch should not be reachable in practice. Kept as a defensive fallback
+        // that stays equally sanitized if that registration is ever missing.
+        httpContext.Response.ContentType = "application/problem+json";
+        await httpContext.Response.WriteAsJsonAsync(problemDetails, cancellationToken);
+        return true;
+    }
+}

--- a/src/Services/Sorcha.ApiGateway/Program.cs
+++ b/src/Services/Sorcha.ApiGateway/Program.cs
@@ -99,6 +99,10 @@ builder.Services.Configure<Microsoft.AspNetCore.Builder.ForwardedHeadersOptions>
 
 var app = builder.Build();
 
+// Issue #1433 — sanitized global exception handler, FIRST in the pipeline so it wraps every
+// other middleware's unhandled exceptions too (see ServiceDefaults.Extensions for rationale).
+app.UseSanitizedExceptionHandling();
+
 // Configure the HTTP request pipeline
 app.MapDefaultEndpoints();
 

--- a/src/Services/Sorcha.Blueprint.Service/Program.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Program.cs
@@ -692,6 +692,10 @@ builder.AddSorchaCors();
 var app = builder.Build();
 var logger = app.Logger;
 
+// Issue #1433 — sanitized global exception handler, FIRST in the pipeline so it wraps every
+// other middleware's unhandled exceptions too (see ServiceDefaults.Extensions for rationale).
+app.UseSanitizedExceptionHandling();
+
 // Apply database migrations on startup (if PostgreSQL is configured)
 if (!string.IsNullOrEmpty(blueprintDbConn))
 {

--- a/src/Services/Sorcha.Haip.Service/Program.cs
+++ b/src/Services/Sorcha.Haip.Service/Program.cs
@@ -193,6 +193,10 @@ builder.Services.AddScoped<Sorcha.ServiceClients.Did.SorchaDidResolver>(sp =>
 
 var app = builder.Build();
 
+// Issue #1433 — sanitized global exception handler, FIRST in the pipeline so it wraps every
+// other middleware's unhandled exceptions too (see ServiceDefaults.Extensions for rationale).
+app.UseSanitizedExceptionHandling();
+
 // OpenAPI and Scalar UI
 app.MapSorchaOpenApiUi("Sorcha HAIP Service API");
 

--- a/src/Services/Sorcha.Peer.Service/Program.cs
+++ b/src/Services/Sorcha.Peer.Service/Program.cs
@@ -240,6 +240,10 @@ builder.Services.AddHttpClient();
 
 var app = builder.Build();
 
+// Issue #1433 — sanitized global exception handler, FIRST in the pipeline so it wraps every
+// other middleware's unhandled exceptions too (see ServiceDefaults.Extensions for rationale).
+app.UseSanitizedExceptionHandling();
+
 // Apply PeerDbContext migrations on startup (matching Blueprint/Wallet/Tenant pattern)
 if (!string.IsNullOrEmpty(peerDbConnectionString))
 {

--- a/src/Services/Sorcha.Register.Service/Program.cs
+++ b/src/Services/Sorcha.Register.Service/Program.cs
@@ -335,6 +335,10 @@ builder.Services.AddRegisterAuthorization();
 
 var app = builder.Build();
 
+// Issue #1433 — sanitized global exception handler, FIRST in the pipeline so it wraps every
+// other middleware's unhandled exceptions too (see ServiceDefaults.Extensions for rationale).
+app.UseSanitizedExceptionHandling();
+
 if (storageType.Equals("MongoDB", StringComparison.OrdinalIgnoreCase))
 {
     app.Logger.LogInformation("Register Service using MongoDB storage");

--- a/src/Services/Sorcha.Tenant.Service/Endpoints/PlatformOrgEndpoints.cs
+++ b/src/Services/Sorcha.Tenant.Service/Endpoints/PlatformOrgEndpoints.cs
@@ -113,11 +113,11 @@ public static class PlatformOrgEndpoints
     /// Returns a paginated list of all organisations with user counts.
     /// </summary>
     private static async Task<IResult> ListOrganizations(
-        string? status,
-        int page,
-        int pageSize,
         TenantDbContext db,
-        CancellationToken ct)
+        CancellationToken ct,
+        string? status,
+        int page = 1,
+        int pageSize = 50)
     {
         page = Math.Max(1, page);
         pageSize = Math.Clamp(pageSize, 1, 100);
@@ -223,10 +223,10 @@ public static class PlatformOrgEndpoints
     /// </summary>
     private static async Task<IResult> GetOrganizationUsers(
         Guid orgId,
-        int page,
-        int pageSize,
         TenantDbContext db,
-        CancellationToken ct)
+        CancellationToken ct,
+        int page = 1,
+        int pageSize = 20)
     {
         var orgExists = await db.Organizations.AnyAsync(o => o.Id == orgId, ct);
         if (!orgExists)

--- a/src/Services/Sorcha.Tenant.Service/Program.cs
+++ b/src/Services/Sorcha.Tenant.Service/Program.cs
@@ -211,6 +211,10 @@ builder.Services.AddSorchaAddressLookup(builder.Configuration);
 
 var app = builder.Build();
 
+// Issue #1433 — sanitized global exception handler, FIRST in the pipeline so it wraps every
+// other middleware's unhandled exceptions too (see ServiceDefaults.Extensions for rationale).
+app.UseSanitizedExceptionHandling();
+
 // Feature 146 — fail closed at startup if no at-rest secret-protection key can be resolved
 // (resolves the singleton, which runs TenantSecretKeyResolver.ResolveProtectionKey()).
 _ = app.Services.GetRequiredService<Sorcha.Tenant.Service.Services.ISecretProtectionProvider>();

--- a/src/Services/Sorcha.Validator.Service/Program.cs
+++ b/src/Services/Sorcha.Validator.Service/Program.cs
@@ -222,6 +222,10 @@ builder.Services.AddGrpc(options =>
 
 var app = builder.Build();
 
+// Issue #1433 — sanitized global exception handler, FIRST in the pipeline so it wraps every
+// other middleware's unhandled exceptions too (see ServiceDefaults.Extensions for rationale).
+app.UseSanitizedExceptionHandling();
+
 // Configure the HTTP request pipeline
 app.MapDefaultEndpoints();
 

--- a/src/Services/Sorcha.Wallet.Service/Program.cs
+++ b/src/Services/Sorcha.Wallet.Service/Program.cs
@@ -350,6 +350,10 @@ builder.Services.AddWalletAuthorization();
 
 var app = builder.Build();
 
+// Issue #1433 — sanitized global exception handler, FIRST in the pipeline so it wraps every
+// other middleware's unhandled exceptions too (see ServiceDefaults.Extensions for rationale).
+app.UseSanitizedExceptionHandling();
+
 // Apply database migrations automatically (only if PostgreSQL is configured)
 await app.Services.ApplyWalletDatabaseMigrationsAsync();
 

--- a/tests/Sorcha.ServiceDefaults.Tests/SanitizedExceptionHandlerTests.cs
+++ b/tests/Sorcha.ServiceDefaults.Tests/SanitizedExceptionHandlerTests.cs
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Net;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Hosting;
+using Sorcha.ServiceDefaults;
+
+namespace Sorcha.ServiceDefaults.Tests;
+
+/// <summary>
+/// Issue #1433: before this handler existed, Sorcha had no exception-handling middleware anywhere,
+/// so ASP.NET Core's auto-added DeveloperExceptionPage served full stack traces whenever
+/// <c>ASPNETCORE_ENVIRONMENT=Development</c> — including on an internet-facing node that was
+/// (mis)configured that way. These tests exercise the real <c>AddServiceDefaults</c> /
+/// <c>UseSanitizedExceptionHandling</c> wiring end-to-end via a <see cref="TestServer"/>, in BOTH
+/// the "Development" and "Production" environment names, to prove the sanitized response is the
+/// only possible outcome regardless of environment.
+/// </summary>
+public class SanitizedExceptionHandlerTests
+{
+    private static async Task<WebApplication> BuildAppAsync(string environmentName)
+    {
+        var builder = WebApplication.CreateBuilder(new WebApplicationOptions
+        {
+            EnvironmentName = environmentName
+        });
+
+        builder.WebHost.UseTestServer();
+
+        // Exercises the actual production wiring: AddServiceDefaults registers AddProblemDetails()
+        // and AddExceptionHandler<SanitizedExceptionHandler>() (see Extensions.cs), so a regression
+        // in that registration fails this test, not just a hand-rolled equivalent.
+        builder.AddServiceDefaults();
+
+        var app = builder.Build();
+
+        // Mirrors the FIRST-in-pipeline placement every service's Program.cs uses.
+        app.UseSanitizedExceptionHandling();
+
+        app.MapGet("/throws", () =>
+        {
+            throw new InvalidOperationException(
+                "Sensitive internal detail that must never reach the HTTP response body.");
+#pragma warning disable CS0162 // Unreachable code detected — required to satisfy IResult return type
+            return Results.Ok();
+#pragma warning restore CS0162
+        });
+
+        app.MapGet("/ok", () => Results.Ok(new { status = "fine" }));
+
+        await app.StartAsync();
+        return app;
+    }
+
+    [Theory]
+    [InlineData("Development")]
+    [InlineData("Production")]
+    public async Task UnhandledException_AnyEnvironment_ReturnsSanitizedProblemDetails(string environmentName)
+    {
+        // Arrange
+        await using var app = await BuildAppAsync(environmentName);
+        var client = app.GetTestClient();
+
+        // Act
+        var response = await client.GetAsync("/throws");
+        var body = await response.Content.ReadAsStringAsync();
+
+        // Assert — status + content type are the RFC 7807 shape.
+        response.StatusCode.Should().Be(HttpStatusCode.InternalServerError);
+        response.Content.Headers.ContentType?.MediaType.Should().Be("application/problem+json");
+
+        // Assert — no stack trace ever reaches the body (a stack trace frame always contains " at ",
+        // and .NET's default DeveloperExceptionPage / exception formatting always names the file).
+        body.Should().NotContain(" at ", "a stack trace frame must never appear in the response body");
+        body.Should().NotContain(".cs:line", "a source file/line reference must never appear in the response body");
+
+        // Assert — no exception type name or message leaks either.
+        body.Should().NotContain(nameof(InvalidOperationException));
+        body.Should().NotContain("Sensitive internal detail");
+
+        // Assert — the response is still useful: generic title + a trace id an operator can correlate
+        // against the server-side log this handler also writes.
+        body.Should().Contain("\"title\"");
+        body.Should().Contain("\"traceId\"");
+    }
+
+    [Fact]
+    public async Task NoException_ReturnsOkUnaffected()
+    {
+        // The global handler must only intercept UNHANDLED exceptions — normal successful responses
+        // must pass through completely unchanged.
+        await using var app = await BuildAppAsync("Production");
+        var client = app.GetTestClient();
+
+        var response = await client.GetAsync("/ok");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadAsStringAsync();
+        body.Should().Contain("fine");
+    }
+}

--- a/tests/Sorcha.ServiceDefaults.Tests/Sorcha.ServiceDefaults.Tests.csproj
+++ b/tests/Sorcha.ServiceDefaults.Tests/Sorcha.ServiceDefaults.Tests.csproj
@@ -22,6 +22,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Moq" />
     <PackageReference Include="xunit.v3" />

--- a/tests/Sorcha.Tenant.Service.Tests/Endpoints/PlatformOrgEndpointsTests.cs
+++ b/tests/Sorcha.Tenant.Service.Tests/Endpoints/PlatformOrgEndpointsTests.cs
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Net;
+using System.Net.Http.Json;
+using FluentAssertions;
+using Sorcha.Tenant.Service.Models.Dtos;
+using Sorcha.Tenant.Service.Tests.Infrastructure;
+using Xunit;
+
+namespace Sorcha.Tenant.Service.Tests.Endpoints;
+
+/// <summary>
+/// Issue #1433 (seam bug #14): <c>GET /api/platform/organizations</c> declared <c>page</c>/
+/// <c>pageSize</c> as REQUIRED minimal-API query parameters, so a bare request (no query string)
+/// 400'd with "Required parameter 'int page' was not provided" instead of defaulting to page 1 —
+/// contrary to the documented contract. Reflection-invoked endpoint tests can't see this class of
+/// defect because they skip the model binder entirely; these tests go through the real ASP.NET Core
+/// binding pipeline via <see cref="TenantServiceWebApplicationFactory"/>.
+/// </summary>
+public class PlatformOrgEndpointsTests : IClassFixture<TenantServiceWebApplicationFactory>, IAsyncLifetime
+{
+    private readonly TenantServiceWebApplicationFactory _factory;
+    private HttpClient _client = null!;
+
+    public PlatformOrgEndpointsTests(TenantServiceWebApplicationFactory factory)
+    {
+        _factory = factory;
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        _client = _factory.CreateSystemAdminClient();
+        await _factory.SeedTestDataAsync();
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        _client?.Dispose();
+        return ValueTask.CompletedTask;
+    }
+
+    [Fact]
+    public async Task ListOrganizations_NoQueryParams_ReturnsOkWithPageOne()
+    {
+        // Act — bare request, no ?page=/&pageSize= at all.
+        var response = await _client.GetAsync("/api/platform/organizations");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var result = await response.Content.ReadFromJsonAsync<PlatformOrgListResponse>();
+        result.Should().NotBeNull();
+        result!.Page.Should().Be(1);
+        result.PageSize.Should().Be(50);
+    }
+
+    [Fact]
+    public async Task ListOrganizations_ExplicitPageAndPageSize_HonoursValues()
+    {
+        // Act
+        var response = await _client.GetAsync("/api/platform/organizations?page=2&pageSize=10");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var result = await response.Content.ReadFromJsonAsync<PlatformOrgListResponse>();
+        result.Should().NotBeNull();
+        result!.Page.Should().Be(2);
+        result.PageSize.Should().Be(10);
+    }
+
+    [Fact]
+    public async Task GetOrganizationUsers_NoQueryParams_ReturnsOkWithPageOne()
+    {
+        // Arrange
+        var orgId = TestDataSeeder.TestOrganizationId;
+
+        // Act — bare request, no ?page=/&pageSize= at all.
+        var response = await _client.GetAsync($"/api/platform/organizations/{orgId}/users");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var result = await response.Content.ReadFromJsonAsync<OrgUserListResponse>();
+        result.Should().NotBeNull();
+        result!.Page.Should().Be(1);
+        result.PageSize.Should().Be(20);
+    }
+}

--- a/tests/Sorcha.Tenant.Service.Tests/Infrastructure/TenantServiceWebApplicationFactory.cs
+++ b/tests/Sorcha.Tenant.Service.Tests/Infrastructure/TenantServiceWebApplicationFactory.cs
@@ -328,6 +328,20 @@ public class TenantServiceWebApplicationFactory : WebApplicationFactory<Program>
     }
 
     /// <summary>
+    /// Create an HTTP client with test authentication configured for a platform SystemAdmin
+    /// (system-admin org membership + SystemAdmin role) — required by the "RequireSystemAdmin"
+    /// policy that gates <c>/api/platform/*</c> endpoints (see AuthorizationPolicyExtensions).
+    /// </summary>
+    public HttpClient CreateSystemAdminClient()
+    {
+        var client = CreateClient();
+        client.DefaultRequestHeaders.Add("X-Test-Role", "SystemAdmin");
+        client.DefaultRequestHeaders.Add("X-Test-User-Id", TestDataSeeder.AdminUserId.ToString());
+        client.DefaultRequestHeaders.Add("X-Test-Organization-Id", WellKnownIds.SystemAdminOrgId.ToString());
+        return client;
+    }
+
+    /// <summary>
     /// Create an HTTP client with test authentication configured for a regular member.
     /// </summary>
     public HttpClient CreateMemberClient()


### PR DESCRIPTION
## Summary

Fixes #1433. Unhandled-exception responses leaked raw stack traces in the
response body — live in production, because no exception-handling
middleware existed anywhere in Sorcha, so ASP.NET Core auto-added the
DeveloperExceptionPage whenever a node ran `ASPNETCORE_ENVIRONMENT=Development`
(n1 does, while internet-facing).

### Part 1 — global sanitized exception-handling posture (`Sorcha.ServiceDefaults`)

- `SanitizedExceptionHandler` (`IExceptionHandler`) logs full exception detail
  (type, message, stack trace) server-side via `ILogger`, but returns RFC 7807
  problem+json with a generic title, the HTTP status, and a `traceId` — **no**
  exception type, message, or stack trace ever reaches the response body.
- `AddServiceDefaults()` now calls `AddProblemDetails()` +
  `AddExceptionHandler<SanitizedExceptionHandler>()`, so every service gets
  this automatically.
- New `UseSanitizedExceptionHandling()` is called as the **first** line after
  `builder.Build()` in all 8 services (Tenant, Blueprint, Wallet, Register,
  Validator, Peer, HAIP, API Gateway) — before `UseForwardedHeaders`,
  Serilog request logging, security headers, input validation, CORS, auth,
  and rate limiting — so it wraps every other middleware's unhandled
  exceptions too.
- **Deliberately not gated to Production/Staging.** The leak happened
  specifically because a node was misconfigured as `Development` while
  public — an environment-gated fix would not have caught that case. The
  sanitized response is now the only possible unhandled-exception response,
  in every environment.
- Existing typed/`IResult`-based error responses (the overwhelming majority
  in Sorcha) are untouched — this only catches genuinely unhandled throws.

### Part 2 — the specific trigger (seam bug #14)

`PlatformOrgEndpoints.ListOrganizations` / `GetOrganizationUsers` declared
`page`/`pageSize` as **required** minimal-API query parameters (no default
value), so a bare `GET /api/platform/organizations` 400'd with `"Required
parameter 'int page' was not provided"` instead of defaulting to page 1 —
unlike every sibling paginated endpoint in the service
(`AuditEndpoints`, `ParticipantEndpoints`, `MeInboxEndpoints`,
`OrganizationEndpoints`, `RegisterSubscriptionEndpoints`, all of which
already use `int page = 1`). Both endpoints now default `page=1` and a
bounded `pageSize` (50 / 20, matching their existing internal clamp bounds).

## Test plan

- [x] `SanitizedExceptionHandlerTests` (new, `Sorcha.ServiceDefaults.Tests`) —
      exercises the real `AddServiceDefaults` + `UseSanitizedExceptionHandling`
      wiring via `TestServer`, in both `Development` and `Production`
      environment names. Asserts the response body never contains a stack
      trace frame (`" at "`), a source file/line reference (`".cs:line"`), or
      the exception's type name/message. A control test confirms
      non-throwing endpoints are unaffected.
- [x] `PlatformOrgEndpointsTests` (new, `Sorcha.Tenant.Service.Tests`) —
      `WebApplicationFactory` tests (real ASP.NET Core model binder, not
      reflection-invoked — per the seam-#14 lesson) proving a bare
      `GET /api/platform/organizations` and
      `GET /api/platform/organizations/{id}/users` now return `200` at page 1
      instead of `400`.
- [x] `Sorcha.ServiceDefaults.Tests` — 202/202 green
- [x] `Sorcha.Tenant.Service.Tests` — 1663/1663 green (8 pre-existing skips)
- [x] `Sorcha.ApiGateway.Tests` — 65/65 green
- [x] All 8 services + both touched test projects build with 0 errors
- [x] `AddProblemDetails()` only changes the *default* shape of
      framework-generated errors (e.g. minimal-API binding failures) — no
      existing test asserted the old shape, so no reconciliation was needed
- [ ] `Sorcha.Gateway.Integration.Tests` (Aspire full-distributed-app spin-up)
      was started but not waited on — it provisions Postgres/Mongo/Redis +
      all 8 services under Docker and is orthogonal to this change (routing/
      health/OpenAPI aggregation, not error shapes); `Sorcha.ApiGateway.Tests`
      already covers gateway-level error/rate-limit response shapes.
- [ ] **Live confirmation on n1 needs a deploy** — this is a
      `Sorcha.ServiceDefaults` change, so it requires an image rebuild for
      every service. After deploy, re-probe
      `GET /api/platform/organizations` (no auth, no query string): expect a
      sanitized/bodiless response, not a raw stack trace.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

https://claude.ai/code/session_016GvgN77L1QD85tUES8n4D2