### PR TITLE
fix: [#1427] - Walkthrough currency pass: every credential walkthrough run on n1

### DIFF
--- a/.github/workflows/walkthrough-secrets-gate.yml
+++ b/.github/workflows/walkthrough-secrets-gate.yml
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Sorcha Contributors
+#
+# Walkthrough-secrets contract CI gate. Fails when a walkthrough script calls
+# `Get-SorchaSecrets -WalkthroughName "<key>"` for a key that
+# walkthroughs/initialize-secrets.ps1 does not generate.
+#
+# The two sides are hand-maintained lists in different files with nothing relating them. A missing
+# entry produces no compile error and no failing test — the walkthrough simply dies in setup with
+# "No secrets found for walkthrough '<key>'", which reads like a local-environment problem and
+# survives the obvious `initialize-secrets.ps1 -Force` remedy. Two walkthroughs shipped that way
+# (#1427).
+#
+# See scripts/check-walkthrough-secrets.ps1.
+
+name: walkthrough-secrets-gate
+
+on:
+  pull_request:
+    paths:
+      - "walkthroughs/**/*.ps1"
+      - "scripts/check-walkthrough-secrets.ps1"
+      - ".github/workflows/walkthrough-secrets-gate.yml"
+  workflow_dispatch:
+
+jobs:
+  walkthrough-secrets:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run walkthrough-secrets contract gate
+        shell: pwsh
+        run: ./scripts/check-walkthrough-secrets.ps1

--- a/.gitignore
+++ b/.gitignore
@@ -275,6 +275,11 @@ walkthroughs/**/state.json
 # Cross-node walkthrough run artefacts + ad-hoc compliance reports (local-only, never commit)
 walkthroughs/**/crossnode-state.json
 walkthroughs/COMPLIANCE-REPORT.md
+# Setup-generated state under a bespoke name. The council setup writes council-state.json (shared by
+# PropertyInspection), which the `state.json` rule above does not match — it showed up untracked
+# after a run. Same class of runtime artefact, same treatment.
+walkthroughs/**/council-state.json
+walkthroughs/**/logs/
 
 # Performance benchmark test results
 walkthroughs/PerformanceBenchmark/results/*.json

--- a/scripts/check-walkthrough-secrets.ps1
+++ b/scripts/check-walkthrough-secrets.ps1
@@ -1,0 +1,122 @@
+#!/usr/bin/env pwsh
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Sorcha Contributors
+#
+# Walkthrough-secrets contract CI gate.
+#
+# Every walkthrough script that calls
+#
+#     Get-SorchaSecrets -WalkthroughName "<key>"
+#
+# needs a matching "<key>" block in walkthroughs/initialize-secrets.ps1, which is the ONLY thing
+# that generates walkthroughs/.secrets/passwords.json.
+#
+# Why this is gated rather than left to review:
+#
+#   The two sides are hand-maintained lists in different files and nothing relates them. Add a
+#   walkthrough and forget the generator entry, and there is no compile error, no failing test,
+#   and nothing at all until somebody runs that walkthrough on a machine whose passwords.json was
+#   generated before it existed — where it dies in setup at
+#
+#       No secrets found for walkthrough 'cyber-essentials-uac' in .../passwords.json
+#
+#   That reads like a local-environment problem ("regenerate your secrets"), so the natural
+#   response is `initialize-secrets.ps1 -Force`, which does not help because the key was never in
+#   the generator. Both cyber-essentials-uac and ping-pong-n1 were missing this way (#1427); only
+#   the first was noticed, and only because someone tried to run it.
+#
+# The gate derives BOTH sides from source — the requested keys by scanning the walkthroughs, the
+# provided keys by parsing the generator's own hashtable — so it cannot itself drift out of date.
+
+param([switch]$Quiet)
+
+$ErrorActionPreference = 'Stop'
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$walkthroughsDir = Join-Path $repoRoot 'walkthroughs'
+$generator = Join-Path $walkthroughsDir 'initialize-secrets.ps1'
+
+if (-not (Test-Path $generator)) {
+    Write-Host "[FAIL] Secrets generator is missing: $generator" -ForegroundColor Red
+    Write-Host "       It is the single source of walkthrough credentials; this gate reads its keys."
+    exit 1
+}
+
+# --- Side A: keys the generator provides -------------------------------------------------------
+# Match the quoted keys of the $secrets [ordered]@{ ... } literal: lines of the form
+#     "key-name" = @{
+$generatorText = Get-Content $generator -Raw
+$providedKeys = [regex]::Matches($generatorText, '(?m)^\s*"(?<key>[a-z0-9][a-z0-9-]*)"\s*=\s*@\{') |
+    ForEach-Object { $_.Groups['key'].Value } |
+    Sort-Object -Unique
+
+# Vacuous-guard protection: if the literal is ever reshaped so the regex stops matching, the gate
+# would silently "pass" against zero provided keys AND (worse) report every walkthrough as broken.
+# Assert a plausible floor instead of trusting an empty parse.
+if ($providedKeys.Count -lt 10) {
+    Write-Host "[FAIL] Parsed only $($providedKeys.Count) credential blocks from $generator." -ForegroundColor Red
+    Write-Host "       Expected at least 10. The generator's hashtable shape probably changed —"
+    Write-Host "       fix this gate's parser rather than the generator."
+    exit 1
+}
+
+# --- Side B: keys the walkthroughs ask for -----------------------------------------------------
+$requested = @{}   # key -> list of "relative/path.ps1:line"
+$scripts = Get-ChildItem -Path $walkthroughsDir -Filter '*.ps1' -Recurse -File |
+    Where-Object { $_.FullName -ne $generator }
+
+foreach ($file in $scripts) {
+    $lineNo = 0
+    foreach ($line in (Get-Content $file.FullName)) {
+        $lineNo++
+        foreach ($m in [regex]::Matches($line, 'Get-SorchaSecrets\s+-WalkthroughName\s+"(?<key>[^"]+)"')) {
+            $key = $m.Groups['key'].Value
+            $rel = $file.FullName.Substring($repoRoot.Length + 1).Replace('\', '/')
+            if (-not $requested.ContainsKey($key)) { $requested[$key] = @() }
+            $requested[$key] += "${rel}:${lineNo}"
+        }
+    }
+}
+
+# Same protection on this side: an empty scan must fail loudly, not pass quietly.
+if ($requested.Count -lt 10) {
+    Write-Host "[FAIL] Found only $($requested.Count) Get-SorchaSecrets call sites under $walkthroughsDir." -ForegroundColor Red
+    Write-Host "       Expected at least 10. The call shape probably changed — fix this gate's scanner."
+    exit 1
+}
+
+# --- The join ----------------------------------------------------------------------------------
+$missing = $requested.Keys | Where-Object { $providedKeys -notcontains $_ } | Sort-Object
+
+if ($missing) {
+    Write-Host ""
+    Write-Host "[FAIL] Walkthroughs request credential keys that initialize-secrets.ps1 does not generate:" -ForegroundColor Red
+    foreach ($key in $missing) {
+        Write-Host ""
+        Write-Host "  '$key' requested by:" -ForegroundColor Yellow
+        foreach ($site in $requested[$key]) { Write-Host "    $site" }
+    }
+    Write-Host ""
+    # NB @(...) — a single missing key is a bare string, and [0] would index its first CHARACTER.
+    Write-Host "  Fix: add a `"$(@($missing)[0])`" = @{ ... } block to walkthroughs/initialize-secrets.ps1"
+    Write-Host "  with the fields that walkthrough's scripts read (adminEmail / adminPassword /"
+    Write-Host "  DefaultPassword / per-role emails). Do NOT work around it by hand-editing a local"
+    Write-Host "  .secrets/passwords.json — that fixes one machine and leaves the walkthrough broken"
+    Write-Host "  everywhere else."
+    Write-Host ""
+    exit 1
+}
+
+# Unused generator entries are reported but do NOT fail: a walkthrough may legitimately be
+# script-less (UI-driven demos) or read its block through a path this scanner cannot see.
+$unused = $providedKeys |
+    Where-Object { $_ -ne 'platform' -and $requested.Keys -notcontains $_ } |
+    Sort-Object
+
+if (-not $Quiet) {
+    Write-Host "[OK] All $($requested.Count) requested walkthrough credential keys are generated by initialize-secrets.ps1." -ForegroundColor Green
+    if ($unused) {
+        Write-Host "     Note — generated but not requested by any script (not a failure): $($unused -join ', ')" -ForegroundColor DarkGray
+    }
+}
+
+exit 0

--- a/walkthroughs/AssuredIdentity/run-phase1-identity.ps1
+++ b/walkthroughs/AssuredIdentity/run-phase1-identity.ps1
@@ -239,6 +239,10 @@ Write-WtSuccess "Action 2 approved — credential issuance triggered (target: So
 # ============================================================================
 Write-WtStep "Step 6: Poll Sorcha Wallet /credentials for AssuredIdentityCredential"
 
+# The vct declared by blueprints/assured-identity.json action 2 (credentialIssuanceConfig.vct).
+# Kept beside the poll it drives so the two cannot drift apart silently again.
+$AssuredIdentityVct = "https://sorcha.dev/vc/assured-identity/v1"
+
 $deadline = (Get-Date).AddSeconds($DeliveryTimeoutSeconds)
 $delivered = $false
 $credentialId = $null
@@ -249,7 +253,16 @@ while ((Get-Date) -lt $deadline) {
             -Uri "$($state.walletUrl)/v1/wallet/credentials" `
             -Headers $citizenSession.Headers
         if ($snapshot.credentials -and $snapshot.credentials.Count -gt 0) {
-            $hit = $snapshot.credentials | Where-Object { $_.vct -match "AssuredIdentity" -or $_.displayLabel -match "Assured" } | Select-Object -First 1
+            # Match the vct the blueprint actually issues. It is a URI, and a kebab-case one:
+            #   https://sorcha.dev/vc/assured-identity/v1
+            # The old test `-match "AssuredIdentity"` was written when the vct was the PascalCase
+            # type name, and after the VCT decoupling (#1187 — vct-only URIs) it matches NOTHING.
+            # displayLabel is empty on this endpoint, so the `-or` arm never saved it either. The
+            # credential arrived within seconds; the script polled the full 60 s past it and reported
+            # "did not land" for a credential sitting in the response it was reading (#1427).
+            $hit = $snapshot.credentials |
+                Where-Object { $_.vct -eq $AssuredIdentityVct } |
+                Select-Object -First 1
             if ($hit) {
                 $delivered = $true
                 $credentialId = $hit.id

--- a/walkthroughs/CyberEssentialsUac/setup.ps1
+++ b/walkthroughs/CyberEssentialsUac/setup.ps1
@@ -402,12 +402,40 @@ Set-SorchaOrgMasterKey `
 # ============================================================================
 # Blueprint B's credentialRequirements.trustPolicy.allowedIssuers contains the
 # literal placeholder "{{ASSESSOR_ISSUER_DID}}" that must be replaced with the
-# assessor's real DID before publish. The DID is did:sorcha:org:<walletAddress>.
+# assessor's real DID before publish.
+#
+# That DID is NOT did:sorcha:org:<operational wallet address>. Once the org has a
+# Feature 083 master key — which this walkthrough provisions, because it must, to
+# issue a verifiable credential at all — credentials are signed by a DERIVED
+# vc-issuance child key, and `iss` carries that child's address. Pinning the
+# operational address produces a policy that matches nothing: the credential is
+# issued and delivered perfectly, and the gate then refuses it with
+# "No trust source vouched for the issuer under the AnyOf policy" (blueprint-service
+# TrustEvaluator), surfaced to the caller as a bare sanitized 400.
+#
+# Observed on n1 (#1427) — the two addresses side by side:
+#   operational : did:sorcha:org:ws11qrg5jnsc5ckvcy5w4yyrxqfnzxx7j54ch5uf9ylztxxxz2lx9l2dc9h2g09
+#   credential  : did:sorcha:org:ws11qplqu8nhcy36uz5she75pg24a23aw458gzm9ty8na9luaqnupwr3vvj7gwf
+#
+# The org's DID document is the authority for which one to pin: its `id` IS the
+# issuance DID, and it lists the #vc-issuance-N verification method the credential's
+# kid names. Resolve it rather than reconstructing the string. NB the endpoint is
+# served at /orgs/{orgId}/did.json — NOT under /api.
 
 Write-WtStep "Step 7: Resolve Assessor Issuer DID → Blueprint B"
 
-$assessorDid  = "did:sorcha:org:$($assessorWallet.Address)"
-Write-WtInfo "Assessor issuer DID: $assessorDid"
+$assessorDidDocUrl = "$($sorchaEnv.GatewayUrl)/orgs/$assessorOrgId/did.json"
+$assessorDidDoc = Invoke-SorchaApi -Method GET -Uri $assessorDidDocUrl
+$assessorDid = $assessorDidDoc.id
+if (-not $assessorDid) {
+    throw ("Could not resolve the assessor org's issuance DID from $assessorDidDocUrl. " +
+           "Without it the trust policy would pin the operational wallet DID, which no issued " +
+           "credential ever carries, and every credential-gated submission would be refused.")
+}
+Write-WtInfo "Assessor issuer DID (from org DID document): $assessorDid"
+if ($assessorDid -eq "did:sorcha:org:$($assessorWallet.Address)") {
+    Write-WtWarn "  Issuance DID equals the operational wallet DID — the org master key may not be provisioned."
+}
 
 $bpBTemplatePath  = Join-Path $scriptDir "cyber-insurance-application-template.json"
 $bpBResolvedPath  = Join-Path $scriptDir ".bpB.resolved.json"

--- a/walkthroughs/PropertyInspection/actors/building-inspector.json
+++ b/walkthroughs/PropertyInspection/actors/building-inspector.json
@@ -4,7 +4,7 @@
     "description": "Building Inspector — safety sign-off for Emergency severity jobs"
   },
   "connection": {
-    "gatewayUrl": "http://localhost",
+    "gatewayUrl": "{{gatewayUrl}}",
     "registerId": "{{registerId}}",
     "credentials": {
       "email": "{{roles.building-inspector.email}}",

--- a/walkthroughs/PropertyInspection/actors/contractor.json
+++ b/walkthroughs/PropertyInspection/actors/contractor.json
@@ -4,7 +4,7 @@
     "description": "Site Operative — completes repair work with photo evidence and delivery note"
   },
   "connection": {
-    "gatewayUrl": "http://localhost",
+    "gatewayUrl": "{{gatewayUrl}}",
     "registerId": "{{registerId}}",
     "credentials": {
       "email": "{{roles.contractor.email}}",

--- a/walkthroughs/PropertyInspection/actors/housing-officer.json
+++ b/walkthroughs/PropertyInspection/actors/housing-officer.json
@@ -4,7 +4,7 @@
     "description": "Housing Officer — triages requests, allocates contractor, reviews completion"
   },
   "connection": {
-    "gatewayUrl": "http://localhost",
+    "gatewayUrl": "{{gatewayUrl}}",
     "registerId": "{{registerId}}",
     "credentials": {
       "email": "{{roles.housing-officer.email}}",

--- a/walkthroughs/PropertyInspection/actors/tenant.json
+++ b/walkthroughs/PropertyInspection/actors/tenant.json
@@ -4,7 +4,7 @@
     "description": "Council tenant — reports problem with photo, verifies operative, confirms satisfaction"
   },
   "connection": {
-    "gatewayUrl": "http://localhost",
+    "gatewayUrl": "{{gatewayUrl}}",
     "registerId": "{{registerId}}",
     "credentials": {
       "email": "{{roles.tenant.email}}",

--- a/walkthroughs/PropertyInspection/property-inspection-template.json
+++ b/walkthroughs/PropertyInspection/property-inspection-template.json
@@ -10,6 +10,7 @@
   "template": {
     "id": "property-inspection-generated",
     "title": "Council Property Inspection",
+    "description": "Council property repair workflow — a tenant reports a problem with photo evidence, the council triages and allocates a contractor, the tenant verifies the operative's identity credential on arrival, and the work is completed, reviewed and signed off. The description lives here as well as on the outer wrapper because the publisher posts THIS object; a wrapper-only description publishes as empty and is refused (minimum 5 characters).",
     "version": 1,
     "metadata": {
       "category": "Council Services",
@@ -32,7 +33,7 @@
         "name": "Council Tenant",
         "organisation": "Public",
         "description": "Reports problem with photo evidence, verifies operative identity, confirms satisfaction",
-        "walletAddress": "addr_patched_by_publish_blueprint"
+        "walletAddress": null
       },
       {
         "id": "housing-officer",
@@ -219,6 +220,10 @@
         "title": "Verify Operative",
         "description": "Tenant verifies the contractor's identity using the JobAssignmentCredential before granting access",
         "sender": "tenant",
+        "rejectionConfig": {
+          "requireReason": true,
+          "isTerminal": true
+        },
         "dataSchemas": [
           {
             "type": "object",

--- a/walkthroughs/PropertyInspection/run-agents.ps1
+++ b/walkthroughs/PropertyInspection/run-agents.ps1
@@ -63,7 +63,12 @@ $instance = Invoke-SorchaApi -Method POST `
         tenantId    = $housingRole.organizationId
     }
 
-if (-not $instance?.id) {
+# ${instance}?.id, NOT $instance?.id — "?" is a legal character in a PowerShell variable name, so
+# the unbraced form parses as ${instance?}.id, reads an undefined variable, and yields $null. The
+# guard was therefore ALWAYS true: this script reported "Failed to create blueprint instance" and
+# exited 1 on every run, including the runs where the instance was created perfectly well. Proven by
+# printing the value beside the check — id 36c8bb1a-… present, guard still firing (#1427).
+if (-not ${instance}?.id) {
     Write-Error "Failed to create blueprint instance."
     exit 1
 }
@@ -71,9 +76,25 @@ Write-WtSuccess "Instance created: $($instance.id)"
 
 # ── Resolve agent command ─────────────────────────────────────────
 if (-not $AgentBinary) {
-    $agentProject = Join-Path $walkthroughDir ".." ".." "src" "Apps" "Sorcha.Agent" "Sorcha.Agent.csproj"
+    $agentProject = (Resolve-Path (Join-Path $walkthroughDir ".." ".." "src" "Apps" "Sorcha.Agent" "Sorcha.Agent.csproj")).Path
+
+    # Build ONCE, here, then run every agent with --no-build.
+    #
+    # Four `dotnet run` processes start within milliseconds of each other and each tries to build the
+    # same project into the same obj/bin. They collide on the intermediate assemblies and all four die
+    # with CS2012 "Cannot open ... for writing ... being used by another process" — a build race that
+    # reads like a Sorcha failure and has nothing to do with the workflow. Serialising the build is
+    # enough; the agents themselves are independent (#1427).
+    Write-WtInfo "Building sorcha-agent once (four concurrent 'dotnet run' builds race on obj/bin)..."
+    $buildLog = & dotnet build $agentProject -v quiet --nologo 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        $buildLog | Select-Object -Last 20 | ForEach-Object { Write-Host $_ }
+        Write-Error "sorcha-agent failed to build — cannot launch actors."
+        exit 1
+    }
+
     $agentCmd = "dotnet"
-    $agentBaseArgs = @("run", "--project", (Resolve-Path $agentProject).Path, "--")
+    $agentBaseArgs = @("run", "--project", $agentProject, "--no-build", "--")
 } else {
     $agentCmd = $AgentBinary
     $agentBaseArgs = @()

--- a/walkthroughs/PropertyInspection/setup.ps1
+++ b/walkthroughs/PropertyInspection/setup.ps1
@@ -125,18 +125,27 @@ Add-SorchaPublicOrgSubscription -TenantUrl $sorchaEnv.TenantUrl `
 # ── Publish participants to register ──────────────────────────────
 Write-WtStep "Publishing participants to register"
 
+# The tenant is deliberately ABSENT. They are the sender of action 0, the starting action, which
+# makes them the Feature 103 OPEN participant: late-bound to whoever actually submits, not declared
+# up front. Every other walkthrough with a citizen starting-participant does the same (AssuredIdentity
+# publishes only the analyst and licensing officer; ConstructionPermit only the four org roles).
+#
+# Publishing them was not merely redundant, it could not work: the call publishes a participant record
+# FOR AN ORGANISATION, and the tenant's organisation is the shared Public org, authorised with the
+# citizen's own consumer-tier session. n1 answers
+# POST /api/organizations/00000000-0000-0000-0000-000000000002/participants/publish with 403, and
+# setup died there before reaching the blueprint publish (#1427).
 $participantPublishDefs = @(
-    @{ role = "tenant"; name = $tenantDef.name; org = "Public"; address = $tenantWallet.Address; publicKey = $tenantParticipant.PublicKey ?? $tenantWallet.PublicKey; orgId = $publicOrgId; session = $tenantSession }
     @{ role = "housing-officer"; name = $housingRole.name; org = "Strathcarron Council"; address = $housingRole.walletAddress; publicKey = $housingRole.publicKey; orgId = $housingRole.organizationId; session = $housingSession }
     @{ role = "contractor"; name = $contractorRole.name; org = "Stoniebridge Construction"; address = $contractorRole.walletAddress; publicKey = $contractorRole.publicKey; orgId = $contractorRole.organizationId; session = $contractorSession }
     @{ role = "building-inspector"; name = $councilState.roles."building-inspector".name; org = "Strathcarron Council"; address = $councilState.roles."building-inspector".walletAddress; publicKey = $councilState.roles."building-inspector".publicKey; orgId = $councilState.roles."building-inspector".organizationId; session = $null }
 )
 
-# Building inspector session
+# Building inspector session (last entry — index tracks the list above)
 $biRole = $councilState.roles."building-inspector"
 $biSession = Connect-SorchaUser -TenantUrl $sorchaEnv.TenantUrl `
     -Email $biRole.email -Password $biRole.password -OrganizationId $biRole.organizationId
-$participantPublishDefs[3].session = $biSession
+$participantPublishDefs[-1].session = $biSession
 
 foreach ($p in $participantPublishDefs) {
     Publish-SorchaParticipant -TenantUrl $sorchaEnv.TenantUrl `
@@ -181,8 +190,10 @@ Set-SorchaOrgMasterKey `
 # ── Publish blueprint ─────────────────────────────────────────────
 Write-WtStep "Publishing blueprint"
 
+# "tenant" is intentionally absent — open participant, late-bound at runtime (see the
+# participant-publish block above). Publish-SorchaBlueprint would skip it anyway, but leaving it out
+# keeps the map honest about who is actually pre-bound.
 $walletMap = @{
-    "tenant"            = $tenantWallet.Address
     "housing-officer"   = $housingRole.walletAddress
     "contractor"        = $contractorRole.walletAddress
     "building-inspector" = $biRole.walletAddress
@@ -204,21 +215,27 @@ if ($blueprint.Warnings) {
 # ── Create tenant persona ────────────────────────────────────────
 Write-WtStep "Creating tenant persona"
 
+# Field names and formats are the SERVER's, not this script's invention:
+#   PersonaAddress is (Line1, Line2?, City, Region?, PostalCode, Country, IsDefault, Label?)
+#   — Sorcha.Tenant.Models.Persona.PersonaAddress. The older "street"/"locality" spellings bound to
+#   nothing, so PUT /api/me/persona answered 400 addresses[0].line1=required, addresses[0].city=required.
+#   PersonaService validates phones against E.164 (PersonaService.E164Regex), so the number must carry
+#   no spaces: "+441463555201", not "+44 1463 555 201" — the spaced form returned invalid_phone.
 $personaDefs = @{
     a = @{
         givenName = "Flora"; familyName = "MacInnes"; fullName = "Flora MacInnes"
-        phones = @(@{ value = "+44 1463 555 201"; isDefault = $true })
-        addresses = @(@{ street = "14 Moray Crescent"; locality = "Carronbridge"; postalCode = "SC4 2TL"; country = "GB"; isDefault = $true })
+        phones = @(@{ value = "+441463555201"; isDefault = $true })
+        addresses = @(@{ line1 = "14 Moray Crescent"; city = "Carronbridge"; postalCode = "SC4 2TL"; country = "GB"; isDefault = $true })
     }
     b = @{
         givenName = "Angus"; familyName = "Beaton"; fullName = "Angus Beaton"
-        phones = @(@{ value = "+44 1463 555 302"; isDefault = $true })
-        addresses = @(@{ street = "7 Loch Morach Drive"; locality = "Dalreoch"; postalCode = "SC6 8JN"; country = "GB"; isDefault = $true })
+        phones = @(@{ value = "+441463555302"; isDefault = $true })
+        addresses = @(@{ line1 = "7 Loch Morach Drive"; city = "Dalreoch"; postalCode = "SC6 8JN"; country = "GB"; isDefault = $true })
     }
     c = @{
         givenName = "Eilidh"; familyName = "Drummond"; fullName = "Eilidh Drummond"
-        phones = @(@{ value = "+44 1463 555 403"; isDefault = $true })
-        addresses = @(@{ street = "3 Invercarron Row"; locality = "Invercarron"; postalCode = "SC2 5PA"; country = "GB"; isDefault = $true })
+        phones = @(@{ value = "+441463555403"; isDefault = $true })
+        addresses = @(@{ line1 = "3 Invercarron Row"; city = "Invercarron"; postalCode = "SC2 5PA"; country = "GB"; isDefault = $true })
     }
 }
 

--- a/walkthroughs/Strathcarron/setup-blue-badge-demo.ps1
+++ b/walkthroughs/Strathcarron/setup-blue-badge-demo.ps1
@@ -67,7 +67,14 @@ $sorchaEnv = Initialize-SorchaEnvironment -Profile $Profile -SkipHealthCheck:$Sk
 # ============================================================================
 Write-WtStep "Step 2: Sign in as Strathcarron council admin"
 $councilOrgId = $coldStartState.councilOrgId
-$councilAdminEmail = "council-admin@strathcarron.local"
+# Take the operator from cold-start state rather than repeating the address here — the two scripts
+# drifted apart exactly this way, and a hardcoded email that is not a member of the council org logs
+# in against the Public org instead, then fails several steps later with an unrelated-looking 403.
+$councilAdminEmail = $coldStartState.councilAdminEmail
+if (-not $councilAdminEmail) {
+    throw ("Cold-start state carries no councilAdminEmail — it was written by a revision of " +
+           "setup-cold-start-demo.ps1 that predates this field. Re-run setup-cold-start-demo.ps1.")
+}
 $councilSession = Connect-SorchaUser `
     -TenantUrl $sorchaEnv.TenantUrl `
     -Email $councilAdminEmail `

--- a/walkthroughs/Strathcarron/setup-cold-start-demo.ps1
+++ b/walkthroughs/Strathcarron/setup-cold-start-demo.ps1
@@ -77,37 +77,56 @@ Write-WtInfo "Public org enabled"
 # ============================================================================
 Write-WtStep "Step 3: Create Strathcarron Council org"
 
-$councilAdminEmail    = "council-admin@strathcarron.local"
+# The council admin is an ORG OPERATOR, so it is provisioned org-scoped — never registered as a
+# public user first. Registering publicly and then naming the same address as -AdminEmail is the
+# documented anti-pattern (walkthrough-builder skill): it makes the operator multi-org at best, and
+# on a node where the org ALREADY EXISTS it does nothing at all — New-SorchaOrganization's duplicate
+# recovery returns the existing org without adopting the admin, so the user stays Public-only. On n1,
+# where the `council` walkthrough had already created Strathcarron Council, that produced a session
+# scoped to the Public org and a 403 four steps later at master-key provisioning (#1427).
+#
+# The address is deliberately distinct from council-admin@strathcarron.local, which earlier revisions
+# of this script left behind as a public account on any node they ran against; /users/provision
+# requires an email that is new platform-wide.
+$councilAdminEmail    = "council-issuer@strathcarron.local"
 $councilAdminPassword = $secrets.DefaultPassword
-
-Register-SorchaPublicUser `
-    -TenantUrl $sorchaEnv.TenantUrl `
-    -Email $councilAdminEmail `
-    -Password $councilAdminPassword `
-    -DisplayName "Strathcarron Council Admin" | Out-Null
-
-$publicUsers = Invoke-SorchaApi -Method GET `
-    -Uri "$($sorchaEnv.TenantUrl)/organizations/$publicOrgId/users?includeInactive=true" `
-    -Headers $sysAdmin.Headers
-$councilAdminUser = $publicUsers.users | Where-Object { $_.email -eq $councilAdminEmail } | Select-Object -First 1
-if ($councilAdminUser) {
-    Confirm-SorchaUserEmail `
-        -TenantUrl $sorchaEnv.TenantUrl `
-        -OrganizationId $publicOrgId `
-        -UserId $councilAdminUser.id `
-        -Headers $sysAdmin.Headers
-    Write-WtInfo "Verified council-admin email"
-}
 
 $councilOrg = New-SorchaOrganization `
     -TenantUrl $sorchaEnv.TenantUrl `
     -Name "Strathcarron Council" `
     -Subdomain "strathcarron" `
     -AdminEmail $councilAdminEmail `
+    -AdminPassword $councilAdminPassword `
+    -AdminDisplayName "Strathcarron Council Issuer" `
+    -AdminEmailVerified `
     -Headers $sysAdmin.Headers `
     -Description "Issues licences and other credentials to Strathcarron citizens"
 $councilOrgId = $councilOrg.OrganizationId
 Write-WtSuccess "Council org: $councilOrgId"
+
+# Whether the org was created just now or recovered as an existing one, make sure the operator is
+# actually IN it. The recovery path cannot create members, and a re-run finds the user already there
+# — both are fine, both are handled here rather than surfacing later as an unexplained 403.
+if (-not $councilOrg.AdminDirectlyAdded) {
+    try {
+        New-SorchaOrgUser `
+            -TenantUrl $sorchaEnv.TenantUrl `
+            -OrganizationId $councilOrgId `
+            -Email $councilAdminEmail `
+            -Password $councilAdminPassword `
+            -DisplayName "Strathcarron Council Issuer" `
+            -Roles @("Administrator") `
+            -EmailVerified `
+            -Headers $sysAdmin.Headers | Out-Null
+    } catch {
+        # Already provisioned by an earlier run — the password is deterministic, so the login below
+        # picks the existing account up. Anything else is a real failure and must not be swallowed.
+        $body = ''
+        try { $body = Get-SorchaErrorBody $_ } catch { }
+        if ("$body$($_.Exception.Message)" -notmatch 'already exists|duplicate|409') { throw }
+        Write-WtInfo "Council operator already provisioned — reusing"
+    }
+}
 
 # ============================================================================
 # Step 4: Council Admin — Login, Wallet
@@ -143,6 +162,23 @@ Write-WtSuccess "Council wallet: $($councilWallet.Address)"
 
 Write-WtStep "Step 4b: Provision credential-issuer org master key"
 
+# Register the council admin as a participant FIRST — creating a wallet is not enough.
+#
+# wallet_address is put on a JWT by TokenService.AddWalletAddressClaimAsync, which looks up the
+# PARTICIPANT record for (user, org) and takes its first active wallet LINK. A wallet with no
+# participant record produces no claim, no matter how many times you log in again. Without the claim
+# the F142 publish gate refuses the blueprint with
+# "You do not hold a publish-governance role (Owner, Admin, or Designer) on the target register." —
+# on a register this very user owns, which is what makes it so misleading. Verified on n1: a fresh
+# register created by this user, with an empty wallet_address claim, was refused (#1427).
+$null = Register-SorchaParticipant `
+    -TenantUrl $sorchaEnv.TenantUrl `
+    -WalletUrl $sorchaEnv.WalletUrl `
+    -OrganizationId $councilOrgId `
+    -WalletAddress $councilWallet.Address `
+    -DisplayName "Strathcarron Council Issuer" `
+    -Headers $councilSession.Headers
+
 $councilIssuerSession = Connect-SorchaUser `
     -TenantUrl $sorchaEnv.TenantUrl `
     -Email $councilAdminEmail `
@@ -153,6 +189,17 @@ Set-SorchaOrgMasterKey `
     -WalletUrl $sorchaEnv.WalletUrl `
     -OrganizationId $councilOrgId `
     -Headers $councilIssuerSession.Headers
+
+# From here on, use the RE-LOGGED session for everything wallet-authorized.
+#
+# $councilSession was obtained at Step 4 BEFORE the council wallet existed, and wallet_address is
+# added to a JWT only at login (TokenService.AddWalletAddressClaimAsync). So that token carries no
+# wallet_address for the rest of its life, and the F142 publish gate — which matches the caller's
+# wallet_address against the register's governance roster — refuses it with
+# "You do not hold a publish-governance role (Owner, Admin, or Designer) on the target register."
+# The message reads like a ROLE problem; the admin's roles were never in question. Noted as a
+# pre-existing gap in #1427 and confirmed live on n1.
+$councilSession = $councilIssuerSession
 
 # ============================================================================
 # Step 5: Register + Blueprint
@@ -271,6 +318,9 @@ $state = @{
     blueprintUrl           = $sorchaEnv.BlueprintUrl
     publicOrgId            = $publicOrgId
     councilOrgId           = $councilOrgId
+    # Recorded so setup-blue-badge-demo.ps1 signs in as whoever THIS script provisioned, instead of
+    # hardcoding an address the two files have to keep in step by hand.
+    councilAdminEmail      = $councilAdminEmail
     councilWalletAddress   = $councilWallet.Address
     registerId             = $register.RegisterId
     blueprintId            = $blueprint.BlueprintId

--- a/walkthroughs/initialize-secrets.ps1
+++ b/walkthroughs/initialize-secrets.ps1
@@ -1,4 +1,4 @@
-﻿#!/usr/bin/env pwsh
+#!/usr/bin/env pwsh
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2026 Sorcha Contributors
 #
@@ -238,6 +238,17 @@ $secrets = [ordered]@{
         housingOfficerEmail         = "housing@strathcarron.local"
         housingOfficerPassword      = "Dev_Pass_2025!"
         housingOfficerName          = "Housing Officer"
+    }
+    "cyber-essentials-uac" = @{
+        adminEmail      = $platformEmail
+        adminPassword   = $platformPassword
+        adminName       = $platformName
+        DefaultPassword = $platformPassword
+    }
+    "ping-pong-n1" = @{
+        adminEmail    = $platformEmail
+        adminPassword = $platformPassword
+        adminName     = $platformName
     }
     "property-inspection" = @{
         tenantAEmail    = "tenant-a@citizen.local"

--- a/walkthroughs/modules/SorchaWalkthrough/SorchaWalkthrough.psm1
+++ b/walkthroughs/modules/SorchaWalkthrough/SorchaWalkthrough.psm1
@@ -560,10 +560,24 @@ function Connect-SorchaUser {
         -Uri "$TenantUrl/auth/login" `
         -Body $loginBody
 
-    # Single-org user: token returned directly
+    # Single-org user: token returned directly.
+    #
+    # The server picks the org here — there is no selection step — so the token may be scoped to an
+    # org OTHER than the one the caller asked for. That is always a bug in the caller's setup (the
+    # user was never added to the org they are about to act in), and it used to pass silently: the
+    # session looked fine and every later call against the requested org failed with a bare 403,
+    # pointing at permissions rather than at the wrong-org session. Strathcarron lost a whole setup
+    # run to it — the council admin existed only in the Public org, so master-key provisioning 403'd
+    # four steps later (#1427). Fail here, where the cause is still visible.
     if ($loginResponse.access_token) {
         $token = $loginResponse.access_token
         $jwt = Decode-SorchaJwt -Token $token
+        if ($jwt.org_id -and $OrganizationId -and $jwt.org_id -ne $OrganizationId) {
+            throw ("Connect-SorchaUser: $Email is single-org in $($jwt.org_id), but org $OrganizationId was requested. " +
+                   "The user is not a member of the requested org, so every org-scoped call will 403. " +
+                   "Provision them into it with New-SorchaOrgUser (org-scoped, single-org) rather than " +
+                   "registering a public account and hoping org creation adopts it.")
+        }
         Write-WtSuccess "Logged in as $Email (single-org: $($jwt.org_id))"
         return @{
             Token          = $token
@@ -1903,9 +1917,15 @@ function New-SorchaOrganization {
             $existing = $orgs.items | Where-Object { $_.subdomain -eq $Subdomain } | Select-Object -First 1
             if ($existing) {
                 Write-WtSuccess "Found existing org: $($existing.id)"
+                # AdminDirectlyAdded = $false, and that is the whole point of reporting it: this path
+                # recovers an org that someone else created, so the -AdminEmail passed to THIS call
+                # was never provisioned into it. Saying $true here (as it used to) told callers the
+                # admin was ready when they had no membership at all, and the first org-scoped call
+                # they made 403'd with nothing to connect it to (#1427). Callers must ensure
+                # membership themselves — see New-SorchaOrgUser.
                 return @{
                     OrganizationId    = "$($existing.id)"
-                    AdminDirectlyAdded = $true
+                    AdminDirectlyAdded = $false
                 }
             }
             throw "Organization '$Name' looked like a duplicate but could not be found by subdomain"


### PR DESCRIPTION
Closes the walkthrough-side of #1427. Every credential-issuing walkthrough was run **against n1** —
unit-green proves nothing here, and every defect below was found by execution, not review.

Two platform defects found by the same pass shipped separately and are already merged and deployed to
n1: **#1444** (instance projector rebinding a participant to the wrong wallet) and **#1445** (inlined
core-schema `$id` collisions). The results below are on n1 *with* those deployed.

## Results

| Walkthrough | Result on n1 |
|---|---|
| ConstructionPermit | **PASS** — 3/3 scenarios; credential signed `did:sorcha:org:…#vc-issuance-1` |
| ForestryCertification | **PASS** — DPP credential issued, issuer DID verified |
| TradeFinance | **PASS** — 3/3 scenarios, 22 actions (was dead at action 3) |
| SelfBuildHouse | **PASS** — 3/3 scenarios across 2 registers (was dead at action 5) |
| AssuredIdentity Phase 1 | **PASS** — credential delivered + claimed (was dead at action 1) |
| Strathcarron | **setup PASS** (both scripts); browser walk is manual by design |
| CyberEssentialsUac | **partial** — issuance + trust now pass; blocked at revocation (#1447) |
| PropertyInspection | **partial** — setup + agents now run; blocked at open-participant inbox (#1446) |

## What was fixed here

**Missing credential blocks + a gate.** `cyber-essentials-uac` and `ping-pong-n1` were requested by
`Get-SorchaSecrets` and generated by nothing, so both died with "No secrets found" on any machine
whose `passwords.json` predated them. #1427 recorded one; the second was found by scanning. New CI
gate derives *both* sides from source, asserts a floor on each scan so an empty parse fails loudly,
and was mutation-tested. Also worth correcting: `-Force` is **not** destructive — every password is a
literal, verified by diffing all fields before/after (2 added, 0 changed).

**PropertyInspection — six defects, none of them the workflow.** Published the citizen as a
participant using their own consumer session (403); pre-bound that open participant to the literal
`"addr_patched_by_publish_blueprint"` (the only one of 17 templates not using `null`); no
`description` on the object the publisher posts; missing `rejectionConfig.isTerminal` (VAL_BP_CRED_003);
a persona payload using field names and a phone format the server rejects; and
`if (-not $instance?.id)` — `?` is legal in a PowerShell variable name, so that parses as
`${instance?}.id`, is always `$null`, and made the launcher report failure on every run **including
the successful ones**. Plus a four-way `dotnet run` build race and actor configs hardcoded to
localhost.

**Strathcarron — the misleading one.** Publishing failed with *"You do not hold a publish-governance
role (Owner, Admin, or Designer)"* on a register that user owns. `wallet_address` comes from the
**participant record**, not from owning a wallet, so no amount of re-logging in helps; the script now
registers a participant first. Also replaced the public-user anti-pattern (which silently did nothing
on a node where the org already existed) with org-scoped provisioning.

**CyberEssentialsUac** pinned `did:sorcha:org:<operational wallet>` in its trust policy; a credential
signed under an F083 master key carries the **derived** vc-issuance address, so the allowlist matched
nothing. Now resolved from the org's DID document.

**AssuredIdentity** polled for `vct -match "AssuredIdentity"`; post-#1187 the value is
`https://sorcha.dev/vc/assured-identity/v1`. It waited 60s past a credential in the response it was
reading.

**Two shared-module fixes**, both about failing where the cause is visible: `Connect-SorchaUser`
silently returned a session for a *different* org than requested (now throws), and
`New-SorchaOrganization`'s duplicate-recovery path claimed `AdminDirectlyAdded=$true` having added
nobody.

## Filed rather than forced

- **#1446** — the pending-actions inbox offers an action to every participant *except* the one who can
  send it. Blocks agent-driven open-participant workflows; PropertyInspection's remaining blocker.
- **#1447** — every credential on every deployment points its status list at `https://sorcha.example`
  (`StatusList:BaseUrl` is wired nowhere), so `FailClosed` revocation can never resolve.
  CyberEssentialsUac's remaining blocker.
- **#1443** — service-auth token endpoints bind camelCase JSON but snake_case form.
- AssuredIdentity Phase 2 is skipped by its own setup (F142 publish gate: licensing-admin holds no
  Owner role on the shared register) — a governance-ownership decision, not drift.
- 36 actor configs across the suite still hardcode `http://localhost`, so agent-based walkthroughs
  cannot target n1 without editing files. Only PropertyInspection's four are fixed here.
- PropertyInspection action 6 (citizen self-issue under the Public org) remains the design question
  #1427 already records — untouched deliberately.

n1 leftovers from this pass (for #1403): register `156fc1ba…` "Strathcarron DL Verify 1427", plus the
usual walkthrough orgs/registers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)