### PR TITLE
fix: [#1427] - Stop inlined core-schema $id collisions rejecting valid blueprints

### DIFF
--- a/src/Services/Sorcha.Blueprint.Service/Services/SchemaRefResolver.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Services/SchemaRefResolver.cs
@@ -31,6 +31,15 @@ public sealed class SchemaRefResolver : ISchemaRefResolver
         "x-width"
     ];
 
+    /// <summary>
+    /// Document-identity keywords that are dropped when a component is inlined. They identify the
+    /// primitive as a standalone document; inside a host schema they identify nothing, and a
+    /// retained <c>$id</c> makes two blueprints that share a primitive collide in the JSON Schema
+    /// implementation's process-wide registry. See ResolveCoreRefInPlace for the failure this caused.
+    /// </summary>
+    private static readonly HashSet<string> IdentityKeywords =
+        new(StringComparer.Ordinal) { "$id", "$schema" };
+
     private readonly ICoreSchemaRepository _repository;
     private readonly ILogger<SchemaRefResolver> _logger;
 
@@ -175,8 +184,23 @@ public sealed class SchemaRefResolver : ISchemaRefResolver
         // Replace site contents with the resolved component contents in place.
         // This works whether `site` is a property value, an array item, or the
         // root node — the parent reference is preserved.
+        //
+        // The component's identity keywords are deliberately NOT carried across. $id and $schema
+        // identify the primitive AS A DOCUMENT; once its body is spliced into a property site of a
+        // different document they identify nothing, and there is no longer any reference into the
+        // subtree for them to resolve. Leaving them in is actively harmful: JSON Schema
+        // implementations register every identified subschema they parse in a process-wide registry,
+        // so the second blueprint to inline the same primitive fails to parse at all. On n1 the
+        // Validator rejected every AssuredIdentity submission with VAL_SCHEMA_005 "Malformed JSON
+        // schema ... Overwriting registered schemas is not permitted", naming a blueprint that was
+        // not malformed (#1427). Had it not thrown, the registration would have been worse: one
+        // blueprint's schema silently resolving another's dangling $ref, making validation depend on
+        // parse order.
         site.Clear();
-        var componentKeys = resolvedObj.Select(kvp => kvp.Key).ToList();
+        var componentKeys = resolvedObj
+            .Select(kvp => kvp.Key)
+            .Where(key => !IdentityKeywords.Contains(key))
+            .ToList();
         foreach (var key in componentKeys)
         {
             // Detach the value from the cloned component so we can reparent it.

--- a/src/Services/Sorcha.Validator.Service/Services/ValidationEngine.cs
+++ b/src/Services/Sorcha.Validator.Service/Services/ValidationEngine.cs
@@ -2193,8 +2193,28 @@ public class ValidationEngine : IValidationEngine
     /// blueprints embed UI-renderer hints (x-pages, x-sections, x-introduction,
     /// x-width, x-rule, x-persona, x-file) that must survive round-trips
     /// without interfering with schema validation.
+    /// <para>
+    /// Also strips <c>$id</c> everywhere. An action schema reaching the validator is a
+    /// SELF-CONTAINED document: Blueprint Service's <c>SchemaRefResolver.Flatten</c> has already
+    /// inlined every <c>https://schemas.sorcha.dev/core/*</c> reference, copying the primitive's own
+    /// <c>$id</c> along with its body, and catalogue-derived schemas (DPP, FHIR, ISO 20022,
+    /// schema.org) carry a root <c>$id</c> of their source URL. Identity keywords only matter for
+    /// resolving references BETWEEN documents, which cannot happen here — but Json.Schema registers
+    /// every identified schema it parses in a process-wide registry, so retaining them has two
+    /// consequences and no benefit:
+    /// </para>
+    /// <list type="bullet">
+    /// <item>The second blueprint to inline a shared primitive fails to parse outright —
+    /// "Overwriting registered schemas is not permitted" — reported as VAL_SCHEMA_005 "Malformed
+    /// JSON schema", which points the operator at a blueprint that is not malformed. Every
+    /// submission to it is rejected and never seals. Found on n1 by the AssuredIdentity walkthrough
+    /// (#1427), whose action 1 inlines four core primitives.</item>
+    /// <item>Worse than the failure: had it not thrown, one blueprint's registered schema could
+    /// silently resolve a DIFFERENT blueprint's dangling <c>$ref</c>, making validation depend on
+    /// which blueprint the process happened to parse first.</item>
+    /// </list>
     /// </summary>
-    private static string StripCustomExtensionKeywords(JsonElement root)
+    internal static string StripCustomExtensionKeywords(JsonElement root)
     {
         var node = JsonNode.Parse(root.GetRawText());
         StripXPrefixedKeysRecursive(node);
@@ -2207,7 +2227,8 @@ public class ValidationEngine : IValidationEngine
         {
             case JsonObject obj:
                 var toRemove = obj
-                    .Where(kvp => kvp.Key.StartsWith("x-", StringComparison.Ordinal))
+                    .Where(kvp => kvp.Key.StartsWith("x-", StringComparison.Ordinal)
+                               || string.Equals(kvp.Key, "$id", StringComparison.Ordinal))
                     .Select(kvp => kvp.Key)
                     .ToList();
                 foreach (var key in toRemove)

--- a/tests/Sorcha.Blueprint.Service.Tests/SchemaRefResolverTests.cs
+++ b/tests/Sorcha.Blueprint.Service.Tests/SchemaRefResolverTests.cs
@@ -52,6 +52,39 @@ public class SchemaRefResolverTests
     }
 
     [Fact]
+    public void Flatten_DropsTheComponentsOwnIdentityKeywords()
+    {
+        // $id and $schema identify the PRIMITIVE AS A DOCUMENT. Once its body is spliced into a
+        // property site of a different document they no longer identify anything — but they are not
+        // merely redundant, they are harmful: JSON Schema implementations register every identified
+        // subschema they parse in a process-wide registry, so two blueprints that inline the same
+        // primitive collide. On n1 the Validator refused every AssuredIdentity submission with
+        // VAL_SCHEMA_005 "Malformed JSON schema ... Overwriting registered schemas is not
+        // permitted" — a blueprint that was not malformed, named as the culprit (#1427).
+        //
+        // The identifier is also what a reader would use to resolve a $ref INTO this subtree; there
+        // is nothing left to resolve once the content is inlined.
+        _repo.Upsert(PostalAddressUri, BuildPostalAddress());
+
+        var consumer = JsonNode.Parse($$"""
+            {
+              "type": "object",
+              "properties": {
+                "address": { "$ref": "{{PostalAddressUri}}" }
+              }
+            }
+            """)!;
+
+        var flattened = _sut.Flatten(consumer);
+
+        var address = flattened["properties"]!["address"]!.AsObject();
+        address.ContainsKey("$id").Should().BeFalse("an inlined component no longer identifies a document");
+        address.ContainsKey("$schema").Should().BeFalse("the dialect is declared by the host schema, not the inlined fragment");
+        // The constraints must survive — dropping identity must not drop meaning.
+        address["properties"]!["line1"]!["type"]!.GetValue<string>().Should().Be("string");
+    }
+
+    [Fact]
     public void Flatten_DoesNotMutateInputTree()
     {
         _repo.Upsert(PostalAddressUri, BuildPostalAddress());

--- a/tests/Sorcha.Validator.Service.Tests/Services/InlinedCoreSchemaIdTests.cs
+++ b/tests/Sorcha.Validator.Service.Tests/Services/InlinedCoreSchemaIdTests.cs
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using FluentAssertions;
+using Sorcha.Validator.Service.Services;
+
+namespace Sorcha.Validator.Service.Tests.Services;
+
+/// <summary>
+/// A blueprint action schema may <c>$ref</c> a Sorcha core primitive
+/// (<c>https://schemas.sorcha.dev/core/PersonName/v1</c>). Blueprint Service's
+/// <c>SchemaRefResolver.Flatten</c> INLINES that primitive into the action schema before the
+/// blueprint is hashed and sealed — and it copies every key of the component, <c>$id</c> included.
+/// The sealed schema therefore carries an absolute <c>$id</c> on an embedded subschema.
+///
+/// JsonSchema.Net registers every identified subschema it parses. Parsing a SECOND, textually
+/// different schema that embeds the SAME <c>$id</c> throws "Overwriting registered schemas is not
+/// permitted" — which the validator reports as VAL_SCHEMA_005 "Malformed JSON schema", pointing the
+/// operator at the blueprint rather than at the collision.
+///
+/// This bites the moment two blueprints share a core primitive, or one blueprint is republished with
+/// any textual change at all: the first parse succeeds and every later one fails, for the life of the
+/// validator process. Found on n1 by the AssuredIdentity walkthrough (#1427), where action 1 inlines
+/// four core primitives and every submission was rejected unsealed.
+/// </summary>
+public class InlinedCoreSchemaIdTests
+{
+    /// <summary>
+    /// The shape SchemaRefResolver actually emits: the core primitive's own <c>$id</c> and
+    /// <c>$schema</c> copied into the property site.
+    /// </summary>
+    private static string ActionSchemaEmbeddingPersonName(string extraTitle) => $$"""
+    {
+      "type": "object",
+      "title": "{{extraTitle}}",
+      "properties": {
+        "applicantName": {
+          "$id": "https://schemas.sorcha.dev/core/PersonName/v1",
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
+          "type": "object",
+          "properties": {
+            "givenName": { "type": "string" },
+            "familyName": { "type": "string" }
+          },
+          "required": ["givenName", "familyName"]
+        }
+      },
+      "required": ["applicantName"]
+    }
+    """;
+
+    /// <summary>
+    /// Exactly the production sequence at ValidationEngine.ValidateSchema — strip, then parse.
+    /// Testing the two together is the point: the strip is what makes the parse safe, and a test
+    /// that called the parser alone would prove nothing about the path the validator runs.
+    /// </summary>
+    private static Json.Schema.JsonSchema ParseAsValidatorDoes(string schemaJson)
+    {
+        var element = System.Text.Json.JsonSerializer.Deserialize<System.Text.Json.JsonElement>(schemaJson);
+        return ValidationEngine.GetOrParseActionSchema(
+            ValidationEngine.StripCustomExtensionKeywords(element));
+    }
+
+    [Fact]
+    public void TwoSchemasEmbeddingTheSameCoreId_BothParse()
+    {
+        // Two different blueprints (or two revisions of one) that both inline PersonName. Nothing
+        // about the second is malformed — it embeds the same core primitive the first did, which is
+        // the entire point of a shared primitive library.
+        var first = ParseAsValidatorDoes(ActionSchemaEmbeddingPersonName("Identity Application"));
+        first.Should().NotBeNull();
+
+        var parseSecond = () => ParseAsValidatorDoes(ActionSchemaEmbeddingPersonName("Licence Application"));
+
+        parseSecond.Should().NotThrow(
+            "a core primitive is meant to be reused across blueprints; the second blueprint to inline "
+            + "it must not be rejected as malformed");
+    }
+
+    [Fact]
+    public void SchemaEmbeddingACoreId_StillValidatesPayloads()
+    {
+        // Guards the fix from degenerating into "swallow the exception": dropping the identifier
+        // must not drop the constraints the identified subschema carries.
+        var schema = ParseAsValidatorDoes(ActionSchemaEmbeddingPersonName("Evaluates Correctly"));
+
+        var valid = System.Text.Json.JsonSerializer.Deserialize<System.Text.Json.JsonElement>(
+            """{ "applicantName": { "givenName": "Alex", "familyName": "MacLeod" } }""");
+        var invalid = System.Text.Json.JsonSerializer.Deserialize<System.Text.Json.JsonElement>(
+            """{ "applicantName": { "givenName": "Alex" } }""");
+
+        schema.Evaluate(valid).IsValid.Should().BeTrue();
+        schema.Evaluate(invalid).IsValid.Should().BeFalse("familyName is required by the inlined primitive");
+    }
+
+    [Fact]
+    public void RootLevelIdIsAlsoStripped_SoTwoBlueprintsMaySharaACatalogueSchema()
+    {
+        // Catalogue-derived schemas (DppSchemaProvider, FhirSchemaProvider, Iso20022Provider,
+        // SchemaOrgProvider) set $id at the ROOT to their source URL. Two blueprints built from the
+        // same catalogue entry collide the same way an inlined primitive does.
+        const string catalogueSchema = """
+        {
+          "$id": "https://hl7.org/fhir/StructureDefinition/Patient",
+          "type": "object",
+          "properties": { "id": { "type": "string" } }
+        }
+        """;
+        const string catalogueSchemaOtherBlueprint = """
+        {
+          "$id": "https://hl7.org/fhir/StructureDefinition/Patient",
+          "type": "object",
+          "title": "Second blueprint using the same catalogue entry",
+          "properties": { "id": { "type": "string" } }
+        }
+        """;
+
+        ParseAsValidatorDoes(catalogueSchema).Should().NotBeNull();
+        var parseSecond = () => ParseAsValidatorDoes(catalogueSchemaOtherBlueprint);
+        parseSecond.Should().NotThrow();
+    }
+}


### PR DESCRIPTION
Second platform defect found by running the walkthrough suite against n1 for the #1427 currency pass.

## Symptom

Every AssuredIdentity submission on n1 was refused and never sealed:

```
VAL_SCHEMA_005: Malformed JSON schema in blueprint 'assured-identity-20260815173122' action 1:
Overwriting registered schemas is not permitted.
```

The blueprint is not malformed, and nothing in the walkthrough had changed.

## Cause

Action 1 `$ref`s four Sorcha core primitives. `SchemaRefResolver.Flatten` inlines each one by copying
**every** key of the component — including the primitive's own identifier:

```json
"applicantName": {
  "$id": "https://schemas.sorcha.dev/core/PersonName/v1",   // <- copied in
  "$schema": "https://json-schema.org/draft/2020-12/schema",
  "type": "object", ...
}
```

The sealed schema therefore carries absolute `$id`s on embedded subschemas, and `Json.Schema`
registers every identified schema it parses in a **process-wide** registry. The first parse
succeeds; any later parse of different text carrying the same `$id` throws.

So the second blueprint to use a shared primitive — or the first one republished with *any* textual
change — becomes permanently unvalidatable for the life of the validator process. The whole point of
a shared primitive library is reuse, so this is not an edge case; and the error names the blueprint
as the culprit, which sends you looking in the wrong place.

**Had it not thrown it would have been worse.** A successful registration means one blueprint's
schema can silently resolve a *different* blueprint's dangling `$ref` — validation whose outcome
depends on which blueprint the process happened to parse first.

## Fix — both sides of the seam

| Where | Change | Why this side too |
|---|---|---|
| `SchemaRefResolver` | Don't copy `$id`/`$schema` when inlining a component | Stops the shape being produced. They identify the primitive *as a document*; spliced into a host schema they identify nothing and there is no reference left to resolve into the subtree. |
| `ValidationEngine.StripCustomExtensionKeywords` | Also strip `$id` (alongside the `x-*` keywords it already removes) | Repairs the blueprints **already sealed** on n1 with the identifier baked in — those cannot be edited. Also covers catalogue-derived schemas (DPP, FHIR, ISO 20022, schema.org) which set a **root** `$id` of their source URL and collide the same way when two blueprints share an entry. |

An action schema reaching the validator is a self-contained document — identity keywords only matter
for resolving references *between* documents, which cannot happen there.

## Tests

- `InlinedCoreSchemaIdTests` (new, 3 tests) drive the **real production pair**, `StripCustomExtensionKeywords`
  then `GetOrParseActionSchema` — testing the parser alone would have proved nothing about the path
  the validator runs. All went **RED first** with the exact production exception
  (`Json.Schema.JsonSchemaException: Overwriting registered schemas is not permitted`). One covers
  the root-`$id` catalogue case; one asserts the parsed schema still *evaluates*, so the fix cannot
  degenerate into swallowing the error.
- `SchemaRefResolverTests.Flatten_DropsTheComponentsOwnIdentityKeywords` (new) — RED first; asserts
  the inlined component keeps its constraints but loses its identity.

Suites: **Blueprint.Service 1114 passed**, **Validator.Service 1084 passed**, 0 failures.

## Verification still outstanding

I will redeploy `blueprint-service` and `validator-service` to n1 after merge and re-run
**AssuredIdentity** end to end, then post the result here. Stacked with #1444 (a separate projector
defect from the same pass); both need the same deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)