### PR TITLE
fix: [#1420] - Fold n1 F191 retire posture into docker-compose.n1.yml

### DIFF
--- a/docker-compose.n1.yml
+++ b/docker-compose.n1.yml
@@ -99,6 +99,23 @@ services:
       SocialProviders__1__Name: GitHub
       SocialProviders__1__ClientId: ${GITHUB_OAUTH_CLIENT_ID:-}
       SocialProviders__1__ClientSecret: ${GITHUB_OAUTH_CLIENT_SECRET:-}
+      # F191 (#1420) retire switch — n1 runs cert-only service-to-service auth.
+      # Every service mints its service token against the Tenant mTLS listener
+      # (https://tenant-service:8443) with its workload certificate; this refuses
+      # any secret-presenting mint with an explicit 400. Live-verified on n1
+      # 2026-08-15 (SC-007) before being folded in here.
+      #
+      # It lives in THIS file, not a separate override, deliberately: the flag was
+      # briefly carried by a 4th compose file on the box, so the documented 3-file
+      # `-f` command silently dropped it on the next tenant-service recreate — a
+      # posture regression with no error. n1's standard command now carries it.
+      #
+      # Precondition (already met on n1): the F191 workload-certificate block must
+      # be present in the host .env (8 client certs + CA bundle + server cert +
+      # WORKLOAD_CERT_PASSWORD, provisioned by /opt/sorcha/f191-provision.sh).
+      # Without it no service can mint at all. Rollback: comment this out and
+      # `up -d --force-recreate --no-deps tenant-service`.
+      ServiceAuth__DisableSharedSecrets: "true"
 
   peer-service:
     image: sorchadev/peer-service:latest

--- a/docs/guides/AUTHENTICATION-SETUP.md
+++ b/docs/guides/AUTHENTICATION-SETUP.md
@@ -925,6 +925,12 @@ Only after live verification — never as a big-bang cutover:
 5. **Optionally remove** the 8 `*_SERVICE_SECRET` client wirings from the deployment configuration
    at leisure — they are inert once the switch is on.
 
+**Put the flag in the deployment's own compose override, not a separate extra file.** A retire flag
+carried by an additional `-f` file drops silently the moment anyone runs that deployment's documented
+compose command — the Tenant Service simply comes back in coexistence mode, with no error and no log
+to distinguish it. n1 hit exactly this and now carries `ServiceAuth__DisableSharedSecrets: "true"` in
+`docker-compose.n1.yml` itself, so its standard three-file command cannot lose the posture.
+
 Troubleshooting: a service failing at startup naming its client certificate means the mounted
 material is missing/unreadable — check the mount and `WORKLOAD_CERT_PASSWORD` (this is deliberate
 fail-fast, not a bug). A mint refused on identity mismatch means the PFX belongs to a different


### PR DESCRIPTION
## Problem

After F191 (#1420) n1 runs **cert-only** service-to-service auth, but the
`ServiceAuth__DisableSharedSecrets` flag that enforces it was carried by a **4th compose file**
(`docker-compose.f191retire.yml`) that existed only on the box.

n1's documented compose command is three files. So the next time anyone recreates
`tenant-service` with the standard command, the flag is dropped and the service reverts to
secret/cert **coexistence** — no error, no failure, no log line distinguishing it from the
hardened state. A posture regression that is invisible unless you go looking.

## Fix

Fold the flag into `docker-compose.n1.yml`'s `tenant-service` environment, so n1's standard
three-file command carries it. The separate override file on the box becomes redundant.

Also generalised in the retirement runbook (`docs/guides/AUTHENTICATION-SETUP.md`): put the retire
flag in the deployment's own override, never an extra `-f` file, and the reason why.

## Verification

- `docker compose -f docker-compose.yml -f docker-compose.n1.yml -f docker-compose.ports.yml config`
  renders `ServiceAuth__DisableSharedSecrets: "true"` under `tenant-service` (line 815 of the
  merged config) — i.e. the three-file command now carries the posture.
- Live n1 verification (secret refused 400 / cert mint still working) recorded in the PR comments
  after deploy.

Precondition unchanged and already met on n1: the F191 workload-certificate block must be in the
host `.env` — without it no service can mint at all. Rollback is commenting the line out plus a
tenant-service recreate.

Documentation updated: `docs/guides/AUTHENTICATION-SETUP.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)