### PR TITLE
fix: [#1427] - Stop the instance projector rebinding a participant to the wrong wallet

### DIFF
--- a/src/Services/Sorcha.Blueprint.Service/Services/Implementation/InstanceProjectionResolver.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Services/Implementation/InstanceProjectionResolver.cs
@@ -114,10 +114,12 @@ public static class InstanceProjectionResolver
 
     /// <summary>
     /// Resolves participant-id → wallet bindings this transaction contributes, keyed by the
-    /// blueprint participant id (never self-keyed by wallet address). Binds the completed action's
-    /// sender to the tx sender, and the next action's sender to the recipient (the next actor), so
-    /// bindings accumulate across the chain. Best-effort — on any resolution failure the transaction
-    /// still folds control state with whatever bindings resolved.
+    /// blueprint participant id (never self-keyed by wallet address). Three sources, in descending
+    /// order of authority: the wallets the published blueprint binds; the completed action's sender,
+    /// bound to the wallet that signed this transaction; and — only where neither of those already
+    /// says who someone is — an unambiguous hand-off to the next action's sender. Bindings
+    /// accumulate across the chain. Best-effort: on any resolution failure the transaction still
+    /// folds control state with whatever bindings resolved.
     /// </summary>
     public static async Task<IReadOnlyDictionary<string, string>> ResolveParticipantBindingsAsync(
         string blueprintId,

--- a/src/Services/Sorcha.Blueprint.Service/Services/Implementation/InstanceProjectionResolver.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Services/Implementation/InstanceProjectionResolver.cs
@@ -156,15 +156,41 @@ public static class InstanceProjectionResolver
             if (completedAction is { Sender.Length: > 0 } && !string.IsNullOrEmpty(tx.SenderWallet))
                 bindings[completedAction.Sender] = tx.SenderWallet;
 
-            var recipientWallet = tx.RecipientsWallets?.FirstOrDefault(
-                w => !string.IsNullOrEmpty(w) && !string.Equals(w, tx.SenderWallet, StringComparison.OrdinalIgnoreCase));
-            if (recipientWallet is not null)
+            // Hand-off binding: name the NEXT actor from this transaction's recipients, so an open
+            // participant who has not yet acted is discoverable before their first submission.
+            //
+            // This is a GUESS and is treated as one. A transaction fans out to every participant a
+            // disclosure names, so RecipientsWallets is a set whose ORDER carries no meaning —
+            // "the first entry that isn't the sender" identifies the next actor only when there is
+            // exactly one candidate. It is therefore applied only where nothing better is known,
+            // and never allowed to displace a fact:
+            //
+            //   - a participant the BLUEPRINT binds is already seeded above, authoritatively;
+            //   - a participant who SIGNED this transaction was just bound from tx.SenderWallet;
+            //   - more than one non-sender recipient means the fan-out does not identify anyone.
+            //
+            // Overwriting either fact is not a lesser evil than leaving a participant unbound: the
+            // fold merges these bindings last-writer-wins, and instance.ParticipantWallets is what
+            // InstanceParticipantGate and GetPendingActionsByWalletAsync authorise against. A wrong
+            // entry therefore locks the real participant out of the instance that is waiting for
+            // them — 403 "You are not a participant on this instance", and nothing in their pending
+            // list — whereas an absent entry costs only pre-action discoverability and repairs
+            // itself the moment they act. Found live on n1 by the TradeFinance walkthrough (#1427),
+            // where two consecutive actions share a sender and folding the first rebound that
+            // sender to whichever recipient happened to be listed first.
+            var handOffCandidates = tx.RecipientsWallets?
+                .Where(w => !string.IsNullOrEmpty(w) && !string.Equals(w, tx.SenderWallet, StringComparison.OrdinalIgnoreCase))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList() ?? [];
+
+            if (handOffCandidates.Count == 1)
             {
+                var recipientWallet = handOffCandidates[0];
                 foreach (var nextId in nextActionIds)
                 {
                     var nextAction = actionResolver.GetActionDefinition(bp, nextId.ToString());
                     if (nextAction is { Sender.Length: > 0 })
-                        bindings[nextAction.Sender] = recipientWallet;
+                        bindings.TryAdd(nextAction.Sender, recipientWallet);
                 }
             }
         }

--- a/tests/Sorcha.Blueprint.Service.Tests/Projection/InstanceProjectionResolverTests.cs
+++ b/tests/Sorcha.Blueprint.Service.Tests/Projection/InstanceProjectionResolverTests.cs
@@ -299,4 +299,256 @@ public class InstanceProjectionResolverTests
         instance!.DecisionRouteId.Should().Be("route-refuse");
         instance.DecisionReasonCode.Should().Be("DOC_UNREADABLE");
     }
+
+    // ---- The recipient-derived binding must never overwrite an authoritative one. ----
+    //
+    // The resolver binds "the next action's sender" to a wallet picked out of the transaction's
+    // RecipientsWallets. That is a GUESS: a transaction fans out to every participant a disclosure
+    // names, so "the first recipient that isn't the sender" is whoever happens to be first in a list
+    // whose order carries no meaning. Where the blueprint already states the participant's wallet,
+    // or the participant just signed the transaction being folded, the guess is not merely
+    // unnecessary — it silently replaces a fact with a coin toss, and the fold's last-writer-wins
+    // merge makes the coin toss the value the instance keeps.
+    //
+    // Found live on n1 by the TradeFinance walkthrough (#1427): actions 2 and 3 share a sender
+    // (sales-mgr). Folding action 2 bound sales-mgr to the FIRST recipient of their own
+    // transaction — procurement-mgr's wallet — so sales-mgr, the one participant who had to act
+    // next, was refused their own instance with "You are not a participant on this instance."
+
+    /// <summary>
+    /// The TradeFinance shape, from the real sealed ledger: two consecutive actions with the SAME
+    /// pre-bound sender, and a transaction that fans out to three recipients.
+    /// </summary>
+    private static IActionResolverService ConsecutiveSameSenderResolver()
+    {
+        var blueprint = new Sorcha.Blueprint.Models.Blueprint
+        {
+            Id = "bp-1",
+            Participants =
+            [
+                new Participant { Id = "procurement-mgr", Name = "Procurement Manager", WalletAddress = null },
+                new Participant { Id = "sales-mgr", Name = "Sales Manager", WalletAddress = "ws-sales" },
+                new Participant { Id = "site-mgr", Name = "Site Manager", WalletAddress = "ws-site" },
+            ],
+            Actions =
+            [
+                new Sorcha.Blueprint.Models.Action { Id = 1, Sender = "procurement-mgr", IsStartingAction = true },
+                new Sorcha.Blueprint.Models.Action { Id = 2, Sender = "sales-mgr" },
+                new Sorcha.Blueprint.Models.Action { Id = 3, Sender = "sales-mgr" },
+                new Sorcha.Blueprint.Models.Action { Id = 4, Sender = "site-mgr" },
+            ],
+        };
+
+        var mock = new Mock<IActionResolverService>();
+        mock.Setup(r => r.GetBlueprintAsync("bp-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(blueprint);
+        mock.Setup(r => r.GetActionDefinition(blueprint, It.IsAny<string>()))
+            .Returns((Sorcha.Blueprint.Models.Blueprint bp, string id) => bp.Actions.FirstOrDefault(a => a.Id.ToString() == id));
+        return mock.Object;
+    }
+
+    [Fact]
+    public async Task ResolveAsync_ConsecutiveActionsBySameSender_DoesNotRebindThatSenderToARecipient()
+    {
+        // Action 2, sent by sales-mgr, routes to action 3 — also sent by sales-mgr. The recipient
+        // list is exactly what the ledger held on n1: procurement-mgr first, then the sender, then
+        // site-mgr.
+        var tx = new TransactionModel
+        {
+            TxId = "tx-action2",
+            PrevTxId = "tx-action1",
+            SenderWallet = "ws-sales",
+            RecipientsWallets = ["ws-procurement", "ws-sales", "ws-site"],
+            MetaData = new TransactionMetaData
+            {
+                BlueprintId = "bp-1",
+                InstanceId = "inst-1",
+                ActionId = 2,
+                TransactionType = TransactionType.Action,
+                RoutingDecision = Decision(2, 3),
+            },
+        };
+
+        var resolved = await InstanceProjectionResolver.ResolveAsync(
+            tx, ConsecutiveSameSenderResolver(), NullLogger.Instance, CancellationToken.None);
+
+        resolved.Should().NotBeNull();
+        resolved!.Tx.ParticipantBindings["sales-mgr"].Should().Be(
+            "ws-sales",
+            "sales-mgr signed this transaction and the blueprint binds them — neither fact may be "
+            + "displaced by whichever recipient happens to be first in the fan-out list");
+    }
+
+    [Fact]
+    public async Task ResolveAsync_NextActionSenderIsPreBoundInBlueprint_KeepsTheBlueprintWallet()
+    {
+        // Action 1 (open starter) routes to action 4, whose sender site-mgr IS pre-bound in the
+        // blueprint. The blueprint is authoritative; the recipient guess must not displace it.
+        var tx = new TransactionModel
+        {
+            TxId = "tx-action1",
+            PrevTxId = string.Empty,
+            SenderWallet = "ws-procurement",
+            RecipientsWallets = ["ws-sales", "ws-procurement", "ws-site"],
+            MetaData = new TransactionMetaData
+            {
+                BlueprintId = "bp-1",
+                InstanceId = "inst-1",
+                ActionId = 1,
+                TransactionType = TransactionType.Action,
+                RoutingDecision = Decision(1, 4),
+            },
+        };
+
+        var resolved = await InstanceProjectionResolver.ResolveAsync(
+            tx, ConsecutiveSameSenderResolver(), NullLogger.Instance, CancellationToken.None);
+
+        resolved!.Tx.ParticipantBindings["site-mgr"].Should().Be(
+            "ws-site",
+            "the blueprint states site-mgr's wallet; 'first recipient that isn't the sender' is a guess");
+        // The open starter still late-binds from the signed sender.
+        resolved.Tx.ParticipantBindings["procurement-mgr"].Should().Be("ws-procurement");
+    }
+
+    [Fact]
+    public async Task ResolveAsync_AmbiguousRecipients_DoesNotBindAnOpenNextSender()
+    {
+        // The next action's sender is genuinely open (no blueprint wallet, has not acted) — but the
+        // transaction fans out to TWO candidates, so "the recipient" does not identify anyone.
+        // Binding one at random is worse than leaving the participant unbound: they bind
+        // authoritatively the moment they act, whereas a wrong binding locks them out until then.
+        var blueprint = new Sorcha.Blueprint.Models.Blueprint
+        {
+            Id = "bp-1",
+            Participants =
+            [
+                new Participant { Id = "starter", Name = "Starter", WalletAddress = "ws-starter" },
+                new Participant { Id = "open-next", Name = "Open Next", WalletAddress = null },
+            ],
+            Actions =
+            [
+                new Sorcha.Blueprint.Models.Action { Id = 1, Sender = "starter", IsStartingAction = true },
+                new Sorcha.Blueprint.Models.Action { Id = 2, Sender = "open-next" },
+            ],
+        };
+        var mock = new Mock<IActionResolverService>();
+        mock.Setup(r => r.GetBlueprintAsync("bp-1", It.IsAny<CancellationToken>())).ReturnsAsync(blueprint);
+        mock.Setup(r => r.GetActionDefinition(blueprint, It.IsAny<string>()))
+            .Returns((Sorcha.Blueprint.Models.Blueprint bp, string id) => bp.Actions.FirstOrDefault(a => a.Id.ToString() == id));
+
+        var tx = new TransactionModel
+        {
+            TxId = "tx-action1",
+            PrevTxId = string.Empty,
+            SenderWallet = "ws-starter",
+            RecipientsWallets = ["ws-candidate-a", "ws-starter", "ws-candidate-b"],
+            MetaData = new TransactionMetaData
+            {
+                BlueprintId = "bp-1",
+                InstanceId = "inst-1",
+                ActionId = 1,
+                TransactionType = TransactionType.Action,
+                RoutingDecision = Decision(1, 2),
+            },
+        };
+
+        var resolved = await InstanceProjectionResolver.ResolveAsync(
+            tx, mock.Object, NullLogger.Instance, CancellationToken.None);
+
+        resolved!.Tx.ParticipantBindings.Should().NotContainKey(
+            "open-next",
+            "two non-sender recipients means the fan-out does not identify the next actor");
+    }
+
+    [Fact]
+    public async Task ResolveAsync_SingleRecipientHandOff_StillBindsAnOpenNextSender()
+    {
+        // The case the recipient rule exists for, and which must keep working: a hand-off to a
+        // genuinely open next participant, with exactly ONE non-sender recipient naming them.
+        var blueprint = new Sorcha.Blueprint.Models.Blueprint
+        {
+            Id = "bp-1",
+            Participants =
+            [
+                new Participant { Id = "starter", Name = "Starter", WalletAddress = "ws-starter" },
+                new Participant { Id = "open-next", Name = "Open Next", WalletAddress = null },
+            ],
+            Actions =
+            [
+                new Sorcha.Blueprint.Models.Action { Id = 1, Sender = "starter", IsStartingAction = true },
+                new Sorcha.Blueprint.Models.Action { Id = 2, Sender = "open-next" },
+            ],
+        };
+        var mock = new Mock<IActionResolverService>();
+        mock.Setup(r => r.GetBlueprintAsync("bp-1", It.IsAny<CancellationToken>())).ReturnsAsync(blueprint);
+        mock.Setup(r => r.GetActionDefinition(blueprint, It.IsAny<string>()))
+            .Returns((Sorcha.Blueprint.Models.Blueprint bp, string id) => bp.Actions.FirstOrDefault(a => a.Id.ToString() == id));
+
+        var tx = new TransactionModel
+        {
+            TxId = "tx-action1",
+            PrevTxId = string.Empty,
+            SenderWallet = "ws-starter",
+            RecipientsWallets = ["ws-starter", "ws-the-next-actor"],
+            MetaData = new TransactionMetaData
+            {
+                BlueprintId = "bp-1",
+                InstanceId = "inst-1",
+                ActionId = 1,
+                TransactionType = TransactionType.Action,
+                RoutingDecision = Decision(1, 2),
+            },
+        };
+
+        var resolved = await InstanceProjectionResolver.ResolveAsync(
+            tx, mock.Object, NullLogger.Instance, CancellationToken.None);
+
+        resolved!.Tx.ParticipantBindings["open-next"].Should().Be("ws-the-next-actor");
+    }
+
+    [Fact]
+    public async Task RecipientRebind_WouldLockTheNextActorOutOfTheirOwnInstance()
+    {
+        // The user-visible consequence, asserted end to end through the fold: the instance's
+        // ParticipantWallets is exactly what InstanceParticipantGate and
+        // GetPendingActionsByWalletAsync match on. If sales-mgr's entry holds someone else's
+        // wallet, sales-mgr cannot read the instance and it never appears in their pending list —
+        // while the instance sits waiting for them.
+        var action1 = new TransactionModel
+        {
+            TxId = "tx-action1",
+            PrevTxId = string.Empty,
+            SenderWallet = "ws-procurement",
+            RecipientsWallets = ["ws-procurement", "ws-sales", "ws-site"],
+            MetaData = new TransactionMetaData
+            {
+                BlueprintId = "bp-1", InstanceId = "inst-1", ActionId = 1,
+                TransactionType = TransactionType.Action, RoutingDecision = Decision(1, 2),
+            },
+        };
+        var action2 = new TransactionModel
+        {
+            TxId = "tx-action2",
+            PrevTxId = "tx-action1",
+            SenderWallet = "ws-sales",
+            RecipientsWallets = ["ws-procurement", "ws-sales", "ws-site"],
+            MetaData = new TransactionMetaData
+            {
+                BlueprintId = "bp-1", InstanceId = "inst-1", ActionId = 2,
+                TransactionType = TransactionType.Action, RoutingDecision = Decision(2, 3),
+            },
+        };
+
+        var resolver = ConsecutiveSameSenderResolver();
+        var r1 = await InstanceProjectionResolver.ResolveAsync(action1, resolver, NullLogger.Instance, CancellationToken.None);
+        var r2 = await InstanceProjectionResolver.ResolveAsync(action2, resolver, NullLogger.Instance, CancellationToken.None);
+
+        var instance = InstanceProjection.Project(
+            "inst-1", "reg", "bp-1", 1, "tenant", [r1!.Tx, r2!.Tx]);
+
+        instance!.CurrentActionIds.Should().Equal(3);
+        instance.ParticipantWallets["sales-mgr"].Should().Be(
+            "ws-sales",
+            "action 3 is waiting for sales-mgr; the participant map is what authorises them to see it");
+    }
 }


### PR DESCRIPTION
Found by running the walkthrough suite against n1 for the #1427 currency pass. This is a **platform
defect**, not walkthrough drift — it blocks two walkthroughs and, more importantly, would silently
lock real users out of their own workflow instances.

## The defect

`InstanceProjectionResolver.ResolveParticipantBindingsAsync` binds *the next action's sender* to a
wallet picked out of the transaction's `RecipientsWallets`:

```csharp
var recipientWallet = tx.RecipientsWallets?.FirstOrDefault(w => w != tx.SenderWallet);
foreach (var nextId in nextActionIds)
    bindings[nextAction.Sender] = recipientWallet;   // assignment — overwrites
```

A transaction fans out to **every participant a disclosure names**, so `RecipientsWallets` is a set
whose order carries no meaning. "The first entry that isn't the sender" identifies the next actor
only by luck — and because it assigns, it displaces two authoritative facts: the wallet the
**blueprint** binds, and the wallet that **just signed** the transaction being folded.

`instance.ParticipantWallets` is what `InstanceParticipantGate` and
`GetPendingActionsByWalletAsync` authorise against. A wrong entry means the real participant gets
**403 "You are not a participant on this instance"** and the instance never appears in their pending
list — while it sits waiting for them.

## Two live failures, same shape

Both confirmed against the **sealed ledger on n1**, not inferred from code:

| Walkthrough | What happened |
|---|---|
| TradeFinance | Actions 2 and 3 share a sender (`sales-mgr`). Folding action 2 rebound `sales-mgr` to `procurement-mgr`'s wallet — first in the fan-out — so action 3's own sender was locked out. |
| SelfBuildHouse | `utilities-officer` rebound to `planning-officer`'s wallet; action 5, the utilities-officer's own action, became unreachable. |

Ledger evidence (TradeFinance action 2 — sender is `ws11qpym…`, and the first recipient is somebody else):

```
action=2 sender=ws11qpym0zwf... recipients=["ws11qregpfukv...","ws11qpym0zwf...","ws11qqnklup0..."]
```

Resulting instance map — `sales-mgr` holding `procurement-mgr`'s wallet:

```
"sales-mgr":       "ws11qregpfukv..."   <-- wrong (procurement-mgr's)
"procurement-mgr": "ws11qregpfukv..."
```

## The fix

Keep the hand-off binding for the case it exists for — an open participant who has not yet acted —
but apply it only where nothing better is known:

- **exactly one** distinct non-sender recipient (otherwise the fan-out identifies nobody), and
- `TryAdd`, so it can never displace the blueprint seed or the signed sender.

An absent binding costs only pre-action discoverability and repairs itself the moment the
participant acts. A wrong one does not.

## Tests

5 new tests in `InstanceProjectionResolverTests`, written from the real ledger shapes:

- `ResolveAsync_ConsecutiveActionsBySameSender_DoesNotRebindThatSenderToARecipient` — the TradeFinance case
- `ResolveAsync_NextActionSenderIsPreBoundInBlueprint_KeepsTheBlueprintWallet`
- `ResolveAsync_AmbiguousRecipients_DoesNotBindAnOpenNextSender`
- `ResolveAsync_SingleRecipientHandOff_StillBindsAnOpenNextSender` — pins behaviour the fix must preserve
- `RecipientRebind_WouldLockTheNextActorOutOfTheirOwnInstance` — end to end through the fold, asserting the user-visible consequence

**4 of the 5 went RED first** for exactly the predicted reason. The 5th passed before and after — it
exists to prove the fix does not remove the intended hand-off. The recipient path had **no test
coverage at all** before this; it has been unchanged since F145 US4 (#895).

Full `Sorcha.Blueprint.Service.Tests` suite: **1113 passed, 0 failed**.

## Verification still outstanding

Unit-green is not the bar here. Once this merges and Docker Publish lands, I will redeploy
`blueprint-service` to n1 and re-run **TradeFinance** and **SelfBuildHouse** end to end; I will post
the result on this PR. Both were failing on n1 before the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)